### PR TITLE
Update fly schema to include missing release_command_vm property

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -741,6 +741,44 @@
           "description": "Command to run after a build, with access to the production environment, but before deployment. Non-zero exit status will abort the deployment.\n\n```toml\n[deploy]\n  release_command =\"bundle exec rails db:migrate\"\n```",
           "type": "string"
         },
+        "release_command_vm": {
+          "description": "VM configuration to use when running the release command.",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "string",
+              "enum": [
+                "shared-cpu-1x",
+                "shared-cpu-2x",
+                "shared-cpu-4x",
+                "shared-cpu-8x",
+                "performance-1x",
+                "performance-2x",
+                "performance-4x",
+                "performance-8x",
+                "performance-16x"
+              ]
+            },
+            "memory": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "cpus": {
+              "type": "integer",
+              "enum": [1, 2, 4, 8, 16]
+            },
+            "cpu_kind": {
+              "type": "string",
+              "enum": ["shared", "performance"]
+            }
+          }
+        },
         "max_unavailable": {
           "description": "For rolling deploys, you can use max_unavailable to control how many Machines can be down at a time.",
           "type": "number"


### PR DESCRIPTION
PR updates the fly.json to include the `release_command_vm` property, as specified here: https://fly.io/docs/reference/configuration/#the-deploy-section