### PR TITLE
feat(schema): Add `dotnet-sdk` to dependabot-2.0

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -652,6 +652,7 @@
         "composer",
         "devcontainers",
         "docker",
+        "dotnet-sdk",
         "elm",
         "gitsubmodule",
         "github-actions",


### PR DESCRIPTION
Basic support for `package-ecosystem: "dotnet-sdk"` was added in [dependabot-core v0.284.0](https://github.com/dependabot/dependabot-core/releases/tag/v0.284.0). This PR just adds the additionally allowed enum value.

- [Official documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-)
- [MS Dev Blogs announcement](https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/)