### PR TITLE
feat: add speakeasy generation config json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4985,6 +4985,12 @@
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/workflow.schema.json"
     },
     {
+      "name": "Speakeasy Generation Config File",
+      "description": "Speakeasy generation configuration file. Read more at https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml",
+      "fileMatch": ["**/.speakeasy/gen.yaml"],
+      "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/gen.config.schema.json"
+    },
+    {
       "name": "SpecIF",
       "description": "The Specification Integration Facility (SpecIF) integrates partial system models from different methods and tools in a semantic net. Documentation: https://specif.de and https://github.com/GfSE",
       "fileMatch": ["*.specif", "*.specif.json"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Adds support for a variety of [Speakeasy](https://speakeasy.com/) generation [configuration files](https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml) to the catalog. The JSON schemas for these configuration files are hosted on GitHub.
