### PR TITLE
Add support for Node.js 22.x in tunnelhub schema

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -41,6 +41,7 @@
             "nodejs16.x",
             "nodejs18.x",
             "nodejs20.x",
+            "nodejs22.x",
             "nodejs4.3",
             "nodejs4.3-edge",
             "nodejs6.10",

--- a/src/test/tunnelhub/tunnelhub.yml
+++ b/src/test/tunnelhub/tunnelhub.yml
@@ -1,3 +1,4 @@
+
 service:
   type: automation
   uuid: d0af2363-d02b-4a9d-ba53-3a6252c00121

--- a/src/test/tunnelhub/tunnelhub.yml
+++ b/src/test/tunnelhub/tunnelhub.yml
@@ -1,4 +1,3 @@
-
 service:
   type: automation
   uuid: d0af2363-d02b-4a9d-ba53-3a6252c00121


### PR DESCRIPTION
Updated the JSON schema to include Node.js 22.x as a supported runtime version. Also included a minor formatting change in the related YAML test file, ensuring consistency.