### PR TITLE
feat: add "x-tombi-toml-version".

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -562,7 +562,7 @@
     "cargo.json": {
       "externalSchema": ["base.json"],
       "unknownFormat": ["uint32", "semver", "semver-requirement"],
-      "unknownKeywords": ["x-taplo", "x-taplo-info"]
+      "unknownKeywords": ["x-taplo", "x-taplo-info", "x-tombi-toml-version"]
     },
     "cheatsheets.json": {
       "externalSchema": ["base.json"]
@@ -1016,6 +1016,7 @@
         "markdownDescription",
         "x-taplo",
         "x-taplo-info",
+        "x-tombi-toml-version",
         "x-intellij-html-description",
         "x-intellij-language-injection"
       ]

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/cargo.json",
+  "x-tombi-toml-version": "v1.0.0",
   "definitions": {
     "Build": {
       "title": "Build",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/pyproject.json",
   "$comment": "there are multiple resources describing pyproject.toml. The canonical reference is at https://packaging.python.org/en/latest/specifications/declaring-project-metadata/, which refers to multiple proposals such as PEP 517, PEP 518 and PEP 621",
+  "x-tombi-toml-version": "v1.0.0",
   "additionalProperties": false,
   "definitions": {
     "projectAuthor": {


### PR DESCRIPTION
I am developing a TOML Language Server named [tombi](https://github.com/tombi-toml/tombi).

In order to support multiple TOML versions, I want the JSON Schema to have the TOML version supported by each schema's runtime (e.g. Cargo) as meta-information.

I realize that my project is young and it may be premature to issue this PR.

There may be other suitable methods.
As this is my first PR for this project, any advice would be appreciated.