### PR TITLE
Allow external package mappings in `imports` field in `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -187,6 +187,73 @@
         }
       ]
     },
+    "packageImportsEntryPath": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The module path that is resolved when this specifier is imported. Set to `null` to disallow importing this module."
+    },
+    "packageImportsEntryObject": {
+      "type": "object",
+      "description": "Used to specify conditional exports, note that Conditional exports are unsupported in older environments, so it's recommended to use the fallback array option if support for those environments is a concern.",
+      "properties": {
+        "require": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this specifier is imported as a CommonJS module using the `require(...)` function."
+        },
+        "import": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this specifier is imported as an ECMAScript module using an `import` declaration or the dynamic `import(...)` function."
+        },
+        "node": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment is Node.js."
+        },
+        "default": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when no other export type matches."
+        },
+        "types": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions."
+        }
+      },
+      "patternProperties": {
+        "^[^.0-9]+$": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment matches the property name."
+        }
+      },
+      "additionalProperties": false
+    },
+    "packageImportsEntry": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageImportsEntryPath"
+        },
+        {
+          "$ref": "#/definitions/packageImportsEntryObject"
+        }
+      ]
+    },
+    "packageImportsFallback": {
+      "type": "array",
+      "description": "Used to allow fallbacks in case this environment doesn't support the preceding entries.",
+      "items": {
+        "$ref": "#/definitions/packageImportsEntry"
+      }
+    },
+    "packageImportsEntryOrFallback": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageImportsEntry"
+        },
+        {
+          "$ref": "#/definitions/packageImportsFallback"
+        }
+      ]
+    },
     "fundingUrl": {
       "type": "string",
       "format": "uri",
@@ -349,7 +416,7 @@
       "type": "object",
       "patternProperties": {
         "^#.+$": {
-          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
         }
       },

--- a/src/test/package/imports-test4.json
+++ b/src/test/package/imports-test4.json
@@ -1,0 +1,7 @@
+{
+  "description": "different package",
+  "imports": {
+    "#foo": "different-package"
+  },
+  "name": "my-mod"
+}


### PR DESCRIPTION
It is [allowed to write package names in `imports` field mappings](https://nodejs.org/api/packages.html#subpath-imports:~:text=the%20%22imports%22%20field%20permits%20mapping%20to%20external%20packages.) like:
```json
{
  "imports": {
    "#foo": "different-package"
  }
}
```
But this was not allowed by the schema (only strings with `./` prefix was allowed).

This PR fixes that.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
