### PR TITLE
Add mypy `install_types`and `non_interactive`

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -838,6 +838,18 @@
           }
         }
       }
+    },
+    "install_types": {
+      "description": "Install detected missing library stub packages using pip",
+      "x-intellij-html-description": "Install detected missing library stub packages using pip",
+      "default": false,
+      "type": "boolean"
+    },
+    "non_interactive": {
+      "description": "Install stubs without asking for confirmation and hide errors, with --install-types",
+      "x-intellij-html-description": "Install stubs without asking for confirmation and hide errors, with --install-types",
+      "default": false,
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
Support additional mypy options:
- `install_types`: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-install-types
- `non_interactive`: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-non-interactive