### PR TITLE
Check TOML and YAML files for schema filepath pragma

### DIFF
--- a/src/negative_test/accelerator/accelerator-invalid-engine-strategy.yaml
+++ b/src/negative_test/accelerator/accelerator-invalid-engine-strategy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Hello
 

--- a/src/negative_test/accelerator/accelerator-invalid-engine-transform-type.yaml
+++ b/src/negative_test/accelerator/accelerator-invalid-engine-transform-type.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Hello
 

--- a/src/negative_test/accelerator/accelerator-invalid-include-ant-pattern.yaml
+++ b/src/negative_test/accelerator/accelerator-invalid-include-ant-pattern.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Hello
 

--- a/src/negative_test/accelerator/accelerator-invalid-options-datatype.yaml
+++ b/src/negative_test/accelerator/accelerator-invalid-options-datatype.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Hello
   options:

--- a/src/negative_test/accelerator/accelerator-invalid-options-name.yaml
+++ b/src/negative_test/accelerator/accelerator-invalid-options-name.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Hello
   options:

--- a/src/negative_test/aurora-1.0/invalid-http-method.aurora.yaml
+++ b/src/negative_test/aurora-1.0/invalid-http-method.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/negative_test/aurora-1.0/invalid-index-type.aurora.yaml
+++ b/src/negative_test/aurora-1.0/invalid-index-type.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/negative_test/aurora-1.0/invalid-property-type.aurora.yaml
+++ b/src/negative_test/aurora-1.0/invalid-property-type.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/negative_test/aurora-1.0/invalid-relationship-type.aurora.yaml
+++ b/src/negative_test/aurora-1.0/invalid-relationship-type.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/negative_test/aurora-1.0/invalid-resolve-type.aurora.yaml
+++ b/src/negative_test/aurora-1.0/invalid-resolve-type.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/negative_test/bigconfig/invalid-row-creation-time.yaml
+++ b/src/negative_test/bigconfig/invalid-row-creation-time.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 type: BIGCONFIG_FILE
 auto_apply_on_indexing: true
 

--- a/src/negative_test/bigconfig/invalid-saved-metric-def.yaml
+++ b/src/negative_test/bigconfig/invalid-saved-metric-def.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 type: BIGCONFIG_FILE
 auto_apply_on_indexing: true
 

--- a/src/negative_test/bigconfig/invalid-tag-definitions.yaml
+++ b/src/negative_test/bigconfig/invalid-tag-definitions.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 type: BIGCONFIG_FILE
 auto_apply_on_indexing: true
 

--- a/src/negative_test/bigconfig/invalid-tag-deployments.yaml
+++ b/src/negative_test/bigconfig/invalid-tag-deployments.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 type: BIGCONFIG_FILE
 auto_apply_on_indexing: true
 

--- a/src/negative_test/bigconfig/invalid-type-bigconfig.yaml
+++ b/src/negative_test/bigconfig/invalid-type-bigconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 # Purposefully used incorrect type
 type: BIGCONFIG
 auto_apply_on_indexing: true

--- a/src/negative_test/bosh-deploy-config/exclude-only.yaml
+++ b/src/negative_test/bosh-deploy-config/exclude-only.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 exclude:
   - test_deployment

--- a/src/negative_test/bosh-deploy-config/include-and-exclude.yaml
+++ b/src/negative_test/bosh-deploy-config/include-and-exclude.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 exclude:
   - test_deployment
 

--- a/src/negative_test/bosh-deploy-config/include-only.yaml
+++ b/src/negative_test/bosh-deploy-config/include-only.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 include:
   - test_deployment

--- a/src/negative_test/bosh-deploy-config/invalid-flag-and-exclude.yaml
+++ b/src/negative_test/bosh-deploy-config/invalid-flag-and-exclude.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - invalid_flag
   - fix-releases

--- a/src/negative_test/bosh-deploy-config/invalid-flag-and-include.yaml
+++ b/src/negative_test/bosh-deploy-config/invalid-flag-and-include.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - invalid_flag
   - fix-releases

--- a/src/negative_test/bosh-deploy-config/invalid-flag-only.yaml
+++ b/src/negative_test/bosh-deploy-config/invalid-flag-only.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - invalid_flag

--- a/src/negative_test/bosh-deploy-config/invalid-types.yaml
+++ b/src/negative_test/bosh-deploy-config/invalid-types.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags: not an array
 exclude:
   - 'abc'

--- a/src/negative_test/cibuildwheel/cibuildwheel-bad-override.toml
+++ b/src/negative_test/cibuildwheel/cibuildwheel-bad-override.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/cibuildwheel.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"

--- a/src/negative_test/cibuildwheel/cibuildwheel-unreco.toml
+++ b/src/negative_test/cibuildwheel/cibuildwheel-unreco.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/cibuildwheel.json
 [tool.cibuildwheel]
 not-an-option = true

--- a/src/negative_test/cloud-run-v1/incorrect-name.yaml
+++ b/src/negative_test/cloud-run-v1/incorrect-name.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloud-run-v1.json
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/src/negative_test/cloud-run-v1/incorrect-port.yaml
+++ b/src/negative_test/cloud-run-v1/incorrect-port.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloud-run-v1.json
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/src/negative_test/cloudbuild/invalid-args.yaml
+++ b/src/negative_test/cloudbuild/invalid-args.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudbuild.json
 # `args` should be array of strings
 steps:
   - name: hashicorp/terraform

--- a/src/negative_test/cloudbuild/invalid-steps.yaml
+++ b/src/negative_test/cloudbuild/invalid-steps.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudbuild.json
 # Missing required `steps`
 - name: hashicorp/terraform
   args: ['--version']

--- a/src/negative_test/github-discussion/no_body.yaml
+++ b/src/negative_test/github-discussion/no_body.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/github-discussion.json
 title: 'General'
 labels: ['General Introduction']

--- a/src/negative_test/github-workflow/all-steps-must-contain-run-or-uses.yaml
+++ b/src/negative_test/github-workflow/all-steps-must-contain-run-or-uses.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: all-steps-must-contain-run-or-uses
 on:
   - push

--- a/src/negative_test/github-workflow/empty_json_must_always_fail.yaml
+++ b/src/negative_test/github-workflow/empty_json_must_always_fail.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 {}

--- a/src/negative_test/github-workflow/env-must-be-object-or-has-from-json.yaml
+++ b/src/negative_test/github-workflow/env-must-be-object-or-has-from-json.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Invalid env type
 on:
   - push

--- a/src/negative_test/github-workflow/permissions-event-has-wrong-level.yaml
+++ b/src/negative_test/github-workflow/permissions-event-has-wrong-level.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions:

--- a/src/negative_test/github-workflow/permissions-event-has-wrong-property-keys.yaml
+++ b/src/negative_test/github-workflow/permissions-event-has-wrong-property-keys.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions:

--- a/src/negative_test/github-workflow/permissions-must-be-object-or-string.yaml
+++ b/src/negative_test/github-workflow/permissions-must-be-object-or-string.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions: 123

--- a/src/negative_test/github-workflow/permissions-string-is-not-from-enum.yaml
+++ b/src/negative_test/github-workflow/permissions-string-is-not-from-enum.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions: speak-all

--- a/src/negative_test/github-workflow/reusable-workflow-input-must-declare-type.yaml
+++ b/src/negative_test/github-workflow/reusable-workflow-input-must-declare-type.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   workflow_call:
     secrets:

--- a/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-filetype.yaml
+++ b/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-filetype.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: publish on release
 on:
   release:

--- a/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-pattern.yaml
+++ b/src/negative_test/github-workflow/reusable-workflow-uses-has-wrong-pattern.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: publish on release
 on:
   release:

--- a/src/negative_test/github-workflow/runs-on.yaml
+++ b/src/negative_test/github-workflow/runs-on.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test runs-on
 on:
   push:

--- a/src/negative_test/github-workflow/steps-must-contain-run-or-uses.yaml
+++ b/src/negative_test/github-workflow/steps-must-contain-run-or-uses.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 

--- a/src/negative_test/github-workflow/with-must-be-object-or-has-from-json-copy.yaml
+++ b/src/negative_test/github-workflow/with-must-be-object-or-has-from-json-copy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Invalid with type
 on:
   - push

--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-bool-default-.yaml
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-bool-default-.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: inputs
 on:
   workflow_dispatch:

--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-choice-without-options.yaml
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-choice-without-options.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: inputs
 on:
   workflow_dispatch:

--- a/src/negative_test/github-workflow/workflow_dispatch-inputs-string-default-bool.yaml
+++ b/src/negative_test/github-workflow/workflow_dispatch-inputs-string-default-bool.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: inputs
 on:
   workflow_dispatch:

--- a/src/negative_test/grpc-api-gateway/invalid-multiple-methods.yaml
+++ b/src/negative_test/grpc-api-gateway/invalid-multiple-methods.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/grpc-api-gateway.json
 gateway:
   endpoints:
     - selector: '~.QueryParamsTest.Echo'

--- a/src/negative_test/grpc-api-gateway/invalid-root-value.yaml
+++ b/src/negative_test/grpc-api-gateway/invalid-root-value.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/grpc-api-gateway.json
 some_random_key: true

--- a/src/negative_test/hatch/both-dev-mode-dirs-and-exact.toml
+++ b/src/negative_test/hatch/both-dev-mode-dirs-and-exact.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [build]
 dev-mode-dirs = ["."]
 dev-mode-exact = true

--- a/src/negative_test/hatch/both-vcs-and-static.toml
+++ b/src/negative_test/hatch/both-vcs-and-static.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [version]
 source = 'vcs'
 path = 'foo.py'

--- a/src/negative_test/hatch/invalid-platform-override.toml
+++ b/src/negative_test/hatch/invalid-platform-override.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/hatch.json
 [envs.x.overrides]
 platform.dos.scripts = ['MD STALLMAN']

--- a/src/negative_test/hatch/try-redefining-pypi.toml
+++ b/src/negative_test/hatch/try-redefining-pypi.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/hatch.json
 [publish.index.repos.main]
 url = "https://example.com"

--- a/src/negative_test/hugo-theme/basic-requirement.toml
+++ b/src/negative_test/hugo-theme/basic-requirement.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo-theme.json
 license = "MIT"
 licenselink = "https://example.com/mit"
 description = "Theme description"

--- a/src/negative_test/hugo-theme/incorrect-values.toml
+++ b/src/negative_test/hugo-theme/incorrect-values.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo-theme.json
 name = 100
 license = false
 licenselink = "Link to theme's license"

--- a/src/negative_test/hugo-theme/mistake-author-s.toml
+++ b/src/negative_test/hugo-theme/mistake-author-s.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo-theme.json
 name = "Theme Name"
 license = "MIT"
 licenselink = "https://example.com/mit"

--- a/src/negative_test/hws-config/hws-config.yaml
+++ b/src/negative_test/hws-config/hws-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/hws-config.json
 # Hardware Sentry
 
 # Number of jobs that Hardware Sentry can run simultaneously.

