### PR TITLE
Add DeployStack configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1123,6 +1123,15 @@
       "url": "https://raw.githubusercontent.com/sverweij/dependency-cruiser/main/src/schema/configuration.schema.json"
     },
     {
+      "name": "DeployStack Configuration",
+      "description": "Configuration schema for DeployStack applications, supporting app customization and deployment settings",
+      "fileMatch": [
+        "**/.deploystack/config.yml",
+        "**/.deploystack/config.yaml"
+      ],
+      "url": "https://cdnx.deploystack.io/schema/config.yml.json"
+    },    
+    {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",
       "fileMatch": ["Spacefile"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1124,13 +1124,13 @@
     },
     {
       "name": "DeployStack Configuration",
-      "description": "Configuration schema for DeployStack applications, supporting app customization and deployment settings",
+      "description": "Configuration for DeployStack applications, supporting app customization and deployment settings",
       "fileMatch": [
         "**/.deploystack/config.yml",
         "**/.deploystack/config.yaml"
       ],
       "url": "https://cdnx.deploystack.io/schema/config.yml.json"
-    },    
+    },  
     {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",


### PR DESCRIPTION
Add DeployStack configuration schema

This adds support for `.deploystack/config.yml` configuration files used to customize application deployments in DeployStack. The schema enables validation and autocompletion for:

- Application metadata (name, description, logo)
- Branch-specific deployment configuration

The schema is hosted externally at cdnx.deploystack.io and maintained by the DeployStack team.