### PR TITLE
Remove error-pages schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2054,15 +2054,6 @@
       "url": "https://json.schemastore.org/epr-manifest.json"
     },
     {
-      "name": "Error pages",
-      "description": "Error-Pages configuration file",
-      "fileMatch": ["error-pages*.yml", "error-pages*.yaml"],
-      "url": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json",
-      "versions": {
-        "1.0": "https://cdn.jsdelivr.net/gh/tarampampam/error-pages@latest/schemas/config/1.0.schema.json"
-      }
-    },
-    {
       "name": "electron-builder configuration file",
       "description": "electron-build configuration file",
       "fileMatch": ["electron-builder.json"],


### PR DESCRIPTION
Since the [error-pages](https://github.com/tarampampam/error-pages) project no longer includes configuration files, the schema link can be safely removed. Thank you!