--- a/src/negative_test/img-catapult-psp-1.0.0/contents-additional-properties.yaml
+++ b/src/negative_test/img-catapult-psp-1.0.0/contents-additional-properties.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test to check additional properties are not allowed
 platform:
   vendor: Imagination Technologies

--- a/src/negative_test/img-catapult-psp-1.0.0/contents-buildConfig-not-uppercase.yaml
+++ b/src/negative_test/img-catapult-psp-1.0.0/contents-buildConfig-not-uppercase.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test to check buildConfig validation
 platform:
   vendor: Imagination Technologies

--- a/src/negative_test/img-catapult-psp-1.0.0/contents-missing-properties.yaml
+++ b/src/negative_test/img-catapult-psp-1.0.0/contents-missing-properties.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test to check missing properties are not allowed
 platform:
   vendor: Imagination Technologies

--- a/src/negative_test/img-catapult-psp-1.0.0/contents-name-more-than-30-chars.yaml
+++ b/src/negative_test/img-catapult-psp-1.0.0/contents-name-more-than-30-chars.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test to check name validation
 platform:
   vendor: Imagination Technologies

--- a/src/negative_test/metricshub-connector/metricshub-connector.yaml
+++ b/src/negative_test/metricshub-connector/metricshub-connector.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=../../schemas/json/metricshub-connector.json

--- a/src/negative_test/metricshub/metricshub.yaml
+++ b/src/negative_test/metricshub/metricshub.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/metricshub.json
 # MetricsHub Configuration
 
 # Default logger level

--- a/src/negative_test/pantsbuild-2.14.0/pants-isort-version-not-string.toml
+++ b/src/negative_test/pantsbuild-2.14.0/pants-isort-version-not-string.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pantsbuild-2.14.0.json
 [isort]
 version = ["1.2.3", "1.2.4"]

--- a/src/negative_test/pantsbuild-2.14.0/pants-python-interpreter-constraints-not-array.toml
+++ b/src/negative_test/pantsbuild-2.14.0/pants-python-interpreter-constraints-not-array.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pantsbuild-2.14.0.json
 [python]
 interpreter_constraints = false

--- a/src/negative_test/pantsbuild-2.14.0/pants-version-not-string.toml
+++ b/src/negative_test/pantsbuild-2.14.0/pants-version-not-string.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pantsbuild-2.14.0.json
 [GLOBAL]
 pants_version = 2

--- a/src/negative_test/prettierrc/.prettierrc.yaml
+++ b/src/negative_test/prettierrc/.prettierrc.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/prettierrc.json
 # invalid config, prettier config is a mapping, not a list!
 []

--- a/src/negative_test/pubspec/bad_asset_transformer.yaml
+++ b/src/negative_test/pubspec/bad_asset_transformer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: heyya
 flutter:
   assets:

--- a/src/negative_test/pubspec/bad_executables.yaml
+++ b/src/negative_test/pubspec/bad_executables.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: cowsay_pkg
 executables:
   cowsay:

--- a/src/negative_test/pubspec/bad_name.yaml
+++ b/src/negative_test/pubspec/bad_name.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: IM

--- a/src/negative_test/pubspec/bad_platforms.yaml
+++ b/src/negative_test/pubspec/bad_platforms.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: test
 platforms:
   web:

--- a/src/negative_test/pubspec/bad_publish_to.yaml
+++ b/src/negative_test/pubspec/bad_publish_to.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: hi
 publish_to: some

--- a/src/negative_test/pubspec/no_name.yaml
+++ b/src/negative_test/pubspec/no_name.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json

--- a/src/negative_test/pubspec/screenshot_missing_description.yaml
+++ b/src/negative_test/pubspec/screenshot_missing_description.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: this-is-fine
 screenshots:
   - description: 'This screenshot shows the transformation of a number of bytes to a human-readable expression.'

--- a/src/negative_test/pyproject/black-invalid.toml
+++ b/src/negative_test/pyproject/black-invalid.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.black]
 invalid-option = true

--- a/src/negative_test/pyproject/black-target.toml
+++ b/src/negative_test/pyproject/black-target.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.black]
 target-version = ['pp31']

--- a/src/negative_test/pyproject/cibuildwheel-bad-inherit.toml
+++ b/src/negative_test/pyproject/cibuildwheel-bad-inherit.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"
 inherit.not-a-setting = "prepend"

--- a/src/negative_test/pyproject/cibuildwheel-bad-override.toml
+++ b/src/negative_test/pyproject/cibuildwheel-bad-override.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"

--- a/src/negative_test/pyproject/cibuildwheel-unreco.toml
+++ b/src/negative_test/pyproject/cibuildwheel-unreco.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.cibuildwheel]
 not-an-option = true

--- a/src/negative_test/pyproject/dependency-groups-1.toml
+++ b/src/negative_test/pyproject/dependency-groups-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/negative_test/pyproject/dependency-groups-2.toml
+++ b/src/negative_test/pyproject/dependency-groups-2.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/negative_test/pyproject/dependency-groups-3.toml
+++ b/src/negative_test/pyproject/dependency-groups-3.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/negative_test/pyproject/dynamic-version-specified.toml
+++ b/src/negative_test/pyproject/dynamic-version-specified.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "setuptools-scm[toml] >= 6.2", "wheel"]

--- a/src/negative_test/pyproject/extra-top-level.toml
+++ b/src/negative_test/pyproject/extra-top-level.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "wheel"]

--- a/src/negative_test/pyproject/mypy-emptymodule.toml
+++ b/src/negative_test/pyproject/mypy-emptymodule.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.mypy.overrides]]
 module = []
 disallow_untyped_defs = true

--- a/src/negative_test/pyproject/mypy-extra.toml
+++ b/src/negative_test/pyproject/mypy-extra.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 # mypy global options:
 
 [tool.mypy]

--- a/src/negative_test/pyproject/mypy-nomodule.toml
+++ b/src/negative_test/pyproject/mypy-nomodule.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.mypy.overrides]]
 disallow_untyped_defs = true

--- a/src/negative_test/pyproject/pdm-path-required.toml
+++ b/src/negative_test/pyproject/pdm-path-required.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.pdm.build.wheel-data]
 data = [{ file_path = "data/**" }]

--- a/src/negative_test/pyproject/pdm-script-method-exclusive.toml
+++ b/src/negative_test/pyproject/pdm-script-method-exclusive.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.pdm.scripts]
 start = { cmd = "flask" }
 lint = { shell = "mypy", cmd = "mypy", call = "mypy:main", composite = [

--- a/src/negative_test/pyproject/pdm-source-no-name.toml
+++ b/src/negative_test/pyproject/pdm-source-no-name.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.pdm.source]]
 url = "https://myindex.example.org"

--- a/src/negative_test/pyproject/pep639-mismatch.toml
+++ b/src/negative_test/pyproject/pep639-mismatch.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "example"
 version = "1.2.3"

--- a/src/negative_test/pyproject/poetry-bad-multiline.toml
+++ b/src/negative_test/pyproject/poetry-bad-multiline.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "bad-multiline"
 version = "1.2.3"

--- a/src/negative_test/pyproject/poetry-invalid-package.toml
+++ b/src/negative_test/pyproject/poetry-invalid-package.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry.dependencies]
 python = "~3.12"

--- a/src/negative_test/pyproject/poetry-plugin-dotenv-example-1.toml
+++ b/src/negative_test/pyproject/poetry-plugin-dotenv-example-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = ""
 version = "0.0.0"

--- a/src/negative_test/pyproject/poetry-source-1.toml
+++ b/src/negative_test/pyproject/poetry-source-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "foo"
 version = "1.2.3"

--- a/src/negative_test/pyproject/poetry-source-2.toml
+++ b/src/negative_test/pyproject/poetry-source-2.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "foo"
 version = "1.2.3"

--- a/src/negative_test/pyproject/poetry-source-3.toml
+++ b/src/negative_test/pyproject/poetry-source-3.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "foo"
 version = "1.2.3"

--- a/src/negative_test/pyproject/poetry-source-4.toml
+++ b/src/negative_test/pyproject/poetry-source-4.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "foo"
 version = "1.2.3"

--- a/src/negative_test/pyproject/ruff-bad-line-length.toml
+++ b/src/negative_test/pyproject/ruff-bad-line-length.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.ruff]
 line-length = "79"

--- a/src/negative_test/pyproject/scikit-build-no-template.toml
+++ b/src/negative_test/pyproject/scikit-build-no-template.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.scikit-build.generate]]
 path = "sample"
 location = "install"

--- a/src/negative_test/pyproject/scikit-build-unknown.toml
+++ b/src/negative_test/pyproject/scikit-build-unknown.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.scikit-build]
 not-a-real-option = true

--- a/src/negative_test/pyproject/setuptools-invalid-find.toml
+++ b/src/negative_test/pyproject/setuptools-invalid-find.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.setuptools.packages.find]
 where = "src"

--- a/src/negative_test/pyproject/tox-invalid-legacy.toml
+++ b/src/negative_test/pyproject/tox-invalid-legacy.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.tox]
 legacy_tox_ini = ["min_version = 4.0"]

--- a/src/negative_test/pyproject/uv-bad-index-url.toml
+++ b/src/negative_test/pyproject/uv-bad-index-url.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.uv.pip]
 index-url = 1

--- a/src/negative_test/pyproject/version-unspecified.toml
+++ b/src/negative_test/pyproject/version-unspecified.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "wheel"]

--- a/src/negative_test/qodana-1.0/dotnet-solution-and-project.yaml
+++ b/src/negative_test/qodana-1.0/dotnet-solution-and-project.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/qodana-1.0.json
 version: '1.0'
 
 dotnet:

--- a/src/negative_test/rancher-fleet-0.5/unkown-fields.yaml
+++ b/src/negative_test/rancher-fleet-0.5/unkown-fields.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.5.json
 defaultNamespace: cluster-autoscaler
 imageScans:
   - image: cluster-autoscaler

--- a/src/negative_test/rancher-fleet-0.8/false-type-do-not-deploy.yaml
+++ b/src/negative_test/rancher-fleet-0.8/false-type-do-not-deploy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.8.json
 defaultNamespace: cluster-autoscaler
 imageScans:
   - image: cluster-autoscaler

--- a/src/negative_test/rancher-fleet-0.8/unkown-fields.yaml
+++ b/src/negative_test/rancher-fleet-0.8/unkown-fields.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.8.json
 defaultNamespace: cluster-autoscaler
 imageScans:
   - image: cluster-autoscaler

--- a/src/negative_test/samt/samt.yaml
+++ b/src/negative_test/samt/samt.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/samt.json
 plugins:
   - type: maven
     path: ./path/to/plugin.jar

--- a/src/negative_test/sil-kit-participant-configuration/full-wrong-additional-root.silkit.yaml
+++ b/src/negative_test/sil-kit-participant-configuration/full-wrong-additional-root.silkit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-participant-configuration.json
 ---
 '$schema': ParticipantConfiguration.schema.json
 schemaVersion: 0

