### PR TITLE
Add Metatype configuration to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3327,6 +3327,12 @@
       "url": "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/metadata.schema.json"
     },
     {
+      "name": "Metatype Configuration",
+      "description": "Metatype configuration file",
+      "fileMatch": ["metatype.yml", "metatype.yaml"],
+      "url": "https://raw.githubusercontent.com/metatypedev/metatype/main/tools/schema/metatype.json"
+    },
+    {
       "name": "MetricsHub Configuration",
       "description": "MetricsHub configuration file",
       "fileMatch": ["*metricshub.yaml", "*metricshub.yml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Hello, I am a core team member of the [Metatype](https://metatype.dev/) project and we would like to add our [configuration schema](https://github.com/metatypedev/metatype/blob/main/tools/schema/metatype.json) to Schemastore. This PR adds a reference in the catalog to our self-hosted schema.