### PR TITLE
Update lefthook schema URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3207,7 +3207,7 @@
       "fileMatch": [
         "{.lefthook,lefthook,lefthook-local,.lefthook-local}.{yml,yaml,toml,json}"
       ],
-      "url": "https://json.schemastore.org/lefthook.json"
+      "url": "https://raw.githubusercontent.com/evilmartians/lefthook/master/schema.json"
     },
     {
       "name": "lego.json",


### PR DESCRIPTION
Closes https://github.com/SchemaStore/schemastore/issues/4311

**:broom: Summary**

Set URL for lefthook schema to repo's [schema.json](https://github.com/evilmartians/lefthook/blob/master/schema.json) to avoid issues with maintaining the actual schema.