--- a/src/negative_test/sil-kit-participant-configuration/not-object.silkit.yaml
+++ b/src/negative_test/sil-kit-participant-configuration/not-object.silkit.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-participant-configuration.json
 5

--- a/src/negative_test/sil-kit-registry-configuration/full-wrong-additional-root.silkit-registry.yaml
+++ b/src/negative_test/sil-kit-registry-configuration/full-wrong-additional-root.silkit-registry.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 ---
 '$schema': RegistryConfiguration.schema.json
 SchemaVersion: 0

--- a/src/negative_test/sil-kit-registry-configuration/no-log-from-remotes.silkit-registry.yaml
+++ b/src/negative_test/sil-kit-registry-configuration/no-log-from-remotes.silkit-registry.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 ---
 '$schema': RegistryConfiguration.schema.json
 SchemaVersion: 0

--- a/src/negative_test/sil-kit-registry-configuration/no-remote-logging.silkit-registry.yaml
+++ b/src/negative_test/sil-kit-registry-configuration/no-remote-logging.silkit-registry.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 ---
 '$schema': RegistryConfiguration.schema.json
 SchemaVersion: 0

--- a/src/negative_test/sil-kit-registry-configuration/not-object.sillkit.silkit-registry.yaml
+++ b/src/negative_test/sil-kit-registry-configuration/not-object.sillkit.silkit-registry.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 5

--- a/src/negative_test/sourcery_yaml_schema/.sourcery-deprecated.yaml
+++ b/src/negative_test/sourcery_yaml_schema/.sourcery-deprecated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sourcery_yaml_schema.json
 ignore: []
 
 refactor:

--- a/src/negative_test/venvironment-basic-schema-v2.1.0/invalid-version.yaml
+++ b/src/negative_test/venvironment-basic-schema-v2.1.0/invalid-version.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v2.1.0.json
 version: 2.0.0

--- a/src/negative_test/venvironment-basic-schema-v2.1.0/missing-version.yaml
+++ b/src/negative_test/venvironment-basic-schema-v2.1.0/missing-version.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v2.1.0.json
 can-networks:
   - name: can

--- a/src/negative_test/venvironment-basic-schema-v3.2.0/invalid-version.yaml
+++ b/src/negative_test/venvironment-basic-schema-v3.2.0/invalid-version.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v3.2.0.json
 version: 2.2.0

--- a/src/negative_test/venvironment-basic-schema-v3.2.0/missing-version.yaml
+++ b/src/negative_test/venvironment-basic-schema-v3.2.0/missing-version.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v3.2.0.json
 can-networks:
   - name: can

--- a/src/negative_test/venvironment-schema-v2.2.0/invalid-version.yaml
+++ b/src/negative_test/venvironment-schema-v2.2.0/invalid-version.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: 2.0.0

--- a/src/negative_test/venvironment-schema-v2.2.0/missing-version.yaml
+++ b/src/negative_test/venvironment-schema-v2.2.0/missing-version.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 can-networks:
   - name: can

--- a/src/negative_test/venvironment-schema-v3.2.0/invalid-version.yaml
+++ b/src/negative_test/venvironment-schema-v3.2.0/invalid-version.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: 2.2.0

--- a/src/negative_test/venvironment-schema-v3.2.0/missing-version.yaml
+++ b/src/negative_test/venvironment-schema-v3.2.0/missing-version.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 can-networks:
   - name: can

--- a/src/negative_test/vhwdebugger-binding-schema/empty.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/empty.vhwdebugger-binding.yaml
@@ -1,0 +1,1 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json

--- a/src/negative_test/vhwdebugger-binding-schema/float_version.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/float_version.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: 1.0
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_empty_client_path.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_empty_client_path.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_empty_symbol_path.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_empty_symbol_path.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_feature_unavailable.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_feature_unavailable.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: 1.0
 
 default-debugger: MyDebugger1

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_invalid_run.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_invalid_run.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: 1.1
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_no_client_path.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_no_client_path.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_no_gdb_settings.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_no_gdb_settings.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_no_run.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_no_run.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: 1.1
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/gdb_no_symbol_path.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/gdb_no_symbol_path.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_bool.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_bool.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_name.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_name.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 default-debugger: MyDebugger1

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_name2.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_name2.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 default-debugger: MyDebugger1

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_specific_settings.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_debugger_specific_settings.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_default_debugger.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_default_debugger.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 default-debugger:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_lauterbach_packlen.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_lauterbach_packlen.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_port.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_port.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_port2.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_port2.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_string.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_string.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/invalid_type.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/invalid_type.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/no_debugger.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_debugger.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 debuggers: {}

--- a/src/negative_test/vhwdebugger-binding-schema/no_debugger_list.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_debugger_list.vhwdebugger-binding.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'

--- a/src/negative_test/vhwdebugger-binding-schema/no_node.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_node.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/no_object.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_object.vhwdebugger-binding.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 'ABC'

--- a/src/negative_test/vhwdebugger-binding-schema/no_port.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_port.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/no_type.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_type.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/no_version.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/no_version.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 debuggers:
   MyDebugger1:
     type: isystem

--- a/src/negative_test/vhwdebugger-binding-schema/unknown_setting_debugger.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/unknown_setting_debugger.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/unknown_setting_root.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/unknown_setting_root.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/unsupported_version.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/unsupported_version.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '0.1'
 
 debuggers:

--- a/src/negative_test/vhwdebugger-binding-schema/wrong_version_format.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/wrong_version_format.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.2b'
 
 debuggers:

--- a/src/negative_test/vtesttree-schema-v1.0.0/invalid-version.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v1.0.0/invalid-version.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 0.0.0
 test-tree:
   - capl-test-case: MyTestCase

--- a/src/negative_test/vtesttree-schema-v1.0.0/missing-version.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v1.0.0/missing-version.vtesttree.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 test-tree:
   - capl-test-case: MyTestCase

--- a/src/negative_test/vtesttree-schema-v1.0.0/test-fixture-in-v1.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v1.0.0/test-fixture-in-v1.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - test-fixture: TestFixture

--- a/src/negative_test/vtesttree-schema-v2.0.0/test-group-in-v2.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.0.0/test-group-in-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - test-group: TestGroup

--- a/src/negative_test/vtesttree-schema-v2.1.0/multiple-completions.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.1.0/multiple-completions.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - test-fixture: test fixture

--- a/src/negative_test/vtesttree-schema-v2.1.0/multiple-preparations.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.1.0/multiple-preparations.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - test-fixture: test fixture

--- a/src/negative_test/vtesttree-schema-v2.1.0/variant-dependencies-in-v210.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.1.0/variant-dependencies-in-v210.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 
 test-tree:

--- a/src/negative_test/vtesttree-schema-v2.2.0/variant-dependencies-numeric.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.2.0/variant-dependencies-numeric.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.2.0.json
 version: 2.2.0
 
 test-tree:

--- a/src/negative_test/vtesttree-schema-v2.3.0/test-case_sequence_list.vtesttree.yaml
+++ b/src/negative_test/vtesttree-schema-v2.3.0/test-case_sequence_list.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.3.0.json
 version: 2.3.0
 
 test-tree:

--- a/src/negative_test/vtestunit-schema/invalid-test-unit-information.vtestunit.yaml
+++ b/src/negative_test/vtestunit-schema/invalid-test-unit-information.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 test-unit-information:

--- a/src/negative_test/vtestunit-schema/invalid-version.vtestunit.yaml
+++ b/src/negative_test/vtestunit-schema/invalid-version.vtestunit.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 1.1.0

--- a/src/negative_test/vtestunit-schema/missing-key-addInfo.vtestunit.yaml
+++ b/src/negative_test/vtestunit-schema/missing-key-addInfo.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.0.0
 
 test-unit-information:

--- a/src/negative_test/vtestunit-schema/missing-version.vtestunit.yaml
+++ b/src/negative_test/vtestunit-schema/missing-version.vtestunit.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 test-unit-information:
   caption: MyCaption2

--- a/src/negative_test/vtestunit-schema/wrong-source-file.vtestunit.yaml
+++ b/src/negative_test/vtestunit-schema/wrong-source-file.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 test-unit-implementation:

--- a/src/negative_test/zuul/jobs-workspace-scheme.yaml
+++ b/src/negative_test/zuul/jobs-workspace-scheme.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/zuul.json
 - job:
     name: d
     description: invalid workspace-scheme

--- a/src/negative_test/zuul/jobs.yaml
+++ b/src/negative_test/zuul/jobs.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/zuul.json
 - jobs: # <-- job is correct
     name: minimal

--- a/src/negative_test/zuul/jobs2.yaml
+++ b/src/negative_test/zuul/jobs2.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/zuul.json
 # invalid as zuul jobs are lists of dictionaries, not a dictionary
 foo: bar

--- a/src/test/accelerator/accelerator-full-valid.yaml
+++ b/src/test/accelerator/accelerator-full-valid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Demo Input Types
   description: 'Accelerator with options for each inputType'

--- a/src/test/accelerator/accelerator-short-valid.yaml
+++ b/src/test/accelerator/accelerator-short-valid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/accelerator.json
 accelerator:
   displayName: Spring PetClinic
   description: A sample Spring-based application

--- a/src/test/app-config/app-config.yaml
+++ b/src/test/app-config/app-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/app-config.json
 app:
   title: Backstage Example App
   baseUrl: http://localhost:3000

--- a/src/test/architectfx/architectfx.yaml
+++ b/src/test/architectfx/architectfx.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/architectfx.json
 # Imports are unnecessary unless two classes with the same name are detected at runtime
 # The following imports are not really necessary, I'm adding them just to test the parser
 # Although it has to be said, adding imports makes the parsing much faster

--- a/src/test/aurora-1.0/author.aurora.yaml
+++ b/src/test/aurora-1.0/author.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: author

--- a/src/test/aurora-1.0/book.aurora.yaml
+++ b/src/test/aurora-1.0/book.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/test/aurora-1.0/country.aurora.yaml
+++ b/src/test/aurora-1.0/country.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: common
 moduleName: country

--- a/src/test/aurora-1.0/lang.aurora.yaml
+++ b/src/test/aurora-1.0/lang.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.0.json
 version: 0.0.1
 boundedContextName: common
 moduleName: lang

--- a/src/test/aurora-1.1/author.aurora.yaml
+++ b/src/test/aurora-1.1/author.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.1.json
 version: 0.0.1
 boundedContextName: library
 moduleName: author

--- a/src/test/aurora-1.1/book.aurora.yaml
+++ b/src/test/aurora-1.1/book.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.1.json
 version: 0.0.1
 boundedContextName: library
 moduleName: book

--- a/src/test/aurora-1.1/country.aurora.yaml
+++ b/src/test/aurora-1.1/country.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.1.json
 version: 0.0.1
 boundedContextName: common
 moduleName: country

--- a/src/test/aurora-1.1/lang.aurora.yaml
+++ b/src/test/aurora-1.1/lang.aurora.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-1.1.json
 version: 0.0.1
 boundedContextName: common
 moduleName: lang

