### PR TITLE
Add KSail external JSON Schema to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2260,6 +2260,21 @@
       }
     },
     {
+      "name": "KSail",
+      "description": "Configuration for KSail",
+      "fileMatch": [
+        "ksail-cluster.yaml",
+        "ksail-cluster.yml",
+        "ksail-config.yaml",
+        "ksail-config.yml",
+        "ksail.yaml",
+        "ksail.yml",
+        "*.ksail.yaml",
+        "*.ksail.yml"
+      ],
+      "url": "https://github.com/devantler/ksail/blob/main/schemas/ksail-cluster-schema.json"
+    },
+    {
       "name": "function.json",
       "description": "Azure Functions function.json files",
       "fileMatch": ["function.json"],


### PR DESCRIPTION
This PR adds the KSail schema to the catalog.json file, to make the KSail schema available in the SchemaStore.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
