### PR TITLE
Add `rustdoc` key to `workspace.lints` table

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -293,6 +293,13 @@
           "additionalProperties": {
             "$ref": "#/definitions/Lint"
           }
+        },
+        "rustdoc": {
+          "description": "Lint settings for [Rustdoc](https://doc.rust-lang.org/rustdoc/). See Rustdoc's [individual lints](https://doc.rust-lang.org/rustdoc/lints.html) (rustdoc does not have lint groups)",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Lint"
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
This is an undocumented, but valid key for the workspace lints table.

Resolves #4369
Related to #3399

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