--- a/src/test/bigconfig/bigconfig.yaml
+++ b/src/test/bigconfig/bigconfig.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bigconfig.json
 type: BIGCONFIG_FILE
 auto_apply_on_indexing: true
 

--- a/src/test/bosh-deploy-config/flags-all-only.yaml
+++ b/src/test/bosh-deploy-config/flags-all-only.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - fix
   - fix-releases

--- a/src/test/bosh-deploy-config/flags-and-exclude.yaml
+++ b/src/test/bosh-deploy-config/flags-and-exclude.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - recreate-persistent-disks
   - fix

--- a/src/test/bosh-deploy-config/flags-and-include.yaml
+++ b/src/test/bosh-deploy-config/flags-and-include.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-deploy-config.json
 flags:
   - recreate
   - fix-releases

--- a/src/test/buf.gen/buf-examples.gen.yaml
+++ b/src/test/buf.gen/buf-examples.gen.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Below is from https://github.com/bufbuild/buf-examples/blob/59593726295d04a2103d08837fc8e00e77e3f1cc/managed-mode/buf.gen.yaml
 
 version: v1

--- a/src/test/buf.gen/buf.gen.v1.protoc_path.yaml
+++ b/src/test/buf.gen/buf.gen.v1.protoc_path.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 version: v1
 plugins:
   - name: cpp

--- a/src/test/buf.gen/buf.gen.v2.protoc_path.yaml
+++ b/src/test/buf.gen/buf.gen.v2.protoc_path.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 version: v2
 plugins:
   - local: cpp

--- a/src/test/buf.gen/buf.gen.yaml
+++ b/src/test/buf.gen/buf.gen.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Below is from https://buf.build/docs/reference/cli/buf/generate#usage.
 
 # buf.gen.yaml

--- a/src/test/buf.gen/buf.managed.yaml
+++ b/src/test/buf.gen/buf.managed.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Below is from https://github.com/connectrpc/connect-kotlin/blob/65fb4e45d6b72a632460de59b2de905bc62b9d97/examples/buf.gen.yaml
 
 version: v1

--- a/src/test/buf.gen/name.buf.gen.yaml
+++ b/src/test/buf.gen/name.buf.gen.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Below is from https://github.com/connectrpc/connect-go/blob/96effedc8ac84da9f49392e5f7bdfee2e648247b/buf.gen.yaml
 
 version: v1

--- a/src/test/buf.gen/remote.buf.gen.yaml
+++ b/src/test/buf.gen/remote.buf.gen.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Below is from https://github.com/grpc-ecosystem/grpc-gateway/blob/bb2225c08f5f8ff7ed3935b68cfcbb1538af6475/buf.gen.yaml
 
 version: v1

--- a/src/test/buf.gen/v2.buf.gen.yaml
+++ b/src/test/buf.gen/v2.buf.gen.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.gen.json
 # Stitched together from examples at
 # https://buf.build/docs/configuration/v2/buf-gen-yaml
 

--- a/src/test/buf.plugin/buf-cargo.plugin.yaml
+++ b/src/test/buf.plugin/buf-cargo.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/community/neoeinstein-prost/v0.3.1/buf.plugin.yaml
 version: v1
 name: buf.build/community/neoeinstein-prost

--- a/src/test/buf.plugin/buf-cmake.plugin.yaml
+++ b/src/test/buf.plugin/buf-cmake.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/grpc/cpp/v1.65.1/buf.plugin.yaml
 version: v1
 name: buf.build/grpc/cpp

--- a/src/test/buf.plugin/buf-go.plugin.yaml
+++ b/src/test/buf.plugin/buf-go.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/connectrpc/go/v1.13.0/buf.plugin.yaml
 
 version: v1

--- a/src/test/buf.plugin/buf-maven.plugin.yaml
+++ b/src/test/buf.plugin/buf-maven.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/connectrpc/kotlin/v0.3.1/buf.plugin.yaml
 
 version: v1

--- a/src/test/buf.plugin/buf-npm.plugin.yaml
+++ b/src/test/buf.plugin/buf-npm.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/connectrpc/es/v1.1.4/buf.plugin.yaml
 
 version: v1

--- a/src/test/buf.plugin/buf-nuget.plugin.yaml
+++ b/src/test/buf.plugin/buf-nuget.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/protocolbuffers/csharp/v27.2/buf.plugin.yaml
 version: v1
 name: buf.build/protocolbuffers/csharp

--- a/src/test/buf.plugin/buf-python.plugin.yaml
+++ b/src/test/buf.plugin/buf-python.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/protocolbuffers/python/v25.1/buf.plugin.yaml
 
 version: v1

--- a/src/test/buf.plugin/buf-swift.plugin.yaml
+++ b/src/test/buf.plugin/buf-swift.plugin.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.plugin.json
 # Below is from https://github.com/bufbuild/plugins/blob/main/plugins/connectrpc/swift/v0.10.1/buf.plugin.yaml
 
 version: v1

--- a/src/test/buf.work/buf.work.yaml
+++ b/src/test/buf.work/buf.work.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.work.json
 # Below is from https://buf.build/docs/configuration/v1/buf-work-yaml.
 
 version: v1

--- a/src/test/buf/buf.protovalidate.yaml
+++ b/src/test/buf/buf.protovalidate.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 version: v1
 lint:
   use:

--- a/src/test/buf/buf.test2.yaml
+++ b/src/test/buf/buf.test2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 # Below is from https://buf.build/docs/configuration/v1/buf-yaml.
 
 version: v1

--- a/src/test/buf/buf.test3.yaml
+++ b/src/test/buf/buf.test3.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 version: v1
 build:
   excludes: [node_modules]

--- a/src/test/buf/buf.test4.yaml
+++ b/src/test/buf/buf.test4.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 # Below is excerpted from https://github.com/bufbuild/buf/blob/44af737aea49f9975394b873639a1ae1a05e0144/proto/buf.yaml.
 
 version: v1

--- a/src/test/buf/buf.v2.yaml
+++ b/src/test/buf/buf.v2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 # via https://buf.build/docs/configuration/v2/buf-yaml
 
 version: v2

--- a/src/test/buf/buf.yaml
+++ b/src/test/buf/buf.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/buf.json
 # Below is the output of `buf mod init --doc`, with `build:` commented-out.
 
 # This specifies the configuration file version.

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/bunfig.json
 # Reduce memory usage at the cost of performance
 smol = true
 

--- a/src/test/cargo/config.toml
+++ b/src/test/cargo/config.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [dependencies]
 native-windows-gui = { version = "1.0.12" }
 debug_print = "1.0"

--- a/src/test/cargo/package-inheritance.toml
+++ b/src/test/cargo/package-inheritance.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = { workspace = true }

--- a/src/test/cargo/playdate-metadata-assets-list.toml
+++ b/src/test/cargo/playdate-metadata-assets-list.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = "0.0.0"

--- a/src/test/cargo/playdate-metadata-assets-opts.toml
+++ b/src/test/cargo/playdate-metadata-assets-opts.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = "0.0.0"

--- a/src/test/cargo/playdate-metadata-assets-table.toml
+++ b/src/test/cargo/playdate-metadata-assets-table.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = "0.0.0"

--- a/src/test/cargo/playdate-metadata-info-max.toml
+++ b/src/test/cargo/playdate-metadata-info-max.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = "0.0.0"

--- a/src/test/cargo/playdate-metadata-info-min.toml
+++ b/src/test/cargo/playdate-metadata-info-min.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [package]
 name = "bar"
 version = "0.0.0"

--- a/src/test/cargo/workspace-inheritance.toml
+++ b/src/test/cargo/workspace-inheritance.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cargo.json
 [workspace]
 members = ["bar"]
 

--- a/src/test/chisel-slices/base-files.yaml
+++ b/src/test/chisel-slices/base-files.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/chisel-slices.json
 package: base-files
 
 slices:

--- a/src/test/chisel-slices/base-passwd.yaml
+++ b/src/test/chisel-slices/base-passwd.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/chisel-slices.json
 package: base-passwd
 
 slices:

--- a/src/test/chisel-slices/ca-certificates.yaml
+++ b/src/test/chisel-slices/ca-certificates.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/chisel-slices.json
 package: ca-certificates
 
 slices:

--- a/src/test/cibuildwheel/cibuildwheel-default.toml
+++ b/src/test/cibuildwheel/cibuildwheel-default.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cibuildwheel.json
 [tool.cibuildwheel]
 build = "*"
 skip = ""

--- a/src/test/cibuildwheel/cibuildwheel-overrides.toml
+++ b/src/test/cibuildwheel/cibuildwheel-overrides.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/cibuildwheel.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"
 test-command = "something"

--- a/src/test/circleciconfig/570.yaml
+++ b/src/test/circleciconfig/570.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/circleciconfig.json
 version: 2.1
 jobs:
   prepare:

--- a/src/test/cirrus/credentials.yaml
+++ b/src/test/cirrus/credentials.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/cirrus.json
 ---
 gcp_credentials: ENCRYPTED[!abc123!]

--- a/src/test/clang-tidy/clang-tidy-grpc.yaml
+++ b/src/test/clang-tidy/clang-tidy-grpc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/clang-tidy.json
 ---
 # SPDX-License-Identifier: Apache-2.0
 # From https://github.com/grpc/grpc.

--- a/src/test/clang-tidy/dump-clang-tidy.yaml
+++ b/src/test/clang-tidy/dump-clang-tidy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/clang-tidy.json
 ---
 Checks: 'clang-diagnostic-*,clang-analyzer-*'
 WarningsAsErrors: ''

--- a/src/test/cloud-run-v1/correct1.yaml
+++ b/src/test/cloud-run-v1/correct1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloud-run-v1.json
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/src/test/cloudbuild/test-1.yaml
+++ b/src/test/cloudbuild/test-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudbuild.json
 options:
   machineType: UNSPECIFIED
 

--- a/src/test/cloudfoundry-application-manifest/test-1.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudfoundry-application-manifest.json
 ---
 version: 1
 applications:

--- a/src/test/cloudfoundry-application-manifest/test-2.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudfoundry-application-manifest.json
 ---
 version: 1
 applications:

--- a/src/test/cloudfoundry-application-manifest/test-3.yaml
+++ b/src/test/cloudfoundry-application-manifest/test-3.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/cloudfoundry-application-manifest.json
 ---
 version: 1
 applications:

--- a/src/test/ctfd/minimal.yaml
+++ b/src/test/ctfd/minimal.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/ctfd.json
 appearance:
   name: 'MyCTF 20XX'
   description: 'MyCTF description'

--- a/src/test/dependabot-2.0/groups.yaml
+++ b/src/test/dependabot-2.0/groups.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/dependabot-2.0.json
 version: 2
 updates:
   - package-ecosystem: 'npm'

--- a/src/test/dependabot-2.0/issue-3777.yaml
+++ b/src/test/dependabot-2.0/issue-3777.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/dependabot-2.0.json
 version: 2
 updates:
   - package-ecosystem: 'npm'

