### PR TITLE
Add MrDocs schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3520,6 +3520,12 @@
       }
     },
     {
+      "name": "mrdocs.yml",
+      "description": "MrDocs configuration file",
+      "fileMatch": ["mrdocs.yml"],
+      "url": "https://raw.githubusercontent.com/cppalliance/mrdocs/refs/heads/master/docs/mrdocs.schema.json"
+    },
+    {
       "name": "MLOS Configs",
       "description": "Config files for the mlos_bench utility in MLOS",
       "fileMatch": ["*.mlos.jsonc", "*.mlos.json", "*.mlos.yaml", "*.mlos.yml"],


### PR DESCRIPTION
This PR adds a reference to the schema of MrDocs: (https://github.com/cppalliance/mrdocs / www.mrdocs.com)

These schemas are autogenerated on every release.