### PR TITLE
Update Vela schema location

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5443,7 +5443,7 @@
       "name": "Vela Pipeline Configuration",
       "description": "Vela Pipeline Configuration File",
       "fileMatch": [".vela.yml", ".vela.yaml"],
-      "url": "https://github.com/go-vela/types/releases/latest/download/schema.json"
+      "url": "https://github.com/go-vela/server/releases/latest/download/schema.json"
     },
     {
       "name": "venvironment.yaml",


### PR DESCRIPTION
The current repo (go-vela/types) has been deprecated and the schema is now generated in a different repo (go-vela/server).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