--- a/src/test/drone/kubernetes_volumes.yaml
+++ b/src/test/drone/kubernetes_volumes.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/drone.json
 kind: pipeline
 type: kubernetes
 name: default

--- a/src/test/gitea-issue-config/example2.yaml
+++ b/src/test/gitea-issue-config/example2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/gitea-issue-config.json
 blank_issues_enabled: false
 contact_links:
   - name: Security Concern

--- a/src/test/gitea-issue-forms/example2.yaml
+++ b/src/test/gitea-issue-forms/example2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/gitea-issue-forms.json
 # source: https://docs.gitea.com/next/usage/issue-pull-request-templates
 name: Bug Report
 about: File a bug report

--- a/src/test/github-discussion/test.yaml
+++ b/src/test/github-discussion/test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-discussion.json
 title: 'General'
 labels: ['General Introduction']
 body:

--- a/src/test/github-discussion/test2.yaml
+++ b/src/test/github-discussion/test2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-discussion.json
 body:
   - type: input
     id: suggestion

--- a/src/test/github-workflow/1162.yaml
+++ b/src/test/github-workflow/1162.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: PR review reminders
 on:
   schedule:

--- a/src/test/github-workflow/1567.yaml
+++ b/src/test/github-workflow/1567.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Deploy
 
 on:

--- a/src/test/github-workflow/2579-1.yaml
+++ b/src/test/github-workflow/2579-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: learn-github-actions
 on: [push]
 jobs:

--- a/src/test/github-workflow/2579-2.yaml
+++ b/src/test/github-workflow/2579-2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: learn-github-actions
 on: [push]
 jobs:

--- a/src/test/github-workflow/918.yaml
+++ b/src/test/github-workflow/918.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Node.js Release
 on:
   create:

--- a/src/test/github-workflow/919.yaml
+++ b/src/test/github-workflow/919.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test on Pull
 on:
   - push

--- a/src/test/github-workflow/call-reusable-workflow-inherit-secrets.yaml
+++ b/src/test/github-workflow/call-reusable-workflow-inherit-secrets.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: publish on release
 on:
   release:

--- a/src/test/github-workflow/call-reusable-workflow-local-file.yaml
+++ b/src/test/github-workflow/call-reusable-workflow-local-file.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: publish on release
 on:
   release:

--- a/src/test/github-workflow/call-reusable-workflow.yaml
+++ b/src/test/github-workflow/call-reusable-workflow.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: publish on release
 on:
   release:

--- a/src/test/github-workflow/concurrency.yaml
+++ b/src/test/github-workflow/concurrency.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test concurrency
 on:
   - push

--- a/src/test/github-workflow/conditions.yaml
+++ b/src/test/github-workflow/conditions.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test if-conditions
 on:
   - push

--- a/src/test/github-workflow/containers.yaml
+++ b/src/test/github-workflow/containers.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test containers
 on:
   - push

--- a/src/test/github-workflow/continue-on-error.yaml
+++ b/src/test/github-workflow/continue-on-error.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test continue-on-error
 on:
   - push

--- a/src/test/github-workflow/defaults.yaml
+++ b/src/test/github-workflow/defaults.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 jobs:

--- a/src/test/github-workflow/env-from-json.yaml
+++ b/src/test/github-workflow/env-from-json.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Using fromJSON() for env key
 on:
   - push

--- a/src/test/github-workflow/env-with-simple-expression.yaml
+++ b/src/test/github-workflow/env-with-simple-expression.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: env from expression
 on:
   - push

--- a/src/test/github-workflow/environments.yaml
+++ b/src/test/github-workflow/environments.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test environment
 on:
   - push

--- a/src/test/github-workflow/event-trigger.yaml
+++ b/src/test/github-workflow/event-trigger.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test on triggers
 on:
   push:

--- a/src/test/github-workflow/fail-fast.yaml
+++ b/src/test/github-workflow/fail-fast.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   pull_request:
   push:

--- a/src/test/github-workflow/issue_2463_file_1.yaml
+++ b/src/test/github-workflow/issue_2463_file_1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: 'Example workflow for schema store'
 
 on:

--- a/src/test/github-workflow/issue_2463_file_2.yaml
+++ b/src/test/github-workflow/issue_2463_file_2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 ---
 name: 👷tests
 

--- a/src/test/github-workflow/matrix_from_json.yaml
+++ b/src/test/github-workflow/matrix_from_json.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test on Pull
 on:
   - push

--- a/src/test/github-workflow/matrix_include.yaml
+++ b/src/test/github-workflow/matrix_include.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test on Pull
 on:
   - push

--- a/src/test/github-workflow/matrix_include_expression.yaml
+++ b/src/test/github-workflow/matrix_include_expression.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test on Pull
 on:
   - push

--- a/src/test/github-workflow/npm-publish.yaml
+++ b/src/test/github-workflow/npm-publish.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Node.js Package
 on:
   release:

