### PR TITLE
Add FlexGet config file to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2217,6 +2217,15 @@
       "url": "https://gitlab.cern.ch/steam/fiqus/-/raw/master/docs/schema.json"
     },
     {
+      "name": "FlexGet Config",
+      "description": "FlexGet config file",
+      "fileMatch": [
+        "**/.flexget/config.yml",
+        "**/flexget/config.yml"
+      ],
+      "url": "https://github.com/Flexget/Flexget/releases/latest/download/flexget-config.schema.json"
+    },
+    {
       "name": "first-timers-bot",
       "description": "A bot that helps onboarding new open-source contributors",
       "fileMatch": ["**/.github/first-timers.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2219,10 +2219,7 @@
     {
       "name": "FlexGet Config",
       "description": "FlexGet config file",
-      "fileMatch": [
-        "**/.flexget/config.yml",
-        "**/flexget/config.yml"
-      ],
+      "fileMatch": ["**/.flexget/config.yml", "**/flexget/config.yml"],
       "url": "https://github.com/Flexget/Flexget/releases/latest/download/flexget-config.schema.json"
     },
     {


### PR DESCRIPTION
Adds schema for the [FlexGet](https://flexget.com) config file. This schema gets automatically updated with every release.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
