### PR TITLE
Add `goModules` to `cloudbuild.json`

### DIFF
--- a/src/schemas/json/cloudbuild.json
+++ b/src/schemas/json/cloudbuild.json
@@ -283,6 +283,13 @@
           "description": "A list of objects to be uploaded to Cloud Storage upon successful completion of all build steps. Files in the workspace matching specified paths globs will be uploaded to the specified Cloud Storage location using the builder service account's credentials. The location and generation of the uploaded objects will be stored in the Build resource's results field. If any objects fail to be pushed, the build is marked FAILURE.",
           "markdownDescription": "A list of objects to be uploaded to Cloud Storage upon successful completion of all build steps. Files in the workspace matching specified paths globs will be uploaded to the specified Cloud Storage location using the builder service account's credentials. The location and generation of the uploaded objects will be stored in the Build resource's results field. If any objects fail to be pushed, the build is marked `FAILURE`."
         },
+        "goModules": {
+          "description": "Allows you to upload non-container Go modules to Go repositories in Artifact Registry.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GoModules"
+          }
+        },
         "mavenArtifacts": {
           "description": "Allows you to upload non-container Java artifacts to Maven repositories in Artifact Registry.",
           "type": "array",
@@ -323,6 +330,45 @@
           }
         }
       }
+    },
+    "GoModules": {
+      "description": "Allows you to upload non-container Go modules to Go repositories in Artifact Registry.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repositoryName": {
+          "description": "The name of your Go repository in Artifact Registry.",
+          "type": "string"
+        },
+        "repositoryLocation": {
+          "description": "The location for your repository in Artifact Registry.",
+          "type": "string"
+        },
+        "repositoryProject_id": {
+          "description": "The ID of the Google Cloud project that contains your Artifact Registry Go repository.",
+          "type": "string"
+        },
+        "sourcePath": {
+          "description": "The path to the go.mod file in the build's workspace.",
+          "type": "string"
+        },
+        "modulePath": {
+          "description": "The local directory that contains the Go module to upload. It is recommended to use an absolute path for the value.",
+          "type": "string"
+        },
+        "moduleVersion": {
+          "description": "The version of the Go module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repositoryName",
+        "repositoryLocation",
+        "repositoryProject_id",
+        "sourcePath",
+        "modulePath",
+        "moduleVersion"
+      ]
     },
     "MavenArtifacts": {
       "description": "Allows you to upload non-container Java artifacts to Maven repositories in Artifact Registry.",


### PR DESCRIPTION
Closes #4379. It seems likely that this portion of the schema definition may change, as the [docs](https://cloud.google.com/build/docs/build-config-file-schema#gomodules) include a [link that results in a 404](https://cloud.google.com/build/docs/building/build-go-no-container) and there is a mix of camel and snake case in some of the keys:

```yaml
artifacts:
  goModules:
    repositoryName: 'quickstart-go-repo'
    repositoryLocation: 'us-central1'
    repositoryProject_id: 'argo-local-myname'
    sourcePath: '/workspace/myapp'
    modulePath: 'example.com/myapp'
    moduleVersion: 'v1.0.0'
```

I can update if these idiosyncrasies result in a change.