### PR TITLE
WebExtension Manifest Version 3

### DIFF
--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -1113,7 +1113,8 @@
     "browser_style": {
       "deprecated": true,
       "description": "Do not set browser_style to true: its not support in Manifest V3 from Firefox 118. See Manifest V3 migration for browser_style.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration",
-      "const": false
+      "type": "boolean",
+      "default": false
     },
     "color": {
       "oneOf": [

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -1075,12 +1075,7 @@
       "properties": {
         "default_area": {
           "description": "Defines the part of the browser in which the button is initially placed.\n\nThis property is only supported in Firefox.",
-          "enum": [
-            "navbar",
-            "menupanel",
-            "tabstrip",
-            "personaltoolbar"
-          ],
+          "enum": ["navbar", "menupanel", "tabstrip", "personaltoolbar"],
           "default": "menupanel"
         },
         "theme_icons": {
@@ -1090,11 +1085,7 @@
             "title": "theme icon",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "dark",
-              "light",
-              "size"
-            ],
+            "required": ["dark", "light", "size"],
             "properties": {
               "dark": {
                 "description": "A URL pointing to an icon. This icon displays when a theme using dark text is active (such as the Firefox Light theme, and the Default theme if no default_icon is specified).\n\nIcons are specified as URLs relative to the manifest.json file.",
@@ -1109,10 +1100,7 @@
               "size": {
                 "description": "The size of the two icons in pixels.",
                 "type": "integer",
-                "enum": [
-                  16,
-                  32
-                ]
+                "enum": [16, 32]
               }
             }
           }

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -18,6 +18,15 @@
       "browser_action": {
         "$ref": "#/definitions/action",
         "description": "A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key is replaced by action in Manifest V3 extensions.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button.\n\nYou can also create and manipulate browser actions programmatically using the browserAction API.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action"
+      },
+      "options_ui": {
+        "properties": {
+          "browser_style": {
+            "description": "Use this to include a stylesheet in your page that will make it look consistent with the browser's UI and with other add-ons that use the browser_style property.",
+            "type": "boolean",
+            "default": true
+          }
+        }
       }
     },
     "definitions": {
@@ -27,15 +36,6 @@
             "description": "Your extension can include user interface elements - browser and page action popups, sidebars, and options pages - that are specified by:\n1. creating an HTML file defining the structure of the UI element.\n2. adding a manifest.json key (action, browser_action, page_action, sidebar_action, or options_ui) pointing to that HTML file.\n\nYou can style these elements to match the browser's style. The manifest.json keys include an optional property to help with this: browser_style. If this is included and set to true, your document gets one or more extra stylesheets that help make it look consistent with the browser's UI and with other extensions that use the browser_style property.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles",
             "type": "boolean",
             "default": false
-          }
-        }
-      },
-      "options_ui": {
-        "properties": {
-          "browser_style": {
-            "default": true,
-            "type": "boolean",
-            "description": "Use this to include a stylesheet in your page that will make it look consistent with the browser's UI and with other add-ons that use the browser_style property."
           }
         }
       },

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -63,6 +63,11 @@
           }
         }
       }
+    },
+    "definitions": {
+      "browser_style": {
+        "const": false
+      }
     }
   },
   "properties": {
@@ -1115,9 +1120,7 @@
     },
     "browser_style": {
       "deprecated": true,
-      "description": "Do not set browser_style to true: its not support in Manifest V3 from Firefox 118. See Manifest V3 migration for browser_style.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration",
-      "type": "boolean",
-      "default": false
+      "description": "Do not set browser_style to true: its not support in Manifest V3 from Firefox 118. See Manifest V3 migration for browser_style.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration"
     },
     "color": {
       "oneOf": [

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -487,7 +487,7 @@
     "manifest_version": {
       "description": "This key specifies the version of manifest.json used by this extension.<br><br>https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version",
       "type": "integer",
-      "enum": [2]
+      "enum": [2, 3]
     },
     "name": {
       "description": "Name of the extension. This is used to identify the extension in the browser's user interface and on sites like addons.mozilla.org.<br>It's good practice to keep the name short enough to display in the UI. Also, the length of the name of a published extension may be limited.<br>These restrictions do not apply to self-hosted extensions or extensions distributed outside the stores.<br>This is a localizable property.<br><br>https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name",

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -770,6 +770,9 @@
           "description": "Determines whether the sidebar should open on install. The default behavior is to open the sidebar when installation is completed.",
           "type": "boolean",
           "default": true
+        },
+        "browser_style": {
+          "$ref": "#/definitions/browser_style"
         }
       }
     },

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -6,6 +6,17 @@
   "required": ["manifest_version", "name", "version"],
   "type": "object",
   "additionalProperties": true,
