### PR TITLE
add Tugboat QA configuration schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7455,6 +7455,12 @@
       "description": "A configuration file for the test environment of the gematik Tiger test platform",
       "fileMatch": ["**/tiger.yml", "**/tiger.yaml"],
       "url": "https://json.schemastore.org/gematik-tiger.json"
+    },
+    {
+      "name": "Tugboat QA config.yml",
+      "description": "Configuration file for Tugboat QA",
+      "fileMatch": ["**/.tugboat/config.yml"],
+      "url": "https://raw.githubusercontent.com/TugboatQA/docs/refs/heads/main/static/config-schema.json"
     }
   ]
 }


### PR DESCRIPTION
This adds the JSON schema for [Tugboat QA](https://www.tugboatqa.com) `.tugboat/config.yml` files to the catalog. The schema is hosted publicly at https://docs.tugboatqa.com/config-schema.json which is maintained at https://github.com/TugboatQA/docs/blob/main/static/config-schema.json, so we opted for using raw GitHub link since it seems like that is what most other external schemas are doing. Let us know if that's not preferred. It didn't seem like the order of items in the catalog were sorted by any particular criteria so I just added ours at the end. Let me know if I missed something there. :)