### PR TITLE
Remove JSON-WF format

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7027,12 +7027,6 @@
       "url": "https://raw.githubusercontent.com/kaitai-io/ksy_schema/master/ksy_schema.json"
     },
     {
-      "name": "JSON-WF",
-      "description": "A blogroll interchange format",
-      "fileMatch": [],
-      "url": "https://www.json-wf.org.uk/json-wf-schema-1.0.json"
-    },
-    {
       "name": "Cloud Foundry Application Manifest",
       "description": "A manifest describes a Cloud Foundry application and can be used to deploy it to a Foundation",
       "fileMatch": [],


### PR DESCRIPTION
Removes the JSON-WF format since it was never used in the wild and has now been deprecated.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