--- a/src/test/github-workflow/on-event_name-null.yaml
+++ b/src/test/github-workflow/on-event_name-null.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test null values for /on/*
 on:
   branch_protection_rule:

--- a/src/test/github-workflow/permissions-none.yaml
+++ b/src/test/github-workflow/permissions-none.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions: {}

--- a/src/test/github-workflow/permissions-object.yaml
+++ b/src/test/github-workflow/permissions-object.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions:

--- a/src/test/github-workflow/permissions-string.yaml
+++ b/src/test/github-workflow/permissions-string.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 permissions: read-all

--- a/src/test/github-workflow/reusable-workflow.yaml
+++ b/src/test/github-workflow/reusable-workflow.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   workflow_call:
     secrets:

--- a/src/test/github-workflow/runs-on-interpolated.yaml
+++ b/src/test/github-workflow/runs-on-interpolated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 on:
   push:
 jobs:

--- a/src/test/github-workflow/runs-on.yaml
+++ b/src/test/github-workflow/runs-on.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Test runs-on
 on:
   push:

--- a/src/test/github-workflow/with-from-json.yaml
+++ b/src/test/github-workflow/with-from-json.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Using fromJSON() for with key
 on:
   - push

--- a/src/test/github-workflow/workflow_call_input_issue_2501.yaml
+++ b/src/test/github-workflow/workflow_call_input_issue_2501.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: Terraform Command
 
 on:

--- a/src/test/github-workflow/workflow_dispatch-inputs.yaml
+++ b/src/test/github-workflow/workflow_dispatch-inputs.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
 name: inputs
 on:
   workflow_dispatch:

--- a/src/test/grpc-api-gateway/gateway.yaml
+++ b/src/test/grpc-api-gateway/gateway.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/grpc-api-gateway.json
 gateway:
   endpoints:
     - selector: '~.QueryParamsTest.Echo'

--- a/src/test/hatch/collector-env.toml
+++ b/src/test/hatch/collector-env.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [env]
 requires = ["..."]
 

--- a/src/test/hatch/minimal.toml
+++ b/src/test/hatch/minimal.toml
@@ -1,0 +1,1 @@
+#:schema ../../schemas/json/hatch.json

--- a/src/test/hatch/oroborous.toml
+++ b/src/test/hatch/oroborous.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [envs.default]
 dependencies = [
   "coverage[toml]>=6.2",

--- a/src/test/hatch/version-path.toml
+++ b/src/test/hatch/version-path.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [version]
 path = "pkg/__init__.py"
 pattern = "BUILD = 'b(?P<version>[^']+)'"

--- a/src/test/hatch/version-vcs.toml
+++ b/src/test/hatch/version-vcs.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hatch.json
 [version]
 source = "vcs"
 [build.hooks.vcs]

--- a/src/test/hemtt-0.6.2/hemtt-test.toml
+++ b/src/test/hemtt-0.6.2/hemtt-test.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hemtt-0.6.2.json
 name = "Advanced Banana Environment"
 prefix = "ABE3"
 author = "ACE Mod Team"

--- a/src/test/hugo-theme/multiple-authors.toml
+++ b/src/test/hugo-theme/multiple-authors.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo-theme.json
 name = "Theme Name"
 license = "MIT"
 licenselink = "https://example.com/mit"

--- a/src/test/hugo-theme/single-author.toml
+++ b/src/test/hugo-theme/single-author.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo-theme.json
 name = "Theme Name"
 license = "MIT"
 licenselink = "https://example.com/mit"

--- a/src/test/hugo/example-1.toml
+++ b/src/test/hugo/example-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo.json
 baseURL = "a"
 languageCode = "en-us"
 title = "b"

--- a/src/test/hugo/example-3.toml
+++ b/src/test/hugo/example-3.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/hugo.json
 baseURL = 'https://yoursite.example.com/'
 title = 'My Hugo Site'
 [params]

--- a/src/test/hugo/example-4.yaml
+++ b/src/test/hugo/example-4.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/hugo.json
 frontmatter:
   date:
     - ':default'

--- a/src/test/hws-config/hws-config.yaml
+++ b/src/test/hws-config/hws-config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/hws-config.json
 # Hardware Sentry
 
 # Number of jobs that Hardware Sentry can run simultaneously.

--- a/src/test/img-catapult-psp-1.0.0/contents-min.yaml
+++ b/src/test/img-catapult-psp-1.0.0/contents-min.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test for minimum config options
 platform:
   vendor: Imagination Technologies

--- a/src/test/img-catapult-psp-1.0.0/contents.yaml
+++ b/src/test/img-catapult-psp-1.0.0/contents.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/img-catapult-psp-1.0.0.json
 # Test for all config options
 platform:
   vendor: Imagination Technologies

--- a/src/test/jekyll/_config.yaml
+++ b/src/test/jekyll/_config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/jekyll.json
 # Default jekyll configuration from
 # https://jekyllrb.com/docs/configuration/default/
 

--- a/src/test/jekyll/arbitrary_permalink.yaml
+++ b/src/test/jekyll/arbitrary_permalink.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/jekyll.json
 # Test a permalink with an arbitrary path
 
 collections:

--- a/src/test/jekyll/issue-3702.yaml
+++ b/src/test/jekyll/issue-3702.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/jekyll.json
 defaults:
   - scope:
       path: '' # an empty string here means all files in the project

--- a/src/test/jekyll/permalink.yaml
+++ b/src/test/jekyll/permalink.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/jekyll.json
 # Test a more complex permalink example
 
 permalink: '/:categories/:year/:week/:short_day/:title:output_ext'

--- a/src/test/kestra-0.18.0/hello_world.yaml
+++ b/src/test/kestra-0.18.0/hello_world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kestra-0.18.0.json
 id: hello-world
 namespace: company.team
 

--- a/src/test/kestra-0.18.1/hello_world.yaml
+++ b/src/test/kestra-0.18.1/hello_world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kestra-0.18.1.json
 id: hello-world
 namespace: company.team
 

--- a/src/test/kestra-0.18.2/hello_world.yaml
+++ b/src/test/kestra-0.18.2/hello_world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kestra-0.18.2.json
 id: hello-world
 namespace: company.team
 

--- a/src/test/kestra-0.18.3/hello_world.yaml
+++ b/src/test/kestra-0.18.3/hello_world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kestra-0.18.3.json
 id: hello-world
 namespace: company.team
 

--- a/src/test/kestra-0.19.0/hello_world.yaml
+++ b/src/test/kestra-0.19.0/hello_world.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kestra-0.19.0.json
 id: hello-world
 namespace: company.team
 

--- a/src/test/kode-ci-build-1.0.0/app-release.yaml
+++ b/src/test/kode-ci-build-1.0.0/app-release.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kode-ci-build-1.0.0.json
 on:
   push:
     branches:

--- a/src/test/kode-ci-build-1.0.0/build-condition-test.yaml
+++ b/src/test/kode-ci-build-1.0.0/build-condition-test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kode-ci-build-1.0.0.json
 jobs:
   - name: test
     execute:

--- a/src/test/kode-ci-build-1.0.0/ci-build.yaml
+++ b/src/test/kode-ci-build-1.0.0/ci-build.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kode-ci-build-1.0.0.json
 on:
   push:
     branches:

--- a/src/test/kode-ci-build-1.0.0/gitops-deploy.yaml
+++ b/src/test/kode-ci-build-1.0.0/gitops-deploy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kode-ci-build-1.0.0.json
 jobs:
   - name: build
     execute:

--- a/src/test/kode-ci-build-1.0.0/macos-build.yaml
+++ b/src/test/kode-ci-build-1.0.0/macos-build.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kode-ci-build-1.0.0.json
 jobs:
   - name: build
     execute:

--- a/src/test/kustomization/helmCharts2.yaml
+++ b/src/test/kustomization/helmCharts2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/kustomization.json
 helmCharts:
   - name: minecraft
     repo: https://kubernetes-charts.storage.googleapis.com

--- a/src/test/lazydocker/default.yaml
+++ b/src/test/lazydocker/default.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/lazydocker.json
 gui:
   scrollHeight: 2
   language: 'auto' # one of 'auto' | 'en' | 'pl' | 'nl' | 'de' | 'tr'

--- a/src/test/loki/loki.yaml
+++ b/src/test/loki/loki.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/loki.json
 auth_enabled: false
 
 server:

--- a/src/test/mapehr/blood_pressure.map.yaml
+++ b/src/test/mapehr/blood_pressure.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Blood pressure (with ranges)

--- a/src/test/mapehr/bmi.map.yaml
+++ b/src/test/mapehr/bmi.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Body Mass Index (BMI)

--- a/src/test/mapehr/comment.map.yaml
+++ b/src/test/mapehr/comment.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # General comment

--- a/src/test/mapehr/device_name.map.yaml
+++ b/src/test/mapehr/device_name.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Device name

--- a/src/test/mapehr/entity_address.map.yaml
+++ b/src/test/mapehr/entity_address.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Entity address

--- a/src/test/mapehr/hemoglobin_in_blood.map.yaml
+++ b/src/test/mapehr/hemoglobin_in_blood.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 # Formulas
 rules:
   # LOINC based formulas

--- a/src/test/mapehr/medication.map.yaml
+++ b/src/test/mapehr/medication.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Medication amount dispensed

--- a/src/test/mapehr/medication_order.map.yaml
+++ b/src/test/mapehr/medication_order.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Medication order

--- a/src/test/mapehr/organization_simple_name.map.yaml
+++ b/src/test/mapehr/organization_simple_name.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Organization's simple name

--- a/src/test/mapehr/party_relationship.map.yaml
+++ b/src/test/mapehr/party_relationship.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     79191-3:

--- a/src/test/mapehr/person_simple_name.map.yaml
+++ b/src/test/mapehr/person_simple_name.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Person's simple name

--- a/src/test/mapehr/person_structured_name.map.yaml
+++ b/src/test/mapehr/person_structured_name.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Person's structured name

--- a/src/test/mapehr/problem_diagnosis.map.yaml
+++ b/src/test/mapehr/problem_diagnosis.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 rules:
   loinc:
     # Problem diagnosis

--- a/src/test/mapehr/units.map.yaml
+++ b/src/test/mapehr/units.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 # Shortcuts for often used units
 define:
   cm_snomed: http://snomed.info/id/258672001

--- a/src/test/mapehr/vital_signs.map.yaml
+++ b/src/test/mapehr/vital_signs.map.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/mapehr.json
 # Formulas
 rules:
   # LOINC based formulas

--- a/src/test/metricshub-connector/metricshub-connector.yaml
+++ b/src/test/metricshub-connector/metricshub-connector.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/metricshub-connector.json
 extends:
   - ../System/System
 metrics:

--- a/src/test/metricshub/metricshub.yaml
+++ b/src/test/metricshub/metricshub.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/metricshub.json
 # MetricsHub Configuration
 
 # Default logger level

--- a/src/test/monade-stack-config/example.yaml
+++ b/src/test/monade-stack-config/example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/monade-stack-config.json
 name: myapp
 nginx: local
 services:

--- a/src/test/nuejs-site/simple-blog-site.yaml
+++ b/src/test/nuejs-site/simple-blog-site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/nuejs-site.json
 globals: ['@global']
 libs: ['@library']
 

--- a/src/test/openutau-character/openutau-character.yaml
+++ b/src/test/openutau-character/openutau-character.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/openutau-character.json
 # Source: https://github.com/stakira/OpenUtau/wiki/tech-note:-character.yaml
 
 name: 闇音レンリ・連続音Ver1.5

--- a/src/test/openutau-ustx/bulaomeng.ustx.yaml
+++ b/src/test/openutau-ustx/bulaomeng.ustx.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/openutau-ustx.json
 ﻿name: 不老梦
 comment: ''
 output_dir: Vocal

--- a/src/test/pantsbuild-2.14.0/pants.toml
+++ b/src/test/pantsbuild-2.14.0/pants.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pantsbuild-2.14.0.json
 [GLOBAL]
 pants_version = "2.14.0"
 pythonpath = ["%(buildroot)s/pants-plugins"]

--- a/src/test/paper-plugin/commands.yaml
+++ b/src/test/paper-plugin/commands.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/paper-plugin.json
 name: something
 version: 1.0.0
 main: testplugin.ExamplePlugin

--- a/src/test/paper-plugin/example-1.yaml
+++ b/src/test/paper-plugin/example-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/paper-plugin.json
 name: ExamplePlugin
 version: 1.0.0
 main: testplugin.ExamplePlugin

--- a/src/test/paper-plugin/permissions.yaml
+++ b/src/test/paper-plugin/permissions.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/paper-plugin.json
 name: something
 version: 1.0.0
 main: testplugin.ExamplePlugin

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pnpm-workspace.json
 # https://pnpm.io/pnpm-workspace_yaml
 packages:
   - packages/*

--- a/src/test/prometheus.rules.test/rules.test.yaml
+++ b/src/test/prometheus.rules.test/rules.test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/prometheus.rules.test.json
 # This is the main input for unit testing.
 # Only this file is passed as command line argument.
 

--- a/src/test/pubspec/asset_transformer.yaml
+++ b/src/test/pubspec/asset_transformer.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: asset_transformation
 description: 'A new Flutter project.'
 publish_to: 'none'

--- a/src/test/pubspec/executables.yaml
+++ b/src/test/pubspec/executables.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: this_name_is_allowed
 executables:
   slidy: main

--- a/src/test/pubspec/platforms.yaml
+++ b/src/test/pubspec/platforms.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: my_name
 platforms:
   android:

--- a/src/test/pubspec/pubspec.yaml
+++ b/src/test/pubspec/pubspec.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 homepage: https://pub.dev
 name: foo
 description: My package description

--- a/src/test/pubspec/screenshots.yaml
+++ b/src/test/pubspec/screenshots.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: screenshots-are-allowed
 screenshots:
   - description: 'This screenshot shows the transformation of a number of bytes to a human-readable expression.'

--- a/src/test/pubspec/shaders.yaml
+++ b/src/test/pubspec/shaders.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: blender_4d
 flutter:
   shaders:

--- a/src/test/pubspec/some_flutter_example.yaml
+++ b/src/test/pubspec/some_flutter_example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pubspec.json
 name: project
 description: A new Flutter project.
 

--- a/src/test/pulumi/Pulumi.yaml
+++ b/src/test/pulumi/Pulumi.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/pulumi.json
 name: Example Pulumi project file with all possible attributes
 runtime: yaml
 description: An example project

--- a/src/test/pyproject/01-setuptools.toml
+++ b/src/test/pyproject/01-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "some-project"
 authors = [{ name = "Anderson Bravalheri" }]

--- a/src/test/pyproject/01-setuptools_scm.toml
+++ b/src/test/pyproject/01-setuptools_scm.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.setuptools_scm]
 write_to = "foo/bar.py"

--- a/src/test/pyproject/02-setuptools.toml
+++ b/src/test/pyproject/02-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "package"
 description = "description"

--- a/src/test/pyproject/03-setuptools.toml
+++ b/src/test/pyproject/03-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "project"
 description = "description"

--- a/src/test/pyproject/04-setuptools.toml
+++ b/src/test/pyproject/04-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "project"
 readme = "README.md"

--- a/src/test/pyproject/05-setuptools.toml
+++ b/src/test/pyproject/05-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "myproj"
 version = "3.8"

--- a/src/test/pyproject/06-setuptools.toml
+++ b/src/test/pyproject/06-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "myproj"
 keywords = ["some", "key", "words"]

--- a/src/test/pyproject/07-setuptools.toml
+++ b/src/test/pyproject/07-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "myproj"
 keywords = ["some", "key", "words"]

--- a/src/test/pyproject/08-setuptools.toml
+++ b/src/test/pyproject/08-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 # Setuptools should allow stub-only package names in `packages` (PEP 561)
 [build-system]
 requires = ["setuptools", "setuptools-scm"]

--- a/src/test/pyproject/09-setuptools.toml
+++ b/src/test/pyproject/09-setuptools.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 # Setuptools should allow stub-only package names in `package-dir` (PEP 561)
 [build-system]
 requires = ["setuptools", "setuptools-scm"]

--- a/src/test/pyproject/3021.toml
+++ b/src/test/pyproject/3021.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "project"
 version = "0.1.0"

--- a/src/test/pyproject/3616.toml
+++ b/src/test/pyproject/3616.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "myotherlib"
 version = "0.1.0"

--- a/src/test/pyproject/3821.toml
+++ b/src/test/pyproject/3821.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "project"
 version = "0.1.0"

--- a/src/test/pyproject/black-examp1.toml
+++ b/src/test/pyproject/black-examp1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.black]
 line-length = 98
 include = "\\.pyi?$"

--- a/src/test/pyproject/black-examp2.toml
+++ b/src/test/pyproject/black-examp2.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.black]
 line-length = 90
 target-version = ['py311']

--- a/src/test/pyproject/cibuildwheel-default.toml
+++ b/src/test/pyproject/cibuildwheel-default.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.cibuildwheel]
 build = "*"
 skip = ""

--- a/src/test/pyproject/cibuildwheel-inherit.toml
+++ b/src/test/pyproject/cibuildwheel-inherit.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"
 inherit.test-command = "prepend"

--- a/src/test/pyproject/cibuildwheel-overrides.toml
+++ b/src/test/pyproject/cibuildwheel-overrides.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [[tool.cibuildwheel.overrides]]
 select = "cp*"
 test-command = "something"

--- a/src/test/pyproject/dependency-groups-1.toml
+++ b/src/test/pyproject/dependency-groups-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/test/pyproject/dependency-groups-2.toml
+++ b/src/test/pyproject/dependency-groups-2.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/test/pyproject/dependency-groups-3.toml
+++ b/src/test/pyproject/dependency-groups-3.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "schemastore"
 version = "0.1.0"

--- a/src/test/pyproject/dynamic.toml
+++ b/src/test/pyproject/dynamic.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "setuptools-scm[toml] >= 6.2", "wheel"]

--- a/src/test/pyproject/hatch.toml
+++ b/src/test/pyproject/hatch.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/test/pyproject/mypy-01.toml
+++ b/src/test/pyproject/mypy-01.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 # mypy global options:
 
 [tool.mypy]

--- a/src/test/pyproject/mypy-02.toml
+++ b/src/test/pyproject/mypy-02.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.mypy]
 files = "src"
 python_version = "3.8"

--- a/src/test/pyproject/pdm_tool.toml
+++ b/src/test/pyproject/pdm_tool.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.pdm]
 plugins = ["sync-pre-commit-lock"]
 distribution = false

--- a/src/test/pyproject/pdm_tool_dockerize.toml
+++ b/src/test/pyproject/pdm_tool_dockerize.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.pdm.dockerize]
 include = "*"
 exclude = "some-script"

--- a/src/test/pyproject/pdm_tool_dockerize_list.toml
+++ b/src/test/pyproject/pdm_tool_dockerize_list.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.pdm.dockerize]
 include = ["*"]
 exclude = ["some-script"]

--- a/src/test/pyproject/pep639.toml
+++ b/src/test/pyproject/pep639.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [project]
 name = "example"
 version = "1.2.3"

--- a/src/test/pyproject/poetry-author-no-email.toml
+++ b/src/test/pyproject/poetry-author-no-email.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "single-python"
 version = "0.1"

--- a/src/test/pyproject/poetry-capital-in-author-email.toml
+++ b/src/test/pyproject/poetry-capital-in-author-email.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "single-python"
 version = "0.1"

--- a/src/test/pyproject/poetry-complete.toml
+++ b/src/test/pyproject/poetry-complete.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "poetry"
 version = "0.5.0"

--- a/src/test/pyproject/poetry-git-urls.toml
+++ b/src/test/pyproject/poetry-git-urls.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = ""
 version = "0.0.0"

--- a/src/test/pyproject/poetry-inline-table.toml
+++ b/src/test/pyproject/poetry-inline-table.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "with-include"
 version = "1.2.3"

--- a/src/test/pyproject/poetry-non-package.toml
+++ b/src/test/pyproject/poetry-non-package.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 package-mode = false
 

--- a/src/test/pyproject/poetry-plugin-dotenv-example-1.toml
+++ b/src/test/pyproject/poetry-plugin-dotenv-example-1.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = ""
 version = "0.0.0"

--- a/src/test/pyproject/poetry-plugin-dotenv-example-2.toml
+++ b/src/test/pyproject/poetry-plugin-dotenv-example-2.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = ""
 version = "0.0.0"

--- a/src/test/pyproject/poetry-readme-files.toml
+++ b/src/test/pyproject/poetry-readme-files.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "single-python"
 version = "0.1"

--- a/src/test/pyproject/poetry-sample-project.toml
+++ b/src/test/pyproject/poetry-sample-project.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.poetry]
 name = "my-package"
 version = "1.2.3"

--- a/src/test/pyproject/ruff-sample-project.toml
+++ b/src/test/pyproject/ruff-sample-project.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.ruff]
 
 [tool.ruff.isort]

--- a/src/test/pyproject/scikit-build-defaults.toml
+++ b/src/test/pyproject/scikit-build-defaults.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.scikit-build]
 cmake.minimum-version = "3.15"
 cmake.args = ["sample"]

--- a/src/test/pyproject/simple.toml
+++ b/src/test/pyproject/simple.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64.0", "wheel"]

--- a/src/test/pyproject/tox-legacy.toml
+++ b/src/test/pyproject/tox-legacy.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.tox]
 # Taken from https://tox.wiki/en/4.18.0/config.html
 legacy_tox_ini = """

--- a/src/test/pyproject/tox-minimal.toml
+++ b/src/test/pyproject/tox-minimal.toml
@@ -1,2 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.tox]
 min_version = "4.0"

--- a/src/test/pyproject/uv-sample-project.toml
+++ b/src/test/pyproject/uv-sample-project.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
 [tool.uv]
 
 [tool.uv.pip]

--- a/src/test/qodana-1.0/dotnet-project.yaml
+++ b/src/test/qodana-1.0/dotnet-project.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/qodana-1.0.json
 version: '1.0'
 
 dotnet:

--- a/src/test/qodana-1.0/dotnet-solution.yaml
+++ b/src/test/qodana-1.0/dotnet-solution.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/qodana-1.0.json
 version: '1.0'
 
 dotnet:

--- a/src/test/qodana-1.0/properties.yaml
+++ b/src/test/qodana-1.0/properties.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/qodana-1.0.json
 version: '1.0'
 properties:
   idea.log.config.file: info.xml

--- a/src/test/rancher-fleet-0.5/fleet-official-example.yaml
+++ b/src/test/rancher-fleet-0.5/fleet-official-example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.5.json
 # The default namespace to be applied to resources. This field is not used to
 # enforce or lock down the deployment to a specific namespace, but instead
 # provide the default value of the namespace field if one is not specified

--- a/src/test/rancher-fleet-0.5/yaml-overlays.yaml
+++ b/src/test/rancher-fleet-0.5/yaml-overlays.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.5.json
 defaultNamespace: cluster-autoscaler
 imageScans:
   - image: cluster-autoscaler

--- a/src/test/rancher-fleet-0.8/fleet-official-example.yaml
+++ b/src/test/rancher-fleet-0.8/fleet-official-example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.8.json
 # The default namespace to be applied to resources. This field is not used to
 # enforce or lock down the deployment to a specific namespace, but instead
 # provide the default value of the namespace field if one is not specified

--- a/src/test/rancher-fleet-0.8/helm-overlays-with-do-not-deploy.yaml
+++ b/src/test/rancher-fleet-0.8/helm-overlays-with-do-not-deploy.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.8.json
 defaultNamespace: cluster-autoscaler
 helm:
   chart: ./chart

--- a/src/test/rancher-fleet-0.8/yaml-overlays.yaml
+++ b/src/test/rancher-fleet-0.8/yaml-overlays.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/rancher-fleet-0.8.json
 defaultNamespace: cluster-autoscaler
 imageScans:
   - image: cluster-autoscaler

--- a/src/test/rust-toolchain/components-any-3782.toml
+++ b/src/test/rust-toolchain/components-any-3782.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/rust-toolchain.json
 [toolchain]
 components = ['cranelift']
 targets = ['random-arch']

--- a/src/test/safebox-schema-v1.0.0/safebox-full-valid.yaml
+++ b/src/test/safebox-schema-v1.0.0/safebox-full-valid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/safebox-schema-v1.0.0.json
 service: safebox
 provider: ssm
 prefix: '/test/'

--- a/src/test/safebox-schema-v1.0.0/safebox-short-valid.yaml
+++ b/src/test/safebox-schema-v1.0.0/safebox-short-valid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/safebox-schema-v1.0.0.json
 service: safebox
 provider: ssm
 

--- a/src/test/samt/samt.yaml
+++ b/src/test/samt/samt.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/samt.json
 source: ./some/other/src
 
 repositories:

--- a/src/test/samtrc/.samtrc.yaml
+++ b/src/test/samtrc/.samtrc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/samtrc.json
 extends: recommended
 
 rules:

--- a/src/test/sigrid-scope-file.schema/sigrid.yaml
+++ b/src/test/sigrid-scope-file.schema/sigrid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sigrid-scope-file.schema.json
 component_depth: 1
 
 exclude:

--- a/src/test/sil-kit-participant-configuration/empty.silkit.yaml
+++ b/src/test/sil-kit-participant-configuration/empty.silkit.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-participant-configuration.json
 {}

--- a/src/test/sil-kit-participant-configuration/full.silkit.yaml
+++ b/src/test/sil-kit-participant-configuration/full.silkit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-participant-configuration.json
 ---
 '$schema': ParticipantConfiguration.schema.json
 schemaVersion: 0

--- a/src/test/sil-kit-participant-configuration/logging.silkit.yaml
+++ b/src/test/sil-kit-participant-configuration/logging.silkit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-participant-configuration.json
 Description: Sample configuration for CAN
 Logging:
   Sinks:

--- a/src/test/sil-kit-registry-configuration/empty.silkit-registry.yaml
+++ b/src/test/sil-kit-registry-configuration/empty.silkit-registry.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 {}

--- a/src/test/sil-kit-registry-configuration/silkit-registry.yaml
+++ b/src/test/sil-kit-registry-configuration/silkit-registry.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sil-kit-registry-configuration.json
 ---
 '$schema': RegistryConfiguration.schema.json
 SchemaVersion: 2

--- a/src/test/sourcery_yaml_schema/.sourcery-docs.yaml
+++ b/src/test/sourcery_yaml_schema/.sourcery-docs.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sourcery_yaml_schema.json
 ignore: []
 
 rule_settings:

--- a/src/test/sourcery_yaml_schema/.sourcery-init.yaml
+++ b/src/test/sourcery_yaml_schema/.sourcery-init.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sourcery_yaml_schema.json
 # 🪄 This is your project's Sourcery configuration file.
 
 # You can use it to get Sourcery working in the way you want, such as

--- a/src/test/sqlc-2.0/example.sqlc.yaml
+++ b/src/test/sqlc-2.0/example.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 sql:
   - schema: 'postgresql/schema.sql'

--- a/src/test/sqlc-2.0/global_overrides.sqlc.yaml
+++ b/src/test/sqlc-2.0/global_overrides.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 overrides:
   go:

--- a/src/test/sqlc-2.0/override.sqlc.yaml
+++ b/src/test/sqlc-2.0/override.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 sql:
   - schema: 'postgresql/schema.sql'

--- a/src/test/sqlc-2.0/plugins.sqlc.yaml
+++ b/src/test/sqlc-2.0/plugins.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 plugins:
   - name: 'py'

--- a/src/test/sqlc-2.0/python.sqlc.yaml
+++ b/src/test/sqlc-2.0/python.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 plugins:
   - name: py

--- a/src/test/sqlc-2.0/rules.sqlc.yaml
+++ b/src/test/sqlc-2.0/rules.sqlc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sqlc-2.0.json
 version: '2'
 sql:
   - schema: 'query.sql'

--- a/src/test/sublime-syntax/Manpage.sublime-syntax.yaml
+++ b/src/test/sublime-syntax/Manpage.sublime-syntax.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/sublime-syntax.json
 %YAML 1.2
 ---
 # http://www.sublimetext.com/docs/3/syntax.html

--- a/src/test/tmuxinator/yaml.yaml
+++ b/src/test/tmuxinator/yaml.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/tmuxinator.json
 # ~/.tmuxinator/sample.yml
 # you can make as many tabs as you wish...
 

--- a/src/test/venvironment-basic-schema-v2.1.0/empty.yaml
+++ b/src/test/venvironment-basic-schema-v2.1.0/empty.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v2.1.0.json
 version: '2.1.0'

--- a/src/test/venvironment-basic-schema-v2.1.0/unicode-1.yaml
+++ b/src/test/venvironment-basic-schema-v2.1.0/unicode-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v2.1.0.json
 ﻿version: '2.1.0'
 
 system-variables:

--- a/src/test/venvironment-basic-schema-v2.1.0/vcdls.yaml
+++ b/src/test/venvironment-basic-schema-v2.1.0/vcdls.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v2.1.0.json
 version: '2.1.0'
 
 datasources:

--- a/src/test/venvironment-basic-schema-v3.2.0/empty.yaml
+++ b/src/test/venvironment-basic-schema-v3.2.0/empty.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v3.2.0.json
 version: '3.2.0'

--- a/src/test/venvironment-basic-schema-v3.2.0/unicode-1.yaml
+++ b/src/test/venvironment-basic-schema-v3.2.0/unicode-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v3.2.0.json
 ﻿version: '3.2.0'
 
 system-variables:

--- a/src/test/venvironment-basic-schema-v3.2.0/vcdls.yaml
+++ b/src/test/venvironment-basic-schema-v3.2.0/vcdls.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-basic-schema-v3.2.0.json
 version: '3.2.0'
 
 datasources:

--- a/src/test/venvironment-schema-v2.2.0/can-and-canfd.yaml
+++ b/src/test/venvironment-schema-v2.2.0/can-and-canfd.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: '2.2.0'
 databases:
   - name: Easy

--- a/src/test/venvironment-schema-v2.2.0/empty.yaml
+++ b/src/test/venvironment-schema-v2.2.0/empty.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: '2.2.0'

--- a/src/test/venvironment-schema-v2.2.0/unicode-1.yaml
+++ b/src/test/venvironment-schema-v2.2.0/unicode-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 ﻿version: '2.2.0'
 
 system-variables:

--- a/src/test/venvironment-schema-v2.2.0/unicode-2.yaml
+++ b/src/test/venvironment-schema-v2.2.0/unicode-2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: '2.2.0'
 
 variables:

--- a/src/test/venvironment-schema-v2.2.0/vcdls.yaml
+++ b/src/test/venvironment-schema-v2.2.0/vcdls.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: '2.2.0'
 
 datasources:

--- a/src/test/venvironment-schema-v2.2.0/xcp.yaml
+++ b/src/test/venvironment-schema-v2.2.0/xcp.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v2.2.0.json
 version: '2.2.0'
 
 databases:

--- a/src/test/venvironment-schema-v3.2.0/can-and-canfd.yaml
+++ b/src/test/venvironment-schema-v3.2.0/can-and-canfd.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: '3.2.0'
 
 databases:

--- a/src/test/venvironment-schema-v3.2.0/empty.yaml
+++ b/src/test/venvironment-schema-v3.2.0/empty.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: '3.2.0'

--- a/src/test/venvironment-schema-v3.2.0/unicode-1.yaml
+++ b/src/test/venvironment-schema-v3.2.0/unicode-1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 ﻿version: '3.2.0'
 
 system-variables:

--- a/src/test/venvironment-schema-v3.2.0/unicode-2.yaml
+++ b/src/test/venvironment-schema-v3.2.0/unicode-2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: '3.2.0'
 
 variables:

--- a/src/test/venvironment-schema-v3.2.0/vcdls.yaml
+++ b/src/test/venvironment-schema-v3.2.0/vcdls.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: '3.2.0'
 
 datasources:

--- a/src/test/venvironment-schema-v3.2.0/xcp.yaml
+++ b/src/test/venvironment-schema-v3.2.0/xcp.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/venvironment-schema-v3.2.0.json
 version: '3.2.0'
 
 databases:

--- a/src/test/vhwdebugger-binding-schema/success.1.0.vhwdebugger-binding.yaml
+++ b/src/test/vhwdebugger-binding-schema/success.1.0.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.0'
 
 default-debugger: DefaultValues

--- a/src/test/vhwdebugger-binding-schema/success.1.1.vhwdebugger-binding.yaml
+++ b/src/test/vhwdebugger-binding-schema/success.1.1.vhwdebugger-binding.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
 version: '1.1'
 
 default-debugger: DefaultValues

--- a/src/test/vtesttree-schema-v1.0.0/empty-parameters.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/empty-parameters.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 
 test-tree:

--- a/src/test/vtesttree-schema-v1.0.0/empty-test-group-elements.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/empty-test-group-elements.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - test-group: TestGroup

--- a/src/test/vtesttree-schema-v1.0.0/empty-test-group.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/empty-test-group.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - test-group: TestGroup

--- a/src/test/vtesttree-schema-v1.0.0/empty-tree.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/empty-tree.vtesttree.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree: []

--- a/src/test/vtesttree-schema-v1.0.0/empty.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/empty.vtesttree.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0

--- a/src/test/vtesttree-schema-v1.0.0/full-tree.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/full-tree.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - capl-test-case: CaplTestCase

--- a/src/test/vtesttree-schema-v1.0.0/mixed-parameters.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/mixed-parameters.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - capl-test-sequence: FullyParametrizedTestSequence

--- a/src/test/vtesttree-schema-v1.0.0/nested-groups.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/nested-groups.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - test-group: Outer Group

--- a/src/test/vtesttree-schema-v1.0.0/simple-test-case.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/simple-test-case.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - capl-test-case: MyTestCase

--- a/src/test/vtesttree-schema-v1.0.0/test-sequence-params.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v1.0.0/test-sequence-params.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v1.0.0.json
 version: 1.0.0
 test-tree:
   - capl-test-sequence: MyTestSequence

--- a/src/test/vtesttree-schema-v2.0.0/empty-parameters-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/empty-parameters-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 
 test-tree:

--- a/src/test/vtesttree-schema-v2.0.0/empty-test-fixture-elements-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/empty-test-fixture-elements-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - test-fixture: TestFixture

--- a/src/test/vtesttree-schema-v2.0.0/empty-test-fixture-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/empty-test-fixture-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - test-fixture: TestFixture

--- a/src/test/vtesttree-schema-v2.0.0/empty-tree-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/empty-tree-v2.vtesttree.yaml
@@ -1,2 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree: []

--- a/src/test/vtesttree-schema-v2.0.0/empty-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/empty-v2.vtesttree.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0

--- a/src/test/vtesttree-schema-v2.0.0/full-tree-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/full-tree-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - capl-test-case: CaplTestCase

--- a/src/test/vtesttree-schema-v2.0.0/mixed-parameters-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/mixed-parameters-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - capl-test-sequence: FullyParametrizedTestSequence

--- a/src/test/vtesttree-schema-v2.0.0/nested-fixtures-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/nested-fixtures-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - test-fixture: Outer Fixture

--- a/src/test/vtesttree-schema-v2.0.0/simple-test-case-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/simple-test-case-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - capl-test-case: MyTestCase

--- a/src/test/vtesttree-schema-v2.0.0/test-sequence-params-v2.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.0.0/test-sequence-params-v2.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.0.0.json
 version: 2.0.0
 test-tree:
   - capl-test-sequence: MyTestSequence

--- a/src/test/vtesttree-schema-v2.1.0/completions.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.1.0/completions.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - test-fixture: test fixture 1

--- a/src/test/vtesttree-schema-v2.1.0/dotnet-tests.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.1.0/dotnet-tests.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - dotnet-test-case: DotnetTestCase

--- a/src/test/vtesttree-schema-v2.1.0/mixed-prep-comp.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.1.0/mixed-prep-comp.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - test-fixture: test fixture 1

--- a/src/test/vtesttree-schema-v2.1.0/preparations.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.1.0/preparations.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - test-fixture: test fixture 1

--- a/src/test/vtesttree-schema-v2.1.0/python-tests.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.1.0/python-tests.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.1.0.json
 version: 2.1.0
 test-tree:
   - python-test-case: python_test_case

--- a/src/test/vtesttree-schema-v2.2.0/variant-dependencies.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.2.0/variant-dependencies.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.2.0.json
 version: 2.2.0
 
 test-tree:

--- a/src/test/vtesttree-schema-v2.3.0/test-case-list.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.3.0/test-case-list.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.3.0.json
 version: 2.3.0
 
 test-tree:

--- a/src/test/vtesttree-schema-v2.3.0/test-sequence-list.vtesttree.yaml
+++ b/src/test/vtesttree-schema-v2.3.0/test-sequence-list.vtesttree.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtesttree-schema-v2.3.0.json
 version: 2.3.0
 
 test-tree:

--- a/src/test/vtestunit-schema/full-blown.vtestunit.yaml
+++ b/src/test/vtestunit-schema/full-blown.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 includes:

--- a/src/test/vtestunit-schema/include.vtestunit.yaml
+++ b/src/test/vtestunit-schema/include.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 includes:

--- a/src/test/vtestunit-schema/test-impl.vtestunit.yaml
+++ b/src/test/vtestunit-schema/test-impl.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 test-unit-implementation:

--- a/src/test/vtestunit-schema/test-inf.vtestunit.yaml
+++ b/src/test/vtestunit-schema/test-inf.vtestunit.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0
 
 test-unit-information:

--- a/src/test/vtestunit-schema/version.vtestunit.yaml
+++ b/src/test/vtestunit-schema/version.vtestunit.yaml
@@ -1,1 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/vtestunit-schema.json
 version: 2.1.0

--- a/src/test/zuul/jobs.yaml
+++ b/src/test/zuul/jobs.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/zuul.json
 # valid zuul config sample
 - job:
     name: minimal


### PR DESCRIPTION
Adds code to automatically check all TOML and YAML testing files for a schema filepath pragma. This assumes RedHat's `yaml-language-server` an Taplo's TOML Language server implementations, but other tools should check for these comments too if they want to be relevant.

This was not done for JSON because JSON does not allow comments, making things less straightforward. For example, adding `$schema` creates an `Unexpected property: $schema`-type error unless this is specifically handled.

This error can automatically be fixed by passing `--fix`:

```bash
node ./cli.js check --fix
```

This is the first auto-fixable error. Hopefully more errors are autofixable in time

Closes #3847