### PR TITLE
fix: support Poetry's 2's support of project section

### DIFF
--- a/src/negative_test/pyproject/poetry-invalid-package.toml
+++ b/src/negative_test/pyproject/poetry-invalid-package.toml
@@ -1,3 +1,0 @@
-#:schema ../../schemas/json/pyproject.json
-[tool.poetry.dependencies]
-python = "~3.12"

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -707,29 +707,5 @@
         }
       }
     }
-  },
-  "if": {
-    "properties": {
-      "package-mode": {
-        "const": true
-      }
-    }
-  },
-  "then": {
-    "required": ["name", "version", "description", "authors"],
-    "properties": {
-      "name": {
-        "$ref": "#/definitions/poetry-name"
-      },
-      "version": {
-        "$ref": "#/definitions/poetry-version"
-      },
-      "description": {
-        "$ref": "#/definitions/poetry-description"
-      },
-      "authors": {
-        "$ref": "#/definitions/poetry-authors"
-      }
-    }
   }
 }


### PR DESCRIPTION
This is a possible fix for https://github.com/SchemaStore/schemastore/issues/4338. Poetry now (2.0) supports the `[project]` table instead of only its own configuration. This makes the requirement here much more complex, as `project.name` OR `tool.poetry.name` can be set. Fixing by removing the requirement here.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