+  "if": {
+    "properties": {
+      "manifest_version": {
+        "const": 2
+      }
+    }
+  },
+  "then": {
+  },
+  "else": {
+  },
   "properties": {
     "author": {
       "description": "The extension's author, intended for display in the browser's user interface. If the developer key is supplied and it contains the \"name`\" property, it will override the author key. There's no way to specify multiple authors.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author",

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -64,8 +64,11 @@
         }
       },
       "host_permissions": {
-        "$ref": "#/definitions/match_pattern",
-        "description": "Use the host_permissions key to request access for the APIs in your extension that read or modify host data, such as cookies, webRequest, and tabs. This key is an array of strings, and each string is a request for a permission. Users can grant or revoke host permissions on an ad hoc basis. Therefore., most browsers treat host_permissions as optional.\n\nThe extra privileges include:\nXMLHttpRequest and fetch access to those origins without cross-origin restrictions (though not for requests from content scripts, as was the case in Manifest V2).\nthe ability to read tab-specific metadata without the \"tabs\" permission, such as the url, title, and favIconUrl properties of tabs.Tab objects.\nthe ability to inject scripts programmatically (using tabs.executeScript()) into pages served from those origins.\nthe ability to receive events from the webRequest API for these hosts.\nthe ability to access cookies for that host using the cookies API, as long as the \"cookies\" API permission is also included.\nbypassing tracking protection for extension pages where a host is specified as a full domain or with wildcards.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions"
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/match_pattern",
+          "description": "Use the host_permissions key to request access for the APIs in your extension that read or modify host data, such as cookies, webRequest, and tabs. This key is an array of strings, and each string is a request for a permission. Users can grant or revoke host permissions on an ad hoc basis. Therefore., most browsers treat host_permissions as optional.\n\nThe extra privileges include:\nXMLHttpRequest and fetch access to those origins without cross-origin restrictions (though not for requests from content scripts, as was the case in Manifest V2).\nthe ability to read tab-specific metadata without the \"tabs\" permission, such as the url, title, and favIconUrl properties of tabs.Tab objects.\nthe ability to inject scripts programmatically (using tabs.executeScript()) into pages served from those origins.\nthe ability to receive events from the webRequest API for these hosts.\nthe ability to access cookies for that host using the cookies API, as long as the \"cookies\" API permission is also included.\nbypassing tracking protection for extension pages where a host is specified as a full domain or with wildcards.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions"
+        }
       }
     },
     "definitions": {

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -14,8 +14,38 @@
     }
   },
   "then": {
+    "properties": {
+      "browser_action": {
+        "$ref": "#/definitions/action",
+        "description": "A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key is replaced by action in Manifest V3 extensions.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button.\n\nYou can also create and manipulate browser actions programmatically using the browserAction API.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
+      }
+    },
+    "definitions": {
+      "common_action": {
+        "properties": {
+          "browser_style": {
+            "description": "Your extension can include user interface elements - browser and page action popups, sidebars, and options pages - that are specified by:\n1. creating an HTML file defining the structure of the UI element.\n2. adding a manifest.json key (action, browser_action, page_action, sidebar_action, or options_ui) pointing to that HTML file.\n\nYou can style these elements to match the browser's style. The manifest.json keys include an optional property to help with this: browser_style. If this is included and set to true, your document gets one or more extra stylesheets that help make it look consistent with the browser's UI and with other extensions that use the browser_style property.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    }
   },
   "else": {
+    "properties": {
+      "action": {
+        "$ref": "#/definitions/action",
+        "description": "An action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key replaces browser_action in Manifest V3 extensions.\n\nYou must specify this key to include a browser toolbar button in your extension. When specified, you can manipulate the button programmatically using the action API.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button."
+      },
+      "background": {
+        "properties": {
+          "persistent": {
+            "const": false
+          }
+        }
+      }
+    }
   },
   "properties": {
     "author": {
@@ -51,46 +81,6 @@
           "description": "Determines whether the scripts specified in \"scripts\" are loaded as ES modules.\n\n`classic` indicates the background scripts or service workers are not included as an ES Module.\n\nIf omitted, this property defaults to classic.",
           "type": "string",
           "enum": ["classic", "module"]
-        }
-      }
-    },
-    "browser_action": {
-      "$ref": "#/definitions/common_action",
-      "title": "extension button",
-      "description": "A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key is replaced by action in Manifest V3 extensions.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button.\n\nYou can also create and manipulate browser actions programmatically using the browserAction API.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
-      "type": "object",
-      "properties": {
-        "default_area": {
-          "description": "Defines the part of the browser in which the button is initially placed.\n\nThis property is only supported in Firefox.",
-          "enum": ["navbar", "menupanel", "tabstrip", "personaltoolbar"],
-          "default": "menupanel"
-        },
-        "theme_icons": {
-          "description": "This property enables you to specify different icons for themes depending on whether Firefox detects that the theme uses dark or light text.",
-          "type": "array",
-          "items": {
-            "title": "theme icon",
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["dark", "light", "size"],
-            "properties": {
-              "dark": {
-                "description": "A URL pointing to an icon. This icon displays when a theme using dark text is active (such as the Firefox Light theme, and the Default theme if no default_icon is specified).\n\nIcons are specified as URLs relative to the manifest.json file.",
-                "type": "string",
-                "format": "uri-reference"
-              },
-              "light": {
-                "description": "A URL pointing to an icon. This icon displays when a theme using light text is active (such as the Firefox Dark theme).\n\nIcons are specified as URLs relative to the manifest.json file.",
-                "type": "string",
-                "format": "uri-reference"
-              },
-              "size": {
-                "description": "The size of the two icons in pixels.",
-                "type": "integer",
-                "enum": [16, 32]
-              }
-            }
-          }
         }
       }
     },
@@ -1070,6 +1060,57 @@
     }
   },
   "definitions": {
+    "action": {
+      "$ref": "#/definitions/common_action",
+      "title": "extension button",
+      "type": "object",
+      "properties": {
+        "default_area": {
+          "description": "Defines the part of the browser in which the button is initially placed.\n\nThis property is only supported in Firefox.",
+          "enum": [
+            "navbar",
+            "menupanel",
+            "tabstrip",
+            "personaltoolbar"
+          ],
+          "default": "menupanel"
+        },
+        "theme_icons": {
+          "description": "This property enables you to specify different icons for themes depending on whether Firefox detects that the theme uses dark or light text.",
+          "type": "array",
+          "items": {
+            "title": "theme icon",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "dark",
+              "light",
+              "size"
+            ],
+            "properties": {
+              "dark": {
+                "description": "A URL pointing to an icon. This icon displays when a theme using dark text is active (such as the Firefox Light theme, and the Default theme if no default_icon is specified).\n\nIcons are specified as URLs relative to the manifest.json file.",
+                "type": "string",
+                "format": "uri-reference"
+              },
+              "light": {
+                "description": "A URL pointing to an icon. This icon displays when a theme using light text is active (such as the Firefox Dark theme).\n\nIcons are specified as URLs relative to the manifest.json file.",
+                "type": "string",
+                "format": "uri-reference"
+              },
+              "size": {
+                "description": "The size of the two icons in pixels.",
+                "type": "integer",
+                "enum": [
+                  16,
+                  32
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "color": {
       "oneOf": [
         {
@@ -1136,11 +1177,6 @@
     },
     "common_action": {
       "properties": {
-        "browser_style": {
-          "description": "Your extension can include user interface elements - browser and page action popups, sidebars, and options pages - that are specified by:\n1. creating an HTML file defining the structure of the UI element.\n2. adding a manifest.json key (action, browser_action, page_action, sidebar_action, or options_ui) pointing to that HTML file.\n\nYou can style these elements to match the browser's style. The manifest.json keys include an optional property to help with this: browser_style. If this is included and set to true, your document gets one or more extra stylesheets that help make it look consistent with the browser's UI and with other extensions that use the browser_style property.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles",
-          "type": "boolean",
-          "default": false
-        },
         "default_icon": {
           "$ref": "#/definitions/icon",
           "description": " Use this to specify one or more icons for the browser action. The icon is shown in the browser toolbar by default.\n\nIcons are specified as URLs relative to the manifest.json file itself.\n\nYou can specify a single icon file by supplying a string here\n\nTo specify multiple icons in different sizes, specify an object here. The name of each property is the icon's height in pixels, and must be convertible to an integer. The value is the URL."

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -578,6 +578,9 @@
           "type": "string",
           "format": "uri-reference"
         },
+        "browser_style": {
+          "$ref": "#/definitions/browser_style"
+        },
         "open_in_tab": {
           "default": false,
           "type": "boolean",
@@ -1107,6 +1110,11 @@
         }
       }
     },
+    "browser_style": {
+      "deprecated": true,
+      "description": "Do not set browser_style to true: its not support in Manifest V3 from Firefox 118. See Manifest V3 migration for browser_style.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration",
+      "const": false
+    },
     "color": {
       "oneOf": [
         {
@@ -1185,6 +1193,9 @@
         "default_title": {
           "description": "Tooltip for the button, displayed when the user moves their mouse over it. If the button is added to the browser's menu panel, this is also shown under the app icon.\n\nThis is a localizable property.",
           "type": "string"
+        },
+        "browser_style": {
+          "$ref": "#/definitions/browser_style"
         }
       }
     },

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -17,7 +17,7 @@
     "properties": {
       "browser_action": {
         "$ref": "#/definitions/action",
-        "description": "A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key is replaced by action in Manifest V3 extensions.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button.\n\nYou can also create and manipulate browser actions programmatically using the browserAction API.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
+        "description": "A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.\n\nThis key is replaced by action in Manifest V3 extensions.\n\nIf you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's background scripts when the user clicks the button.\n\nYou can also create and manipulate browser actions programmatically using the browserAction API.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action"
       }
     },
     "definitions": {

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -62,6 +62,10 @@
             "const": false
           }
         }
+      },
+      "host_permissions": {
+        "$ref": "#/definitions/match_pattern",
+        "description": "Use the host_permissions key to request access for the APIs in your extension that read or modify host data, such as cookies, webRequest, and tabs. This key is an array of strings, and each string is a request for a permission. Users can grant or revoke host permissions on an ad hoc basis. Therefore., most browsers treat host_permissions as optional.\n\nThe extra privileges include:\nXMLHttpRequest and fetch access to those origins without cross-origin restrictions (though not for requests from content scripts, as was the case in Manifest V2).\nthe ability to read tab-specific metadata without the \"tabs\" permission, such as the url, title, and favIconUrl properties of tabs.Tab objects.\nthe ability to inject scripts programmatically (using tabs.executeScript()) into pages served from those origins.\nthe ability to receive events from the webRequest API for these hosts.\nthe ability to access cookies for that host using the cookies API, as long as the \"cookies\" API permission is also included.\nbypassing tracking protection for extension pages where a host is specified as a full domain or with wildcards.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions"
       }
     },
     "definitions": {

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -29,6 +29,24 @@
             "default": false
           }
         }
+      },
+      "options_ui": {
+        "properties": {
+          "browser_style": {
+            "default": true,
+            "type": "boolean",
+            "description": "Use this to include a stylesheet in your page that will make it look consistent with the browser's UI and with other add-ons that use the browser_style property."
+          }
+        }
+      },
+      "sidebar_action": {
+        "properties": {
+          "browser_style": {
+            "description": "In Firefox, the stylesheet can be seen at chrome://browser/content/extension.css or chrome://browser/content/extension-mac.css on macOS.",
+            "type": "boolean",
+            "default": true
+          }
+        }
       }
     }
   },
@@ -560,11 +578,6 @@
           "type": "string",
           "format": "uri-reference"
         },
-        "browser_style": {
-          "default": true,
-          "type": "boolean",
-          "description": "Use this to include a stylesheet in your page that will make it look consistent with the browser's UI and with other add-ons that use the browser_style property."
-        },
         "open_in_tab": {
           "default": false,
           "type": "boolean",
@@ -739,11 +752,6 @@
       "additionalProperties": false,
       "required": ["default_panel"],
       "properties": {
-        "browser_style": {
-          "description": "In Firefox, the stylesheet can be seen at chrome://browser/content/extension.css or chrome://browser/content/extension-mac.css on macOS.",
-          "type": "boolean",
-          "default": true
-        },
         "default_icon": {
           "$ref": "#/definitions/icon"
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Add support for Manifest V3, while preserving Manifest V2 support as well, based on the `manifest_version` property

I'm somewhat new to both JSON Schemas and the WebExtension spec, so this might be incomplete. I followed the [V2 to V3 Migration guide](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide) and relied on the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).