### PR TITLE
updates to `bun.lock` schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -843,7 +843,7 @@
       "name": "bun.lock",
       "description": "bun.lock file",
       "fileMatch": ["bun.lock"],
-      "url": "https://json.schemastore.org/bun.lock.json"
+      "url": "https://json.schemastore.org/bun-lock.json"
     },
     {
       "name": "bundleconfig.json",

--- a/src/schemas/json/bun-lock.json
+++ b/src/schemas/json/bun-lock.json
@@ -4,7 +4,6 @@
   "title": "Bun.lock file",
   "description": "Schema definition for Bun's `bun.lock` file (package manager lockfile). See https://bun.sh/docs/install/lockfile",
   "type": "object",
-  "additionalProperties": true,
   "allowTrailingCommas": true,
   "properties": {
     "lockfileVersion": {

--- a/src/schemas/json/bun-lock.json
+++ b/src/schemas/json/bun-lock.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/bun.lock.json",
+  "$id": "https://json.schemastore.org/bun-lock.json",
   "title": "Bun.lock file",
   "description": "Schema definition for Bun's `bun.lock` file (package manager lockfile). See https://bun.sh/docs/install/lockfile",
   "type": "object",
@@ -9,8 +9,8 @@
   "properties": {
     "lockfileVersion": {
       "type": "integer",
-      "enum": [0],
-      "description": "Specifies the version of the lockfile format. Currently only 0."
+      "enum": [0, 1],
+      "description": "Specifies the version of the lockfile format. Currently only sypporting 0 or 1."
     },
     "workspaces": {
       "type": "object",
@@ -105,6 +105,26 @@
           "items": {
             "type": "string"
           }
+        },
+        "bin": {
+          "description": "Executable binaries provided by the package.",
+          "oneOf": [
+            {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "binDir": {
+          "type": "string",
+          "description": "Directory where the package's binaries are located."
         }
       }
     },
@@ -166,26 +186,6 @@
               ],
               "description": "Specifies CPU architectures supported by this package."
             },
-            "bin": {
-              "description": "Executable binaries provided by the package.",
-              "oneOf": [
-                {
-                  "type": "object",
-                  "patternProperties": {
-                    ".*": {
-                      "type": "string"
-                    }
-                  }
-                },
-                {
-                  "type": "string"
-                }
-              ]
-            },
-            "binDir": {
-              "type": "string",
-              "description": "Directory where the package's binaries are located."
-            },
             "bundled": {
               "type": "boolean",
               "enum": [true],
@@ -224,12 +224,12 @@
           "maxItems": 4
         },
         {
-          "description": "Represents a symlink, folder, tarball, or workspace package.",
+          "description": "Represents a symlink, folder, or tarball package.",
           "type": "array",
           "items": [
             {
               "type": "string",
-              "description": "Package name with a path or workspace prefix."
+              "description": "Package name with a path."
             },
             {
               "$ref": "#/definitions/BunLockFilePackageInfo",
@@ -238,6 +238,18 @@
           ],
           "minItems": 2,
           "maxItems": 2
+        },
+        {
+          "description": "Represents workspace package.",
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "description": "Package name with a workspace path."
+            }
+          ],
+          "minItems": 1,
+          "maxItems": 1
         },
         {
           "description": "Represents a git or GitHub package.",

--- a/src/test/bun-lock/bun.lock.json
+++ b/src/test/bun-lock/bun.lock.json
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 0,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "name": "schemastore.org",


### PR DESCRIPTION
@hyperupcall I think this should fix the path to be usable. Also updates it to support v1 schema which changes a very few minor things.