### PR TITLE
Fix include propoerty: includes -> include

### DIFF
--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -48,7 +48,7 @@
     "BitriseDataModel": {
       "anyOf": [
         { "required": ["format_version"] },
-        { "required": ["includes"] }
+        { "required": ["include"] }
       ],
       "properties": {
         "format_version": {
@@ -134,7 +134,7 @@
           },
           "type": "object"
         },
-        "includes": {
+        "include": {
           "items": {
             "$ref": "#/definitions/IncludeItemModel"
           },


### PR DESCRIPTION
This PR fixes bitrise.yml schema's `include` property. 
Instead of the current `includes` keyword it should be `include` ([related Bitrise DevCenter article](https://devcenter.bitrise.io/en/builds/configuration-yaml/modular-yaml-configuration.html#including-configuration-from-multiple-yaml-files)).