### PR TITLE
Update Databricks Asset Bundles schema to v0.239.1

### DIFF
--- a/src/schemas/json/databricks-asset-bundles.json
+++ b/src/schemas/json/databricks-asset-bundles.json
@@ -1,9 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/databricks-asset-bundles.json",
   "$defs": {
     "bool": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "boolean"
         },
@@ -30,7 +28,7 @@
       ]
     },
     "float64": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "number"
         },
@@ -61,42 +59,117 @@
         "cli": {
           "bundle": {
             "config": {
+              "resources.App": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "active_deployment": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeployment"
+                      },
+                      "app_status": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.ApplicationStatus"
+                      },
+                      "compute_status": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.ComputeStatus"
+                      },
+                      "config": {
+                        "$ref": "#/$defs/map/interface"
+                      },
+                      "create_time": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "creator": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "default_source_code_path": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "description": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "pending_deployment": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeployment"
+                      },
+                      "permissions": {
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                      },
+                      "resources": {
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/apps.AppResource"
+                      },
+                      "service_principal_client_id": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "service_principal_id": {
+                        "$ref": "#/$defs/int64"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "source_code_path": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "update_time": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "updater": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "url": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "source_code_path",
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
               "resources.Cluster": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "apply_policy_default_values": {
-                        "$ref": "#/$defs/bool",
-                        "description": "When set to true, fixed and default values from the policy will be used for fields that are omitted. When set to false, only fixed values from the policy will be applied."
+                        "description": "When set to true, fixed and default values from the policy will be used for fields that are omitted. When set to false, only fixed values from the policy will be applied.",
+                        "$ref": "#/$defs/bool"
                       },
                       "autoscale": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AutoScale",
-                        "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later."
+                        "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AutoScale"
                       },
                       "autotermination_minutes": {
-                        "$ref": "#/$defs/int",
-                        "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                        "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination.",
+                        "$ref": "#/$defs/int"
                       },
                       "aws_attributes": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes",
-                        "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used."
+                        "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes"
                       },
                       "azure_attributes": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes",
-                        "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used."
+                        "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes"
                       },
                       "cluster_log_conf": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf",
-                        "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`."
+                        "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf"
                       },
                       "cluster_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                        "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "custom_tags": {
-                        "$ref": "#/$defs/map/string",
-                        "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags"
+                        "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                        "$ref": "#/$defs/map/string"
                       },
                       "data_security_mode": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DataSecurityMode"
@@ -105,70 +178,81 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DockerImage"
                       },
                       "driver_instance_pool_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                        "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned.",
+                        "$ref": "#/$defs/string"
                       },
                       "driver_node_type_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                        "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "enable_elastic_disk": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                        "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details.",
+                        "$ref": "#/$defs/bool"
                       },
                       "enable_local_disk_encryption": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether to enable LUKS on cluster VMs' local disks"
+                        "description": "Whether to enable LUKS on cluster VMs' local disks",
+                        "$ref": "#/$defs/bool"
                       },
                       "gcp_attributes": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes",
-                        "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used."
+                        "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes"
                       },
                       "init_scripts": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo",
-                        "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`."
+                        "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo"
                       },
                       "instance_pool_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "The optional ID of the instance pool to which the cluster belongs."
+                        "description": "The optional ID of the instance pool to which the cluster belongs.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "is_single_node": {
+                        "description": "This field can only be used with `kind`.\n\nWhen set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`\n",
+                        "$ref": "#/$defs/bool"
+                      },
+                      "kind": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Kind"
                       },
                       "node_type_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                        "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "num_workers": {
-                        "$ref": "#/$defs/int",
-                        "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                        "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned.",
+                        "$ref": "#/$defs/int"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "policy_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "The ID of the cluster policy used to create the cluster if applicable."
+                        "description": "The ID of the cluster policy used to create the cluster if applicable.",
+                        "$ref": "#/$defs/string"
                       },
                       "runtime_engine": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.RuntimeEngine"
                       },
                       "single_user_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                        "description": "Single user name if data_security_mode is `SINGLE_USER`",
+                        "$ref": "#/$defs/string"
                       },
                       "spark_conf": {
-                        "$ref": "#/$defs/map/string",
-                        "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n"
+                        "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                        "$ref": "#/$defs/map/string"
                       },
                       "spark_env_vars": {
-                        "$ref": "#/$defs/map/string",
-                        "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`"
+                        "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                        "$ref": "#/$defs/map/string"
                       },
                       "spark_version": {
-                        "$ref": "#/$defs/string",
-                        "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                        "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "ssh_public_keys": {
-                        "$ref": "#/$defs/slice/string",
-                        "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified."
+                        "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                        "$ref": "#/$defs/slice/string"
+                      },
+                      "use_ml_runtime": {
+                        "description": "This field can only be used with `kind`.\n\n`effective_spark_version` is determined by `spark_version` (DBR release), this field `use_ml_runtime`, and whether `node_type_id` is gpu node or not.\n",
+                        "$ref": "#/$defs/bool"
                       },
                       "workload_type": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.WorkloadType"
@@ -182,20 +266,88 @@
                   }
                 ]
               },
+              "resources.Dashboard": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "create_time": {
+                        "description": "The timestamp of when the dashboard was created.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "dashboard_id": {
+                        "description": "UUID identifying the dashboard.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "display_name": {
+                        "description": "The display name of the dashboard.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "embed_credentials": {
+                        "$ref": "#/$defs/bool"
+                      },
+                      "etag": {
+                        "description": "The etag for the dashboard. Can be optionally provided on updates to ensure that the dashboard\nhas not been modified since the last read.\nThis field is excluded in List Dashboards responses.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "file_path": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "lifecycle_state": {
+                        "description": "The state of the dashboard resource. Used for tracking trashed status.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/dashboards.LifecycleState"
+                      },
+                      "parent_path": {
+                        "description": "The workspace path of the folder containing the dashboard. Includes leading slash and no\ntrailing slash.\nThis field is excluded in List Dashboards responses.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "path": {
+                        "description": "The workspace path of the dashboard asset, including the file name.\nExported dashboards always have the file extension `.lvdash.json`.\nThis field is excluded in List Dashboards responses.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "permissions": {
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                      },
+                      "serialized_dashboard": {
+                        "description": "The contents of the dashboard in serialized string form.\nThis field is excluded in List Dashboards responses.\nUse the [get dashboard API](https://docs.databricks.com/api/workspace/lakeview/get)\nto retrieve an example response, which includes the `serialized_dashboard` field.\nThis field provides the structure of the JSON string that represents the dashboard's\nlayout and components.",
+                        "$ref": "#/$defs/interface"
+                      },
+                      "update_time": {
+                        "description": "The timestamp of when the dashboard was last updated by the user.\nThis field is excluded in List Dashboards responses.",
+                        "$ref": "#/$defs/string"
+                      },
+                      "warehouse_id": {
+                        "description": "The warehouse ID used to run the dashboard.",
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
               "resources.Grant": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "principal": {
+                        "description": "The name of the principal that will be granted privileges",
                         "$ref": "#/$defs/string"
                       },
                       "privileges": {
+                        "description": "The privileges to grant to the specified entity",
                         "$ref": "#/$defs/slice/string"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["privileges", "principal"]
+                    "required": [
+                      "privileges",
+                      "principal"
+                    ]
                   },
                   {
                     "type": "string",
@@ -204,86 +356,90 @@
                 ]
               },
               "resources.Job": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
+                      "budget_policy_id": {
+                        "description": "The id of the user specified budget policy to use for this job.\nIf not specified, a default budget policy may be applied when creating or modifying the job.\nSee `effective_budget_policy_id` for the budget policy used by this workload.",
+                        "$ref": "#/$defs/string"
+                      },
                       "continuous": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Continuous",
-                        "description": "An optional continuous property for this job. The continuous property will ensure that there is always one run executing. Only one of `schedule` and `continuous` can be used."
+                        "description": "An optional continuous property for this job. The continuous property will ensure that there is always one run executing. Only one of `schedule` and `continuous` can be used.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Continuous"
                       },
                       "description": {
-                        "$ref": "#/$defs/string",
-                        "description": "An optional description for the job. The maximum length is 27700 characters in UTF-8 encoding."
+                        "description": "An optional description for the job. The maximum length is 27700 characters in UTF-8 encoding.",
+                        "$ref": "#/$defs/string"
                       },
                       "email_notifications": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobEmailNotifications",
-                        "description": "An optional set of email addresses that is notified when runs of this job begin or complete as well as when this job is deleted."
+                        "description": "An optional set of email addresses that is notified when runs of this job begin or complete as well as when this job is deleted.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobEmailNotifications"
                       },
                       "environments": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobEnvironment",
-                        "description": "A list of task execution environment specifications that can be referenced by serverless tasks of this job.\nAn environment is required to be present for serverless tasks.\nFor serverless notebook tasks, the environment is accessible in the notebook environment panel.\nFor other serverless tasks, the task environment is required to be specified using environment_key in the task settings."
+                        "description": "A list of task execution environment specifications that can be referenced by serverless tasks of this job.\nAn environment is required to be present for serverless tasks.\nFor serverless notebook tasks, the environment is accessible in the notebook environment panel.\nFor other serverless tasks, the task environment is required to be specified using environment_key in the task settings.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobEnvironment"
                       },
                       "git_source": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.GitSource",
-                        "description": "An optional specification for a remote Git repository containing the source code used by tasks. Version-controlled source code is supported by notebook, dbt, Python script, and SQL File tasks.\n\nIf `git_source` is set, these tasks retrieve the file from the remote repository by default. However, this behavior can be overridden by setting `source` to `WORKSPACE` on the task.\n\nNote: dbt and SQL File tasks support only version-controlled sources. If dbt or SQL File tasks are used, `git_source` must be defined on the job."
+                        "description": "An optional specification for a remote Git repository containing the source code used by tasks. Version-controlled source code is supported by notebook, dbt, Python script, and SQL File tasks.\n\nIf `git_source` is set, these tasks retrieve the file from the remote repository by default. However, this behavior can be overridden by setting `source` to `WORKSPACE` on the task.\n\nNote: dbt and SQL File tasks support only version-controlled sources. If dbt or SQL File tasks are used, `git_source` must be defined on the job.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.GitSource"
                       },
                       "health": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobsHealthRules"
                       },
                       "job_clusters": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobCluster",
-                        "description": "A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings."
+                        "description": "A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.\nIf more than 100 job clusters are available, you can paginate through them using :method:jobs/get.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobCluster"
                       },
                       "max_concurrent_runs": {
-                        "$ref": "#/$defs/int",
-                        "description": "An optional maximum allowed number of concurrent runs of the job.\nSet this value if you want to be able to execute multiple runs of the same job concurrently.\nThis is useful for example if you trigger your job on a frequent schedule and want to allow consecutive runs to overlap with each other, or if you want to trigger multiple runs which differ by their input parameters.\nThis setting affects only new runs. For example, suppose the job’s concurrency is 4 and there are 4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs.\nHowever, from then on, new runs are skipped unless there are fewer than 3 active runs.\nThis value cannot exceed 1000. Setting this value to `0` causes all new runs to be skipped."
+                        "description": "An optional maximum allowed number of concurrent runs of the job.\nSet this value if you want to be able to execute multiple runs of the same job concurrently.\nThis is useful for example if you trigger your job on a frequent schedule and want to allow consecutive runs to overlap with each other, or if you want to trigger multiple runs which differ by their input parameters.\nThis setting affects only new runs. For example, suppose the job’s concurrency is 4 and there are 4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs.\nHowever, from then on, new runs are skipped unless there are fewer than 3 active runs.\nThis value cannot exceed 1000. Setting this value to `0` causes all new runs to be skipped.",
+                        "$ref": "#/$defs/int"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding."
+                        "description": "An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding.",
+                        "$ref": "#/$defs/string"
                       },
                       "notification_settings": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobNotificationSettings",
-                        "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this job."
+                        "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this job.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobNotificationSettings"
                       },
                       "parameters": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobParameterDefinition",
-                        "description": "Job-level parameter definitions"
+                        "description": "Job-level parameter definitions",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobParameterDefinition"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "queue": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.QueueSettings",
-                        "description": "The queue settings of the job."
+                        "description": "The queue settings of the job.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.QueueSettings"
                       },
                       "run_as": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobRunAs"
                       },
                       "schedule": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.CronSchedule",
-                        "description": "An optional periodic schedule for this job. The default behavior is that the job only runs when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`."
+                        "description": "An optional periodic schedule for this job. The default behavior is that the job only runs when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.CronSchedule"
                       },
                       "tags": {
-                        "$ref": "#/$defs/map/string",
-                        "description": "A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added to the job."
+                        "description": "A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added to the job.",
+                        "$ref": "#/$defs/map/string"
                       },
                       "tasks": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Task",
-                        "description": "A list of task specifications to be executed by this job."
+                        "description": "A list of task specifications to be executed by this job.\nIf more than 100 tasks are available, you can paginate through them using :method:jobs/get. Use the `next_page_token` field at the object root to determine if more results are available.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Task"
                       },
                       "timeout_seconds": {
-                        "$ref": "#/$defs/int",
-                        "description": "An optional timeout applied to each run of this job. A value of `0` means no timeout."
+                        "description": "An optional timeout applied to each run of this job. A value of `0` means no timeout.",
+                        "$ref": "#/$defs/int"
                       },
                       "trigger": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TriggerSettings",
-                        "description": "A configuration to trigger a run when certain conditions are met. The default behavior is that the job runs only when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`."
+                        "description": "A configuration to trigger a run when certain conditions are met. The default behavior is that the job runs only when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TriggerSettings"
                       },
                       "webhook_notifications": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.WebhookNotifications",
-                        "description": "A collection of system notification IDs to notify when runs of this job begin or complete."
+                        "description": "A collection of system notification IDs to notify when runs of this job begin or complete.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.WebhookNotifications"
                       }
                     },
                     "additionalProperties": false
@@ -295,40 +451,40 @@
                 ]
               },
               "resources.MlflowExperiment": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "artifact_location": {
-                        "$ref": "#/$defs/string",
-                        "description": "Location where artifacts for the experiment are stored."
+                        "description": "Location where artifacts for the experiment are stored.",
+                        "$ref": "#/$defs/string"
                       },
                       "creation_time": {
-                        "$ref": "#/$defs/int64",
-                        "description": "Creation time"
+                        "description": "Creation time",
+                        "$ref": "#/$defs/int64"
                       },
                       "experiment_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "Unique identifier for the experiment."
+                        "description": "Unique identifier for the experiment.",
+                        "$ref": "#/$defs/string"
                       },
                       "last_update_time": {
-                        "$ref": "#/$defs/int64",
-                        "description": "Last update time"
+                        "description": "Last update time",
+                        "$ref": "#/$defs/int64"
                       },
                       "lifecycle_stage": {
-                        "$ref": "#/$defs/string",
-                        "description": "Current life cycle stage of the experiment: \"active\" or \"deleted\".\nDeleted experiments are not returned by APIs."
+                        "description": "Current life cycle stage of the experiment: \"active\" or \"deleted\".\nDeleted experiments are not returned by APIs.",
+                        "$ref": "#/$defs/string"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Human readable name that identifies the experiment."
+                        "description": "Human readable name that identifies the experiment.",
+                        "$ref": "#/$defs/string"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "tags": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ExperimentTag",
-                        "description": "Tags: Additional metadata key-value pairs."
+                        "description": "Tags: Additional metadata key-value pairs.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ExperimentTag"
                       }
                     },
                     "additionalProperties": false
@@ -340,40 +496,40 @@
                 ]
               },
               "resources.MlflowModel": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "creation_timestamp": {
-                        "$ref": "#/$defs/int64",
-                        "description": "Timestamp recorded when this `registered_model` was created."
+                        "description": "Timestamp recorded when this `registered_model` was created.",
+                        "$ref": "#/$defs/int64"
                       },
                       "description": {
-                        "$ref": "#/$defs/string",
-                        "description": "Description of this `registered_model`."
+                        "description": "Description of this `registered_model`.",
+                        "$ref": "#/$defs/string"
                       },
                       "last_updated_timestamp": {
-                        "$ref": "#/$defs/int64",
-                        "description": "Timestamp recorded when metadata for this `registered_model` was last updated."
+                        "description": "Timestamp recorded when metadata for this `registered_model` was last updated.",
+                        "$ref": "#/$defs/int64"
                       },
                       "latest_versions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelVersion",
-                        "description": "Collection of latest model versions for each stage.\nOnly contains models with current `READY` status."
+                        "description": "Collection of latest model versions for each stage.\nOnly contains models with current `READY` status.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelVersion"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Unique name for the model."
+                        "description": "Unique name for the model.",
+                        "$ref": "#/$defs/string"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "tags": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelTag",
-                        "description": "Tags: Additional metadata key-value pairs for this `registered_model`."
+                        "description": "Tags: Additional metadata key-value pairs for this `registered_model`.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelTag"
                       },
                       "user_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "User that created this `registered_model`"
+                        "description": "User that created this `registered_model`",
+                        "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false
@@ -385,40 +541,43 @@
                 ]
               },
               "resources.ModelServingEndpoint": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "ai_gateway": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayConfig",
-                        "description": "The AI Gateway configuration for the serving endpoint. NOTE: only external model endpoints are supported as of now."
+                        "description": "The AI Gateway configuration for the serving endpoint. NOTE: only external model endpoints are supported as of now.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayConfig"
                       },
                       "config": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.EndpointCoreConfigInput",
-                        "description": "The core config of the serving endpoint."
+                        "description": "The core config of the serving endpoint.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.EndpointCoreConfigInput"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "The name of the serving endpoint. This field is required and must be unique across a Databricks workspace.\nAn endpoint name can consist of alphanumeric characters, dashes, and underscores.\n"
+                        "description": "The name of the serving endpoint. This field is required and must be unique across a Databricks workspace.\nAn endpoint name can consist of alphanumeric characters, dashes, and underscores.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "rate_limits": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.RateLimit",
-                        "description": "Rate limits to be applied to the serving endpoint. NOTE: this field is deprecated, please use AI Gateway to manage rate limits."
+                        "description": "Rate limits to be applied to the serving endpoint. NOTE: this field is deprecated, please use AI Gateway to manage rate limits.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.RateLimit"
                       },
                       "route_optimized": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Enable route optimization for the serving endpoint."
+                        "description": "Enable route optimization for the serving endpoint.",
+                        "$ref": "#/$defs/bool"
                       },
                       "tags": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.EndpointTag",
-                        "description": "Tags to be attached to the serving endpoint and automatically propagated to billing logs."
+                        "description": "Tags to be attached to the serving endpoint and automatically propagated to billing logs.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.EndpointTag"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["config", "name"]
+                    "required": [
+                      "config",
+                      "name"
+                    ]
                   },
                   {
                     "type": "string",
@@ -427,25 +586,31 @@
                 ]
               },
               "resources.Permission": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/string"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["level"]
+                    "required": [
+                      "level"
+                    ]
                   },
                   {
                     "type": "string",
@@ -454,100 +619,104 @@
                 ]
               },
               "resources.Pipeline": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "budget_policy_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "Budget policy of this pipeline."
+                        "description": "Budget policy of this pipeline.",
+                        "$ref": "#/$defs/string"
                       },
                       "catalog": {
-                        "$ref": "#/$defs/string",
-                        "description": "A catalog in Unity Catalog to publish data from this pipeline to. If `target` is specified, tables in this pipeline are published to a `target` schema inside `catalog` (for example, `catalog`.`target`.`table`). If `target` is not specified, no data is published to Unity Catalog."
+                        "description": "A catalog in Unity Catalog to publish data from this pipeline to. If `target` is specified, tables in this pipeline are published to a `target` schema inside `catalog` (for example, `catalog`.`target`.`table`). If `target` is not specified, no data is published to Unity Catalog.",
+                        "$ref": "#/$defs/string"
                       },
                       "channel": {
-                        "$ref": "#/$defs/string",
-                        "description": "DLT Release Channel that specifies which version to use."
+                        "description": "DLT Release Channel that specifies which version to use.",
+                        "$ref": "#/$defs/string"
                       },
                       "clusters": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineCluster",
-                        "description": "Cluster settings for this pipeline deployment."
+                        "description": "Cluster settings for this pipeline deployment.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineCluster"
                       },
                       "configuration": {
-                        "$ref": "#/$defs/map/string",
-                        "description": "String-String configuration for this pipeline execution."
+                        "description": "String-String configuration for this pipeline execution.",
+                        "$ref": "#/$defs/map/string"
                       },
                       "continuous": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether the pipeline is continuous or triggered. This replaces `trigger`."
+                        "description": "Whether the pipeline is continuous or triggered. This replaces `trigger`.",
+                        "$ref": "#/$defs/bool"
                       },
                       "deployment": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineDeployment",
-                        "description": "Deployment type of this pipeline."
+                        "description": "Deployment type of this pipeline.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineDeployment"
                       },
                       "development": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether the pipeline is in Development mode. Defaults to false."
+                        "description": "Whether the pipeline is in Development mode. Defaults to false.",
+                        "$ref": "#/$defs/bool"
                       },
                       "edition": {
-                        "$ref": "#/$defs/string",
-                        "description": "Pipeline product edition."
+                        "description": "Pipeline product edition.",
+                        "$ref": "#/$defs/string"
                       },
                       "filters": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.Filters",
-                        "description": "Filters on which Pipeline packages to include in the deployed graph."
+                        "description": "Filters on which Pipeline packages to include in the deployed graph.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.Filters"
                       },
                       "gateway_definition": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionGatewayPipelineDefinition",
-                        "description": "The definition of a gateway pipeline to support CDC."
+                        "description": "The definition of a gateway pipeline to support change data capture.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionGatewayPipelineDefinition"
                       },
                       "id": {
-                        "$ref": "#/$defs/string",
-                        "description": "Unique identifier for this pipeline."
+                        "description": "Unique identifier for this pipeline.",
+                        "$ref": "#/$defs/string"
                       },
                       "ingestion_definition": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionPipelineDefinition",
-                        "description": "The configuration for a managed ingestion pipeline. These settings cannot be used with the 'libraries', 'target' or 'catalog' settings."
+                        "description": "The configuration for a managed ingestion pipeline. These settings cannot be used with the 'libraries', 'target' or 'catalog' settings.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionPipelineDefinition"
                       },
                       "libraries": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineLibrary",
-                        "description": "Libraries or code needed by this deployment."
+                        "description": "Libraries or code needed by this deployment.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineLibrary"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Friendly identifier for this pipeline."
+                        "description": "Friendly identifier for this pipeline.",
+                        "$ref": "#/$defs/string"
                       },
                       "notifications": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.Notifications",
-                        "description": "List of notification settings for this pipeline."
+                        "description": "List of notification settings for this pipeline.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.Notifications"
                       },
                       "permissions": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
                       },
                       "photon": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether Photon is enabled for this pipeline."
+                        "description": "Whether Photon is enabled for this pipeline.",
+                        "$ref": "#/$defs/bool"
+                      },
+                      "restart_window": {
+                        "description": "Restart window of this pipeline.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.RestartWindow"
                       },
                       "schema": {
-                        "$ref": "#/$defs/string",
-                        "description": "The default schema (database) where tables are read from or published to. The presence of this field implies that the pipeline is in direct publishing mode."
+                        "description": "The default schema (database) where tables are read from or published to. The presence of this field implies that the pipeline is in direct publishing mode.",
+                        "$ref": "#/$defs/string"
                       },
                       "serverless": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether serverless compute is enabled for this pipeline."
+                        "description": "Whether serverless compute is enabled for this pipeline.",
+                        "$ref": "#/$defs/bool"
                       },
                       "storage": {
-                        "$ref": "#/$defs/string",
-                        "description": "DBFS root directory for storing checkpoints and tables."
+                        "description": "DBFS root directory for storing checkpoints and tables.",
+                        "$ref": "#/$defs/string"
                       },
                       "target": {
-                        "$ref": "#/$defs/string",
-                        "description": "Target schema (database) to add tables in this pipeline to. If not specified, no data is published to the Hive metastore or Unity Catalog. To publish to Unity Catalog, also specify `catalog`."
+                        "description": "Target schema (database) to add tables in this pipeline to. If not specified, no data is published to the Hive metastore or Unity Catalog. To publish to Unity Catalog, also specify `catalog`.",
+                        "$ref": "#/$defs/string"
                       },
                       "trigger": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineTrigger",
-                        "description": "Which pipeline trigger to use. Deprecated: Use `continuous` instead."
+                        "description": "Which pipeline trigger to use. Deprecated: Use `continuous` instead.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineTrigger"
                       }
                     },
                     "additionalProperties": false
@@ -559,65 +728,72 @@
                 ]
               },
               "resources.QualityMonitor": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "assets_dir": {
-                        "$ref": "#/$defs/string",
-                        "description": "The directory to store monitoring assets (e.g. dashboard, metric tables)."
+                        "description": "The directory to store monitoring assets (e.g. dashboard, metric tables).",
+                        "$ref": "#/$defs/string"
                       },
                       "baseline_table_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Name of the baseline table from which drift metrics are computed from.\nColumns in the monitored table should also be present in the baseline table.\n"
+                        "description": "Name of the baseline table from which drift metrics are computed from.\nColumns in the monitored table should also be present in the baseline table.\n",
+                        "$ref": "#/$defs/string"
                       },
                       "custom_metrics": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.MonitorMetric",
-                        "description": "Custom metrics to compute on the monitored table. These can be aggregate metrics, derived\nmetrics (from already computed aggregate metrics), or drift metrics (comparing metrics across time\nwindows).\n"
+                        "description": "Custom metrics to compute on the monitored table. These can be aggregate metrics, derived\nmetrics (from already computed aggregate metrics), or drift metrics (comparing metrics across time\nwindows).\n",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.MonitorMetric"
                       },
                       "data_classification_config": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDataClassificationConfig",
-                        "description": "The data classification config for the monitor."
+                        "description": "The data classification config for the monitor.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDataClassificationConfig"
                       },
                       "inference_log": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorInferenceLog",
-                        "description": "Configuration for monitoring inference logs."
+                        "description": "Configuration for monitoring inference logs.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorInferenceLog"
                       },
                       "notifications": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorNotifications",
-                        "description": "The notification settings for the monitor."
+                        "description": "The notification settings for the monitor.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorNotifications"
                       },
                       "output_schema_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Schema where output metric tables are created."
+                        "description": "Schema where output metric tables are created.",
+                        "$ref": "#/$defs/string"
                       },
                       "schedule": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorCronSchedule",
-                        "description": "The schedule for automatically updating and refreshing metric tables."
+                        "description": "The schedule for automatically updating and refreshing metric tables.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorCronSchedule"
                       },
                       "skip_builtin_dashboard": {
-                        "$ref": "#/$defs/bool",
-                        "description": "Whether to skip creating a default dashboard summarizing data quality metrics."
+                        "description": "Whether to skip creating a default dashboard summarizing data quality metrics.",
+                        "$ref": "#/$defs/bool"
                       },
                       "slicing_exprs": {
-                        "$ref": "#/$defs/slice/string",
-                        "description": "List of column expressions to slice data with for targeted analysis. The data is grouped by\neach expression independently, resulting in a separate slice for each predicate and its\ncomplements. For high-cardinality columns, only the top 100 unique values by frequency will\ngenerate slices.\n"
+                        "description": "List of column expressions to slice data with for targeted analysis. The data is grouped by\neach expression independently, resulting in a separate slice for each predicate and its\ncomplements. For high-cardinality columns, only the top 100 unique values by frequency will\ngenerate slices.\n",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "snapshot": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorSnapshot",
-                        "description": "Configuration for monitoring snapshot tables."
+                        "description": "Configuration for monitoring snapshot tables.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorSnapshot"
+                      },
+                      "table_name": {
+                        "$ref": "#/$defs/string"
                       },
                       "time_series": {
-                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorTimeSeries",
-                        "description": "Configuration for monitoring time series tables."
+                        "description": "Configuration for monitoring time series tables.",
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorTimeSeries"
                       },
                       "warehouse_id": {
-                        "$ref": "#/$defs/string",
-                        "description": "Optional argument to specify the warehouse for dashboard creation. If not specified, the first running\nwarehouse will be used.\n"
+                        "description": "Optional argument to specify the warehouse for dashboard creation. If not specified, the first running\nwarehouse will be used.\n",
+                        "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["assets_dir", "output_schema_name"]
+                    "required": [
+                      "table_name",
+                      "assets_dir",
+                      "output_schema_name"
+                    ]
                   },
                   {
                     "type": "string",
@@ -626,36 +802,40 @@
                 ]
               },
               "resources.RegisteredModel": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "catalog_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "The name of the catalog where the schema and the registered model reside"
+                        "description": "The name of the catalog where the schema and the registered model reside",
+                        "$ref": "#/$defs/string"
                       },
                       "comment": {
-                        "$ref": "#/$defs/string",
-                        "description": "The comment attached to the registered model"
+                        "description": "The comment attached to the registered model",
+                        "$ref": "#/$defs/string"
                       },
                       "grants": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Grant"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "The name of the registered model"
+                        "description": "The name of the registered model",
+                        "$ref": "#/$defs/string"
                       },
                       "schema_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "The name of the schema where the registered model resides"
+                        "description": "The name of the schema where the registered model resides",
+                        "$ref": "#/$defs/string"
                       },
                       "storage_location": {
-                        "$ref": "#/$defs/string",
-                        "description": "The storage location on the cloud under which model version data files are stored"
+                        "description": "The storage location on the cloud under which model version data files are stored",
+                        "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["catalog_name", "name", "schema_name"]
+                    "required": [
+                      "catalog_name",
+                      "name",
+                      "schema_name"
+                    ]
                   },
                   {
                     "type": "string",
@@ -664,35 +844,83 @@
                 ]
               },
               "resources.Schema": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
                       "catalog_name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Name of parent catalog."
+                        "description": "Name of parent catalog.",
+                        "$ref": "#/$defs/string"
                       },
                       "comment": {
-                        "$ref": "#/$defs/string",
-                        "description": "User-provided free-form text description."
+                        "description": "User-provided free-form text description.",
+                        "$ref": "#/$defs/string"
                       },
                       "grants": {
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Grant"
                       },
                       "name": {
-                        "$ref": "#/$defs/string",
-                        "description": "Name of schema, relative to parent catalog."
+                        "description": "Name of schema, relative to parent catalog.",
+                        "$ref": "#/$defs/string"
                       },
                       "properties": {
                         "$ref": "#/$defs/map/string"
                       },
                       "storage_root": {
-                        "$ref": "#/$defs/string",
-                        "description": "Storage root URL for managed tables within schema."
+                        "description": "Storage root URL for managed tables within schema.",
+                        "$ref": "#/$defs/string"
                       }
                     },
                     "additionalProperties": false,
-                    "required": ["catalog_name", "name"]
+                    "required": [
+                      "catalog_name",
+                      "name"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.Volume": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "catalog_name": {
+                        "description": "The name of the catalog where the schema and the volume are",
+                        "$ref": "#/$defs/string"
+                      },
+                      "comment": {
+                        "description": "The comment attached to the volume",
+                        "$ref": "#/$defs/string"
+                      },
+                      "grants": {
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Grant"
+                      },
+                      "name": {
+                        "description": "The name of the volume",
+                        "$ref": "#/$defs/string"
+                      },
+                      "schema_name": {
+                        "description": "The name of the schema where the volume is",
+                        "$ref": "#/$defs/string"
+                      },
+                      "storage_location": {
+                        "description": "The storage location on the cloud",
+                        "$ref": "#/$defs/string"
+                      },
+                      "volume_type": {
+                        "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.VolumeType"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "catalog_name",
+                      "name",
+                      "schema_name"
+                    ]
                   },
                   {
                     "type": "string",
@@ -701,7 +929,7 @@
                 ]
               },
               "variable.Lookup": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
@@ -724,6 +952,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "metastore": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "notification_destination": {
                         "$ref": "#/$defs/string"
                       },
                       "pipeline": {
@@ -756,12 +987,15 @@
                         "$ref": "#/$defs/interface"
                       },
                       "description": {
+                        "description": "The description of the variable.",
                         "$ref": "#/$defs/string"
                       },
                       "lookup": {
+                        "description": "The name of the alert, cluster_policy, cluster, dashboard, instance_pool, job, metastore, pipeline, query, service_principal, or warehouse object for which to retrieve an ID.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/variable.Lookup"
                       },
                       "type": {
+                        "description": "The type of the variable.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/variable.VariableType"
                       }
                     },
@@ -777,12 +1011,16 @@
                     "$ref": "#/$defs/interface"
                   },
                   "description": {
+                    "description": "The description of the variable",
                     "$ref": "#/$defs/string"
                   },
                   "lookup": {
-                    "$ref": "#/$defs/github.com/databricks/cli/bundle/config/variable.Lookup"
+                    "description": "The name of the alert, cluster_policy, cluster, dashboard, instance_pool, job, metastore, pipeline, query, service_principal, or warehouse object for which to retrieve an ID.",
+                    "$ref": "#/$defs/github.com/databricks/cli/bundle/config/variable.Lookup",
+                    "markdownDescription": "The name of the `alert`, `cluster_policy`, `cluster`, `dashboard`, `instance_pool`, `job`, `metastore`, `pipeline`, `query`, `service_principal`, or `warehouse` object for which to retrieve an ID.\""
                   },
                   "type": {
+                    "description": "The type of the variable.",
                     "$ref": "#/$defs/github.com/databricks/cli/bundle/config/variable.VariableType"
                   }
                 },
@@ -793,28 +1031,37 @@
               }
             },
             "config.Artifact": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "build": {
+                      "description": "An optional set of non-default build commands that you want to run locally before deployment.\n\nFor Python wheel builds, the Databricks CLI assumes that it can find a local install of the Python wheel package to run builds, and it runs the command python setup.py bdist_wheel by default during each bundle deployment.\n\nTo specify multiple build commands, separate each command with double-ampersand (\u0026\u0026) characters.",
                       "$ref": "#/$defs/string"
                     },
                     "executable": {
+                      "description": "The executable type.",
                       "$ref": "#/$defs/github.com/databricks/cli/libs/exec.ExecutableType"
                     },
                     "files": {
-                      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config.ArtifactFile"
+                      "description": "The source files for the artifact.",
+                      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config.ArtifactFile",
+                      "markdownDescription": "The source files for the artifact, defined as an [artifact_file](https://docs.databricks.com/dev-tools/bundles/reference.html#artifact_file)."
                     },
                     "path": {
+                      "description": "The location where the built artifact will be saved.",
                       "$ref": "#/$defs/string"
                     },
                     "type": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.ArtifactType"
+                      "description": "The type of the artifact.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.ArtifactType",
+                      "markdownDescription": "The type of the artifact. Valid values are `wheel` or `jar`"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["type"]
+                  "required": [
+                    "type"
+                  ]
                 },
                 {
                   "type": "string",
@@ -823,16 +1070,19 @@
               ]
             },
             "config.ArtifactFile": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "source": {
+                      "description": "The path of the files used to build the artifact.",
                       "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["source"]
+                  "required": [
+                    "source"
+                  ]
                 },
                 {
                   "type": "string",
@@ -844,31 +1094,46 @@
               "type": "string"
             },
             "config.Bundle": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "cluster_id": {
-                      "$ref": "#/$defs/string"
+                      "description": "The ID of a cluster to use to run the bundle.",
+                      "$ref": "#/$defs/string",
+                      "markdownDescription": "The ID of a cluster to use to run the bundle. See [cluster_id](https://docs.databricks.com/dev-tools/bundles/settings.html#cluster_id)."
                     },
                     "compute_id": {
                       "$ref": "#/$defs/string"
                     },
                     "databricks_cli_version": {
-                      "$ref": "#/$defs/string"
+                      "description": "The Databricks CLI version to use for the bundle.",
+                      "$ref": "#/$defs/string",
+                      "markdownDescription": "The Databricks CLI version to use for the bundle. See [databricks_cli_version](https://docs.databricks.com/dev-tools/bundles/settings.html#databricks_cli_version)."
                     },
                     "deployment": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Deployment"
+                      "description": "The definition of the bundle deployment",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Deployment",
+                      "markdownDescription": "The definition of the bundle deployment. For supported attributes, see [deployment](https://docs.databricks.com/dev-tools/bundles/reference.html#deployment) and [link](https://docs.databricks.com/dev-tools/bundles/deployment-modes.html)."
                     },
                     "git": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Git"
+                      "description": "The Git version control details that are associated with your bundle.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Git",
+                      "markdownDescription": "The Git version control details that are associated with your bundle. For supported attributes, see [git](https://docs.databricks.com/dev-tools/bundles/reference.html#git) and [git](https://docs.databricks.com/dev-tools/bundles/settings.html#git)."
                     },
                     "name": {
+                      "description": "The name of the bundle.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "uuid": {
+                      "description": "Reserved. A Universally Unique Identifier (UUID) for the bundle that uniquely identifies the bundle in internal Databricks systems. This is generated when a bundle project is initialized using a Databricks template (using the `databricks bundle init` command).",
                       "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["name"]
+                  "required": [
+                    "name"
+                  ]
                 },
                 {
                   "type": "string",
@@ -880,15 +1145,18 @@
               "type": "string"
             },
             "config.Deployment": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "fail_on_active_runs": {
+                      "description": "Whether to fail on active runs. If this is set to true a deployment that is running can be interrupted.",
                       "$ref": "#/$defs/bool"
                     },
                     "lock": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Lock"
+                      "description": "The deployment lock attributes.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Lock",
+                      "markdownDescription": "The deployment lock attributes. See [lock](https://docs.databricks.com/dev-tools/bundles/reference.html#lock)."
                     }
                   },
                   "additionalProperties": false
@@ -900,20 +1168,28 @@
               ]
             },
             "config.Experimental": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "pydabs": {
+                      "description": "The PyDABs configuration.",
                       "$ref": "#/$defs/github.com/databricks/cli/bundle/config.PyDABs"
                     },
+                    "python": {
+                      "description": "Configures loading of Python code defined with 'databricks-bundles' package.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Python"
+                    },
                     "python_wheel_wrapper": {
+                      "description": "Whether to use a Python wheel wrapper",
                       "$ref": "#/$defs/bool"
                     },
                     "scripts": {
+                      "description": "The commands to run",
                       "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Command"
                     },
                     "use_legacy_run_as": {
+                      "description": "Whether to use the legacy run_as behavior",
                       "$ref": "#/$defs/bool"
                     }
                   },
@@ -926,15 +1202,19 @@
               ]
             },
             "config.Git": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "branch": {
-                      "$ref": "#/$defs/string"
+                      "description": "The Git branch name.",
+                      "$ref": "#/$defs/string",
+                      "markdownDescription": "The Git branch name. See [git](https://docs.databricks.com/dev-tools/bundles/settings.html#git)."
                     },
                     "origin_url": {
-                      "$ref": "#/$defs/string"
+                      "description": "The origin URL of the repository.",
+                      "$ref": "#/$defs/string",
+                      "markdownDescription": "The origin URL of the repository. See [git](https://docs.databricks.com/dev-tools/bundles/settings.html#git)."
                     }
                   },
                   "additionalProperties": false
@@ -946,14 +1226,16 @@
               ]
             },
             "config.Lock": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "enabled": {
+                      "description": "Whether this lock is enabled.",
                       "$ref": "#/$defs/bool"
                     },
                     "force": {
+                      "description": "Whether to force this lock if it is enabled.",
                       "$ref": "#/$defs/bool"
                     }
                   },
@@ -969,23 +1251,32 @@
               "type": "string"
             },
             "config.Presets": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "jobs_max_concurrent_runs": {
+                      "description": "The maximum concurrent runs for a job.",
                       "$ref": "#/$defs/int"
                     },
                     "name_prefix": {
+                      "description": "The prefix for job runs of the bundle.",
                       "$ref": "#/$defs/string"
                     },
                     "pipelines_development": {
+                      "description": "Whether pipeline deployments should be locked in development mode.",
+                      "$ref": "#/$defs/bool"
+                    },
+                    "source_linked_deployment": {
+                      "description": "Whether to link the deployment to the bundle source.",
                       "$ref": "#/$defs/bool"
                     },
                     "tags": {
+                      "description": "The tags for the bundle deployment.",
                       "$ref": "#/$defs/map/string"
                     },
                     "trigger_pause_status": {
+                      "description": "A pause status to apply to all job triggers and schedules. Valid values are PAUSED or UNPAUSED.",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -998,17 +1289,20 @@
               ]
             },
             "config.PyDABs": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "enabled": {
+                      "description": "Whether or not PyDABs (Private Preview) is enabled",
                       "$ref": "#/$defs/bool"
                     },
                     "import": {
+                      "description": "The PyDABs project to import to discover resources, resource generator and mutators",
                       "$ref": "#/$defs/slice/string"
                     },
                     "venv_path": {
+                      "description": "The Python virtual environment path",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -1020,37 +1314,96 @@
                 }
               ]
             },
-            "config.Resources": {
-              "anyOf": [
+            "config.Python": {
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
+                    "mutators": {
+                      "description": "Mutators contains a list of fully qualified function paths to mutator functions.\n\nExample: [\"my_project.mutators:add_default_cluster\"]",
+                      "$ref": "#/$defs/slice/string"
+                    },
+                    "resources": {
+                      "description": "Resources contains a list of fully qualified function paths to load resources\ndefined in Python code.\n\nExample: [\"my_project.resources:load_resources\"]",
+                      "$ref": "#/$defs/slice/string"
+                    },
+                    "venv_path": {
+                      "description": "VEnvPath is path to the virtual environment.\n\nIf enabled, Python code will execute within this environment. If disabled,\nit defaults to using the Python interpreter available in the current shell.",
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "resources",
+                    "mutators"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "config.Resources": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "apps": {
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.App"
+                    },
                     "clusters": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Cluster"
+                      "description": "The cluster definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Cluster",
+                      "markdownDescription": "The cluster definitions for the bundle. See [cluster](https://docs.databricks.com/dev-tools/bundles/resources.html#cluster)"
+                    },
+                    "dashboards": {
+                      "description": "The dashboard definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Dashboard",
+                      "markdownDescription": "The dashboard definitions for the bundle. See [dashboard](https://docs.databricks.com/dev-tools/bundles/resources.html#dashboard)"
                     },
                     "experiments": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.MlflowExperiment"
+                      "description": "The experiment definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.MlflowExperiment",
+                      "markdownDescription": "The experiment definitions for the bundle. See [experiment](https://docs.databricks.com/dev-tools/bundles/resources.html#experiment)"
                     },
                     "jobs": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Job"
+                      "description": "The job definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Job",
+                      "markdownDescription": "The job definitions for the bundle. See [job](https://docs.databricks.com/dev-tools/bundles/resources.html#job)"
                     },
                     "model_serving_endpoints": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.ModelServingEndpoint"
+                      "description": "The model serving endpoint definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.ModelServingEndpoint",
+                      "markdownDescription": "The model serving endpoint definitions for the bundle. See [model_serving_endpoint](https://docs.databricks.com/dev-tools/bundles/resources.html#model_serving_endpoint)"
                     },
                     "models": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.MlflowModel"
+                      "description": "The model definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.MlflowModel",
+                      "markdownDescription": "The model definitions for the bundle. See [model](https://docs.databricks.com/dev-tools/bundles/resources.html#model)"
                     },
                     "pipelines": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Pipeline"
+                      "description": "The pipeline definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Pipeline",
+                      "markdownDescription": "The pipeline definitions for the bundle. See [pipeline](https://docs.databricks.com/dev-tools/bundles/resources.html#pipeline)"
                     },
                     "quality_monitors": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.QualityMonitor"
+                      "description": "The quality monitor definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.QualityMonitor",
+                      "markdownDescription": "The quality monitor definitions for the bundle. See [quality_monitor](https://docs.databricks.com/dev-tools/bundles/resources.html#quality_monitor)"
                     },
                     "registered_models": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.RegisteredModel"
+                      "description": "The registered model definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.RegisteredModel",
+                      "markdownDescription": "The registered model definitions for the bundle. See [registered_model](https://docs.databricks.com/dev-tools/bundles/resources.html#registered_model)"
                     },
                     "schemas": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Schema"
+                      "description": "The schema definitions for the bundle.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Schema",
+                      "markdownDescription": "The schema definitions for the bundle. See [schema](https://docs.databricks.com/dev-tools/bundles/resources.html#schema)"
+                    },
+                    "volumes": {
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/resources.Volume"
                     }
                   },
                   "additionalProperties": false
@@ -1062,17 +1415,20 @@
               ]
             },
             "config.Sync": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "exclude": {
+                      "description": "A list of files or folders to exclude from the bundle.",
                       "$ref": "#/$defs/slice/string"
                     },
                     "include": {
+                      "description": "A list of files or folders to include in the bundle.",
                       "$ref": "#/$defs/slice/string"
                     },
                     "paths": {
+                      "description": "The local folder paths, which can be outside the bundle root, to synchronize to the workspace when the bundle is deployed.",
                       "$ref": "#/$defs/slice/string"
                     }
                   },
@@ -1085,51 +1441,75 @@
               ]
             },
             "config.Target": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "artifacts": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Artifact"
+                      "description": "The artifacts to include in the target deployment.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Artifact",
+                      "markdownDescription": "The artifacts to include in the target deployment. See [artifact](https://docs.databricks.com/dev-tools/bundles/reference.html#artifact)"
                     },
                     "bundle": {
+                      "description": "The name of the bundle when deploying to this target.",
                       "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Bundle"
                     },
                     "cluster_id": {
+                      "description": "The ID of the cluster to use for this target.",
                       "$ref": "#/$defs/string"
                     },
                     "compute_id": {
+                      "description": "Deprecated. The ID of the compute to use for this target.",
                       "$ref": "#/$defs/string"
                     },
                     "default": {
+                      "description": "Whether this target is the default target.",
                       "$ref": "#/$defs/bool"
                     },
                     "git": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Git"
+                      "description": "The Git version control settings for the target.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Git",
+                      "markdownDescription": "The Git version control settings for the target. See [git](https://docs.databricks.com/dev-tools/bundles/reference.html#git)."
                     },
                     "mode": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Mode"
+                      "description": "The deployment mode for the target.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Mode",
+                      "markdownDescription": "The deployment mode for the target. Valid values are `development` or `production`. See [link](https://docs.databricks.com/dev-tools/bundles/deployment-modes.html)."
                     },
                     "permissions": {
-                      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                      "description": "The permissions for deploying and running the bundle in the target.",
+                      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                      "markdownDescription": "The permissions for deploying and running the bundle in the target. See [permission](https://docs.databricks.com/dev-tools/bundles/reference.html#permission)."
                     },
                     "presets": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Presets"
+                      "description": "The deployment presets for the target.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Presets",
+                      "markdownDescription": "The deployment presets for the target. See [preset](https://docs.databricks.com/dev-tools/bundles/reference.html#preset)."
                     },
                     "resources": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Resources"
+                      "description": "The resource definitions for the target.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Resources",
+                      "markdownDescription": "The resource definitions for the target. See [resources](https://docs.databricks.com/dev-tools/bundles/reference.html#resources)."
                     },
                     "run_as": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobRunAs"
+                      "description": "The identity to use to run the bundle.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobRunAs",
+                      "markdownDescription": "The identity to use to run the bundle. See [job_run_as](https://docs.databricks.com/dev-tools/bundles/reference.html#job_run_as) and [link](https://docs.databricks.com/dev-tools/bundles/run_as.html)."
                     },
                     "sync": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Sync"
+                      "description": "The local paths to sync to the target workspace when a bundle is run or deployed.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Sync",
+                      "markdownDescription": "The local paths to sync to the target workspace when a bundle is run or deployed. See [sync](https://docs.databricks.com/dev-tools/bundles/reference.html#sync)."
                     },
                     "variables": {
-                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/variable.TargetVariable"
+                      "description": "The custom variable definitions for the target.",
+                      "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/variable.TargetVariable",
+                      "markdownDescription": "The custom variable definitions for the target. See [variables](https://docs.databricks.com/dev-tools/bundles/settings.html#variables) and [link](https://docs.databricks.com/dev-tools/bundles/variables.html)."
                     },
                     "workspace": {
-                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Workspace"
+                      "description": "The Databricks workspace for the target.",
+                      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Workspace",
+                      "markdownDescription": "The Databricks workspace for the target. [workspace](https://docs.databricks.com/dev-tools/bundles/reference.html#workspace)"
                     }
                   },
                   "additionalProperties": false
@@ -1141,56 +1521,72 @@
               ]
             },
             "config.Workspace": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "artifact_path": {
+                      "description": "The artifact path to use within the workspace for both deployments and workflow runs",
                       "$ref": "#/$defs/string"
                     },
                     "auth_type": {
+                      "description": "The authentication type.",
                       "$ref": "#/$defs/string"
                     },
                     "azure_client_id": {
+                      "description": "The Azure client ID",
                       "$ref": "#/$defs/string"
                     },
                     "azure_environment": {
+                      "description": "The Azure environment",
                       "$ref": "#/$defs/string"
                     },
                     "azure_login_app_id": {
+                      "description": "The Azure login app ID",
                       "$ref": "#/$defs/string"
                     },
                     "azure_tenant_id": {
+                      "description": "The Azure tenant ID",
                       "$ref": "#/$defs/string"
                     },
                     "azure_use_msi": {
+                      "description": "Whether to use MSI for Azure",
                       "$ref": "#/$defs/bool"
                     },
                     "azure_workspace_resource_id": {
+                      "description": "The Azure workspace resource ID",
                       "$ref": "#/$defs/string"
                     },
                     "client_id": {
+                      "description": "The client ID for the workspace",
                       "$ref": "#/$defs/string"
                     },
                     "file_path": {
+                      "description": "The file path to use within the workspace for both deployments and workflow runs",
                       "$ref": "#/$defs/string"
                     },
                     "google_service_account": {
+                      "description": "The Google service account name",
                       "$ref": "#/$defs/string"
                     },
                     "host": {
+                      "description": "The Databricks workspace host URL",
                       "$ref": "#/$defs/string"
                     },
                     "profile": {
+                      "description": "The Databricks workspace profile name",
                       "$ref": "#/$defs/string"
                     },
                     "resource_path": {
+                      "description": "The workspace resource path",
                       "$ref": "#/$defs/string"
                     },
                     "root_path": {
+                      "description": "The Databricks workspace root path",
                       "$ref": "#/$defs/string"
                     },
                     "state_path": {
+                      "description": "The workspace state path",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -1211,27 +1607,414 @@
         },
         "databricks-sdk-go": {
           "service": {
+            "apps.AppDeployment": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "create_time": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "creator": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "deployment_artifacts": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeploymentArtifacts"
+                    },
+                    "deployment_id": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "mode": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeploymentMode"
+                    },
+                    "source_code_path": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "status": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeploymentStatus"
+                    },
+                    "update_time": {
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppDeploymentArtifacts": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "source_code_path": {
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppDeploymentMode": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "SNAPSHOT",
+                    "AUTO_SYNC"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppDeploymentState": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "SUCCEEDED",
+                    "FAILED",
+                    "IN_PROGRESS",
+                    "CANCELLED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppDeploymentStatus": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "state": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeploymentState"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResource": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "job": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceJob"
+                    },
+                    "name": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "secret": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceSecret"
+                    },
+                    "serving_endpoint": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceServingEndpoint"
+                    },
+                    "sql_warehouse": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceSqlWarehouse"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceJob": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "permission": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceJobJobPermission"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "permission"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceJobJobPermission": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "CAN_MANAGE",
+                    "IS_OWNER",
+                    "CAN_MANAGE_RUN",
+                    "CAN_VIEW"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceSecret": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "permission": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceSecretSecretPermission"
+                    },
+                    "scope": {
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "key",
+                    "permission",
+                    "scope"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceSecretSecretPermission": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Permission to grant on the secret scope. Supported permissions are: \"READ\", \"WRITE\", \"MANAGE\".",
+                  "enum": [
+                    "READ",
+                    "WRITE",
+                    "MANAGE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceServingEndpoint": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "permission": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceServingEndpointServingEndpointPermission"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "permission"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceServingEndpointServingEndpointPermission": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "CAN_MANAGE",
+                    "CAN_QUERY",
+                    "CAN_VIEW"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceSqlWarehouse": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "permission": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResourceSqlWarehouseSqlWarehousePermission"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "permission"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.AppResourceSqlWarehouseSqlWarehousePermission": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "CAN_MANAGE",
+                    "CAN_USE",
+                    "IS_OWNER"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.ApplicationState": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "DEPLOYING",
+                    "RUNNING",
+                    "CRASHED",
+                    "UNAVAILABLE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.ApplicationStatus": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "state": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.ApplicationState"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.ComputeState": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "ERROR",
+                    "DELETING",
+                    "STARTING",
+                    "STOPPING",
+                    "UPDATING",
+                    "STOPPED",
+                    "ACTIVE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "apps.ComputeStatus": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "$ref": "#/$defs/string"
+                    },
+                    "state": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.ComputeState"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
             "catalog.MonitorCronSchedule": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "pause_status": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorCronSchedulePauseStatus",
                       "description": "Read only field that indicates whether a schedule is paused or not.",
-                      "enum": ["UNPAUSED", "PAUSED"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorCronSchedulePauseStatus"
                     },
                     "quartz_cron_expression": {
-                      "$ref": "#/$defs/string",
-                      "description": "The expression that determines when to run the monitor. See [examples](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).\n"
+                      "description": "The expression that determines when to run the monitor. See [examples](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).\n",
+                      "$ref": "#/$defs/string"
                     },
                     "timezone_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The timezone id (e.g., ``\"PST\"``) in which to evaluate the quartz expression.\n"
+                      "description": "The timezone id (e.g., ``\"PST\"``) in which to evaluate the quartz expression.\n",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["quartz_cron_expression", "timezone_id"]
+                  "required": [
+                    "quartz_cron_expression",
+                    "timezone_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1240,16 +2023,29 @@
               ]
             },
             "catalog.MonitorCronSchedulePauseStatus": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Read only field that indicates whether a schedule is paused or not.",
+                  "enum": [
+                    "UNPAUSED",
+                    "PAUSED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "catalog.MonitorDataClassificationConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether data classification is enabled."
+                      "description": "Whether data classification is enabled.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -1261,13 +2057,13 @@
               ]
             },
             "catalog.MonitorDestination": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "email_addresses": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "The list of email addresses to send the notification to. A maximum of 5 email addresses is supported."
+                      "description": "The list of email addresses to send the notification to. A maximum of 5 email addresses is supported.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -1279,41 +2075,37 @@
               ]
             },
             "catalog.MonitorInferenceLog": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "granularities": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Granularities for aggregating data into time windows based on their timestamp. Currently the following static\ngranularities are supported:\n{``\"5 minutes\"``, ``\"30 minutes\"``, ``\"1 hour\"``, ``\"1 day\"``, ``\"\u003cn\u003e week(s)\"``, ``\"1 month\"``, ``\"1 year\"``}.\n"
+                      "description": "Granularities for aggregating data into time windows based on their timestamp. Currently the following static\ngranularities are supported:\n{``\"5 minutes\"``, ``\"30 minutes\"``, ``\"1 hour\"``, ``\"1 day\"``, ``\"\u003cn\u003e week(s)\"``, ``\"1 month\"``, ``\"1 year\"``}.\n",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "label_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional column that contains the ground truth for the prediction."
+                      "description": "Optional column that contains the ground truth for the prediction.",
+                      "$ref": "#/$defs/string"
                     },
                     "model_id_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Column that contains the id of the model generating the predictions. Metrics will be computed per model id by\ndefault, and also across all model ids.\n"
+                      "description": "Column that contains the id of the model generating the predictions. Metrics will be computed per model id by\ndefault, and also across all model ids.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "prediction_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Column that contains the output/prediction from the model."
+                      "description": "Column that contains the output/prediction from the model.",
+                      "$ref": "#/$defs/string"
                     },
                     "prediction_proba_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional column that contains the prediction probabilities for each class in a classification problem type.\nThe values in this column should be a map, mapping each class label to the prediction probability for a given\nsample. The map should be of PySpark MapType().\n"
+                      "description": "Optional column that contains the prediction probabilities for each class in a classification problem type.\nThe values in this column should be a map, mapping each class label to the prediction probability for a given\nsample. The map should be of PySpark MapType().\n",
+                      "$ref": "#/$defs/string"
                     },
                     "problem_type": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorInferenceLogProblemType",
                       "description": "Problem type the model aims to solve. Determines the type of model-quality metrics that will be computed.",
-                      "enum": [
-                        "PROBLEM_TYPE_CLASSIFICATION",
-                        "PROBLEM_TYPE_REGRESSION"
-                      ]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorInferenceLogProblemType"
                     },
                     "timestamp_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Column that contains the timestamps of requests. The column must be one of the following:\n- A ``TimestampType`` column\n- A column whose values can be converted to timestamps through the pyspark\n  ``to_timestamp`` [function](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_timestamp.html).\n"
+                      "description": "Column that contains the timestamps of requests. The column must be one of the following:\n- A ``TimestampType`` column\n- A column whose values can be converted to timestamps through the pyspark\n  ``to_timestamp`` [function](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_timestamp.html).\n",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
@@ -1332,37 +2124,45 @@
               ]
             },
             "catalog.MonitorInferenceLogProblemType": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Problem type the model aims to solve. Determines the type of model-quality metrics that will be computed.",
+                  "enum": [
+                    "PROBLEM_TYPE_CLASSIFICATION",
+                    "PROBLEM_TYPE_REGRESSION"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "catalog.MonitorMetric": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "definition": {
-                      "$ref": "#/$defs/string",
-                      "description": "Jinja template for a SQL expression that specifies how to compute the metric. See [create metric definition](https://docs.databricks.com/en/lakehouse-monitoring/custom-metrics.html#create-definition)."
+                      "description": "Jinja template for a SQL expression that specifies how to compute the metric. See [create metric definition](https://docs.databricks.com/en/lakehouse-monitoring/custom-metrics.html#create-definition).",
+                      "$ref": "#/$defs/string"
                     },
                     "input_columns": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of column names in the input table the metric should be computed for.\nCan use ``\":table\"`` to indicate that the metric needs information from multiple columns.\n"
+                      "description": "A list of column names in the input table the metric should be computed for.\nCan use ``\":table\"`` to indicate that the metric needs information from multiple columns.\n",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the metric in the output tables."
+                      "description": "Name of the metric in the output tables.",
+                      "$ref": "#/$defs/string"
                     },
                     "output_data_type": {
-                      "$ref": "#/$defs/string",
-                      "description": "The output type of the custom metric."
+                      "description": "The output type of the custom metric.",
+                      "$ref": "#/$defs/string"
                     },
                     "type": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorMetricType",
                       "description": "Can only be one of ``\"CUSTOM_METRIC_TYPE_AGGREGATE\"``, ``\"CUSTOM_METRIC_TYPE_DERIVED\"``, or ``\"CUSTOM_METRIC_TYPE_DRIFT\"``.\nThe ``\"CUSTOM_METRIC_TYPE_AGGREGATE\"`` and ``\"CUSTOM_METRIC_TYPE_DERIVED\"`` metrics\nare computed on a single table, whereas the ``\"CUSTOM_METRIC_TYPE_DRIFT\"`` compare metrics across\nbaseline and input table, or across the two consecutive time windows.\n- CUSTOM_METRIC_TYPE_AGGREGATE: only depend on the existing columns in your table\n- CUSTOM_METRIC_TYPE_DERIVED: depend on previously computed aggregate metrics\n- CUSTOM_METRIC_TYPE_DRIFT:  depend on previously computed aggregate or derived metrics\n",
-                      "enum": [
-                        "CUSTOM_METRIC_TYPE_AGGREGATE",
-                        "CUSTOM_METRIC_TYPE_DERIVED",
-                        "CUSTOM_METRIC_TYPE_DRIFT"
-                      ]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorMetricType"
                     }
                   },
                   "additionalProperties": false,
@@ -1381,20 +2181,34 @@
               ]
             },
             "catalog.MonitorMetricType": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Can only be one of ``\"CUSTOM_METRIC_TYPE_AGGREGATE\"``, ``\"CUSTOM_METRIC_TYPE_DERIVED\"``, or ``\"CUSTOM_METRIC_TYPE_DRIFT\"``.\nThe ``\"CUSTOM_METRIC_TYPE_AGGREGATE\"`` and ``\"CUSTOM_METRIC_TYPE_DERIVED\"`` metrics\nare computed on a single table, whereas the ``\"CUSTOM_METRIC_TYPE_DRIFT\"`` compare metrics across\nbaseline and input table, or across the two consecutive time windows.\n- CUSTOM_METRIC_TYPE_AGGREGATE: only depend on the existing columns in your table\n- CUSTOM_METRIC_TYPE_DERIVED: depend on previously computed aggregate metrics\n- CUSTOM_METRIC_TYPE_DRIFT:  depend on previously computed aggregate or derived metrics\n",
+                  "enum": [
+                    "CUSTOM_METRIC_TYPE_AGGREGATE",
+                    "CUSTOM_METRIC_TYPE_DERIVED",
+                    "CUSTOM_METRIC_TYPE_DRIFT"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "catalog.MonitorNotifications": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "on_failure": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDestination",
-                      "description": "Who to send notifications to on monitor failure."
+                      "description": "Who to send notifications to on monitor failure.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDestination"
                     },
                     "on_new_classification_tag_detected": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDestination",
-                      "description": "Who to send notifications to when new data classification tags are detected."
+                      "description": "Who to send notifications to when new data classification tags are detected.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDestination"
                     }
                   },
                   "additionalProperties": false
@@ -1406,7 +2220,7 @@
               ]
             },
             "catalog.MonitorSnapshot": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "additionalProperties": false
@@ -1418,21 +2232,39 @@
               ]
             },
             "catalog.MonitorTimeSeries": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "granularities": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Granularities for aggregating data into time windows based on their timestamp. Currently the following static\ngranularities are supported:\n{``\"5 minutes\"``, ``\"30 minutes\"``, ``\"1 hour\"``, ``\"1 day\"``, ``\"\u003cn\u003e week(s)\"``, ``\"1 month\"``, ``\"1 year\"``}.\n"
+                      "description": "Granularities for aggregating data into time windows based on their timestamp. Currently the following static\ngranularities are supported:\n{``\"5 minutes\"``, ``\"30 minutes\"``, ``\"1 hour\"``, ``\"1 day\"``, ``\"\u003cn\u003e week(s)\"``, ``\"1 month\"``, ``\"1 year\"``}.\n",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "timestamp_col": {
-                      "$ref": "#/$defs/string",
-                      "description": "Column that contains the timestamps of requests. The column must be one of the following:\n- A ``TimestampType`` column\n- A column whose values can be converted to timestamps through the pyspark\n  ``to_timestamp`` [function](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_timestamp.html).\n"
+                      "description": "Column that contains the timestamps of requests. The column must be one of the following:\n- A ``TimestampType`` column\n- A column whose values can be converted to timestamps through the pyspark\n  ``to_timestamp`` [function](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.to_timestamp.html).\n",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["granularities", "timestamp_col"]
+                  "required": [
+                    "granularities",
+                    "timestamp_col"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "catalog.VolumeType": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "EXTERNAL",
+                    "MANAGED"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1441,17 +2273,19 @@
               ]
             },
             "compute.Adlsgen2Info": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "abfss destination, e.g. `abfss://\u003ccontainer-name\u003e@\u003cstorage-account-name\u003e.dfs.core.windows.net/\u003cdirectory-name\u003e`."
+                      "description": "abfss destination, e.g. `abfss://\u003ccontainer-name\u003e@\u003cstorage-account-name\u003e.dfs.core.windows.net/\u003cdirectory-name\u003e`.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1460,17 +2294,17 @@
               ]
             },
             "compute.AutoScale": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "max_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`."
+                      "description": "The maximum number of workers to which the cluster can scale up when overloaded.\nNote that `max_workers` must be strictly greater than `min_workers`.",
+                      "$ref": "#/$defs/int"
                     },
                     "min_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                      "description": "The minimum number of workers to which the cluster can scale down when underutilized.\nIt is also the initial number of workers the cluster will have after creation.",
+                      "$ref": "#/$defs/int"
                     }
                   },
                   "additionalProperties": false
@@ -1482,7 +2316,7 @@
               ]
             },
             "compute.AwsAttributes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -1490,39 +2324,39 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAvailability"
                     },
                     "ebs_volume_count": {
-                      "$ref": "#/$defs/int",
-                      "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden."
+                      "description": "The number of volumes launched for each instance. Users can choose up to 10 volumes.\nThis feature is only enabled for supported node types. Legacy node types cannot specify\ncustom EBS volumes.\nFor node types with no instance store, at least one EBS volume needs to be specified;\notherwise, cluster creation will fail.\n\nThese EBS volumes will be mounted at `/ebs0`, `/ebs1`, and etc.\nInstance store volumes will be mounted at `/local_disk0`, `/local_disk1`, and etc.\n\nIf EBS volumes are attached, Databricks will configure Spark to use only the EBS volumes for\nscratch storage because heterogenously sized scratch devices can lead to inefficient disk\nutilization. If no EBS volumes are attached, Databricks will configure Spark to use instance\nstore volumes.\n\nPlease note that if EBS volumes are specified, then the Spark configuration `spark.local.dir`\nwill be overridden.",
+                      "$ref": "#/$defs/int"
                     },
                     "ebs_volume_iops": {
-                      "$ref": "#/$defs/int",
-                      "description": "If using gp3 volumes, what IOPS to use for the disk. If this is not set, the maximum performance of a gp2 volume with the same volume size will be used."
+                      "description": "If using gp3 volumes, what IOPS to use for the disk. If this is not set, the maximum performance of a gp2 volume with the same volume size will be used.",
+                      "$ref": "#/$defs/int"
                     },
                     "ebs_volume_size": {
-                      "$ref": "#/$defs/int",
-                      "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096."
+                      "description": "The size of each EBS volume (in GiB) launched for each instance. For general purpose\nSSD, this value must be within the range 100 - 4096. For throughput optimized HDD,\nthis value must be within the range 500 - 4096.",
+                      "$ref": "#/$defs/int"
                     },
                     "ebs_volume_throughput": {
-                      "$ref": "#/$defs/int",
-                      "description": "If using gp3 volumes, what throughput to use for the disk. If this is not set, the maximum performance of a gp2 volume with the same volume size will be used."
+                      "description": "If using gp3 volumes, what throughput to use for the disk. If this is not set, the maximum performance of a gp2 volume with the same volume size will be used.",
+                      "$ref": "#/$defs/int"
                     },
                     "ebs_volume_type": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.EbsVolumeType"
                     },
                     "first_on_demand": {
-                      "$ref": "#/$defs/int",
-                      "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                      "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nIf this value is greater than 0, the cluster driver node in particular will be placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster.",
+                      "$ref": "#/$defs/int"
                     },
                     "instance_profile_arn": {
-                      "$ref": "#/$defs/string",
-                      "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nomitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is omitted, we will pull in the default from the conf if it exists."
+                      "description": "Nodes for this cluster will only be placed on AWS instances with this instance profile. If\nommitted, nodes will be placed on instances without an IAM instance profile. The instance\nprofile must have previously been added to the Databricks environment by an account\nadministrator.\n\nThis feature may only be available to certain customer plans.\n\nIf this field is ommitted, we will pull in the default from the conf if it exists.",
+                      "$ref": "#/$defs/string"
                     },
                     "spot_bid_price_percent": {
-                      "$ref": "#/$defs/int",
-                      "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent."
+                      "description": "The bid price for AWS spot instances, as a percentage of the corresponding instance type's\non-demand price.\nFor example, if this field is set to 50, and the cluster needs a new `r3.xlarge` spot\ninstance, then the bid price is half of the price of\non-demand `r3.xlarge` instances. Similarly, if this field is set to 200, the bid price is twice\nthe price of on-demand `r3.xlarge` instances. If not specified, the default value is 100.\nWhen spot instances are requested for this cluster, only spot instances whose bid price\npercentage matches this field will be considered.\nNote that, for safety, we enforce this field to be no more than 10000.\n\nThe default value and documentation here should be kept consistent with\nCommonConf.defaultSpotBidPricePercent and CommonConf.maxSpotBidPricePercent.",
+                      "$ref": "#/$defs/int"
                     },
                     "zone_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nThe list of available zones as well as the default value can be found by using the\n`List Zones` method."
+                      "description": "Identifier for the availability zone/datacenter in which the cluster resides.\nThis string will be of a form like \"us-west-2a\". The provided availability\nzone must be in the same region as the Databricks deployment. For example, \"us-west-2a\"\nis not a valid zone id if the Databricks deployment resides in the \"us-east-1\" region.\nThis is an optional field at cluster creation, and if not specified, a default zone will be used.\nIf the zone specified is \"auto\", will try to place cluster in a zone with high availability,\nand will retry placement in a different AZ if there is not enough capacity.\nThe list of available zones as well as the default value can be found by using the\n`List Zones` method.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -1534,12 +2368,24 @@
               ]
             },
             "compute.AwsAvailability": {
-              "type": "string",
-              "description": "Availability type used for all subsequent nodes past the `first_on_demand` ones.\n\nNote: If `first_on_demand` is zero, this availability type will be used for the entire cluster.\n",
-              "enum": ["SPOT", "ON_DEMAND", "SPOT_WITH_FALLBACK"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Availability type used for all subsequent nodes past the `first_on_demand` ones.\n\nNote: If `first_on_demand` is zero, this availability type will be used for the entire cluster.\n",
+                  "enum": [
+                    "SPOT",
+                    "ON_DEMAND",
+                    "SPOT_WITH_FALLBACK"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "compute.AzureAttributes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -1547,16 +2393,16 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAvailability"
                     },
                     "first_on_demand": {
-                      "$ref": "#/$defs/int",
-                      "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster."
+                      "description": "The first `first_on_demand` nodes of the cluster will be placed on on-demand instances.\nThis value should be greater than 0, to make sure the cluster driver node is placed on an\non-demand instance. If this value is greater than or equal to the current cluster size, all\nnodes will be placed on on-demand instances. If this value is less than the current cluster\nsize, `first_on_demand` nodes will be placed on on-demand instances and the remainder will\nbe placed on `availability` instances. Note that this value does not affect\ncluster size and cannot currently be mutated over the lifetime of a cluster.",
+                      "$ref": "#/$defs/int"
                     },
                     "log_analytics_info": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.LogAnalyticsInfo",
-                      "description": "Defines values necessary to configure and run Azure Log Analytics agent"
+                      "description": "Defines values necessary to configure and run Azure Log Analytics agent",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.LogAnalyticsInfo"
                     },
                     "spot_bid_max_price": {
-                      "$ref": "#/$defs/float64",
-                      "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1."
+                      "description": "The max bid price to be used for Azure spot instances.\nThe Max price for the bid cannot be higher than the on-demand price of the instance.\nIf not specified, the default value is -1, which specifies that the instance cannot be evicted\non the basis of price, and only on the basis of availability. Further, the value should \u003e 0 or -1.",
+                      "$ref": "#/$defs/float64"
                     }
                   },
                   "additionalProperties": false
@@ -1568,26 +2414,34 @@
               ]
             },
             "compute.AzureAvailability": {
-              "type": "string",
-              "description": "Availability type used for all subsequent nodes past the `first_on_demand` ones.\nNote: If `first_on_demand` is zero (which only happens on pool clusters), this availability\ntype will be used for the entire cluster.",
-              "enum": [
-                "SPOT_AZURE",
-                "ON_DEMAND_AZURE",
-                "SPOT_WITH_FALLBACK_AZURE"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Availability type used for all subsequent nodes past the `first_on_demand` ones.\nNote: If `first_on_demand` is zero (which only happens on pool clusters), this availability\ntype will be used for the entire cluster.",
+                  "enum": [
+                    "SPOT_AZURE",
+                    "ON_DEMAND_AZURE",
+                    "SPOT_WITH_FALLBACK_AZURE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "compute.ClientsTypes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "jobs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "With jobs set, the cluster can be used for jobs"
+                      "description": "With jobs set, the cluster can be used for jobs",
+                      "$ref": "#/$defs/bool"
                     },
                     "notebooks": {
-                      "$ref": "#/$defs/bool",
-                      "description": "With notebooks set, this cluster can be used for notebooks"
+                      "description": "With notebooks set, this cluster can be used for notebooks",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -1599,17 +2453,17 @@
               ]
             },
             "compute.ClusterLogConf": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "dbfs": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DbfsStorageInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DbfsStorageInfo"
                     },
                     "s3": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.S3StorageInfo",
-                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination."
+                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.S3StorageInfo"
                     }
                   },
                   "additionalProperties": false
@@ -1621,41 +2475,41 @@
               ]
             },
             "compute.ClusterSpec": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "apply_policy_default_values": {
-                      "$ref": "#/$defs/bool",
-                      "description": "When set to true, fixed and default values from the policy will be used for fields that are omitted. When set to false, only fixed values from the policy will be applied."
+                      "description": "When set to true, fixed and default values from the policy will be used for fields that are omitted. When set to false, only fixed values from the policy will be applied.",
+                      "$ref": "#/$defs/bool"
                     },
                     "autoscale": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AutoScale",
-                      "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later."
+                      "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AutoScale"
                     },
                     "autotermination_minutes": {
-                      "$ref": "#/$defs/int",
-                      "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination."
+                      "description": "Automatically terminates the cluster after it is inactive for this time in minutes. If not set,\nthis cluster will not be automatically terminated. If specified, the threshold must be between\n10 and 10000 minutes.\nUsers can also set this value to 0 to explicitly disable automatic termination.",
+                      "$ref": "#/$defs/int"
                     },
                     "aws_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes",
-                      "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes"
                     },
                     "azure_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes",
-                      "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes"
                     },
                     "cluster_log_conf": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf",
-                      "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`."
+                      "description": "The configuration for delivering spark logs to a long-term storage destination.\nTwo kinds of destinations (dbfs and s3) are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf"
                     },
                     "cluster_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n"
+                      "description": "Cluster name requested by the user. This doesn't have to be unique.\nIf not specified at creation, the cluster name will be an empty string.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "custom_tags": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags"
+                      "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                      "$ref": "#/$defs/map/string"
                     },
                     "data_security_mode": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DataSecurityMode"
@@ -1664,67 +2518,78 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DockerImage"
                     },
                     "driver_instance_pool_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                      "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned.",
+                      "$ref": "#/$defs/string"
                     },
                     "driver_node_type_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n"
+                      "description": "The node type of the Spark driver. Note that this field is optional;\nif unset, the driver node type will be set as the same value\nas `node_type_id` defined above.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "enable_elastic_disk": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details."
+                      "description": "Autoscaling Local Storage: when enabled, this cluster will dynamically acquire additional disk\nspace when its Spark workers are running low on disk space. This feature requires specific AWS\npermissions to function correctly - refer to the User Guide for more details.",
+                      "$ref": "#/$defs/bool"
                     },
                     "enable_local_disk_encryption": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether to enable LUKS on cluster VMs' local disks"
+                      "description": "Whether to enable LUKS on cluster VMs' local disks",
+                      "$ref": "#/$defs/bool"
                     },
                     "gcp_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes",
-                      "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes"
                     },
                     "init_scripts": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo",
-                      "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`."
+                      "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo"
                     },
                     "instance_pool_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The optional ID of the instance pool to which the cluster belongs."
+                      "description": "The optional ID of the instance pool to which the cluster belongs.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "is_single_node": {
+                      "description": "This field can only be used with `kind`.\n\nWhen set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`\n",
+                      "$ref": "#/$defs/bool"
+                    },
+                    "kind": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Kind"
                     },
                     "node_type_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                      "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "num_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                      "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned.",
+                      "$ref": "#/$defs/int"
                     },
                     "policy_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The ID of the cluster policy used to create the cluster if applicable."
+                      "description": "The ID of the cluster policy used to create the cluster if applicable.",
+                      "$ref": "#/$defs/string"
                     },
                     "runtime_engine": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.RuntimeEngine"
                     },
                     "single_user_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Single user name if data_security_mode is `SINGLE_USER`"
+                      "description": "Single user name if data_security_mode is `SINGLE_USER`",
+                      "$ref": "#/$defs/string"
                     },
                     "spark_conf": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n"
+                      "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nUsers can also pass in a string of extra JVM options to the driver and the executors via\n`spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` respectively.\n",
+                      "$ref": "#/$defs/map/string"
                     },
                     "spark_env_vars": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`"
+                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                      "$ref": "#/$defs/map/string"
                     },
                     "spark_version": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n"
+                      "description": "The Spark version of the cluster, e.g. `3.3.x-scala2.11`.\nA list of available Spark versions can be retrieved by using\nthe :method:clusters/sparkVersions API call.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "ssh_public_keys": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified."
+                      "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                      "$ref": "#/$defs/slice/string"
+                    },
+                    "use_ml_runtime": {
+                      "description": "This field can only be used with `kind`.\n\n`effective_spark_version` is determined by `spark_version` (DBR release), this field `use_ml_runtime`, and whether `node_type_id` is gpu node or not.\n",
+                      "$ref": "#/$defs/bool"
                     },
                     "workload_type": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.WorkloadType"
@@ -1739,30 +2604,43 @@
               ]
             },
             "compute.DataSecurityMode": {
-              "type": "string",
-              "description": "Data security mode decides what data governance model to use when accessing data\nfrom a cluster.\n\n* `NONE`: No security isolation for multiple users sharing the cluster. Data governance features are not available in this mode.\n* `SINGLE_USER`: A secure cluster that can only be exclusively used by a single user specified in `single_user_name`. Most programming languages, cluster features and data governance features are available in this mode.\n* `USER_ISOLATION`: A secure cluster that can be shared by multiple users. Cluster users are fully isolated so that they cannot see each other's data and credentials. Most data governance features are supported in this mode. But programming languages and cluster features might be limited.\n\nThe following modes are deprecated starting with Databricks Runtime 15.0 and\nwill be removed for future Databricks Runtime versions:\n\n* `LEGACY_TABLE_ACL`: This mode is for users migrating from legacy Table ACL clusters.\n* `LEGACY_PASSTHROUGH`: This mode is for users migrating from legacy Passthrough on high concurrency clusters.\n* `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy Passthrough on standard clusters.\n* `LEGACY_SINGLE_USER_STANDARD`: This mode provides a way that doesn’t have UC nor passthrough enabled.\n",
-              "enum": [
-                "NONE",
-                "SINGLE_USER",
-                "USER_ISOLATION",
-                "LEGACY_TABLE_ACL",
-                "LEGACY_PASSTHROUGH",
-                "LEGACY_SINGLE_USER",
-                "LEGACY_SINGLE_USER_STANDARD"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Data security mode decides what data governance model to use when accessing data\nfrom a cluster.\n\nThe following modes can only be used with `kind`.\n* `DATA_SECURITY_MODE_AUTO`: Databricks will choose the most appropriate access mode depending on your compute configuration.\n* `DATA_SECURITY_MODE_STANDARD`: Alias for `USER_ISOLATION`.\n* `DATA_SECURITY_MODE_DEDICATED`: Alias for `SINGLE_USER`.\n\nThe following modes can be used regardless of `kind`.\n* `NONE`: No security isolation for multiple users sharing the cluster. Data governance features are not available in this mode.\n* `SINGLE_USER`: A secure cluster that can only be exclusively used by a single user specified in `single_user_name`. Most programming languages, cluster features and data governance features are available in this mode.\n* `USER_ISOLATION`: A secure cluster that can be shared by multiple users. Cluster users are fully isolated so that they cannot see each other's data and credentials. Most data governance features are supported in this mode. But programming languages and cluster features might be limited.\n\nThe following modes are deprecated starting with Databricks Runtime 15.0 and\nwill be removed for future Databricks Runtime versions:\n\n* `LEGACY_TABLE_ACL`: This mode is for users migrating from legacy Table ACL clusters.\n* `LEGACY_PASSTHROUGH`: This mode is for users migrating from legacy Passthrough on high concurrency clusters.\n* `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy Passthrough on standard clusters.\n* `LEGACY_SINGLE_USER_STANDARD`: This mode provides a way that doesn’t have UC nor passthrough enabled.\n",
+                  "enum": [
+                    "DATA_SECURITY_MODE_AUTO",
+                    "DATA_SECURITY_MODE_STANDARD",
+                    "DATA_SECURITY_MODE_DEDICATED",
+                    "NONE",
+                    "SINGLE_USER",
+                    "USER_ISOLATION",
+                    "LEGACY_TABLE_ACL",
+                    "LEGACY_PASSTHROUGH",
+                    "LEGACY_SINGLE_USER",
+                    "LEGACY_SINGLE_USER_STANDARD"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "compute.DbfsStorageInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "dbfs destination, e.g. `dbfs:/my/path`"
+                      "description": "dbfs destination, e.g. `dbfs:/my/path`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1771,17 +2649,17 @@
               ]
             },
             "compute.DockerBasicAuth": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "password": {
-                      "$ref": "#/$defs/string",
-                      "description": "Password of the user"
+                      "description": "Password of the user",
+                      "$ref": "#/$defs/string"
                     },
                     "username": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the user"
+                      "description": "Name of the user",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -1793,7 +2671,7 @@
               ]
             },
             "compute.DockerImage": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -1801,8 +2679,8 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DockerBasicAuth"
                     },
                     "url": {
-                      "$ref": "#/$defs/string",
-                      "description": "URL of the docker image."
+                      "description": "URL of the docker image.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -1814,27 +2692,40 @@
               ]
             },
             "compute.EbsVolumeType": {
-              "type": "string",
-              "description": "The type of EBS volumes that will be launched with this cluster.",
-              "enum": ["GENERAL_PURPOSE_SSD", "THROUGHPUT_OPTIMIZED_HDD"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The type of EBS volumes that will be launched with this cluster.",
+                  "enum": [
+                    "GENERAL_PURPOSE_SSD",
+                    "THROUGHPUT_OPTIMIZED_HDD"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "compute.Environment": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "description": "The environment entity used to preserve serverless environment side panel and jobs' environment for non-notebook task.\nIn this minimal environment spec, only pip dependencies are supported.",
                   "properties": {
                     "client": {
-                      "$ref": "#/$defs/string",
-                      "description": "Client version used by the environment\nThe client is the user-facing environment of the runtime.\nEach client comes with a specific set of pre-installed libraries.\nThe version is a string, consisting of the major client version."
+                      "description": "Client version used by the environment\nThe client is the user-facing environment of the runtime.\nEach client comes with a specific set of pre-installed libraries.\nThe version is a string, consisting of the major client version.",
+                      "$ref": "#/$defs/string"
                     },
                     "dependencies": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "List of pip dependencies, as supported by the version of pip in this environment.\nEach dependency is a pip requirement file line https://pip.pypa.io/en/stable/reference/requirements-file-format/\nAllowed dependency could be \u003crequirement specifier\u003e, \u003carchive url/path\u003e, \u003clocal project path\u003e(WSFS or Volumes in Databricks), \u003cvcs project url\u003e\nE.g. dependencies: [\"foo==0.0.1\", \"-r /Workspace/test/requirements.txt\"]"
+                      "description": "List of pip dependencies, as supported by the version of pip in this environment.\nEach dependency is a pip requirement file line https://pip.pypa.io/en/stable/reference/requirements-file-format/\nAllowed dependency could be \u003crequirement specifier\u003e, \u003carchive url/path\u003e, \u003clocal project path\u003e(WSFS or Volumes in Databricks), \u003cvcs project url\u003e\nE.g. dependencies: [\"foo==0.0.1\", \"-r /Workspace/test/requirements.txt\"]",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["client"]
+                  "required": [
+                    "client"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1843,7 +2734,7 @@
               ]
             },
             "compute.GcpAttributes": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -1851,24 +2742,24 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAvailability"
                     },
                     "boot_disk_size": {
-                      "$ref": "#/$defs/int",
-                      "description": "boot disk size in GB"
+                      "description": "boot disk size in GB",
+                      "$ref": "#/$defs/int"
                     },
                     "google_service_account": {
-                      "$ref": "#/$defs/string",
-                      "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator."
+                      "description": "If provided, the cluster will impersonate the google service account when accessing\ngcloud services (like GCS). The google service account\nmust have previously been added to the Databricks environment by an account\nadministrator.",
+                      "$ref": "#/$defs/string"
                     },
                     "local_ssd_count": {
-                      "$ref": "#/$defs/int",
-                      "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type."
+                      "description": "If provided, each node (workers and driver) in the cluster will have this number of local SSDs attached. Each local SSD is 375GB in size. Refer to [GCP documentation](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds) for the supported number of local SSDs for each instance type.",
+                      "$ref": "#/$defs/int"
                     },
                     "use_preemptible_executors": {
-                      "$ref": "#/$defs/bool",
-                      "description": "This field determines whether the spark executors will be scheduled to run on preemptible VMs (when set to true) versus standard compute engine VMs (when set to false; default).\nNote: Soon to be deprecated, use the availability field instead."
+                      "description": "This field determines whether the spark executors will be scheduled to run on preemptible VMs (when set to true) versus standard compute engine VMs (when set to false; default).\nNote: Soon to be deprecated, use the availability field instead.",
+                      "$ref": "#/$defs/bool"
                     },
                     "zone_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "Identifier for the availability zone in which the cluster resides.\nThis can be one of the following:\n- \"HA\" =\u003e High availability, spread nodes across availability zones for a Databricks deployment region [default]\n- \"AUTO\" =\u003e Databricks picks an availability zone to schedule the cluster on.\n- A GCP availability zone =\u003e Pick One of the available zones for (machine type + region) from https://cloud.google.com/compute/docs/regions-zones."
+                      "description": "Identifier for the availability zone in which the cluster resides.\nThis can be one of the following:\n- \"HA\" =\u003e High availability, spread nodes across availability zones for a Databricks deployment region [default]\n- \"AUTO\" =\u003e Databricks picks an availability zone to schedule the cluster on.\n- A GCP availability zone =\u003e Pick One of the available zones for (machine type + region) from https://cloud.google.com/compute/docs/regions-zones.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -1880,26 +2771,36 @@
               ]
             },
             "compute.GcpAvailability": {
-              "type": "string",
-              "description": "This field determines whether the instance pool will contain preemptible\nVMs, on-demand VMs, or preemptible VMs with a fallback to on-demand VMs if the former is unavailable.",
-              "enum": [
-                "PREEMPTIBLE_GCP",
-                "ON_DEMAND_GCP",
-                "PREEMPTIBLE_WITH_FALLBACK_GCP"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "This field determines whether the instance pool will contain preemptible\nVMs, on-demand VMs, or preemptible VMs with a fallback to on-demand VMs if the former is unavailable.",
+                  "enum": [
+                    "PREEMPTIBLE_GCP",
+                    "ON_DEMAND_GCP",
+                    "PREEMPTIBLE_WITH_FALLBACK_GCP"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "compute.GcsStorageInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "GCS destination/URI, e.g. `gs://my-bucket/some-prefix`"
+                      "description": "GCS destination/URI, e.g. `gs://my-bucket/some-prefix`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -1908,37 +2809,37 @@
               ]
             },
             "compute.InitScriptInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "abfss": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Adlsgen2Info",
-                      "description": "destination needs to be provided. e.g.\n`{ \"abfss\" : { \"destination\" : \"abfss://\u003ccontainer-name\u003e@\u003cstorage-account-name\u003e.dfs.core.windows.net/\u003cdirectory-name\u003e\" } }"
+                      "description": "destination needs to be provided. e.g.\n`{ \"abfss\" : { \"destination\" : \"abfss://\u003ccontainer-name\u003e@\u003cstorage-account-name\u003e.dfs.core.windows.net/\u003cdirectory-name\u003e\" } }",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Adlsgen2Info"
                     },
                     "dbfs": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DbfsStorageInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"dbfs\" : { \"destination\" : \"dbfs:/home/cluster_log\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DbfsStorageInfo"
                     },
                     "file": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.LocalFileInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"file\" : { \"destination\" : \"file:/my/local/file.sh\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"file\" : { \"destination\" : \"file:/my/local/file.sh\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.LocalFileInfo"
                     },
                     "gcs": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcsStorageInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"gcs\": { \"destination\": \"gs://my-bucket/file.sh\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"gcs\": { \"destination\": \"gs://my-bucket/file.sh\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcsStorageInfo"
                     },
                     "s3": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.S3StorageInfo",
-                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination."
+                      "description": "destination and either the region or endpoint need to be provided. e.g.\n`{ \"s3\": { \"destination\" : \"s3://cluster_log_bucket/prefix\", \"region\" : \"us-west-2\" } }`\nCluster iam role is used to access s3, please make sure the cluster iam role in\n`instance_profile_arn` has permission to write data to the s3 destination.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.S3StorageInfo"
                     },
                     "volumes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.VolumesStorageInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"volumes\" : { \"destination\" : \"/Volumes/my-init.sh\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"volumes\" : { \"destination\" : \"/Volumes/my-init.sh\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.VolumesStorageInfo"
                     },
                     "workspace": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.WorkspaceStorageInfo",
-                      "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`"
+                      "description": "destination needs to be provided. e.g.\n`{ \"workspace\" : { \"destination\" : \"/Users/user1@databricks.com/my-init.sh\" } }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.WorkspaceStorageInfo"
                     }
                   },
                   "additionalProperties": false
@@ -1949,38 +2850,41 @@
                 }
               ]
             },
+            "compute.Kind": {
+              "type": "string"
+            },
             "compute.Library": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "cran": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.RCranLibrary",
-                      "description": "Specification of a CRAN library to be installed as part of the library"
+                      "description": "Specification of a CRAN library to be installed as part of the library",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.RCranLibrary"
                     },
                     "egg": {
-                      "$ref": "#/$defs/string",
-                      "description": "Deprecated. URI of the egg library to install. Installing Python egg files is deprecated and is not supported in Databricks Runtime 14.0 and above."
+                      "description": "Deprecated. URI of the egg library to install. Installing Python egg files is deprecated and is not supported in Databricks Runtime 14.0 and above.",
+                      "$ref": "#/$defs/string"
                     },
                     "jar": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI of the JAR library to install. Supported URIs include Workspace paths, Unity Catalog Volumes paths, and S3 URIs.\nFor example: `{ \"jar\": \"/Workspace/path/to/library.jar\" }`, `{ \"jar\" : \"/Volumes/path/to/library.jar\" }` or\n`{ \"jar\": \"s3://my-bucket/library.jar\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                      "description": "URI of the JAR library to install. Supported URIs include Workspace paths, Unity Catalog Volumes paths, and S3 URIs.\nFor example: `{ \"jar\": \"/Workspace/path/to/library.jar\" }`, `{ \"jar\" : \"/Volumes/path/to/library.jar\" }` or\n`{ \"jar\": \"s3://my-bucket/library.jar\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI.",
+                      "$ref": "#/$defs/string"
                     },
                     "maven": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.MavenLibrary",
-                      "description": "Specification of a maven library to be installed. For example:\n`{ \"coordinates\": \"org.jsoup:jsoup:1.7.2\" }`"
+                      "description": "Specification of a maven library to be installed. For example:\n`{ \"coordinates\": \"org.jsoup:jsoup:1.7.2\" }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.MavenLibrary"
                     },
                     "pypi": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.PythonPyPiLibrary",
-                      "description": "Specification of a PyPi library to be installed. For example:\n`{ \"package\": \"simplejson\" }`"
+                      "description": "Specification of a PyPi library to be installed. For example:\n`{ \"package\": \"simplejson\" }`",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.PythonPyPiLibrary"
                     },
                     "requirements": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI of the requirements.txt file to install. Only Workspace paths and Unity Catalog Volumes paths are supported.\nFor example: `{ \"requirements\": \"/Workspace/path/to/requirements.txt\" }` or `{ \"requirements\" : \"/Volumes/path/to/requirements.txt\" }`"
+                      "description": "URI of the requirements.txt file to install. Only Workspace paths and Unity Catalog Volumes paths are supported.\nFor example: `{ \"requirements\": \"/Workspace/path/to/requirements.txt\" }` or `{ \"requirements\" : \"/Volumes/path/to/requirements.txt\" }`",
+                      "$ref": "#/$defs/string"
                     },
                     "whl": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI of the wheel library to install. Supported URIs include Workspace paths, Unity Catalog Volumes paths, and S3 URIs.\nFor example: `{ \"whl\": \"/Workspace/path/to/library.whl\" }`, `{ \"whl\" : \"/Volumes/path/to/library.whl\" }` or\n`{ \"whl\": \"s3://my-bucket/library.whl\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI."
+                      "description": "URI of the wheel library to install. Supported URIs include Workspace paths, Unity Catalog Volumes paths, and S3 URIs.\nFor example: `{ \"whl\": \"/Workspace/path/to/library.whl\" }`, `{ \"whl\" : \"/Volumes/path/to/library.whl\" }` or\n`{ \"whl\": \"s3://my-bucket/library.whl\" }`.\nIf S3 is used, please make sure the cluster has read access on the library. You may need to\nlaunch the cluster with an IAM role to access the S3 URI.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -1992,17 +2896,19 @@
               ]
             },
             "compute.LocalFileInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "local file destination, e.g. `file:/my/local/file.sh`"
+                      "description": "local file destination, e.g. `file:/my/local/file.sh`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2011,17 +2917,17 @@
               ]
             },
             "compute.LogAnalyticsInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "log_analytics_primary_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "\u003cneeds content added\u003e"
+                      "description": "\u003cneeds content added\u003e",
+                      "$ref": "#/$defs/string"
                     },
                     "log_analytics_workspace_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "\u003cneeds content added\u003e"
+                      "description": "\u003cneeds content added\u003e",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -2033,25 +2939,27 @@
               ]
             },
             "compute.MavenLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "coordinates": {
-                      "$ref": "#/$defs/string",
-                      "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\"."
+                      "description": "Gradle-style maven coordinates. For example: \"org.jsoup:jsoup:1.7.2\".",
+                      "$ref": "#/$defs/string"
                     },
                     "exclusions": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html."
+                      "description": "List of dependences to exclude. For example: `[\"slf4j:slf4j\", \"*:hadoop-client\"]`.\n\nMaven dependency exclusions:\nhttps://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "repo": {
-                      "$ref": "#/$defs/string",
-                      "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched."
+                      "description": "Maven repo to install the Maven package from. If omitted, both Maven Central Repository\nand Spark Packages are searched.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["coordinates"]
+                  "required": [
+                    "coordinates"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2060,21 +2968,23 @@
               ]
             },
             "compute.PythonPyPiLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "package": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the pypi package to install. An optional exact version specification is also\nsupported. Examples: \"simplejson\" and \"simplejson==3.8.0\"."
+                      "description": "The name of the pypi package to install. An optional exact version specification is also\nsupported. Examples: \"simplejson\" and \"simplejson==3.8.0\".",
+                      "$ref": "#/$defs/string"
                     },
                     "repo": {
-                      "$ref": "#/$defs/string",
-                      "description": "The repository where the package can be found. If not specified, the default pip index is\nused."
+                      "description": "The repository where the package can be found. If not specified, the default pip index is\nused.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["package"]
+                  "required": [
+                    "package"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2083,21 +2993,23 @@
               ]
             },
             "compute.RCranLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "package": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the CRAN package to install."
+                      "description": "The name of the CRAN package to install.",
+                      "$ref": "#/$defs/string"
                     },
                     "repo": {
-                      "$ref": "#/$defs/string",
-                      "description": "The repository where the package can be found. If not specified, the default CRAN repo is used."
+                      "description": "The repository where the package can be found. If not specified, the default CRAN repo is used.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["package"]
+                  "required": [
+                    "package"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2106,46 +3018,60 @@
               ]
             },
             "compute.RuntimeEngine": {
-              "type": "string",
-              "description": "Determines the cluster's runtime engine, either standard or Photon.\n\nThis field is not compatible with legacy `spark_version` values that contain `-photon-`.\nRemove `-photon-` from the `spark_version` and set `runtime_engine` to `PHOTON`.\n\nIf left unspecified, the runtime engine defaults to standard unless the spark_version\ncontains -photon-, in which case Photon will be used.\n",
-              "enum": ["NULL", "STANDARD", "PHOTON"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Determines the cluster's runtime engine, either standard or Photon.\n\nThis field is not compatible with legacy `spark_version` values that contain `-photon-`.\nRemove `-photon-` from the `spark_version` and set `runtime_engine` to `PHOTON`.\n\nIf left unspecified, the runtime engine defaults to standard unless the spark_version\ncontains -photon-, in which case Photon will be used.\n",
+                  "enum": [
+                    "NULL",
+                    "STANDARD",
+                    "PHOTON"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "compute.S3StorageInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "canned_acl": {
-                      "$ref": "#/$defs/string",
-                      "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs."
+                      "description": "(Optional) Set canned access control list for the logs, e.g. `bucket-owner-full-control`.\nIf `canned_cal` is set, please make sure the cluster iam role has `s3:PutObjectAcl` permission on\nthe destination bucket and prefix. The full list of possible canned acl can be found at\nhttp://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl.\nPlease also note that by default only the object owner gets full controls. If you are using cross account\nrole for writing data, you may want to set `bucket-owner-full-control` to make bucket owner able to\nread the logs.",
+                      "$ref": "#/$defs/string"
                     },
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs."
+                      "description": "S3 destination, e.g. `s3://my-bucket/some-prefix` Note that logs will be delivered using\ncluster iam role, please make sure you set cluster iam role and the role has write access to the\ndestination. Please also note that you cannot use AWS keys to deliver logs.",
+                      "$ref": "#/$defs/string"
                     },
                     "enable_encryption": {
-                      "$ref": "#/$defs/bool",
-                      "description": "(Optional) Flag to enable server side encryption, `false` by default."
+                      "description": "(Optional) Flag to enable server side encryption, `false` by default.",
+                      "$ref": "#/$defs/bool"
                     },
                     "encryption_type": {
-                      "$ref": "#/$defs/string",
-                      "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`."
+                      "description": "(Optional) The encryption type, it could be `sse-s3` or `sse-kms`. It will be used only when\nencryption is enabled and the default type is `sse-s3`.",
+                      "$ref": "#/$defs/string"
                     },
                     "endpoint": {
-                      "$ref": "#/$defs/string",
-                      "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used."
+                      "description": "S3 endpoint, e.g. `https://s3-us-west-2.amazonaws.com`. Either region or endpoint needs to be set.\nIf both are set, endpoint will be used.",
+                      "$ref": "#/$defs/string"
                     },
                     "kms_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`."
+                      "description": "(Optional) Kms key which will be used if encryption is enabled and encryption type is set to `sse-kms`.",
+                      "$ref": "#/$defs/string"
                     },
                     "region": {
-                      "$ref": "#/$defs/string",
-                      "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used."
+                      "description": "S3 region, e.g. `us-west-2`. Either region or endpoint needs to be set. If both are set,\nendpoint will be used.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2154,17 +3080,19 @@
               ]
             },
             "compute.VolumesStorageInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "Unity Catalog Volumes file destination, e.g. `/Volumes/my-init.sh`"
+                      "description": "Unity Catalog Volumes file destination, e.g. `/Volumes/my-init.sh`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2173,17 +3101,19 @@
               ]
             },
             "compute.WorkloadType": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "clients": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClientsTypes",
-                      "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs"
+                      "description": " defined what type of clients can use the cluster. E.g. Notebooks, Jobs",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClientsTypes"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["clients"]
+                  "required": [
+                    "clients"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2192,17 +3122,68 @@
               ]
             },
             "compute.WorkspaceStorageInfo": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination": {
-                      "$ref": "#/$defs/string",
-                      "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`"
+                      "description": "workspace files destination, e.g. `/Users/user1@databricks.com/my-init.sh`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["destination"]
+                  "required": [
+                    "destination"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "dashboards.LifecycleState": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "ACTIVE",
+                    "TRASHED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "jobs.CleanRoomsNotebookTask": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "clean_room_name": {
+                      "description": "The clean room that the notebook belongs to.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "etag": {
+                      "description": "Checksum to validate the freshness of the notebook resource (i.e. the notebook being run is the latest version).\nIt can be fetched by calling the :method:cleanroomassets/get API.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "notebook_base_parameters": {
+                      "description": "Base parameters to be used for the clean room notebook job.",
+                      "$ref": "#/$defs/map/string"
+                    },
+                    "notebook_name": {
+                      "description": "Name of the notebook being run.",
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "clean_room_name",
+                    "notebook_name"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2211,29 +3192,44 @@
               ]
             },
             "jobs.Condition": {
-              "type": "string",
-              "enum": ["ANY_UPDATED", "ALL_UPDATED"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "ANY_UPDATED",
+                    "ALL_UPDATED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.ConditionTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "left": {
-                      "$ref": "#/$defs/string",
-                      "description": "The left operand of the condition task. Can be either a string value or a job state or parameter reference."
+                      "description": "The left operand of the condition task. Can be either a string value or a job state or parameter reference.",
+                      "$ref": "#/$defs/string"
                     },
                     "op": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ConditionTaskOp",
-                      "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison."
+                      "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ConditionTaskOp"
                     },
                     "right": {
-                      "$ref": "#/$defs/string",
-                      "description": "The right operand of the condition task. Can be either a string value or a job state or parameter reference."
+                      "description": "The right operand of the condition task. Can be either a string value or a job state or parameter reference.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["left", "op", "right"]
+                  "required": [
+                    "left",
+                    "op",
+                    "right"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2242,25 +3238,33 @@
               ]
             },
             "jobs.ConditionTaskOp": {
-              "type": "string",
-              "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison.",
-              "enum": [
-                "EQUAL_TO",
-                "GREATER_THAN",
-                "GREATER_THAN_OR_EQUAL",
-                "LESS_THAN",
-                "LESS_THAN_OR_EQUAL",
-                "NOT_EQUAL"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that `“12.0” == “12”` will evaluate to `false`.\n* `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands. `“12.0” \u003e= “12”` will evaluate to `true`, `“10.0” \u003e= “12”` will evaluate to `false`.\n\nThe boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`. If a task value was set to a boolean value, it will be serialized to `“true”` or `“false”` for the comparison.",
+                  "enum": [
+                    "EQUAL_TO",
+                    "GREATER_THAN",
+                    "GREATER_THAN_OR_EQUAL",
+                    "LESS_THAN",
+                    "LESS_THAN_OR_EQUAL",
+                    "NOT_EQUAL"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "jobs.Continuous": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "pause_status": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus",
-                      "description": "Indicate whether the continuous execution of the job is paused or not. Defaults to UNPAUSED."
+                      "description": "Indicate whether the continuous execution of the job is paused or not. Defaults to UNPAUSED.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus"
                     }
                   },
                   "additionalProperties": false
@@ -2272,25 +3276,28 @@
               ]
             },
             "jobs.CronSchedule": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "pause_status": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus",
-                      "description": "Indicate whether this schedule is paused or not."
+                      "description": "Indicate whether this schedule is paused or not.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus"
                     },
                     "quartz_cron_expression": {
-                      "$ref": "#/$defs/string",
-                      "description": "A Cron expression using Quartz syntax that describes the schedule for a job. See [Cron Trigger](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) for details. This field is required."
+                      "description": "A Cron expression using Quartz syntax that describes the schedule for a job. See [Cron Trigger](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) for details. This field is required.",
+                      "$ref": "#/$defs/string"
                     },
                     "timezone_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "A Java timezone ID. The schedule for a job is resolved with respect to this timezone. See [Java TimeZone](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html) for details. This field is required."
+                      "description": "A Java timezone ID. The schedule for a job is resolved with respect to this timezone. See [Java TimeZone](https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html) for details. This field is required.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["quartz_cron_expression", "timezone_id"]
+                  "required": [
+                    "quartz_cron_expression",
+                    "timezone_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2299,41 +3306,43 @@
               ]
             },
             "jobs.DbtTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional name of the catalog to use. The value is the top level in the 3-level namespace of Unity Catalog (catalog / schema / relation). The catalog value can only be specified if a warehouse_id is specified. Requires dbt-databricks \u003e= 1.1.1."
+                      "description": "Optional name of the catalog to use. The value is the top level in the 3-level namespace of Unity Catalog (catalog / schema / relation). The catalog value can only be specified if a warehouse_id is specified. Requires dbt-databricks \u003e= 1.1.1.",
+                      "$ref": "#/$defs/string"
                     },
                     "commands": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of dbt commands to execute. All commands must start with `dbt`. This parameter must not be empty. A maximum of up to 10 commands can be provided."
+                      "description": "A list of dbt commands to execute. All commands must start with `dbt`. This parameter must not be empty. A maximum of up to 10 commands can be provided.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "profiles_directory": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional (relative) path to the profiles directory. Can only be specified if no warehouse_id is specified. If no warehouse_id is specified and this folder is unset, the root directory is used."
+                      "description": "Optional (relative) path to the profiles directory. Can only be specified if no warehouse_id is specified. If no warehouse_id is specified and this folder is unset, the root directory is used.",
+                      "$ref": "#/$defs/string"
                     },
                     "project_directory": {
-                      "$ref": "#/$defs/string",
-                      "description": "Path to the project directory. Optional for Git sourced tasks, in which\ncase if no value is provided, the root of the Git repository is used."
+                      "description": "Path to the project directory. Optional for Git sourced tasks, in which\ncase if no value is provided, the root of the Git repository is used.",
+                      "$ref": "#/$defs/string"
                     },
                     "schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional schema to write to. This parameter is only used when a warehouse_id is also provided. If not provided, the `default` schema is used."
+                      "description": "Optional schema to write to. This parameter is only used when a warehouse_id is also provided. If not provided, the `default` schema is used.",
+                      "$ref": "#/$defs/string"
                     },
                     "source": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source",
-                      "description": "Optional location type of the project directory. When set to `WORKSPACE`, the project will be retrieved\nfrom the local Databricks workspace. When set to `GIT`, the project will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: Project is located in Databricks workspace.\n* `GIT`: Project is located in cloud Git provider."
+                      "description": "Optional location type of the project directory. When set to `WORKSPACE`, the project will be retrieved\nfrom the local Databricks workspace. When set to `GIT`, the project will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: Project is located in Databricks workspace.\n* `GIT`: Project is located in cloud Git provider.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source"
                     },
                     "warehouse_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "ID of the SQL warehouse to connect to. If provided, we automatically generate and provide the profile and connection details to dbt. It can be overridden on a per-command basis by using the `--profiles-dir` command line argument."
+                      "description": "ID of the SQL warehouse to connect to. If provided, we automatically generate and provide the profile and connection details to dbt. It can be overridden on a per-command basis by using the `--profiles-dir` command line argument.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["commands"]
+                  "required": [
+                    "commands"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2342,25 +3351,27 @@
               ]
             },
             "jobs.FileArrivalTriggerConfiguration": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "min_time_between_triggers_seconds": {
-                      "$ref": "#/$defs/int",
-                      "description": "If set, the trigger starts a run only after the specified amount of time passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds"
+                      "description": "If set, the trigger starts a run only after the specified amount of time passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds",
+                      "$ref": "#/$defs/int"
                     },
                     "url": {
-                      "$ref": "#/$defs/string",
-                      "description": "URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location."
+                      "description": "URL to be monitored for file arrivals. The path must point to the root or a subpath of the external location.",
+                      "$ref": "#/$defs/string"
                     },
                     "wait_after_last_change_seconds": {
-                      "$ref": "#/$defs/int",
-                      "description": "If set, the trigger starts a run only after no file activity has occurred for the specified amount of time.\nThis makes it possible to wait for a batch of incoming files to arrive before triggering a run. The\nminimum allowed value is 60 seconds."
+                      "description": "If set, the trigger starts a run only after no file activity has occurred for the specified amount of time.\nThis makes it possible to wait for a batch of incoming files to arrive before triggering a run. The\nminimum allowed value is 60 seconds.",
+                      "$ref": "#/$defs/int"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["url"]
+                  "required": [
+                    "url"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2369,25 +3380,28 @@
               ]
             },
             "jobs.ForEachTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "concurrency": {
-                      "$ref": "#/$defs/int",
-                      "description": "An optional maximum allowed number of concurrent runs of the task.\nSet this value if you want to be able to execute multiple runs of the task concurrently."
+                      "description": "An optional maximum allowed number of concurrent runs of the task.\nSet this value if you want to be able to execute multiple runs of the task concurrently.",
+                      "$ref": "#/$defs/int"
                     },
                     "inputs": {
-                      "$ref": "#/$defs/string",
-                      "description": "Array for task to iterate on. This can be a JSON string or a reference to\nan array parameter."
+                      "description": "Array for task to iterate on. This can be a JSON string or a reference to\nan array parameter.",
+                      "$ref": "#/$defs/string"
                     },
                     "task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Task",
-                      "description": "Configuration for the task that will be run for each element in the array"
+                      "description": "Configuration for the task that will be run for each element in the array",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Task"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["inputs", "task"]
+                  "required": [
+                    "inputs",
+                    "task"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2396,31 +3410,50 @@
               ]
             },
             "jobs.Format": {
-              "type": "string",
-              "enum": ["SINGLE_TASK", "MULTI_TASK"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "SINGLE_TASK",
+                    "MULTI_TASK"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.GitProvider": {
-              "type": "string",
-              "enum": [
-                "gitHub",
-                "bitbucketCloud",
-                "azureDevOpsServices",
-                "gitHubEnterprise",
-                "bitbucketServer",
-                "gitLab",
-                "gitLabEnterpriseEdition",
-                "awsCodeCommit"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "gitHub",
+                    "bitbucketCloud",
+                    "azureDevOpsServices",
+                    "gitHubEnterprise",
+                    "bitbucketServer",
+                    "gitLab",
+                    "gitLabEnterpriseEdition",
+                    "awsCodeCommit"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "jobs.GitSnapshot": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "description": "Read-only state of the remote repository at the time the job was run. This field is only included on job runs.",
                   "properties": {
                     "used_commit": {
-                      "$ref": "#/$defs/string",
-                      "description": "Commit that was used to execute the run. If git_branch was specified, this points to the HEAD of the branch at the time of the run; if git_tag was specified, this points to the commit the tag points to."
+                      "description": "Commit that was used to execute the run. If git_branch was specified, this points to the HEAD of the branch at the time of the run; if git_tag was specified, this points to the commit the tag points to.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -2432,34 +3465,37 @@
               ]
             },
             "jobs.GitSource": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "description": "An optional specification for a remote Git repository containing the source code used by tasks. Version-controlled source code is supported by notebook, dbt, Python script, and SQL File tasks.\n\nIf `git_source` is set, these tasks retrieve the file from the remote repository by default. However, this behavior can be overridden by setting `source` to `WORKSPACE` on the task.\n\nNote: dbt and SQL File tasks support only version-controlled sources. If dbt or SQL File tasks are used, `git_source` must be defined on the job.",
                   "properties": {
                     "git_branch": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the branch to be checked out and used by this job. This field cannot be specified in conjunction with git_tag or git_commit."
+                      "description": "Name of the branch to be checked out and used by this job. This field cannot be specified in conjunction with git_tag or git_commit.",
+                      "$ref": "#/$defs/string"
                     },
                     "git_commit": {
-                      "$ref": "#/$defs/string",
-                      "description": "Commit to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_tag."
+                      "description": "Commit to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_tag.",
+                      "$ref": "#/$defs/string"
                     },
                     "git_provider": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.GitProvider",
-                      "description": "Unique identifier of the service used to host the Git repository. The value is case insensitive."
+                      "description": "Unique identifier of the service used to host the Git repository. The value is case insensitive.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.GitProvider"
                     },
                     "git_tag": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the tag to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_commit."
+                      "description": "Name of the tag to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_commit.",
+                      "$ref": "#/$defs/string"
                     },
                     "git_url": {
-                      "$ref": "#/$defs/string",
-                      "description": "URL of the repository to be cloned by this job."
+                      "description": "URL of the repository to be cloned by this job.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["git_provider", "git_url"]
+                  "required": [
+                    "git_provider",
+                    "git_url"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2468,21 +3504,24 @@
               ]
             },
             "jobs.JobCluster": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "job_cluster_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "A unique name for the job cluster. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine which cluster to launch for the task execution."
+                      "description": "A unique name for the job cluster. This field is required and must be unique within the job.\n`JobTaskSettings` may refer to this field to determine which cluster to launch for the task execution.",
+                      "$ref": "#/$defs/string"
                     },
                     "new_cluster": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec",
-                      "description": "If new_cluster, a description of a cluster that is created for each task."
+                      "description": "If new_cluster, a description of a cluster that is created for each task.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["job_cluster_key", "new_cluster"]
+                  "required": [
+                    "job_cluster_key",
+                    "new_cluster"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2491,21 +3530,23 @@
               ]
             },
             "jobs.JobDeployment": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "kind": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobDeploymentKind",
-                      "description": "The kind of deployment that manages the job.\n\n* `BUNDLE`: The job is managed by Databricks Asset Bundle."
+                      "description": "The kind of deployment that manages the job.\n\n* `BUNDLE`: The job is managed by Databricks Asset Bundle.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobDeploymentKind"
                     },
                     "metadata_file_path": {
-                      "$ref": "#/$defs/string",
-                      "description": "Path of the file that contains deployment metadata."
+                      "description": "Path of the file that contains deployment metadata.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["kind"]
+                  "required": [
+                    "kind"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2514,43 +3555,64 @@
               ]
             },
             "jobs.JobDeploymentKind": {
-              "type": "string",
-              "description": "* `BUNDLE`: The job is managed by Databricks Asset Bundle.",
-              "enum": ["BUNDLE"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "* `BUNDLE`: The job is managed by Databricks Asset Bundle.",
+                  "enum": [
+                    "BUNDLE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.JobEditMode": {
-              "type": "string",
-              "description": "Edit mode of the job.\n\n* `UI_LOCKED`: The job is in a locked UI state and cannot be modified.\n* `EDITABLE`: The job is in an editable state and can be modified.",
-              "enum": ["UI_LOCKED", "EDITABLE"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Edit mode of the job.\n\n* `UI_LOCKED`: The job is in a locked UI state and cannot be modified.\n* `EDITABLE`: The job is in an editable state and can be modified.",
+                  "enum": [
+                    "UI_LOCKED",
+                    "EDITABLE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.JobEmailNotifications": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "no_alert_for_skipped_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped.\nThis field is `deprecated`. Please use the `notification_settings.no_alert_for_skipped_runs` field."
+                      "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped.\nThis field is `deprecated`. Please use the `notification_settings.no_alert_for_skipped_runs` field.",
+                      "$ref": "#/$defs/bool"
                     },
                     "on_duration_warning_threshold_exceeded": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. If no rule for the `RUN_DURATION_SECONDS` metric is specified in the `health` field for the job, notifications are not sent."
+                      "description": "A list of email addresses to be notified when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. If no rule for the `RUN_DURATION_SECONDS` metric is specified in the `health` field for the job, notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_failure": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_start": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_streaming_backlog_exceeded": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to notify when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes."
+                      "description": "A list of email addresses to notify when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_success": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -2562,20 +3624,22 @@
               ]
             },
             "jobs.JobEnvironment": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "environment_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The key of an environment. It has to be unique within a job."
+                      "description": "The key of an environment. It has to be unique within a job.",
+                      "$ref": "#/$defs/string"
                     },
                     "spec": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Environment"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["environment_key"]
+                  "required": [
+                    "environment_key"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2584,17 +3648,17 @@
               ]
             },
             "jobs.JobNotificationSettings": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "no_alert_for_canceled_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled.",
+                      "$ref": "#/$defs/bool"
                     },
                     "no_alert_for_skipped_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -2606,21 +3670,24 @@
               ]
             },
             "jobs.JobParameterDefinition": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "default": {
-                      "$ref": "#/$defs/string",
-                      "description": "Default value of the parameter."
+                      "description": "Default value of the parameter.",
+                      "$ref": "#/$defs/string"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the defined parameter. May only contain alphanumeric characters, `_`, `-`, and `.`"
+                      "description": "The name of the defined parameter. May only contain alphanumeric characters, `_`, `-`, and `.`",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["default", "name"]
+                  "required": [
+                    "default",
+                    "name"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2629,18 +3696,18 @@
               ]
             },
             "jobs.JobRunAs": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
-                  "description": "Write-only setting. Specifies the user, service principal or group that the job/pipeline runs as. If not specified, the job/pipeline runs as the user who created the job/pipeline.\n\nExactly one of `user_name`, `service_principal_name`, `group_name` should be specified. If not, an error is thrown.",
+                  "description": "Write-only setting. Specifies the user or service principal that the job runs as. If not specified, the job runs as the user who created the job.\n\nEither `user_name` or `service_principal_name` should be specified. If not, an error is thrown.",
                   "properties": {
                     "service_principal_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role."
+                      "description": "Application ID of an active service principal. Setting this field requires the `servicePrincipal/user` role.",
+                      "$ref": "#/$defs/string"
                     },
                     "user_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The email of an active workspace user. Non-admin users can only set this field to their own email."
+                      "description": "The email of an active workspace user. Non-admin users can only set this field to their own email.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -2652,26 +3719,29 @@
               ]
             },
             "jobs.JobSource": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "description": "The source of the job specification in the remote repository when the job is source controlled.",
                   "properties": {
                     "dirty_state": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobSourceDirtyState",
-                      "description": "Dirty state indicates the job is not fully synced with the job specification in the remote repository.\n\nPossible values are:\n* `NOT_SYNCED`: The job is not yet synced with the remote job specification. Import the remote job specification from UI to make the job fully synced.\n* `DISCONNECTED`: The job is temporary disconnected from the remote job specification and is allowed for live edit. Import the remote job specification again from UI to make the job fully synced."
+                      "description": "Dirty state indicates the job is not fully synced with the job specification in the remote repository.\n\nPossible values are:\n* `NOT_SYNCED`: The job is not yet synced with the remote job specification. Import the remote job specification from UI to make the job fully synced.\n* `DISCONNECTED`: The job is temporary disconnected from the remote job specification and is allowed for live edit. Import the remote job specification again from UI to make the job fully synced.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobSourceDirtyState"
                     },
                     "import_from_git_branch": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the branch which the job is imported from."
+                      "description": "Name of the branch which the job is imported from.",
+                      "$ref": "#/$defs/string"
                     },
                     "job_config_path": {
-                      "$ref": "#/$defs/string",
-                      "description": "Path of the job YAML file that contains the job specification."
+                      "description": "Path of the job YAML file that contains the job specification.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["import_from_git_branch", "job_config_path"]
+                  "required": [
+                    "import_from_git_branch",
+                    "job_config_path"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2680,28 +3750,57 @@
               ]
             },
             "jobs.JobSourceDirtyState": {
-              "type": "string",
-              "description": "Dirty state indicates the job is not fully synced with the job specification\nin the remote repository.\n\nPossible values are:\n* `NOT_SYNCED`: The job is not yet synced with the remote job specification. Import the remote job specification from UI to make the job fully synced.\n* `DISCONNECTED`: The job is temporary disconnected from the remote job specification and is allowed for live edit. Import the remote job specification again from UI to make the job fully synced.",
-              "enum": ["NOT_SYNCED", "DISCONNECTED"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Dirty state indicates the job is not fully synced with the job specification\nin the remote repository.\n\nPossible values are:\n* `NOT_SYNCED`: The job is not yet synced with the remote job specification. Import the remote job specification from UI to make the job fully synced.\n* `DISCONNECTED`: The job is temporary disconnected from the remote job specification and is allowed for live edit. Import the remote job specification again from UI to make the job fully synced.",
+                  "enum": [
+                    "NOT_SYNCED",
+                    "DISCONNECTED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.JobsHealthMetric": {
-              "type": "string",
-              "description": "Specifies the health metric that is being evaluated for a particular health rule.\n\n* `RUN_DURATION_SECONDS`: Expected total time for a run in seconds.\n* `STREAMING_BACKLOG_BYTES`: An estimate of the maximum bytes of data waiting to be consumed across all streams. This metric is in Private Preview.\n* `STREAMING_BACKLOG_RECORDS`: An estimate of the maximum offset lag across all streams. This metric is in Private Preview.\n* `STREAMING_BACKLOG_SECONDS`: An estimate of the maximum consumer delay across all streams. This metric is in Private Preview.\n* `STREAMING_BACKLOG_FILES`: An estimate of the maximum number of outstanding files across all streams. This metric is in Private Preview.",
-              "enum": [
-                "RUN_DURATION_SECONDS",
-                "STREAMING_BACKLOG_BYTES",
-                "STREAMING_BACKLOG_RECORDS",
-                "STREAMING_BACKLOG_SECONDS",
-                "STREAMING_BACKLOG_FILES"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Specifies the health metric that is being evaluated for a particular health rule.\n\n* `RUN_DURATION_SECONDS`: Expected total time for a run in seconds.\n* `STREAMING_BACKLOG_BYTES`: An estimate of the maximum bytes of data waiting to be consumed across all streams. This metric is in Public Preview.\n* `STREAMING_BACKLOG_RECORDS`: An estimate of the maximum offset lag across all streams. This metric is in Public Preview.\n* `STREAMING_BACKLOG_SECONDS`: An estimate of the maximum consumer delay across all streams. This metric is in Public Preview.\n* `STREAMING_BACKLOG_FILES`: An estimate of the maximum number of outstanding files across all streams. This metric is in Public Preview.",
+                  "enum": [
+                    "RUN_DURATION_SECONDS",
+                    "STREAMING_BACKLOG_BYTES",
+                    "STREAMING_BACKLOG_RECORDS",
+                    "STREAMING_BACKLOG_SECONDS",
+                    "STREAMING_BACKLOG_FILES"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "jobs.JobsHealthOperator": {
-              "type": "string",
-              "description": "Specifies the operator used to compare the health metric value with the specified threshold.",
-              "enum": ["GREATER_THAN"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Specifies the operator used to compare the health metric value with the specified threshold.",
+                  "enum": [
+                    "GREATER_THAN"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.JobsHealthRule": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -2712,12 +3811,16 @@
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobsHealthOperator"
                     },
                     "value": {
-                      "$ref": "#/$defs/int64",
-                      "description": "Specifies the threshold value that the health metric should obey to satisfy the health rule."
+                      "description": "Specifies the threshold value that the health metric should obey to satisfy the health rule.",
+                      "$ref": "#/$defs/int64"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["metric", "op", "value"]
+                  "required": [
+                    "metric",
+                    "op",
+                    "value"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2726,7 +3829,7 @@
               ]
             },
             "jobs.JobsHealthRules": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "description": "An optional set of health rules that can be defined for this job.",
@@ -2744,29 +3847,31 @@
               ]
             },
             "jobs.NotebookTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "base_parameters": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Base parameters to be used for each run of this job. If the run is initiated by a call to :method:jobs/run\nNow with parameters specified, the two parameters maps are merged. If the same key is specified in\n`base_parameters` and in `run-now`, the value from `run-now` is used.\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nIf the notebook takes a parameter that is not specified in the job’s `base_parameters` or the `run-now` override parameters,\nthe default value from the notebook is used.\n\nRetrieve these parameters in a notebook using [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-widgets).\n\nThe JSON representation of this field cannot exceed 1MB."
+                      "description": "Base parameters to be used for each run of this job. If the run is initiated by a call to :method:jobs/run\nNow with parameters specified, the two parameters maps are merged. If the same key is specified in\n`base_parameters` and in `run-now`, the value from `run-now` is used.\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nIf the notebook takes a parameter that is not specified in the job’s `base_parameters` or the `run-now` override parameters,\nthe default value from the notebook is used.\n\nRetrieve these parameters in a notebook using [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-widgets).\n\nThe JSON representation of this field cannot exceed 1MB.",
+                      "$ref": "#/$defs/map/string"
                     },
                     "notebook_path": {
-                      "$ref": "#/$defs/string",
-                      "description": "The path of the notebook to be run in the Databricks workspace or remote repository.\nFor notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash.\nFor notebooks stored in a remote repository, the path must be relative. This field is required."
+                      "description": "The path of the notebook to be run in the Databricks workspace or remote repository.\nFor notebooks stored in the Databricks workspace, the path must be absolute and begin with a slash.\nFor notebooks stored in a remote repository, the path must be relative. This field is required.",
+                      "$ref": "#/$defs/string"
                     },
                     "source": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source",
-                      "description": "Optional location type of the notebook. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n* `WORKSPACE`: Notebook is located in Databricks workspace.\n* `GIT`: Notebook is located in cloud Git provider."
+                      "description": "Optional location type of the notebook. When set to `WORKSPACE`, the notebook will be retrieved from the local Databricks workspace. When set to `GIT`, the notebook will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n* `WORKSPACE`: Notebook is located in Databricks workspace.\n* `GIT`: Notebook is located in cloud Git provider.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source"
                     },
                     "warehouse_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional `warehouse_id` to run the notebook on a SQL warehouse. Classic SQL warehouses are NOT supported, please use serverless or pro SQL warehouses.\n\nNote that SQL warehouses only support SQL cells; if the notebook contains non-SQL cells, the run will fail."
+                      "description": "Optional `warehouse_id` to run the notebook on a SQL warehouse. Classic SQL warehouses are NOT supported, please use serverless or pro SQL warehouses.\n\nNote that SQL warehouses only support SQL cells; if the notebook contains non-SQL cells, the run will fail.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["notebook_path"]
+                  "required": [
+                    "notebook_path"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2775,25 +3880,39 @@
               ]
             },
             "jobs.PauseStatus": {
-              "type": "string",
-              "enum": ["UNPAUSED", "PAUSED"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "UNPAUSED",
+                    "PAUSED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.PeriodicTriggerConfiguration": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "interval": {
-                      "$ref": "#/$defs/int",
-                      "description": "The interval at which the trigger should run."
+                      "description": "The interval at which the trigger should run.",
+                      "$ref": "#/$defs/int"
                     },
                     "unit": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PeriodicTriggerConfigurationTimeUnit",
-                      "description": "The unit of time for the interval."
+                      "description": "The unit of time for the interval.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PeriodicTriggerConfigurationTimeUnit"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["interval", "unit"]
+                  "required": [
+                    "interval",
+                    "unit"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2802,17 +3921,29 @@
               ]
             },
             "jobs.PeriodicTriggerConfigurationTimeUnit": {
-              "type": "string",
-              "enum": ["HOURS", "DAYS", "WEEKS"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "HOURS",
+                    "DAYS",
+                    "WEEKS"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.PipelineParams": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "full_refresh": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, triggers a full refresh on the delta live table."
+                      "description": "If true, triggers a full refresh on the delta live table.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -2824,21 +3955,23 @@
               ]
             },
             "jobs.PipelineTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "full_refresh": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, triggers a full refresh on the delta live table."
+                      "description": "If true, triggers a full refresh on the delta live table.",
+                      "$ref": "#/$defs/bool"
                     },
                     "pipeline_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The full name of the pipeline task to execute."
+                      "description": "The full name of the pipeline task to execute.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["pipeline_id"]
+                  "required": [
+                    "pipeline_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2847,29 +3980,32 @@
               ]
             },
             "jobs.PythonWheelTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "entry_point": {
-                      "$ref": "#/$defs/string",
-                      "description": "Named entry point to use, if it does not exist in the metadata of the package it executes the function from the package directly using `$packageName.$entryPoint()`"
+                      "description": "Named entry point to use, if it does not exist in the metadata of the package it executes the function from the package directly using `$packageName.$entryPoint()`",
+                      "$ref": "#/$defs/string"
                     },
                     "named_parameters": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Command-line parameters passed to Python wheel task in the form of `[\"--name=task\", \"--data=dbfs:/path/to/data.json\"]`. Leave it empty if `parameters` is not null."
+                      "description": "Command-line parameters passed to Python wheel task in the form of `[\"--name=task\", \"--data=dbfs:/path/to/data.json\"]`. Leave it empty if `parameters` is not null.",
+                      "$ref": "#/$defs/map/string"
                     },
                     "package_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Name of the package to execute"
+                      "description": "Name of the package to execute",
+                      "$ref": "#/$defs/string"
                     },
                     "parameters": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Command-line parameters passed to Python wheel task. Leave it empty if `named_parameters` is not null."
+                      "description": "Command-line parameters passed to Python wheel task. Leave it empty if `named_parameters` is not null.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["entry_point", "package_name"]
+                  "required": [
+                    "entry_point",
+                    "package_name"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2878,17 +4014,19 @@
               ]
             },
             "jobs.QueueSettings": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, enable queueing for the job. This is a required field."
+                      "description": "If true, enable queueing for the job. This is a required field.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["enabled"]
+                  "required": [
+                    "enabled"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2897,64 +4035,74 @@
               ]
             },
             "jobs.RunIf": {
-              "type": "string",
-              "description": "An optional value indicating the condition that determines whether the task should be run once its dependencies have been completed. When omitted, defaults to `ALL_SUCCESS`.\n\nPossible values are:\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies have been completed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed",
-              "enum": [
-                "ALL_SUCCESS",
-                "ALL_DONE",
-                "NONE_FAILED",
-                "AT_LEAST_ONE_SUCCESS",
-                "ALL_FAILED",
-                "AT_LEAST_ONE_FAILED"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "An optional value indicating the condition that determines whether the task should be run once its dependencies have been completed. When omitted, defaults to `ALL_SUCCESS`.\n\nPossible values are:\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies have been completed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed",
+                  "enum": [
+                    "ALL_SUCCESS",
+                    "ALL_DONE",
+                    "NONE_FAILED",
+                    "AT_LEAST_ONE_SUCCESS",
+                    "ALL_FAILED",
+                    "AT_LEAST_ONE_FAILED"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
               ]
             },
             "jobs.RunJobTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "dbt_commands": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "An array of commands to execute for jobs with the dbt task, for example `\"dbt_commands\": [\"dbt deps\", \"dbt seed\", \"dbt deps\", \"dbt seed\", \"dbt run\"]`"
+                      "description": "An array of commands to execute for jobs with the dbt task, for example `\"dbt_commands\": [\"dbt deps\", \"dbt seed\", \"dbt deps\", \"dbt seed\", \"dbt run\"]`",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "jar_params": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of parameters for jobs with Spark JAR tasks, for example `\"jar_params\": [\"john doe\", \"35\"]`.\nThe parameters are used to invoke the main function of the main class specified in the Spark JAR task.\nIf not specified upon `run-now`, it defaults to an empty list.\njar_params cannot be specified in conjunction with notebook_params.\nThe JSON representation of this field (for example `{\"jar_params\":[\"john doe\",\"35\"]}`) cannot exceed 10,000 bytes.\n\nUse [Task parameter variables](/jobs.html\\\"#parameter-variables\\\") to set parameters containing information about job runs."
+                      "description": "A list of parameters for jobs with Spark JAR tasks, for example `\"jar_params\": [\"john doe\", \"35\"]`.\nThe parameters are used to invoke the main function of the main class specified in the Spark JAR task.\nIf not specified upon `run-now`, it defaults to an empty list.\njar_params cannot be specified in conjunction with notebook_params.\nThe JSON representation of this field (for example `{\"jar_params\":[\"john doe\",\"35\"]}`) cannot exceed 10,000 bytes.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "job_id": {
-                      "$ref": "#/$defs/int64",
-                      "description": "ID of the job to trigger."
+                      "description": "ID of the job to trigger.",
+                      "$ref": "#/$defs/int64"
                     },
                     "job_parameters": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Job-level parameters used to trigger the job."
+                      "description": "Job-level parameters used to trigger the job.",
+                      "$ref": "#/$defs/map/string"
                     },
                     "notebook_params": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "A map from keys to values for jobs with notebook task, for example `\"notebook_params\": {\"name\": \"john doe\", \"age\": \"35\"}`.\nThe map is passed to the notebook and is accessible through the [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html) function.\n\nIf not specified upon `run-now`, the triggered run uses the job’s base parameters.\n\nnotebook_params cannot be specified in conjunction with jar_params.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nThe JSON representation of this field (for example `{\"notebook_params\":{\"name\":\"john doe\",\"age\":\"35\"}}`) cannot exceed 10,000 bytes."
+                      "description": "A map from keys to values for jobs with notebook task, for example `\"notebook_params\": {\"name\": \"john doe\", \"age\": \"35\"}`.\nThe map is passed to the notebook and is accessible through the [dbutils.widgets.get](https://docs.databricks.com/dev-tools/databricks-utils.html) function.\n\nIf not specified upon `run-now`, the triggered run uses the job’s base parameters.\n\nnotebook_params cannot be specified in conjunction with jar_params.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nThe JSON representation of this field (for example `{\"notebook_params\":{\"name\":\"john doe\",\"age\":\"35\"}}`) cannot exceed 10,000 bytes.",
+                      "$ref": "#/$defs/map/string"
                     },
                     "pipeline_params": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PipelineParams",
-                      "description": "Controls whether the pipeline should perform a full refresh"
+                      "description": "Controls whether the pipeline should perform a full refresh",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PipelineParams"
                     },
                     "python_named_params": {
                       "$ref": "#/$defs/map/string"
                     },
                     "python_params": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of parameters for jobs with Python tasks, for example `\"python_params\": [\"john doe\", \"35\"]`.\nThe parameters are passed to Python file as command-line parameters. If specified upon `run-now`, it would overwrite\nthe parameters specified in job setting. The JSON representation of this field (for example `{\"python_params\":[\"john doe\",\"35\"]}`)\ncannot exceed 10,000 bytes.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nImportant\n\nThese parameters accept only Latin characters (ASCII character set). Using non-ASCII characters returns an error.\nExamples of invalid, non-ASCII characters are Chinese, Japanese kanjis, and emojis."
+                      "description": "A list of parameters for jobs with Python tasks, for example `\"python_params\": [\"john doe\", \"35\"]`.\nThe parameters are passed to Python file as command-line parameters. If specified upon `run-now`, it would overwrite\nthe parameters specified in job setting. The JSON representation of this field (for example `{\"python_params\":[\"john doe\",\"35\"]}`)\ncannot exceed 10,000 bytes.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.\n\nImportant\n\nThese parameters accept only Latin characters (ASCII character set). Using non-ASCII characters returns an error.\nExamples of invalid, non-ASCII characters are Chinese, Japanese kanjis, and emojis.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "spark_submit_params": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of parameters for jobs with spark submit task, for example `\"spark_submit_params\": [\"--class\", \"org.apache.spark.examples.SparkPi\"]`.\nThe parameters are passed to spark-submit script as command-line parameters. If specified upon `run-now`, it would overwrite the\nparameters specified in job setting. The JSON representation of this field (for example `{\"python_params\":[\"john doe\",\"35\"]}`)\ncannot exceed 10,000 bytes.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs\n\nImportant\n\nThese parameters accept only Latin characters (ASCII character set). Using non-ASCII characters returns an error.\nExamples of invalid, non-ASCII characters are Chinese, Japanese kanjis, and emojis."
+                      "description": "A list of parameters for jobs with spark submit task, for example `\"spark_submit_params\": [\"--class\", \"org.apache.spark.examples.SparkPi\"]`.\nThe parameters are passed to spark-submit script as command-line parameters. If specified upon `run-now`, it would overwrite the\nparameters specified in job setting. The JSON representation of this field (for example `{\"python_params\":[\"john doe\",\"35\"]}`)\ncannot exceed 10,000 bytes.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs\n\nImportant\n\nThese parameters accept only Latin characters (ASCII character set). Using non-ASCII characters returns an error.\nExamples of invalid, non-ASCII characters are Chinese, Japanese kanjis, and emojis.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "sql_params": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "A map from keys to values for jobs with SQL task, for example `\"sql_params\": {\"name\": \"john doe\", \"age\": \"35\"}`. The SQL alert task does not support custom parameters."
+                      "description": "A map from keys to values for jobs with SQL task, for example `\"sql_params\": {\"name\": \"john doe\", \"age\": \"35\"}`. The SQL alert task does not support custom parameters.",
+                      "$ref": "#/$defs/map/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["job_id"]
+                  "required": [
+                    "job_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -2963,26 +4111,37 @@
               ]
             },
             "jobs.Source": {
-              "type": "string",
-              "description": "Optional location type of the SQL file. When set to `WORKSPACE`, the SQL file will be retrieved\\\nfrom the local Databricks workspace. When set to `GIT`, the SQL file will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: SQL file is located in Databricks workspace.\n* `GIT`: SQL file is located in cloud Git provider.",
-              "enum": ["WORKSPACE", "GIT"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Optional location type of the SQL file. When set to `WORKSPACE`, the SQL file will be retrieved\\\nfrom the local Databricks workspace. When set to `GIT`, the SQL file will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: SQL file is located in Databricks workspace.\n* `GIT`: SQL file is located in cloud Git provider.",
+                  "enum": [
+                    "WORKSPACE",
+                    "GIT"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "jobs.SparkJarTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "jar_uri": {
-                      "$ref": "#/$defs/string",
-                      "description": "Deprecated since 04/2016. Provide a `jar` through the `libraries` field instead. For an example, see :method:jobs/create."
+                      "description": "Deprecated since 04/2016. Provide a `jar` through the `libraries` field instead. For an example, see :method:jobs/create.",
+                      "$ref": "#/$defs/string"
                     },
                     "main_class_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library.\n\nThe code must use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job fail."
+                      "description": "The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library.\n\nThe code must use `SparkContext.getOrCreate` to obtain a Spark context; otherwise, runs of the job fail.",
+                      "$ref": "#/$defs/string"
                     },
                     "parameters": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Parameters passed to the main method.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs."
+                      "description": "Parameters passed to the main method.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -2994,25 +4153,27 @@
               ]
             },
             "jobs.SparkPythonTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "parameters": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Command line parameters passed to the Python file.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs."
+                      "description": "Command line parameters passed to the Python file.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "python_file": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Python file to be executed. Cloud file URIs (such as dbfs:/, s3:/, adls:/, gcs:/) and workspace paths are supported. For python files stored in the Databricks workspace, the path must be absolute and begin with `/`. For files stored in a remote repository, the path must be relative. This field is required."
+                      "description": "The Python file to be executed. Cloud file URIs (such as dbfs:/, s3:/, adls:/, gcs:/) and workspace paths are supported. For python files stored in the Databricks workspace, the path must be absolute and begin with `/`. For files stored in a remote repository, the path must be relative. This field is required.",
+                      "$ref": "#/$defs/string"
                     },
                     "source": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source",
-                      "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved from the local\nDatabricks workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a Databricks workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository."
+                      "description": "Optional location type of the Python file. When set to `WORKSPACE` or not specified, the file will be retrieved from the local\nDatabricks workspace or cloud location (if the `python_file` has a URI format). When set to `GIT`,\nthe Python file will be retrieved from a Git repository defined in `git_source`.\n\n* `WORKSPACE`: The Python file is located in a Databricks workspace or at a cloud filesystem URI.\n* `GIT`: The Python file is located in a remote Git repository.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["python_file"]
+                  "required": [
+                    "python_file"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3021,13 +4182,13 @@
               ]
             },
             "jobs.SparkSubmitTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "parameters": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Command-line parameters passed to spark submit.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs."
+                      "description": "Command-line parameters passed to spark submit.\n\nUse [Task parameter variables](https://docs.databricks.com/jobs.html#parameter-variables) to set parameters containing information about job runs.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -3039,37 +4200,39 @@
               ]
             },
             "jobs.SqlTask": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "alert": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskAlert",
-                      "description": "If alert, indicates that this job must refresh a SQL alert."
+                      "description": "If alert, indicates that this job must refresh a SQL alert.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskAlert"
                     },
                     "dashboard": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskDashboard",
-                      "description": "If dashboard, indicates that this job must refresh a SQL dashboard."
+                      "description": "If dashboard, indicates that this job must refresh a SQL dashboard.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskDashboard"
                     },
                     "file": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskFile",
-                      "description": "If file, indicates that this job runs a SQL file in a remote Git repository."
+                      "description": "If file, indicates that this job runs a SQL file in a remote Git repository.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskFile"
                     },
                     "parameters": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Parameters to be used for each run of this job. The SQL alert task does not support custom parameters."
+                      "description": "Parameters to be used for each run of this job. The SQL alert task does not support custom parameters.",
+                      "$ref": "#/$defs/map/string"
                     },
                     "query": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskQuery",
-                      "description": "If query, indicates that this job must execute a SQL query."
+                      "description": "If query, indicates that this job must execute a SQL query.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskQuery"
                     },
                     "warehouse_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The canonical identifier of the SQL warehouse. Recommended to use with serverless or pro SQL warehouses. Classic SQL warehouses are only supported for SQL alert, dashboard and query tasks and are limited to scheduled single-task jobs."
+                      "description": "The canonical identifier of the SQL warehouse. Recommended to use with serverless or pro SQL warehouses. Classic SQL warehouses are only supported for SQL alert, dashboard and query tasks and are limited to scheduled single-task jobs.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["warehouse_id"]
+                  "required": [
+                    "warehouse_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3078,25 +4241,27 @@
               ]
             },
             "jobs.SqlTaskAlert": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "alert_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The canonical identifier of the SQL alert."
+                      "description": "The canonical identifier of the SQL alert.",
+                      "$ref": "#/$defs/string"
                     },
                     "pause_subscriptions": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, the alert notifications are not sent to subscribers."
+                      "description": "If true, the alert notifications are not sent to subscribers.",
+                      "$ref": "#/$defs/bool"
                     },
                     "subscriptions": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskSubscription",
-                      "description": "If specified, alert notifications are sent to subscribers."
+                      "description": "If specified, alert notifications are sent to subscribers.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskSubscription"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["alert_id"]
+                  "required": [
+                    "alert_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3105,29 +4270,31 @@
               ]
             },
             "jobs.SqlTaskDashboard": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "custom_subject": {
-                      "$ref": "#/$defs/string",
-                      "description": "Subject of the email sent to subscribers of this task."
+                      "description": "Subject of the email sent to subscribers of this task.",
+                      "$ref": "#/$defs/string"
                     },
                     "dashboard_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The canonical identifier of the SQL dashboard."
+                      "description": "The canonical identifier of the SQL dashboard.",
+                      "$ref": "#/$defs/string"
                     },
                     "pause_subscriptions": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, the dashboard snapshot is not taken, and emails are not sent to subscribers."
+                      "description": "If true, the dashboard snapshot is not taken, and emails are not sent to subscribers.",
+                      "$ref": "#/$defs/bool"
                     },
                     "subscriptions": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskSubscription",
-                      "description": "If specified, dashboard snapshots are sent to subscriptions."
+                      "description": "If specified, dashboard snapshots are sent to subscriptions.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.SqlTaskSubscription"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["dashboard_id"]
+                  "required": [
+                    "dashboard_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3136,21 +4303,23 @@
               ]
             },
             "jobs.SqlTaskFile": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "path": {
-                      "$ref": "#/$defs/string",
-                      "description": "Path of the SQL file. Must be relative if the source is a remote Git repository and absolute for workspace paths."
+                      "description": "Path of the SQL file. Must be relative if the source is a remote Git repository and absolute for workspace paths.",
+                      "$ref": "#/$defs/string"
                     },
                     "source": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source",
-                      "description": "Optional location type of the SQL file. When set to `WORKSPACE`, the SQL file will be retrieved\nfrom the local Databricks workspace. When set to `GIT`, the SQL file will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: SQL file is located in Databricks workspace.\n* `GIT`: SQL file is located in cloud Git provider."
+                      "description": "Optional location type of the SQL file. When set to `WORKSPACE`, the SQL file will be retrieved\nfrom the local Databricks workspace. When set to `GIT`, the SQL file will be retrieved from a Git repository\ndefined in `git_source`. If the value is empty, the task will use `GIT` if `git_source` is defined and `WORKSPACE` otherwise.\n\n* `WORKSPACE`: SQL file is located in Databricks workspace.\n* `GIT`: SQL file is located in cloud Git provider.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Source"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["path"]
+                  "required": [
+                    "path"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3159,17 +4328,19 @@
               ]
             },
             "jobs.SqlTaskQuery": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "query_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The canonical identifier of the SQL query."
+                      "description": "The canonical identifier of the SQL query.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["query_id"]
+                  "required": [
+                    "query_id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3178,17 +4349,17 @@
               ]
             },
             "jobs.SqlTaskSubscription": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The canonical identifier of the destination to receive email notification. This parameter is mutually exclusive with user_name. You cannot set both destination_id and user_name for subscription notifications."
+                      "description": "The canonical identifier of the destination to receive email notification. This parameter is mutually exclusive with user_name. You cannot set both destination_id and user_name for subscription notifications.",
+                      "$ref": "#/$defs/string"
                     },
                     "user_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The user name to receive the subscription email. This parameter is mutually exclusive with destination_id. You cannot set both destination_id and user_name for subscription notifications."
+                      "description": "The user name to receive the subscription email. This parameter is mutually exclusive with destination_id. You cannot set both destination_id and user_name for subscription notifications.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3200,25 +4371,25 @@
               ]
             },
             "jobs.TableUpdateTriggerConfiguration": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "condition": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Condition",
-                      "description": "The table(s) condition based on which to trigger a job run."
+                      "description": "The table(s) condition based on which to trigger a job run.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Condition"
                     },
                     "min_time_between_triggers_seconds": {
-                      "$ref": "#/$defs/int",
-                      "description": "If set, the trigger starts a run only after the specified amount of time has passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds."
+                      "description": "If set, the trigger starts a run only after the specified amount of time has passed since\nthe last time the trigger fired. The minimum allowed value is 60 seconds.",
+                      "$ref": "#/$defs/int"
                     },
                     "table_names": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of Delta tables to monitor for changes. The table name must be in the format `catalog_name.schema_name.table_name`."
+                      "description": "A list of Delta tables to monitor for changes. The table name must be in the format `catalog_name.schema_name.table_name`.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "wait_after_last_change_seconds": {
-                      "$ref": "#/$defs/int",
-                      "description": "If set, the trigger starts a run only after no table updates have occurred for the specified time\nand can be used to wait for a series of table updates before triggering a run. The\nminimum allowed value is 60 seconds."
+                      "description": "If set, the trigger starts a run only after no table updates have occurred for the specified time\nand can be used to wait for a series of table updates before triggering a run. The\nminimum allowed value is 60 seconds.",
+                      "$ref": "#/$defs/int"
                     }
                   },
                   "additionalProperties": false
@@ -3230,128 +4401,134 @@
               ]
             },
             "jobs.Task": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
+                    "clean_rooms_notebook_task": {
+                      "description": "The task runs a [clean rooms](https://docs.databricks.com/en/clean-rooms/index.html) notebook\nwhen the `clean_rooms_notebook_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.CleanRoomsNotebookTask"
+                    },
                     "condition_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ConditionTask",
-                      "description": "If condition_task, specifies a condition with an outcome that can be used to control the execution of other tasks. Does not require a cluster to execute and does not support retries or notifications."
+                      "description": "The task evaluates a condition that can be used to control the execution of other tasks when the `condition_task` field is present.\nThe condition task does not require a cluster to execute and does not support retries or notifications.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ConditionTask"
                     },
                     "dbt_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.DbtTask",
-                      "description": "If dbt_task, indicates that this must execute a dbt task. It requires both Databricks SQL and the ability to use a serverless or a pro SQL warehouse."
+                      "description": "The task runs one or more dbt commands when the `dbt_task` field is present. The dbt task requires both Databricks SQL and the ability to use a serverless or a pro SQL warehouse.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.DbtTask"
                     },
                     "depends_on": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.TaskDependency",
-                      "description": "An optional array of objects specifying the dependency graph of the task. All tasks specified in this field must complete before executing this task. The task will run only if the `run_if` condition is true.\nThe key is `task_key`, and the value is the name assigned to the dependent task."
+                      "description": "An optional array of objects specifying the dependency graph of the task. All tasks specified in this field must complete before executing this task. The task will run only if the `run_if` condition is true.\nThe key is `task_key`, and the value is the name assigned to the dependent task.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.TaskDependency"
                     },
                     "description": {
-                      "$ref": "#/$defs/string",
-                      "description": "An optional description for this task."
+                      "description": "An optional description for this task.",
+                      "$ref": "#/$defs/string"
                     },
                     "disable_auto_optimization": {
-                      "$ref": "#/$defs/bool",
-                      "description": "An option to disable auto optimization in serverless"
+                      "description": "An option to disable auto optimization in serverless",
+                      "$ref": "#/$defs/bool"
                     },
                     "email_notifications": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TaskEmailNotifications",
-                      "description": "An optional set of email addresses that is notified when runs of this task begin or complete as well as when this task is deleted. The default behavior is to not send any emails."
+                      "description": "An optional set of email addresses that is notified when runs of this task begin or complete as well as when this task is deleted. The default behavior is to not send any emails.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TaskEmailNotifications"
                     },
                     "environment_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The key that references an environment spec in a job. This field is required for Python script, Python wheel and dbt tasks when using serverless compute."
+                      "description": "The key that references an environment spec in a job. This field is required for Python script, Python wheel and dbt tasks when using serverless compute.",
+                      "$ref": "#/$defs/string"
                     },
                     "existing_cluster_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "If existing_cluster_id, the ID of an existing cluster that is used for all runs.\nWhen running jobs or tasks on an existing cluster, you may need to manually restart\nthe cluster if it stops responding. We suggest running jobs and tasks on new clusters for\ngreater reliability"
+                      "description": "If existing_cluster_id, the ID of an existing cluster that is used for all runs.\nWhen running jobs or tasks on an existing cluster, you may need to manually restart\nthe cluster if it stops responding. We suggest running jobs and tasks on new clusters for\ngreater reliability",
+                      "$ref": "#/$defs/string"
                     },
                     "for_each_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ForEachTask",
-                      "description": "If for_each_task, indicates that this task must execute the nested task within it."
+                      "description": "The task executes a nested task for every input provided when the `for_each_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.ForEachTask"
                     },
                     "health": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobsHealthRules"
                     },
                     "job_cluster_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "If job_cluster_key, this task is executed reusing the cluster specified in `job.settings.job_clusters`."
+                      "description": "If job_cluster_key, this task is executed reusing the cluster specified in `job.settings.job_clusters`.",
+                      "$ref": "#/$defs/string"
                     },
                     "libraries": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.Library",
-                      "description": "An optional list of libraries to be installed on the cluster.\nThe default value is an empty list."
+                      "description": "An optional list of libraries to be installed on the cluster.\nThe default value is an empty list.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.Library"
                     },
                     "max_retries": {
-                      "$ref": "#/$defs/int",
-                      "description": "An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with the `FAILED` result_state or `INTERNAL_ERROR` `life_cycle_state`. The value `-1` means to retry indefinitely and the value `0` means to never retry."
+                      "description": "An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with the `FAILED` result_state or `INTERNAL_ERROR` `life_cycle_state`. The value `-1` means to retry indefinitely and the value `0` means to never retry.",
+                      "$ref": "#/$defs/int"
                     },
                     "min_retry_interval_millis": {
-                      "$ref": "#/$defs/int",
-                      "description": "An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried."
+                      "description": "An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.",
+                      "$ref": "#/$defs/int"
                     },
                     "new_cluster": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec",
-                      "description": "If new_cluster, a description of a new cluster that is created for each run."
+                      "description": "If new_cluster, a description of a new cluster that is created for each run.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec"
                     },
                     "notebook_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.NotebookTask",
-                      "description": "If notebook_task, indicates that this task must run a notebook. This field may not be specified in conjunction with spark_jar_task."
+                      "description": "The task runs a notebook when the `notebook_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.NotebookTask"
                     },
                     "notification_settings": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TaskNotificationSettings",
-                      "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this task."
+                      "description": "Optional notification settings that are used when sending notifications to each of the `email_notifications` and `webhook_notifications` for this task.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TaskNotificationSettings"
                     },
                     "pipeline_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PipelineTask",
-                      "description": "If pipeline_task, indicates that this task must execute a Pipeline."
+                      "description": "The task triggers a pipeline update when the `pipeline_task` field is present. Only pipelines configured to use triggered more are supported.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PipelineTask"
                     },
                     "python_wheel_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PythonWheelTask",
-                      "description": "If python_wheel_task, indicates that this job must execute a PythonWheel."
+                      "description": "The task runs a Python wheel when the `python_wheel_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PythonWheelTask"
                     },
                     "retry_on_timeout": {
-                      "$ref": "#/$defs/bool",
-                      "description": "An optional policy to specify whether to retry a job when it times out. The default behavior\nis to not retry on timeout."
+                      "description": "An optional policy to specify whether to retry a job when it times out. The default behavior\nis to not retry on timeout.",
+                      "$ref": "#/$defs/bool"
                     },
                     "run_if": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.RunIf",
-                      "description": "An optional value specifying the condition determining whether the task is run once its dependencies have been completed.\n\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies have been completed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed"
+                      "description": "An optional value specifying the condition determining whether the task is run once its dependencies have been completed.\n\n* `ALL_SUCCESS`: All dependencies have executed and succeeded\n* `AT_LEAST_ONE_SUCCESS`: At least one dependency has succeeded\n* `NONE_FAILED`: None of the dependencies have failed and at least one was executed\n* `ALL_DONE`: All dependencies have been completed\n* `AT_LEAST_ONE_FAILED`: At least one dependency failed\n* `ALL_FAILED`: ALl dependencies have failed",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.RunIf"
                     },
                     "run_job_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.RunJobTask",
-                      "description": "If run_job_task, indicates that this task must execute another job."
+                      "description": "The task triggers another job when the `run_job_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.RunJobTask"
                     },
                     "spark_jar_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkJarTask",
-                      "description": "If spark_jar_task, indicates that this task must run a JAR."
+                      "description": "The task runs a JAR when the `spark_jar_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkJarTask"
                     },
                     "spark_python_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkPythonTask",
-                      "description": "If spark_python_task, indicates that this task must run a Python file."
+                      "description": "The task runs a Python file when the `spark_python_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkPythonTask"
                     },
                     "spark_submit_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkSubmitTask",
-                      "description": "If `spark_submit_task`, indicates that this task must be launched by the spark submit script. This task can run only on new clusters.\n\nIn the `new_cluster` specification, `libraries` and `spark_conf` are not supported. Instead, use `--jars` and `--py-files` to add Java and Python libraries and `--conf` to set the Spark configurations.\n\n`master`, `deploy-mode`, and `executor-cores` are automatically configured by Databricks; you _cannot_ specify them in parameters.\n\nBy default, the Spark submit job uses all available memory (excluding reserved memory for Databricks services). You can set `--driver-memory`, and `--executor-memory` to a smaller value to leave some room for off-heap usage.\n\nThe `--jars`, `--py-files`, `--files` arguments support DBFS and S3 paths."
+                      "description": "(Legacy) The task runs the spark-submit script when the `spark_submit_task` field is present. This task can run only on new clusters and is not compatible with serverless compute.\n\nIn the `new_cluster` specification, `libraries` and `spark_conf` are not supported. Instead, use `--jars` and `--py-files` to add Java and Python libraries and `--conf` to set the Spark configurations.\n\n`master`, `deploy-mode`, and `executor-cores` are automatically configured by Databricks; you _cannot_ specify them in parameters.\n\nBy default, the Spark submit job uses all available memory (excluding reserved memory for Databricks services). You can set `--driver-memory`, and `--executor-memory` to a smaller value to leave some room for off-heap usage.\n\nThe `--jars`, `--py-files`, `--files` arguments support DBFS and S3 paths.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SparkSubmitTask"
                     },
                     "sql_task": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTask",
-                      "description": "If sql_task, indicates that this job must execute a SQL task."
+                      "description": "The task runs a SQL query or file, or it refreshes a SQL alert or a legacy SQL dashboard when the `sql_task` field is present.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.SqlTask"
                     },
                     "task_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "A unique name for the task. This field is used to refer to this task from other tasks.\nThis field is required and must be unique within its parent job.\nOn Update or Reset, this field is used to reference the tasks to be updated or reset."
+                      "description": "A unique name for the task. This field is used to refer to this task from other tasks.\nThis field is required and must be unique within its parent job.\nOn Update or Reset, this field is used to reference the tasks to be updated or reset.",
+                      "$ref": "#/$defs/string"
                     },
                     "timeout_seconds": {
-                      "$ref": "#/$defs/int",
-                      "description": "An optional timeout applied to each run of this job task. A value of `0` means no timeout."
+                      "description": "An optional timeout applied to each run of this job task. A value of `0` means no timeout.",
+                      "$ref": "#/$defs/int"
                     },
                     "webhook_notifications": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.WebhookNotifications",
-                      "description": "A collection of system notification IDs to notify when runs of this task begin or complete. The default behavior is to not send any system notifications."
+                      "description": "A collection of system notification IDs to notify when runs of this task begin or complete. The default behavior is to not send any system notifications.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.WebhookNotifications"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["task_key"]
+                  "required": [
+                    "task_key"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3360,21 +4537,23 @@
               ]
             },
             "jobs.TaskDependency": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "outcome": {
-                      "$ref": "#/$defs/string",
-                      "description": "Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run."
+                      "description": "Can only be specified on condition task dependencies. The outcome of the dependent task that must be met for this task to run.",
+                      "$ref": "#/$defs/string"
                     },
                     "task_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the task this task depends on."
+                      "description": "The name of the task this task depends on.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["task_key"]
+                  "required": [
+                    "task_key"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3383,33 +4562,33 @@
               ]
             },
             "jobs.TaskEmailNotifications": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "no_alert_for_skipped_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped.\nThis field is `deprecated`. Please use the `notification_settings.no_alert_for_skipped_runs` field."
+                      "description": "If true, do not send email to recipients specified in `on_failure` if the run is skipped.\nThis field is `deprecated`. Please use the `notification_settings.no_alert_for_skipped_runs` field.",
+                      "$ref": "#/$defs/bool"
                     },
                     "on_duration_warning_threshold_exceeded": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. If no rule for the `RUN_DURATION_SECONDS` metric is specified in the `health` field for the job, notifications are not sent."
+                      "description": "A list of email addresses to be notified when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. If no rule for the `RUN_DURATION_SECONDS` metric is specified in the `health` field for the job, notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_failure": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run unsuccessfully completes. A run is considered to have completed unsuccessfully if it ends with an `INTERNAL_ERROR` `life_cycle_state` or a `FAILED`, or `TIMED_OUT` result_state. If this is not specified on job creation, reset, or update the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_start": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run begins. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_streaming_backlog_exceeded": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to notify when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes."
+                      "description": "A list of email addresses to notify when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "on_success": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent."
+                      "description": "A list of email addresses to be notified when a run successfully completes. A run is considered to have completed successfully if it ends with a `TERMINATED` `life_cycle_state` and a `SUCCESS` result_state. If not specified on job creation, reset, or update, the list is empty, and notifications are not sent.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -3421,21 +4600,21 @@
               ]
             },
             "jobs.TaskNotificationSettings": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "alert_on_last_attempt": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send notifications to recipients specified in `on_start` for the retried runs and do not send notifications to recipients specified in `on_failure` until the last retry of the run."
+                      "description": "If true, do not send notifications to recipients specified in `on_start` for the retried runs and do not send notifications to recipients specified in `on_failure` until the last retry of the run.",
+                      "$ref": "#/$defs/bool"
                     },
                     "no_alert_for_canceled_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled."
+                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is canceled.",
+                      "$ref": "#/$defs/bool"
                     },
                     "no_alert_for_skipped_runs": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped."
+                      "description": "If true, do not send notifications to recipients specified in `on_failure` if the run is skipped.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -3447,25 +4626,25 @@
               ]
             },
             "jobs.TriggerSettings": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "file_arrival": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.FileArrivalTriggerConfiguration",
-                      "description": "File arrival trigger settings."
+                      "description": "File arrival trigger settings.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.FileArrivalTriggerConfiguration"
                     },
                     "pause_status": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus",
-                      "description": "Whether this trigger is paused or not."
+                      "description": "Whether this trigger is paused or not.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PauseStatus"
                     },
                     "periodic": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PeriodicTriggerConfiguration",
-                      "description": "Periodic trigger settings."
+                      "description": "Periodic trigger settings.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PeriodicTriggerConfiguration"
                     },
                     "table": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TableUpdateTriggerConfiguration",
-                      "description": "Old table trigger settings name. Deprecated in favor of `table_update`."
+                      "description": "Old table trigger settings name. Deprecated in favor of `table_update`.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TableUpdateTriggerConfiguration"
                     },
                     "table_update": {
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.TableUpdateTriggerConfiguration"
@@ -3480,7 +4659,7 @@
               ]
             },
             "jobs.Webhook": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -3489,7 +4668,9 @@
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["id"]
+                  "required": [
+                    "id"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3498,29 +4679,29 @@
               ]
             },
             "jobs.WebhookNotifications": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "on_duration_warning_threshold_exceeded": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook",
-                      "description": "An optional list of system notification IDs to call when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. A maximum of 3 destinations can be specified for the `on_duration_warning_threshold_exceeded` property."
+                      "description": "An optional list of system notification IDs to call when the duration of a run exceeds the threshold specified for the `RUN_DURATION_SECONDS` metric in the `health` field. A maximum of 3 destinations can be specified for the `on_duration_warning_threshold_exceeded` property.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook"
                     },
                     "on_failure": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook",
-                      "description": "An optional list of system notification IDs to call when the run fails. A maximum of 3 destinations can be specified for the `on_failure` property."
+                      "description": "An optional list of system notification IDs to call when the run fails. A maximum of 3 destinations can be specified for the `on_failure` property.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook"
                     },
                     "on_start": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook",
-                      "description": "An optional list of system notification IDs to call when the run starts. A maximum of 3 destinations can be specified for the `on_start` property."
+                      "description": "An optional list of system notification IDs to call when the run starts. A maximum of 3 destinations can be specified for the `on_start` property.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook"
                     },
                     "on_streaming_backlog_exceeded": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook",
-                      "description": "An optional list of system notification IDs to call when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes.\nA maximum of 3 destinations can be specified for the `on_streaming_backlog_exceeded` property."
+                      "description": "An optional list of system notification IDs to call when any streaming backlog thresholds are exceeded for any stream.\nStreaming backlog thresholds can be set in the `health` field using the following metrics: `STREAMING_BACKLOG_BYTES`, `STREAMING_BACKLOG_RECORDS`, `STREAMING_BACKLOG_SECONDS`, or `STREAMING_BACKLOG_FILES`.\nAlerting is based on the 10-minute average of these metrics. If the issue persists, notifications are resent every 30 minutes.\nA maximum of 3 destinations can be specified for the `on_streaming_backlog_exceeded` property.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook"
                     },
                     "on_success": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook",
-                      "description": "An optional list of system notification IDs to call when the run completes successfully. A maximum of 3 destinations can be specified for the `on_success` property."
+                      "description": "An optional list of system notification IDs to call when the run completes successfully. A maximum of 3 destinations can be specified for the `on_success` property.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.Webhook"
                     }
                   },
                   "additionalProperties": false
@@ -3532,17 +4713,17 @@
               ]
             },
             "ml.ExperimentTag": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag key."
+                      "description": "The tag key.",
+                      "$ref": "#/$defs/string"
                     },
                     "value": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag value."
+                      "description": "The tag value.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3554,17 +4735,17 @@
               ]
             },
             "ml.ModelTag": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag key."
+                      "description": "The tag key.",
+                      "$ref": "#/$defs/string"
                     },
                     "value": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag value."
+                      "description": "The tag value.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3576,66 +4757,61 @@
               ]
             },
             "ml.ModelVersion": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "creation_timestamp": {
-                      "$ref": "#/$defs/int64",
-                      "description": "Timestamp recorded when this `model_version` was created."
+                      "description": "Timestamp recorded when this `model_version` was created.",
+                      "$ref": "#/$defs/int64"
                     },
                     "current_stage": {
-                      "$ref": "#/$defs/string",
-                      "description": "Current stage for this `model_version`."
+                      "description": "Current stage for this `model_version`.",
+                      "$ref": "#/$defs/string"
                     },
                     "description": {
-                      "$ref": "#/$defs/string",
-                      "description": "Description of this `model_version`."
+                      "description": "Description of this `model_version`.",
+                      "$ref": "#/$defs/string"
                     },
                     "last_updated_timestamp": {
-                      "$ref": "#/$defs/int64",
-                      "description": "Timestamp recorded when metadata for this `model_version` was last updated."
+                      "description": "Timestamp recorded when metadata for this `model_version` was last updated.",
+                      "$ref": "#/$defs/int64"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Unique name of the model"
+                      "description": "Unique name of the model",
+                      "$ref": "#/$defs/string"
                     },
                     "run_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "MLflow run ID used when creating `model_version`, if `source` was generated by an\nexperiment run stored in MLflow tracking server."
+                      "description": "MLflow run ID used when creating `model_version`, if `source` was generated by an\nexperiment run stored in MLflow tracking server.",
+                      "$ref": "#/$defs/string"
                     },
                     "run_link": {
-                      "$ref": "#/$defs/string",
-                      "description": "Run Link: Direct link to the run that generated this version"
+                      "description": "Run Link: Direct link to the run that generated this version",
+                      "$ref": "#/$defs/string"
                     },
                     "source": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI indicating the location of the source model artifacts, used when creating `model_version`"
+                      "description": "URI indicating the location of the source model artifacts, used when creating `model_version`",
+                      "$ref": "#/$defs/string"
                     },
                     "status": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.ModelVersionStatus",
                       "description": "Current status of `model_version`",
-                      "enum": [
-                        "PENDING_REGISTRATION",
-                        "FAILED_REGISTRATION",
-                        "READY"
-                      ]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.ModelVersionStatus"
                     },
                     "status_message": {
-                      "$ref": "#/$defs/string",
-                      "description": "Details on current `status`, if it is pending or failed."
+                      "description": "Details on current `status`, if it is pending or failed.",
+                      "$ref": "#/$defs/string"
                     },
                     "tags": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelVersionTag",
-                      "description": "Tags: Additional metadata key-value pairs for this `model_version`."
+                      "description": "Tags: Additional metadata key-value pairs for this `model_version`.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/ml.ModelVersionTag"
                     },
                     "user_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "User that created this `model_version`."
+                      "description": "User that created this `model_version`.",
+                      "$ref": "#/$defs/string"
                     },
                     "version": {
-                      "$ref": "#/$defs/string",
-                      "description": "Model's version number."
+                      "description": "Model's version number.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3647,20 +4823,34 @@
               ]
             },
             "ml.ModelVersionStatus": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Current status of `model_version`",
+                  "enum": [
+                    "PENDING_REGISTRATION",
+                    "FAILED_REGISTRATION",
+                    "READY"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "ml.ModelVersionTag": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag key."
+                      "description": "The tag key.",
+                      "$ref": "#/$defs/string"
                     },
                     "value": {
-                      "$ref": "#/$defs/string",
-                      "description": "The tag value."
+                      "description": "The tag value.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3672,7 +4862,7 @@
               ]
             },
             "pipelines.CronTrigger": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -3691,19 +4881,50 @@
                 }
               ]
             },
+            "pipelines.DayOfWeek": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Days of week in which the restart is allowed to happen (within a five-hour window starting at start_hour).\nIf not specified all days of the week will be used.",
+                  "enum": [
+                    "MONDAY",
+                    "TUESDAY",
+                    "WEDNESDAY",
+                    "THURSDAY",
+                    "FRIDAY",
+                    "SATURDAY",
+                    "SUNDAY"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
             "pipelines.DeploymentKind": {
-              "type": "string",
-              "description": "The deployment method that manages the pipeline:\n- BUNDLE: The pipeline is managed by a Databricks Asset Bundle.\n",
-              "enum": ["BUNDLE"]
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The deployment method that manages the pipeline:\n- BUNDLE: The pipeline is managed by a Databricks Asset Bundle.\n",
+                  "enum": [
+                    "BUNDLE"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "pipelines.FileLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "path": {
-                      "$ref": "#/$defs/string",
-                      "description": "The absolute path of the file."
+                      "description": "The absolute path of the file.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3715,17 +4936,17 @@
               ]
             },
             "pipelines.Filters": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "exclude": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Paths to exclude."
+                      "description": "Paths to exclude.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "include": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "Paths to include."
+                      "description": "Paths to include.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -3737,17 +4958,21 @@
               ]
             },
             "pipelines.IngestionConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
+                    "report": {
+                      "description": "Select a specific source report.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.ReportSpec"
+                    },
                     "schema": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.SchemaSpec",
-                      "description": "Select tables from a specific source schema."
+                      "description": "Select all tables from a specific source schema.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.SchemaSpec"
                     },
                     "table": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpec",
-                      "description": "Select tables from a specific source table."
+                      "description": "Select a specific source table.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpec"
                     }
                   },
                   "additionalProperties": false
@@ -3759,25 +4984,29 @@
               ]
             },
             "pipelines.IngestionGatewayPipelineDefinition": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "connection_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "Immutable. The Unity Catalog connection this gateway pipeline uses to communicate with the source."
+                      "description": "[Deprecated, use connection_name instead] Immutable. The Unity Catalog connection that this gateway pipeline uses to communicate with the source.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "connection_name": {
+                      "description": "Immutable. The Unity Catalog connection that this gateway pipeline uses to communicate with the source.",
+                      "$ref": "#/$defs/string"
                     },
                     "gateway_storage_catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required, Immutable. The name of the catalog for the gateway pipeline's storage location."
+                      "description": "Required, Immutable. The name of the catalog for the gateway pipeline's storage location.",
+                      "$ref": "#/$defs/string"
                     },
                     "gateway_storage_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional. The Unity Catalog-compatible name for the gateway storage location.\nThis is the destination to use for the data that is extracted by the gateway.\nDelta Live Tables system will automatically create the storage location under the catalog and schema.\n"
+                      "description": "Optional. The Unity Catalog-compatible name for the gateway storage location.\nThis is the destination to use for the data that is extracted by the gateway.\nDelta Live Tables system will automatically create the storage location under the catalog and schema.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "gateway_storage_schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required, Immutable. The name of the schema for the gateway pipelines's storage location."
+                      "description": "Required, Immutable. The name of the schema for the gateway pipelines's storage location.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3789,25 +5018,25 @@
               ]
             },
             "pipelines.IngestionPipelineDefinition": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "connection_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "Immutable. The Unity Catalog connection this ingestion pipeline uses to communicate with the source. Specify either ingestion_gateway_id or connection_name."
+                      "description": "Immutable. The Unity Catalog connection that this ingestion pipeline uses to communicate with the source. This is used with connectors for applications like Salesforce, Workday, and so on.",
+                      "$ref": "#/$defs/string"
                     },
                     "ingestion_gateway_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "Immutable. Identifier for the ingestion gateway used by this ingestion pipeline to communicate with the source. Specify either ingestion_gateway_id or connection_name."
+                      "description": "Immutable. Identifier for the gateway that is used by this ingestion pipeline to communicate with the source database. This is used with connectors to databases like SQL Server.",
+                      "$ref": "#/$defs/string"
                     },
                     "objects": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionConfig",
-                      "description": "Required. Settings specifying tables to replicate and the destination for the replicated tables."
+                      "description": "Required. Settings specifying tables to replicate and the destination for the replicated tables.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.IngestionConfig"
                     },
                     "table_configuration": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig",
-                      "description": "Configuration settings to control the ingestion of tables. These settings are applied to all tables in the pipeline."
+                      "description": "Configuration settings to control the ingestion of tables. These settings are applied to all tables in the pipeline.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig"
                     }
                   },
                   "additionalProperties": false
@@ -3819,7 +5048,7 @@
               ]
             },
             "pipelines.ManualTrigger": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "additionalProperties": false
@@ -3831,13 +5060,13 @@
               ]
             },
             "pipelines.NotebookLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "path": {
-                      "$ref": "#/$defs/string",
-                      "description": "The absolute path of the notebook."
+                      "description": "The absolute path of the notebook.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -3849,17 +5078,17 @@
               ]
             },
             "pipelines.Notifications": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "alerts": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of alerts that trigger the sending of notifications to the configured\ndestinations. The supported alerts are:\n\n* `on-update-success`: A pipeline update completes successfully.\n* `on-update-failure`: Each time a pipeline update fails.\n* `on-update-fatal-failure`: A pipeline update fails with a non-retryable (fatal) error.\n* `on-flow-failure`: A single data flow fails.\n"
+                      "description": "A list of alerts that trigger the sending of notifications to the configured\ndestinations. The supported alerts are:\n\n* `on-update-success`: A pipeline update completes successfully.\n* `on-update-failure`: Each time a pipeline update fails.\n* `on-update-fatal-failure`: A pipeline update fails with a non-retryable (fatal) error.\n* `on-flow-failure`: A single data flow fails.\n",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "email_recipients": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "A list of email addresses notified when a configured alert is triggered.\n"
+                      "description": "A list of email addresses notified when a configured alert is triggered.\n",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -3871,85 +5100,85 @@
               ]
             },
             "pipelines.PipelineCluster": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "apply_policy_default_values": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Note: This field won't be persisted. Only API users will check this field."
+                      "description": "Note: This field won't be persisted. Only API users will check this field.",
+                      "$ref": "#/$defs/bool"
                     },
                     "autoscale": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineClusterAutoscale",
-                      "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later."
+                      "description": "Parameters needed in order to automatically scale clusters up and down based on load.\nNote: autoscaling works best with DB runtime versions 3.0 or later.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineClusterAutoscale"
                     },
                     "aws_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes",
-                      "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Amazon Web Services.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes"
                     },
                     "azure_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes",
-                      "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Microsoft Azure.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.AzureAttributes"
                     },
                     "cluster_log_conf": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf",
-                      "description": "The configuration for delivering spark logs to a long-term storage destination.\nOnly dbfs destinations are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.\n"
+                      "description": "The configuration for delivering spark logs to a long-term storage destination.\nOnly dbfs destinations are supported. Only one destination can be specified\nfor one cluster. If the conf is given, the logs will be delivered to the destination every\n`5 mins`. The destination of driver logs is `$destination/$clusterId/driver`, while\nthe destination of executor logs is `$destination/$clusterId/executor`.\n",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterLogConf"
                     },
                     "custom_tags": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags"
+                      "description": "Additional tags for cluster resources. Databricks will tag all cluster resources (e.g., AWS\ninstances and EBS volumes) with these tags in addition to `default_tags`. Notes:\n\n- Currently, Databricks allows at most 45 custom tags\n\n- Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags",
+                      "$ref": "#/$defs/map/string"
                     },
                     "driver_instance_pool_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned."
+                      "description": "The optional ID of the instance pool for the driver of the cluster belongs.\nThe pool cluster uses the instance pool with id (instance_pool_id) if the driver pool is not\nassigned.",
+                      "$ref": "#/$defs/string"
                     },
                     "driver_node_type_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The node type of the Spark driver.\nNote that this field is optional; if unset, the driver node type will be set as the same value\nas `node_type_id` defined above."
+                      "description": "The node type of the Spark driver.\nNote that this field is optional; if unset, the driver node type will be set as the same value\nas `node_type_id` defined above.",
+                      "$ref": "#/$defs/string"
                     },
                     "enable_local_disk_encryption": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether to enable local disk encryption for the cluster."
+                      "description": "Whether to enable local disk encryption for the cluster.",
+                      "$ref": "#/$defs/bool"
                     },
                     "gcp_attributes": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes",
-                      "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used."
+                      "description": "Attributes related to clusters running on Google Cloud Platform.\nIf not specified at cluster creation, a set of default values will be used.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.GcpAttributes"
                     },
                     "init_scripts": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo",
-                      "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`."
+                      "description": "The configuration for storing init scripts. Any number of destinations can be specified. The scripts are executed sequentially in the order provided. If `cluster_log_conf` is specified, init script logs are sent to `\u003cdestination\u003e/\u003ccluster-ID\u003e/init_scripts`.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo"
                     },
                     "instance_pool_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The optional ID of the instance pool to which the cluster belongs."
+                      "description": "The optional ID of the instance pool to which the cluster belongs.",
+                      "$ref": "#/$defs/string"
                     },
                     "label": {
-                      "$ref": "#/$defs/string",
-                      "description": "A label for the cluster specification, either `default` to configure the default cluster, or `maintenance` to configure the maintenance cluster. This field is optional. The default value is `default`."
+                      "description": "A label for the cluster specification, either `default` to configure the default cluster, or `maintenance` to configure the maintenance cluster. This field is optional. The default value is `default`.",
+                      "$ref": "#/$defs/string"
                     },
                     "node_type_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n"
+                      "description": "This field encodes, through a single value, the resources available to each of\nthe Spark nodes in this cluster. For example, the Spark nodes can be provisioned\nand optimized for memory or compute intensive workloads. A list of available node\ntypes can be retrieved by using the :method:clusters/listNodeTypes API call.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "num_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned."
+                      "description": "Number of worker nodes that this cluster should have. A cluster has one Spark Driver\nand `num_workers` Executors for a total of `num_workers` + 1 Spark nodes.\n\nNote: When reading the properties of a cluster, this field reflects the desired number\nof workers rather than the actual current number of workers. For instance, if a cluster\nis resized from 5 to 10 workers, this field will immediately be updated to reflect\nthe target size of 10 workers, whereas the workers listed in `spark_info` will gradually\nincrease from 5 to 10 as the new nodes are provisioned.",
+                      "$ref": "#/$defs/int"
                     },
                     "policy_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The ID of the cluster policy used to create the cluster if applicable."
+                      "description": "The ID of the cluster policy used to create the cluster if applicable.",
+                      "$ref": "#/$defs/string"
                     },
                     "spark_conf": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nSee :method:clusters/create for more details.\n"
+                      "description": "An object containing a set of optional, user-specified Spark configuration key-value pairs.\nSee :method:clusters/create for more details.\n",
+                      "$ref": "#/$defs/map/string"
                     },
                     "spark_env_vars": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`"
+                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs.\nPlease note that key-value pair of the form (X,Y) will be exported as is (i.e.,\n`export X='Y'`) while launching the driver and workers.\n\nIn order to specify an additional set of `SPARK_DAEMON_JAVA_OPTS`, we recommend appending\nthem to `$SPARK_DAEMON_JAVA_OPTS` as shown in the example below. This ensures that all\ndefault databricks managed environmental variables are included as well.\n\nExample Spark environment variables:\n`{\"SPARK_WORKER_MEMORY\": \"28000m\", \"SPARK_LOCAL_DIRS\": \"/local_disk0\"}` or\n`{\"SPARK_DAEMON_JAVA_OPTS\": \"$SPARK_DAEMON_JAVA_OPTS -Dspark.shuffle.service.enabled=true\"}`",
+                      "$ref": "#/$defs/map/string"
                     },
                     "ssh_public_keys": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified."
+                      "description": "SSH public key contents that will be added to each Spark node in this cluster. The\ncorresponding private keys can be used to login with the user name `ubuntu` on port `2200`.\nUp to 10 keys can be specified.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -3961,26 +5190,28 @@
               ]
             },
             "pipelines.PipelineClusterAutoscale": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "max_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "The maximum number of workers to which the cluster can scale up when overloaded. `max_workers` must be strictly greater than `min_workers`."
+                      "description": "The maximum number of workers to which the cluster can scale up when overloaded. `max_workers` must be strictly greater than `min_workers`.",
+                      "$ref": "#/$defs/int"
                     },
                     "min_workers": {
-                      "$ref": "#/$defs/int",
-                      "description": "The minimum number of workers the cluster can scale down to when underutilized.\nIt is also the initial number of workers the cluster will have after creation."
+                      "description": "The minimum number of workers the cluster can scale down to when underutilized.\nIt is also the initial number of workers the cluster will have after creation.",
+                      "$ref": "#/$defs/int"
                     },
                     "mode": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineClusterAutoscaleMode",
                       "description": "Databricks Enhanced Autoscaling optimizes cluster utilization by automatically\nallocating cluster resources based on workload volume, with minimal impact to\nthe data processing latency of your pipelines. Enhanced Autoscaling is available\nfor `updates` clusters only. The legacy autoscaling feature is used for `maintenance`\nclusters.\n",
-                      "enum": ["ENHANCED", "LEGACY"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineClusterAutoscaleMode"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["max_workers", "min_workers"]
+                  "required": [
+                    "max_workers",
+                    "min_workers"
+                  ]
                 },
                 {
                   "type": "string",
@@ -3989,20 +5220,33 @@
               ]
             },
             "pipelines.PipelineClusterAutoscaleMode": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Databricks Enhanced Autoscaling optimizes cluster utilization by automatically\nallocating cluster resources based on workload volume, with minimal impact to\nthe data processing latency of your pipelines. Enhanced Autoscaling is available\nfor `updates` clusters only. The legacy autoscaling feature is used for `maintenance`\nclusters.\n",
+                  "enum": [
+                    "ENHANCED",
+                    "LEGACY"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "pipelines.PipelineDeployment": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "kind": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.DeploymentKind",
-                      "description": "The deployment method that manages the pipeline."
+                      "description": "The deployment method that manages the pipeline.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.DeploymentKind"
                     },
                     "metadata_file_path": {
-                      "$ref": "#/$defs/string",
-                      "description": "The path to the file containing metadata about the deployment."
+                      "description": "The path to the file containing metadata about the deployment.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4014,29 +5258,29 @@
               ]
             },
             "pipelines.PipelineLibrary": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "file": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.FileLibrary",
-                      "description": "The path to a file that defines a pipeline and is stored in the Databricks Repos.\n"
+                      "description": "The path to a file that defines a pipeline and is stored in the Databricks Repos.\n",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.FileLibrary"
                     },
                     "jar": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI of the jar to be installed. Currently only DBFS is supported.\n"
+                      "description": "URI of the jar to be installed. Currently only DBFS is supported.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "maven": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.MavenLibrary",
-                      "description": "Specification of a maven library to be installed.\n"
+                      "description": "Specification of a maven library to be installed.\n",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.MavenLibrary"
                     },
                     "notebook": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.NotebookLibrary",
-                      "description": "The path to a notebook that defines a pipeline and is stored in the Databricks workspace.\n"
+                      "description": "The path to a notebook that defines a pipeline and is stored in the Databricks workspace.\n",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.NotebookLibrary"
                     },
                     "whl": {
-                      "$ref": "#/$defs/string",
-                      "description": "URI of the whl to be installed."
+                      "description": "URI of the whl to be installed.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4048,7 +5292,7 @@
               ]
             },
             "pipelines.PipelineTrigger": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
@@ -4067,30 +5311,93 @@
                 }
               ]
             },
-            "pipelines.SchemaSpec": {
-              "anyOf": [
+            "pipelines.ReportSpec": {
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination_catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Destination catalog to store tables."
+                      "description": "Required. Destination catalog to store table.",
+                      "$ref": "#/$defs/string"
                     },
                     "destination_schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Destination schema to store tables in. Tables with the same name as the source tables are created in this destination schema. The pipeline fails If a table with the same name already exists."
+                      "description": "Required. Destination schema to store table.",
+                      "$ref": "#/$defs/string"
                     },
-                    "source_catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "The source catalog name. Might be optional depending on the type of source."
+                    "destination_table": {
+                      "description": "Required. Destination table name. The pipeline fails if a table with that name already exists.",
+                      "$ref": "#/$defs/string"
                     },
-                    "source_schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Schema name in the source database."
+                    "source_url": {
+                      "description": "Required. Report URL in the source system.",
+                      "$ref": "#/$defs/string"
                     },
                     "table_configuration": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig",
-                      "description": "Configuration settings to control the ingestion of tables. These settings are applied to all tables in this schema and override the table_configuration defined in the IngestionPipelineDefinition object."
+                      "description": "Configuration settings to control the ingestion of tables. These settings override the table_configuration defined in the IngestionPipelineDefinition object.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "pipelines.RestartWindow": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "days_of_week": {
+                      "description": "Days of week in which the restart is allowed to happen (within a five-hour window starting at start_hour).\nIf not specified all days of the week will be used.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.DayOfWeek"
+                    },
+                    "start_hour": {
+                      "description": "An integer between 0 and 23 denoting the start hour for the restart window in the 24-hour day.\nContinuous pipeline restart is triggered only within a five-hour window starting at this hour.",
+                      "$ref": "#/$defs/int"
+                    },
+                    "time_zone_id": {
+                      "description": "Time zone id of restart window. See https://docs.databricks.com/sql/language-manual/sql-ref-syntax-aux-conf-mgmt-set-timezone.html for details.\nIf not specified, UTC will be used.",
+                      "$ref": "#/$defs/string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "start_hour"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
+            },
+            "pipelines.SchemaSpec": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "destination_catalog": {
+                      "description": "Required. Destination catalog to store tables.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "destination_schema": {
+                      "description": "Required. Destination schema to store tables in. Tables with the same name as the source tables are created in this destination schema. The pipeline fails If a table with the same name already exists.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "source_catalog": {
+                      "description": "The source catalog name. Might be optional depending on the type of source.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "source_schema": {
+                      "description": "Required. Schema name in the source database.",
+                      "$ref": "#/$defs/string"
+                    },
+                    "table_configuration": {
+                      "description": "Configuration settings to control the ingestion of tables. These settings are applied to all tables in this schema and override the table_configuration defined in the IngestionPipelineDefinition object.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig"
                     }
                   },
                   "additionalProperties": false
@@ -4102,37 +5409,37 @@
               ]
             },
             "pipelines.TableSpec": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "destination_catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Destination catalog to store table."
+                      "description": "Required. Destination catalog to store table.",
+                      "$ref": "#/$defs/string"
                     },
                     "destination_schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Destination schema to store table."
+                      "description": "Required. Destination schema to store table.",
+                      "$ref": "#/$defs/string"
                     },
                     "destination_table": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional. Destination table name. The pipeline fails If a table with that name already exists. If not set, the source table name is used."
+                      "description": "Optional. Destination table name. The pipeline fails if a table with that name already exists. If not set, the source table name is used.",
+                      "$ref": "#/$defs/string"
                     },
                     "source_catalog": {
-                      "$ref": "#/$defs/string",
-                      "description": "Source catalog name. Might be optional depending on the type of source."
+                      "description": "Source catalog name. Might be optional depending on the type of source.",
+                      "$ref": "#/$defs/string"
                     },
                     "source_schema": {
-                      "$ref": "#/$defs/string",
-                      "description": "Schema name in the source database. Might be optional depending on the type of source."
+                      "description": "Schema name in the source database. Might be optional depending on the type of source.",
+                      "$ref": "#/$defs/string"
                     },
                     "source_table": {
-                      "$ref": "#/$defs/string",
-                      "description": "Required. Table name in the source database."
+                      "description": "Required. Table name in the source database.",
+                      "$ref": "#/$defs/string"
                     },
                     "table_configuration": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig",
-                      "description": "Configuration settings to control the ingestion of tables. These settings override the table_configuration defined in the IngestionPipelineDefinition object and the SchemaSpec."
+                      "description": "Configuration settings to control the ingestion of tables. These settings override the table_configuration defined in the IngestionPipelineDefinition object and the SchemaSpec.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfig"
                     }
                   },
                   "additionalProperties": false
@@ -4144,22 +5451,25 @@
               ]
             },
             "pipelines.TableSpecificConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "primary_keys": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "The primary key of the table used to apply changes."
+                      "description": "The primary key of the table used to apply changes.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "salesforce_include_formula_fields": {
-                      "$ref": "#/$defs/bool",
-                      "description": "If true, formula fields defined in the table are included in the ingestion. This setting is only valid for the Salesforce connector"
+                      "description": "If true, formula fields defined in the table are included in the ingestion. This setting is only valid for the Salesforce connector",
+                      "$ref": "#/$defs/bool"
                     },
                     "scd_type": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfigScdType",
                       "description": "The SCD type to use to ingest the table.",
-                      "enum": ["SCD_TYPE_1", "SCD_TYPE_2"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.TableSpecificConfigScdType"
+                    },
+                    "sequence_by": {
+                      "description": "The column names specifying the logical order of events in the source data. Delta Live Tables uses this sequencing to handle change events that arrive out of order.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -4171,17 +5481,32 @@
               ]
             },
             "pipelines.TableSpecificConfigScdType": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The SCD type to use to ingest the table.",
+                  "enum": [
+                    "SCD_TYPE_1",
+                    "SCD_TYPE_2"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.Ai21LabsConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "ai21labs_api_key": {
+                      "description": "The Databricks secret key reference for an AI21 Labs API key. If you prefer to paste your API key directly, see `ai21labs_api_key_plaintext`. You must provide an API key using one of the following fields: `ai21labs_api_key` or `ai21labs_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     },
                     "ai21labs_api_key_plaintext": {
+                      "description": "An AI21 Labs API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `ai21labs_api_key`. You must provide an API key using one of the following fields: `ai21labs_api_key` or `ai21labs_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -4194,25 +5519,25 @@
               ]
             },
             "serving.AiGatewayConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "guardrails": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrails",
-                      "description": "Configuration for AI Guardrails to prevent unwanted data and unsafe data in requests and responses."
+                      "description": "Configuration for AI Guardrails to prevent unwanted data and unsafe data in requests and responses.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrails"
                     },
                     "inference_table_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayInferenceTableConfig",
-                      "description": "Configuration for payload logging using inference tables. Use these tables to monitor and audit data being sent to and received from model APIs and to improve model quality."
+                      "description": "Configuration for payload logging using inference tables. Use these tables to monitor and audit data being sent to and received from model APIs and to improve model quality.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayInferenceTableConfig"
                     },
                     "rate_limits": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimit",
-                      "description": "Configuration for rate limits which can be set to limit endpoint traffic."
+                      "description": "Configuration for rate limits which can be set to limit endpoint traffic.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimit"
                     },
                     "usage_tracking_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayUsageTrackingConfig",
-                      "description": "Configuration to enable usage tracking using system tables. These tables allow you to monitor operational usage on endpoints and their associated costs."
+                      "description": "Configuration to enable usage tracking using system tables. These tables allow you to monitor operational usage on endpoints and their associated costs.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayUsageTrackingConfig"
                     }
                   },
                   "additionalProperties": false
@@ -4224,25 +5549,25 @@
               ]
             },
             "serving.AiGatewayGuardrailParameters": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "invalid_keywords": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "List of invalid keywords. AI guardrail uses keyword or string matching to decide if the keyword exists in the request or response content."
+                      "description": "List of invalid keywords. AI guardrail uses keyword or string matching to decide if the keyword exists in the request or response content.",
+                      "$ref": "#/$defs/slice/string"
                     },
                     "pii": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailPiiBehavior",
-                      "description": "Configuration for guardrail PII filter."
+                      "description": "Configuration for guardrail PII filter.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailPiiBehavior"
                     },
                     "safety": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Indicates whether the safety filter is enabled."
+                      "description": "Indicates whether the safety filter is enabled.",
+                      "$ref": "#/$defs/bool"
                     },
                     "valid_topics": {
-                      "$ref": "#/$defs/slice/string",
-                      "description": "The list of allowed topics. Given a chat request, this guardrail flags the request if its topic is not in the allowed topics."
+                      "description": "The list of allowed topics. Given a chat request, this guardrail flags the request if its topic is not in the allowed topics.",
+                      "$ref": "#/$defs/slice/string"
                     }
                   },
                   "additionalProperties": false
@@ -4254,18 +5579,19 @@
               ]
             },
             "serving.AiGatewayGuardrailPiiBehavior": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "behavior": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailPiiBehaviorBehavior",
                       "description": "Behavior for PII filter. Currently only 'BLOCK' is supported. If 'BLOCK' is set for the input guardrail and the request contains PII, the request is not sent to the model server and 400 status code is returned; if 'BLOCK' is set for the output guardrail and the model response contains PII, the PII info in the response is redacted and 400 status code is returned.",
-                      "enum": ["NONE", "BLOCK"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailPiiBehaviorBehavior"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["behavior"]
+                  "required": [
+                    "behavior"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4274,20 +5600,33 @@
               ]
             },
             "serving.AiGatewayGuardrailPiiBehaviorBehavior": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Behavior for PII filter. Currently only 'BLOCK' is supported. If 'BLOCK' is set for the input guardrail and the request contains PII, the request is not sent to the model server and 400 status code is returned; if 'BLOCK' is set for the output guardrail and the model response contains PII, the PII info in the response is redacted and 400 status code is returned.",
+                  "enum": [
+                    "NONE",
+                    "BLOCK"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.AiGatewayGuardrails": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "input": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailParameters",
-                      "description": "Configuration for input guardrail filters."
+                      "description": "Configuration for input guardrail filters.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailParameters"
                     },
                     "output": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailParameters",
-                      "description": "Configuration for output guardrail filters."
+                      "description": "Configuration for output guardrail filters.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayGuardrailParameters"
                     }
                   },
                   "additionalProperties": false
@@ -4299,25 +5638,25 @@
               ]
             },
             "serving.AiGatewayInferenceTableConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "catalog_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the catalog in Unity Catalog. Required when enabling inference tables. NOTE: On update, you have to disable inference table first in order to change the catalog name."
+                      "description": "The name of the catalog in Unity Catalog. Required when enabling inference tables. NOTE: On update, you have to disable inference table first in order to change the catalog name.",
+                      "$ref": "#/$defs/string"
                     },
                     "enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Indicates whether the inference table is enabled."
+                      "description": "Indicates whether the inference table is enabled.",
+                      "$ref": "#/$defs/bool"
                     },
                     "schema_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the schema in Unity Catalog. Required when enabling inference tables. NOTE: On update, you have to disable inference table first in order to change the schema name."
+                      "description": "The name of the schema in Unity Catalog. Required when enabling inference tables. NOTE: On update, you have to disable inference table first in order to change the schema name.",
+                      "$ref": "#/$defs/string"
                     },
                     "table_name_prefix": {
-                      "$ref": "#/$defs/string",
-                      "description": "The prefix of the table in Unity Catalog. NOTE: On update, you have to disable inference table first in order to change the prefix name."
+                      "description": "The prefix of the table in Unity Catalog. NOTE: On update, you have to disable inference table first in order to change the prefix name.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4329,27 +5668,28 @@
               ]
             },
             "serving.AiGatewayRateLimit": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "calls": {
-                      "$ref": "#/$defs/int",
-                      "description": "Used to specify how many calls are allowed for a key within the renewal_period."
+                      "description": "Used to specify how many calls are allowed for a key within the renewal_period.",
+                      "$ref": "#/$defs/int"
                     },
                     "key": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimitKey",
                       "description": "Key field for a rate limit. Currently, only 'user' and 'endpoint' are supported, with 'endpoint' being the default if not specified.",
-                      "enum": ["user", "endpoint"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimitKey"
                     },
                     "renewal_period": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimitRenewalPeriod",
                       "description": "Renewal period field for a rate limit. Currently, only 'minute' is supported.",
-                      "enum": ["minute"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AiGatewayRateLimitRenewalPeriod"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["calls", "renewal_period"]
+                  "required": [
+                    "calls",
+                    "renewal_period"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4358,19 +5698,44 @@
               ]
             },
             "serving.AiGatewayRateLimitKey": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Key field for a rate limit. Currently, only 'user' and 'endpoint' are supported, with 'endpoint' being the default if not specified.",
+                  "enum": [
+                    "user",
+                    "endpoint"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.AiGatewayRateLimitRenewalPeriod": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Renewal period field for a rate limit. Currently, only 'minute' is supported.",
+                  "enum": [
+                    "minute"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.AiGatewayUsageTrackingConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether to enable usage tracking."
+                      "description": "Whether to enable usage tracking.",
+                      "$ref": "#/$defs/bool"
                     }
                   },
                   "additionalProperties": false
@@ -4382,38 +5747,40 @@
               ]
             },
             "serving.AmazonBedrockConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "aws_access_key_id": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks secret key reference for an AWS access key ID with permissions to interact with Bedrock services. If you prefer to paste your API key directly, see `aws_access_key_id`. You must provide an API key using one of the following fields: `aws_access_key_id` or `aws_access_key_id_plaintext`."
+                      "description": "The Databricks secret key reference for an AWS access key ID with permissions to interact with Bedrock services. If you prefer to paste your API key directly, see `aws_access_key_id`. You must provide an API key using one of the following fields: `aws_access_key_id` or `aws_access_key_id_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "aws_access_key_id_plaintext": {
-                      "$ref": "#/$defs/string",
-                      "description": "An AWS access key ID with permissions to interact with Bedrock services provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `aws_access_key_id`. You must provide an API key using one of the following fields: `aws_access_key_id` or `aws_access_key_id_plaintext`."
+                      "description": "An AWS access key ID with permissions to interact with Bedrock services provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `aws_access_key_id`. You must provide an API key using one of the following fields: `aws_access_key_id` or `aws_access_key_id_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "aws_region": {
-                      "$ref": "#/$defs/string",
-                      "description": "The AWS region to use. Bedrock has to be enabled there."
+                      "description": "The AWS region to use. Bedrock has to be enabled there.",
+                      "$ref": "#/$defs/string"
                     },
                     "aws_secret_access_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks secret key reference for an AWS secret access key paired with the access key ID, with permissions to interact with Bedrock services. If you prefer to paste your API key directly, see `aws_secret_access_key_plaintext`. You must provide an API key using one of the following fields: `aws_secret_access_key` or `aws_secret_access_key_plaintext`."
+                      "description": "The Databricks secret key reference for an AWS secret access key paired with the access key ID, with permissions to interact with Bedrock services. If you prefer to paste your API key directly, see `aws_secret_access_key_plaintext`. You must provide an API key using one of the following fields: `aws_secret_access_key` or `aws_secret_access_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "aws_secret_access_key_plaintext": {
-                      "$ref": "#/$defs/string",
-                      "description": "An AWS secret access key paired with the access key ID, with permissions to interact with Bedrock services provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `aws_secret_access_key`. You must provide an API key using one of the following fields: `aws_secret_access_key` or `aws_secret_access_key_plaintext`."
+                      "description": "An AWS secret access key paired with the access key ID, with permissions to interact with Bedrock services provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `aws_secret_access_key`. You must provide an API key using one of the following fields: `aws_secret_access_key` or `aws_secret_access_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "bedrock_provider": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AmazonBedrockConfigBedrockProvider",
                       "description": "The underlying provider in Amazon Bedrock. Supported values (case insensitive) include: Anthropic, Cohere, AI21Labs, Amazon.",
-                      "enum": ["anthropic", "cohere", "ai21labs", "amazon"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AmazonBedrockConfigBedrockProvider"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["aws_region", "bedrock_provider"]
+                  "required": [
+                    "aws_region",
+                    "bedrock_provider"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4422,20 +5789,35 @@
               ]
             },
             "serving.AmazonBedrockConfigBedrockProvider": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The underlying provider in Amazon Bedrock. Supported values (case insensitive) include: Anthropic, Cohere, AI21Labs, Amazon.",
+                  "enum": [
+                    "anthropic",
+                    "cohere",
+                    "ai21labs",
+                    "amazon"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.AnthropicConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "anthropic_api_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks secret key reference for an Anthropic API key. If you prefer to paste your API key directly, see `anthropic_api_key_plaintext`. You must provide an API key using one of the following fields: `anthropic_api_key` or `anthropic_api_key_plaintext`."
+                      "description": "The Databricks secret key reference for an Anthropic API key. If you prefer to paste your API key directly, see `anthropic_api_key_plaintext`. You must provide an API key using one of the following fields: `anthropic_api_key` or `anthropic_api_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "anthropic_api_key_plaintext": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Anthropic API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `anthropic_api_key`. You must provide an API key using one of the following fields: `anthropic_api_key` or `anthropic_api_key_plaintext`."
+                      "description": "The Anthropic API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `anthropic_api_key`. You must provide an API key using one of the following fields: `anthropic_api_key` or `anthropic_api_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4447,25 +5829,25 @@
               ]
             },
             "serving.AutoCaptureConfigInput": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "catalog_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the catalog in Unity Catalog. NOTE: On update, you cannot change the catalog name if the inference table is already enabled."
+                      "description": "The name of the catalog in Unity Catalog. NOTE: On update, you cannot change the catalog name if the inference table is already enabled.",
+                      "$ref": "#/$defs/string"
                     },
                     "enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Indicates whether the inference table is enabled."
+                      "description": "Indicates whether the inference table is enabled.",
+                      "$ref": "#/$defs/bool"
                     },
                     "schema_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the schema in Unity Catalog. NOTE: On update, you cannot change the schema name if the inference table is already enabled."
+                      "description": "The name of the schema in Unity Catalog. NOTE: On update, you cannot change the schema name if the inference table is already enabled.",
+                      "$ref": "#/$defs/string"
                     },
                     "table_name_prefix": {
-                      "$ref": "#/$defs/string",
-                      "description": "The prefix of the table in Unity Catalog. NOTE: On update, you cannot change the prefix name if the inference table is already enabled."
+                      "description": "The prefix of the table in Unity Catalog. NOTE: On update, you cannot change the prefix name if the inference table is already enabled.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4477,21 +5859,21 @@
               ]
             },
             "serving.CohereConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "cohere_api_base": {
-                      "$ref": "#/$defs/string",
-                      "description": "This is an optional field to provide a customized base URL for the Cohere API. \nIf left unspecified, the standard Cohere base URL is used.\n"
+                      "description": "This is an optional field to provide a customized base URL for the Cohere API. \nIf left unspecified, the standard Cohere base URL is used.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "cohere_api_key": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks secret key reference for a Cohere API key. If you prefer to paste your API key directly, see `cohere_api_key_plaintext`. You must provide an API key using one of the following fields: `cohere_api_key` or `cohere_api_key_plaintext`."
+                      "description": "The Databricks secret key reference for a Cohere API key. If you prefer to paste your API key directly, see `cohere_api_key_plaintext`. You must provide an API key using one of the following fields: `cohere_api_key` or `cohere_api_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     },
                     "cohere_api_key_plaintext": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Cohere API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `cohere_api_key`. You must provide an API key using one of the following fields: `cohere_api_key` or `cohere_api_key_plaintext`."
+                      "description": "The Cohere API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `cohere_api_key`. You must provide an API key using one of the following fields: `cohere_api_key` or `cohere_api_key_plaintext`.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4503,25 +5885,27 @@
               ]
             },
             "serving.DatabricksModelServingConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "databricks_api_token": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks secret key reference for a Databricks API token that corresponds to a user or service\nprincipal with Can Query access to the model serving endpoint pointed to by this external model.\nIf you prefer to paste your API key directly, see `databricks_api_token_plaintext`.\nYou must provide an API key using one of the following fields: `databricks_api_token` or `databricks_api_token_plaintext`.\n"
+                      "description": "The Databricks secret key reference for a Databricks API token that corresponds to a user or service\nprincipal with Can Query access to the model serving endpoint pointed to by this external model.\nIf you prefer to paste your API key directly, see `databricks_api_token_plaintext`.\nYou must provide an API key using one of the following fields: `databricks_api_token` or `databricks_api_token_plaintext`.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "databricks_api_token_plaintext": {
-                      "$ref": "#/$defs/string",
-                      "description": "The Databricks API token that corresponds to a user or service\nprincipal with Can Query access to the model serving endpoint pointed to by this external model provided as a plaintext string.\nIf you prefer to reference your key using Databricks Secrets, see `databricks_api_token`.\nYou must provide an API key using one of the following fields: `databricks_api_token` or `databricks_api_token_plaintext`.\n"
+                      "description": "The Databricks API token that corresponds to a user or service\nprincipal with Can Query access to the model serving endpoint pointed to by this external model provided as a plaintext string.\nIf you prefer to reference your key using Databricks Secrets, see `databricks_api_token`.\nYou must provide an API key using one of the following fields: `databricks_api_token` or `databricks_api_token_plaintext`.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "databricks_workspace_url": {
-                      "$ref": "#/$defs/string",
-                      "description": "The URL of the Databricks workspace containing the model serving endpoint pointed to by this external model.\n"
+                      "description": "The URL of the Databricks workspace containing the model serving endpoint pointed to by this external model.\n",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["databricks_workspace_url"]
+                  "required": [
+                    "databricks_workspace_url"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4530,25 +5914,25 @@
               ]
             },
             "serving.EndpointCoreConfigInput": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "auto_capture_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AutoCaptureConfigInput",
-                      "description": "Configuration for Inference Tables which automatically logs requests and responses to Unity Catalog."
+                      "description": "Configuration for Inference Tables which automatically logs requests and responses to Unity Catalog.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AutoCaptureConfigInput"
                     },
                     "served_entities": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.ServedEntityInput",
-                      "description": "A list of served entities for the endpoint to serve. A serving endpoint can have up to 15 served entities."
+                      "description": "A list of served entities for the endpoint to serve. A serving endpoint can have up to 15 served entities.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.ServedEntityInput"
                     },
                     "served_models": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInput",
-                      "description": "(Deprecated, use served_entities instead) A list of served models for the endpoint to serve. A serving endpoint can have up to 15 served models."
+                      "description": "(Deprecated, use served_entities instead) A list of served models for the endpoint to serve. A serving endpoint can have up to 15 served models.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInput"
                     },
                     "traffic_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.TrafficConfig",
-                      "description": "The traffic config defining how invocations to the serving endpoint should be routed."
+                      "description": "The traffic config defining how invocations to the serving endpoint should be routed.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.TrafficConfig"
                     }
                   },
                   "additionalProperties": false
@@ -4560,21 +5944,23 @@
               ]
             },
             "serving.EndpointTag": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "key": {
-                      "$ref": "#/$defs/string",
-                      "description": "Key field for a serving endpoint tag."
+                      "description": "Key field for a serving endpoint tag.",
+                      "$ref": "#/$defs/string"
                     },
                     "value": {
-                      "$ref": "#/$defs/string",
-                      "description": "Optional value field for a serving endpoint tag."
+                      "description": "Optional value field for a serving endpoint tag.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["key"]
+                  "required": [
+                    "key"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4583,67 +5969,61 @@
               ]
             },
             "serving.ExternalModel": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "ai21labs_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.Ai21LabsConfig",
-                      "description": "AI21Labs Config. Only required if the provider is 'ai21labs'."
+                      "description": "AI21Labs Config. Only required if the provider is 'ai21labs'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.Ai21LabsConfig"
                     },
                     "amazon_bedrock_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AmazonBedrockConfig",
-                      "description": "Amazon Bedrock Config. Only required if the provider is 'amazon-bedrock'."
+                      "description": "Amazon Bedrock Config. Only required if the provider is 'amazon-bedrock'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AmazonBedrockConfig"
                     },
                     "anthropic_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AnthropicConfig",
-                      "description": "Anthropic Config. Only required if the provider is 'anthropic'."
+                      "description": "Anthropic Config. Only required if the provider is 'anthropic'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.AnthropicConfig"
                     },
                     "cohere_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.CohereConfig",
-                      "description": "Cohere Config. Only required if the provider is 'cohere'."
+                      "description": "Cohere Config. Only required if the provider is 'cohere'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.CohereConfig"
                     },
                     "databricks_model_serving_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.DatabricksModelServingConfig",
-                      "description": "Databricks Model Serving Config. Only required if the provider is 'databricks-model-serving'."
+                      "description": "Databricks Model Serving Config. Only required if the provider is 'databricks-model-serving'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.DatabricksModelServingConfig"
                     },
                     "google_cloud_vertex_ai_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.GoogleCloudVertexAiConfig",
-                      "description": "Google Cloud Vertex AI Config. Only required if the provider is 'google-cloud-vertex-ai'."
+                      "description": "Google Cloud Vertex AI Config. Only required if the provider is 'google-cloud-vertex-ai'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.GoogleCloudVertexAiConfig"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the external model."
+                      "description": "The name of the external model.",
+                      "$ref": "#/$defs/string"
                     },
                     "openai_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.OpenAiConfig",
-                      "description": "OpenAI Config. Only required if the provider is 'openai'."
+                      "description": "OpenAI Config. Only required if the provider is 'openai'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.OpenAiConfig"
                     },
                     "palm_config": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.PaLmConfig",
-                      "description": "PaLM Config. Only required if the provider is 'palm'."
+                      "description": "PaLM Config. Only required if the provider is 'palm'.",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.PaLmConfig"
                     },
                     "provider": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ExternalModelProvider",
                       "description": "The name of the provider for the external model. Currently, the supported providers are 'ai21labs', 'anthropic',\n'amazon-bedrock', 'cohere', 'databricks-model-serving', 'google-cloud-vertex-ai', 'openai', and 'palm'.\",\n",
-                      "enum": [
-                        "ai21labs",
-                        "anthropic",
-                        "amazon-bedrock",
-                        "cohere",
-                        "databricks-model-serving",
-                        "google-cloud-vertex-ai",
-                        "openai",
-                        "palm"
-                      ]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ExternalModelProvider"
                     },
                     "task": {
-                      "$ref": "#/$defs/string",
-                      "description": "The task type of the external model."
+                      "description": "The task type of the external model.",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["name", "provider", "task"]
+                  "required": [
+                    "name",
+                    "provider",
+                    "task"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4652,23 +6032,46 @@
               ]
             },
             "serving.ExternalModelProvider": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The name of the provider for the external model. Currently, the supported providers are 'ai21labs', 'anthropic',\n'amazon-bedrock', 'cohere', 'databricks-model-serving', 'google-cloud-vertex-ai', 'openai', and 'palm'.\",\n",
+                  "enum": [
+                    "ai21labs",
+                    "anthropic",
+                    "amazon-bedrock",
+                    "cohere",
+                    "databricks-model-serving",
+                    "google-cloud-vertex-ai",
+                    "openai",
+                    "palm"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.GoogleCloudVertexAiConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "private_key": {
+                      "description": "The Databricks secret key reference for a private key for the service account which has access to the Google Cloud Vertex AI Service. See [Best practices for managing service account keys](https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys). If you prefer to paste your API key directly, see `private_key_plaintext`. You must provide an API key using one of the following fields: `private_key` or `private_key_plaintext`",
                       "$ref": "#/$defs/string"
                     },
                     "private_key_plaintext": {
+                      "description": "The private key for the service account which has access to the Google Cloud Vertex AI Service provided as a plaintext secret. See [Best practices for managing service account keys](https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys). If you prefer to reference your key using Databricks Secrets, see `private_key`. You must provide an API key using one of the following fields: `private_key` or `private_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     },
                     "project_id": {
+                      "description": "This is the Google Cloud project id that the service account is associated with.",
                       "$ref": "#/$defs/string"
                     },
                     "region": {
+                      "description": "This is the region for the Google Cloud Vertex AI Service. See [supported regions](https://cloud.google.com/vertex-ai/docs/general/locations) for more details. Some models are only available in specific regions.",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -4681,41 +6084,52 @@
               ]
             },
             "serving.OpenAiConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "microsoft_entra_client_id": {
+                      "description": "This field is only required for Azure AD OpenAI and is the Microsoft Entra Client ID.\n",
                       "$ref": "#/$defs/string"
                     },
                     "microsoft_entra_client_secret": {
+                      "description": "The Databricks secret key reference for a client secret used for Microsoft Entra ID authentication.\nIf you prefer to paste your client secret directly, see `microsoft_entra_client_secret_plaintext`.\nYou must provide an API key using one of the following fields: `microsoft_entra_client_secret` or `microsoft_entra_client_secret_plaintext`.\n",
                       "$ref": "#/$defs/string"
                     },
                     "microsoft_entra_client_secret_plaintext": {
+                      "description": "The client secret used for Microsoft Entra ID authentication provided as a plaintext string.\nIf you prefer to reference your key using Databricks Secrets, see `microsoft_entra_client_secret`.\nYou must provide an API key using one of the following fields: `microsoft_entra_client_secret` or `microsoft_entra_client_secret_plaintext`.\n",
                       "$ref": "#/$defs/string"
                     },
                     "microsoft_entra_tenant_id": {
+                      "description": "This field is only required for Azure AD OpenAI and is the Microsoft Entra Tenant ID.\n",
                       "$ref": "#/$defs/string"
                     },
                     "openai_api_base": {
+                      "description": "This is a field to provide a customized base URl for the OpenAI API.\nFor Azure OpenAI, this field is required, and is the base URL for the Azure OpenAI API service\nprovided by Azure.\nFor other OpenAI API types, this field is optional, and if left unspecified, the standard OpenAI base URL is used.\n",
                       "$ref": "#/$defs/string"
                     },
                     "openai_api_key": {
+                      "description": "The Databricks secret key reference for an OpenAI API key using the OpenAI or Azure service. If you prefer to paste your API key directly, see `openai_api_key_plaintext`. You must provide an API key using one of the following fields: `openai_api_key` or `openai_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     },
                     "openai_api_key_plaintext": {
+                      "description": "The OpenAI API key using the OpenAI or Azure service provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `openai_api_key`. You must provide an API key using one of the following fields: `openai_api_key` or `openai_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     },
                     "openai_api_type": {
+                      "description": "This is an optional field to specify the type of OpenAI API to use.\nFor Azure OpenAI, this field is required, and adjust this parameter to represent the preferred security\naccess validation protocol. For access token validation, use azure. For authentication using Azure Active\nDirectory (Azure AD) use, azuread.\n",
                       "$ref": "#/$defs/string"
                     },
                     "openai_api_version": {
+                      "description": "This is an optional field to specify the OpenAI API version.\nFor Azure OpenAI, this field is required, and is the version of the Azure OpenAI service to\nutilize, specified by a date.\n",
                       "$ref": "#/$defs/string"
                     },
                     "openai_deployment_name": {
+                      "description": "This field is only required for Azure OpenAI and is the name of the deployment resource for the\nAzure OpenAI service.\n",
                       "$ref": "#/$defs/string"
                     },
                     "openai_organization": {
+                      "description": "This is an optional field to specify the organization in OpenAI or Azure OpenAI.\n",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -4728,14 +6142,16 @@
               ]
             },
             "serving.PaLmConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "palm_api_key": {
+                      "description": "The Databricks secret key reference for a PaLM API key. If you prefer to paste your API key directly, see `palm_api_key_plaintext`. You must provide an API key using one of the following fields: `palm_api_key` or `palm_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     },
                     "palm_api_key_plaintext": {
+                      "description": "The PaLM API key provided as a plaintext string. If you prefer to reference your key using Databricks Secrets, see `palm_api_key`. You must provide an API key using one of the following fields: `palm_api_key` or `palm_api_key_plaintext`.",
                       "$ref": "#/$defs/string"
                     }
                   },
@@ -4748,27 +6164,28 @@
               ]
             },
             "serving.RateLimit": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "calls": {
-                      "$ref": "#/$defs/int",
-                      "description": "Used to specify how many calls are allowed for a key within the renewal_period."
+                      "description": "Used to specify how many calls are allowed for a key within the renewal_period.",
+                      "$ref": "#/$defs/int"
                     },
                     "key": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.RateLimitKey",
                       "description": "Key field for a serving endpoint rate limit. Currently, only 'user' and 'endpoint' are supported, with 'endpoint' being the default if not specified.",
-                      "enum": ["user", "endpoint"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.RateLimitKey"
                     },
                     "renewal_period": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.RateLimitRenewalPeriod",
                       "description": "Renewal period field for a serving endpoint rate limit. Currently, only 'minute' is supported.",
-                      "enum": ["minute"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.RateLimitRenewalPeriod"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["calls", "renewal_period"]
+                  "required": [
+                    "calls",
+                    "renewal_period"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4777,27 +6194,55 @@
               ]
             },
             "serving.RateLimitKey": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Key field for a serving endpoint rate limit. Currently, only 'user' and 'endpoint' are supported, with 'endpoint' being the default if not specified.",
+                  "enum": [
+                    "user",
+                    "endpoint"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.RateLimitRenewalPeriod": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Renewal period field for a serving endpoint rate limit. Currently, only 'minute' is supported.",
+                  "enum": [
+                    "minute"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.Route": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "served_model_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the served model this route configures traffic for."
+                      "description": "The name of the served model this route configures traffic for.",
+                      "$ref": "#/$defs/string"
                     },
                     "traffic_percentage": {
-                      "$ref": "#/$defs/int",
-                      "description": "The percentage of endpoint traffic to send to this route. It must be an integer between 0 and 100 inclusive."
+                      "description": "The percentage of endpoint traffic to send to this route. It must be an integer between 0 and 100 inclusive.",
+                      "$ref": "#/$defs/int"
                     }
                   },
                   "additionalProperties": false,
-                  "required": ["served_model_name", "traffic_percentage"]
+                  "required": [
+                    "served_model_name",
+                    "traffic_percentage"
+                  ]
                 },
                 {
                   "type": "string",
@@ -4806,53 +6251,53 @@
               ]
             },
             "serving.ServedEntityInput": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "entity_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the entity to be served. The entity may be a model in the Databricks Model Registry, a model in the Unity Catalog (UC),\nor a function of type FEATURE_SPEC in the UC. If it is a UC object, the full name of the object should be given in the form of\n__catalog_name__.__schema_name__.__model_name__.\n"
+                      "description": "The name of the entity to be served. The entity may be a model in the Databricks Model Registry, a model in the Unity Catalog (UC),\nor a function of type FEATURE_SPEC in the UC. If it is a UC object, the full name of the object should be given in the form of\n__catalog_name__.__schema_name__.__model_name__.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "entity_version": {
-                      "$ref": "#/$defs/string",
-                      "description": "The version of the model in Databricks Model Registry to be served or empty if the entity is a FEATURE_SPEC."
+                      "description": "The version of the model in Databricks Model Registry to be served or empty if the entity is a FEATURE_SPEC.",
+                      "$ref": "#/$defs/string"
                     },
                     "environment_vars": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs used for serving this entity.\nNote: this is an experimental feature and subject to change. \nExample entity environment variables that refer to Databricks secrets: `{\"OPENAI_API_KEY\": \"{{secrets/my_scope/my_key}}\", \"DATABRICKS_TOKEN\": \"{{secrets/my_scope2/my_key2}}\"}`"
+                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs used for serving this entity.\nNote: this is an experimental feature and subject to change. \nExample entity environment variables that refer to Databricks secrets: `{\"OPENAI_API_KEY\": \"{{secrets/my_scope/my_key}}\", \"DATABRICKS_TOKEN\": \"{{secrets/my_scope2/my_key2}}\"}`",
+                      "$ref": "#/$defs/map/string"
                     },
                     "external_model": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ExternalModel",
-                      "description": "The external model to be served. NOTE: Only one of external_model and (entity_name, entity_version, workload_size, workload_type, and scale_to_zero_enabled)\ncan be specified with the latter set being used for custom model serving for a Databricks registered model. For an existing endpoint with external_model,\nit cannot be updated to an endpoint without external_model. If the endpoint is created without external_model, users cannot update it to add external_model later.\nThe task type of all external models within an endpoint must be the same.\n"
+                      "description": "The external model to be served. NOTE: Only one of external_model and (entity_name, entity_version, workload_size, workload_type, and scale_to_zero_enabled)\ncan be specified with the latter set being used for custom model serving for a Databricks registered model. For an existing endpoint with external_model,\nit cannot be updated to an endpoint without external_model. If the endpoint is created without external_model, users cannot update it to add external_model later.\nThe task type of all external models within an endpoint must be the same.\n",
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ExternalModel"
                     },
                     "instance_profile_arn": {
-                      "$ref": "#/$defs/string",
-                      "description": "ARN of the instance profile that the served entity uses to access AWS resources."
+                      "description": "ARN of the instance profile that the served entity uses to access AWS resources.",
+                      "$ref": "#/$defs/string"
                     },
                     "max_provisioned_throughput": {
-                      "$ref": "#/$defs/int",
-                      "description": "The maximum tokens per second that the endpoint can scale up to."
+                      "description": "The maximum tokens per second that the endpoint can scale up to.",
+                      "$ref": "#/$defs/int"
                     },
                     "min_provisioned_throughput": {
-                      "$ref": "#/$defs/int",
-                      "description": "The minimum tokens per second that the endpoint can scale down to."
+                      "description": "The minimum tokens per second that the endpoint can scale down to.",
+                      "$ref": "#/$defs/int"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of a served entity. It must be unique across an endpoint. A served entity name can consist of alphanumeric characters, dashes, and underscores.\nIf not specified for an external model, this field defaults to external_model.name, with '.' and ':' replaced with '-', and if not specified for other\nentities, it defaults to \u003centity-name\u003e-\u003centity-version\u003e.\n"
+                      "description": "The name of a served entity. It must be unique across an endpoint. A served entity name can consist of alphanumeric characters, dashes, and underscores.\nIf not specified for an external model, this field defaults to external_model.name, with '.' and ':' replaced with '-', and if not specified for other\nentities, it defaults to \u003centity-name\u003e-\u003centity-version\u003e.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "scale_to_zero_enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether the compute resources for the served entity should scale down to zero."
+                      "description": "Whether the compute resources for the served entity should scale down to zero.",
+                      "$ref": "#/$defs/bool"
                     },
                     "workload_size": {
-                      "$ref": "#/$defs/string",
-                      "description": "The workload size of the served entity. The workload size corresponds to a range of provisioned concurrency that the compute autoscales between.\nA single unit of provisioned concurrency can process one request at a time.\nValid workload sizes are \"Small\" (4 - 4 provisioned concurrency), \"Medium\" (8 - 16 provisioned concurrency), and \"Large\" (16 - 64 provisioned concurrency).\nIf scale-to-zero is enabled, the lower bound of the provisioned concurrency for each workload size is 0.\n"
+                      "description": "The workload size of the served entity. The workload size corresponds to a range of provisioned concurrency that the compute autoscales between.\nA single unit of provisioned concurrency can process one request at a time.\nValid workload sizes are \"Small\" (4 - 4 provisioned concurrency), \"Medium\" (8 - 16 provisioned concurrency), and \"Large\" (16 - 64 provisioned concurrency).\nIf scale-to-zero is enabled, the lower bound of the provisioned concurrency for each workload size is 0.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "workload_type": {
-                      "$ref": "#/$defs/string",
-                      "description": "The workload type of the served entity. The workload type selects which type of compute to use in the endpoint. The default value for this parameter is\n\"CPU\". For deep learning workloads, GPU acceleration is available by selecting workload types like GPU_SMALL and others.\nSee the available [GPU types](https://docs.databricks.com/machine-learning/model-serving/create-manage-serving-endpoints.html#gpu-workload-types).\n"
+                      "description": "The workload type of the served entity. The workload type selects which type of compute to use in the endpoint. The default value for this parameter is\n\"CPU\". For deep learning workloads, GPU acceleration is available by selecting workload types like GPU_SMALL and others.\nSee the available [GPU types](https://docs.databricks.com/machine-learning/model-serving/create-manage-serving-endpoints.html#gpu-workload-types).\n",
+                      "$ref": "#/$defs/string"
                     }
                   },
                   "additionalProperties": false
@@ -4864,57 +6309,49 @@
               ]
             },
             "serving.ServedModelInput": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "environment_vars": {
-                      "$ref": "#/$defs/map/string",
-                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs used for serving this model.\nNote: this is an experimental feature and subject to change. \nExample model environment variables that refer to Databricks secrets: `{\"OPENAI_API_KEY\": \"{{secrets/my_scope/my_key}}\", \"DATABRICKS_TOKEN\": \"{{secrets/my_scope2/my_key2}}\"}`"
+                      "description": "An object containing a set of optional, user-specified environment variable key-value pairs used for serving this model.\nNote: this is an experimental feature and subject to change. \nExample model environment variables that refer to Databricks secrets: `{\"OPENAI_API_KEY\": \"{{secrets/my_scope/my_key}}\", \"DATABRICKS_TOKEN\": \"{{secrets/my_scope2/my_key2}}\"}`",
+                      "$ref": "#/$defs/map/string"
                     },
                     "instance_profile_arn": {
-                      "$ref": "#/$defs/string",
-                      "description": "ARN of the instance profile that the served model will use to access AWS resources."
+                      "description": "ARN of the instance profile that the served model will use to access AWS resources.",
+                      "$ref": "#/$defs/string"
                     },
                     "max_provisioned_throughput": {
-                      "$ref": "#/$defs/int",
-                      "description": "The maximum tokens per second that the endpoint can scale up to."
+                      "description": "The maximum tokens per second that the endpoint can scale up to.",
+                      "$ref": "#/$defs/int"
                     },
                     "min_provisioned_throughput": {
-                      "$ref": "#/$defs/int",
-                      "description": "The minimum tokens per second that the endpoint can scale down to."
+                      "description": "The minimum tokens per second that the endpoint can scale down to.",
+                      "$ref": "#/$defs/int"
                     },
                     "model_name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of the model in Databricks Model Registry to be served or if the model resides in Unity Catalog, the full name of model,\nin the form of __catalog_name__.__schema_name__.__model_name__.\n"
+                      "description": "The name of the model in Databricks Model Registry to be served or if the model resides in Unity Catalog, the full name of model,\nin the form of __catalog_name__.__schema_name__.__model_name__.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "model_version": {
-                      "$ref": "#/$defs/string",
-                      "description": "The version of the model in Databricks Model Registry or Unity Catalog to be served."
+                      "description": "The version of the model in Databricks Model Registry or Unity Catalog to be served.",
+                      "$ref": "#/$defs/string"
                     },
                     "name": {
-                      "$ref": "#/$defs/string",
-                      "description": "The name of a served model. It must be unique across an endpoint. If not specified, this field will default to \u003cmodel-name\u003e-\u003cmodel-version\u003e.\nA served model name can consist of alphanumeric characters, dashes, and underscores.\n"
+                      "description": "The name of a served model. It must be unique across an endpoint. If not specified, this field will default to \u003cmodel-name\u003e-\u003cmodel-version\u003e.\nA served model name can consist of alphanumeric characters, dashes, and underscores.\n",
+                      "$ref": "#/$defs/string"
                     },
                     "scale_to_zero_enabled": {
-                      "$ref": "#/$defs/bool",
-                      "description": "Whether the compute resources for the served model should scale down to zero."
+                      "description": "Whether the compute resources for the served model should scale down to zero.",
+                      "$ref": "#/$defs/bool"
                     },
                     "workload_size": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInputWorkloadSize",
                       "description": "The workload size of the served model. The workload size corresponds to a range of provisioned concurrency that the compute will autoscale between.\nA single unit of provisioned concurrency can process one request at a time.\nValid workload sizes are \"Small\" (4 - 4 provisioned concurrency), \"Medium\" (8 - 16 provisioned concurrency), and \"Large\" (16 - 64 provisioned concurrency).\nIf scale-to-zero is enabled, the lower bound of the provisioned concurrency for each workload size will be 0.\n",
-                      "enum": ["Small", "Medium", "Large"]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInputWorkloadSize"
                     },
                     "workload_type": {
-                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInputWorkloadType",
                       "description": "The workload type of the served model. The workload type selects which type of compute to use in the endpoint. The default value for this parameter is\n\"CPU\". For deep learning workloads, GPU acceleration is available by selecting workload types like GPU_SMALL and others.\nSee the available [GPU types](https://docs.databricks.com/machine-learning/model-serving/create-manage-serving-endpoints.html#gpu-workload-types).\n",
-                      "enum": [
-                        "CPU",
-                        "GPU_SMALL",
-                        "GPU_MEDIUM",
-                        "GPU_LARGE",
-                        "MULTIGPU_MEDIUM"
-                      ]
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServedModelInputWorkloadType"
                     }
                   },
                   "additionalProperties": false,
@@ -4931,19 +6368,49 @@
               ]
             },
             "serving.ServedModelInputWorkloadSize": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The workload size of the served model. The workload size corresponds to a range of provisioned concurrency that the compute will autoscale between.\nA single unit of provisioned concurrency can process one request at a time.\nValid workload sizes are \"Small\" (4 - 4 provisioned concurrency), \"Medium\" (8 - 16 provisioned concurrency), and \"Large\" (16 - 64 provisioned concurrency).\nIf scale-to-zero is enabled, the lower bound of the provisioned concurrency for each workload size will be 0.\n",
+                  "enum": [
+                    "Small",
+                    "Medium",
+                    "Large"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.ServedModelInputWorkloadType": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The workload type of the served model. The workload type selects which type of compute to use in the endpoint. The default value for this parameter is\n\"CPU\". For deep learning workloads, GPU acceleration is available by selecting workload types like GPU_SMALL and others.\nSee the available [GPU types](https://docs.databricks.com/machine-learning/model-serving/create-manage-serving-endpoints.html#gpu-workload-types).\n",
+                  "enum": [
+                    "CPU",
+                    "GPU_SMALL",
+                    "GPU_MEDIUM",
+                    "GPU_LARGE",
+                    "MULTIGPU_MEDIUM"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "serving.TrafficConfig": {
-              "anyOf": [
+              "oneOf": [
                 {
                   "type": "object",
                   "properties": {
                     "routes": {
-                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.Route",
-                      "description": "The list of routes that define traffic to each served entity."
+                      "description": "The list of routes that define traffic to each served entity.",
+                      "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/serving.Route"
                     }
                   },
                   "additionalProperties": false
@@ -4959,7 +6426,7 @@
       }
     },
     "int": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "integer"
         },
@@ -4986,7 +6453,7 @@
       ]
     },
     "int64": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "integer"
         },
@@ -5019,8 +6486,22 @@
           "cli": {
             "bundle": {
               "config": {
+                "resources.App": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.App"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
                 "resources.Cluster": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5033,8 +6514,22 @@
                     }
                   ]
                 },
+                "resources.Dashboard": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Dashboard"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
                 "resources.Job": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5048,7 +6543,7 @@
                   ]
                 },
                 "resources.MlflowExperiment": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5062,7 +6557,7 @@
                   ]
                 },
                 "resources.MlflowModel": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5076,7 +6571,7 @@
                   ]
                 },
                 "resources.ModelServingEndpoint": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5090,7 +6585,7 @@
                   ]
                 },
                 "resources.Pipeline": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5104,7 +6599,7 @@
                   ]
                 },
                 "resources.QualityMonitor": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5118,7 +6613,7 @@
                   ]
                 },
                 "resources.RegisteredModel": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5132,7 +6627,7 @@
                   ]
                 },
                 "resources.Schema": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5145,8 +6640,22 @@
                     }
                   ]
                 },
+                "resources.Volume": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Volume"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
                 "variable.TargetVariable": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5160,7 +6669,7 @@
                   ]
                 },
                 "variable.Variable": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "object",
                       "additionalProperties": {
@@ -5175,7 +6684,7 @@
                 }
               },
               "config.Artifact": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "additionalProperties": {
@@ -5189,7 +6698,7 @@
                 ]
               },
               "config.Command": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "additionalProperties": {
@@ -5203,7 +6712,7 @@
                 ]
               },
               "config.Target": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "additionalProperties": {
@@ -5220,8 +6729,22 @@
           }
         }
       },
+      "interface": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/$defs/interface"
+            }
+          },
+          {
+            "type": "string",
+            "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+          }
+        ]
+      },
       "string": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "object",
             "additionalProperties": {
@@ -5242,7 +6765,7 @@
             "bundle": {
               "config": {
                 "resources.Grant": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "array",
                       "items": {
@@ -5256,7 +6779,7 @@
                   ]
                 },
                 "resources.Permission": {
-                  "anyOf": [
+                  "oneOf": [
                     {
                       "type": "array",
                       "items": {
@@ -5271,7 +6794,7 @@
                 }
               },
               "config.ArtifactFile": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5288,8 +6811,22 @@
           },
           "databricks-sdk-go": {
             "service": {
+              "apps.AppResource": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppResource"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
               "catalog.MonitorMetric": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5303,7 +6840,7 @@
                 ]
               },
               "compute.InitScriptInfo": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5317,7 +6854,7 @@
                 ]
               },
               "compute.Library": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5331,7 +6868,7 @@
                 ]
               },
               "jobs.JobCluster": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5345,7 +6882,7 @@
                 ]
               },
               "jobs.JobEnvironment": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5359,7 +6896,7 @@
                 ]
               },
               "jobs.JobParameterDefinition": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5373,7 +6910,7 @@
                 ]
               },
               "jobs.JobsHealthRule": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5387,7 +6924,7 @@
                 ]
               },
               "jobs.SqlTaskSubscription": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5401,7 +6938,7 @@
                 ]
               },
               "jobs.Task": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5415,7 +6952,7 @@
                 ]
               },
               "jobs.TaskDependency": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5429,7 +6966,7 @@
                 ]
               },
               "jobs.Webhook": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5443,7 +6980,7 @@
                 ]
               },
               "ml.ExperimentTag": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5457,7 +6994,7 @@
                 ]
               },
               "ml.ModelTag": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5471,7 +7008,7 @@
                 ]
               },
               "ml.ModelVersion": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5485,7 +7022,7 @@
                 ]
               },
               "ml.ModelVersionTag": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5498,8 +7035,22 @@
                   }
                 ]
               },
+              "pipelines.DayOfWeek": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.DayOfWeek"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
               "pipelines.IngestionConfig": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5513,7 +7064,7 @@
                 ]
               },
               "pipelines.Notifications": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5527,7 +7078,7 @@
                 ]
               },
               "pipelines.PipelineCluster": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5541,7 +7092,7 @@
                 ]
               },
               "pipelines.PipelineLibrary": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5555,7 +7106,7 @@
                 ]
               },
               "serving.AiGatewayRateLimit": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5569,7 +7120,7 @@
                 ]
               },
               "serving.EndpointTag": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5583,7 +7134,7 @@
                 ]
               },
               "serving.RateLimit": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5597,7 +7148,7 @@
                 ]
               },
               "serving.Route": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5611,7 +7162,7 @@
                 ]
               },
               "serving.ServedEntityInput": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5625,7 +7176,7 @@
                 ]
               },
               "serving.ServedModelInput": {
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "array",
                     "items": {
@@ -5643,7 +7194,7 @@
         }
       },
       "string": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "array",
             "items": {
@@ -5664,41 +7215,59 @@
   "type": "object",
   "properties": {
     "artifacts": {
+      "description": "Defines the attributes to build an artifact",
       "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Artifact"
     },
     "bundle": {
-      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Bundle"
+      "description": "The attributes of the bundle.",
+      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Bundle",
+      "markdownDescription": "The attributes of the bundle. See [bundle](https://docs.databricks.com/dev-tools/bundles/settings.html#bundle)"
     },
     "experimental": {
+      "description": "Defines attributes for experimental features.",
       "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Experimental"
     },
     "include": {
-      "$ref": "#/$defs/slice/string"
+      "description": "Specifies a list of path globs that contain configuration files to include within the bundle.",
+      "$ref": "#/$defs/slice/string",
+      "markdownDescription": "Specifies a list of path globs that contain configuration files to include within the bundle. See [include](https://docs.databricks.com/dev-tools/bundles/settings.html#include)"
     },
     "permissions": {
-      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+      "description": "Defines the permissions to apply to experiments, jobs, pipelines, and models defined in the bundle",
+      "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+      "markdownDescription": "Defines the permissions to apply to experiments, jobs, pipelines, and models defined in the bundle. See [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
     },
     "presets": {
-      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Presets"
+      "description": "Defines bundle deployment presets.",
+      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Presets",
+      "markdownDescription": "Defines bundle deployment presets. See [presets](https://docs.databricks.com/dev-tools/bundles/deployment-modes.html#presets)."
     },
     "resources": {
-      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Resources"
+      "description": "Specifies information about the Databricks resources used by the bundle",
+      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Resources",
+      "markdownDescription": "Specifies information about the Databricks resources used by the bundle. See [link](https://docs.databricks.com/dev-tools/bundles/resources.html)."
     },
     "run_as": {
+      "description": "The identity to use to run the bundle.",
       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobRunAs"
     },
     "sync": {
-      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Sync"
+      "description": "The files and file paths to include or exclude in the bundle.",
+      "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Sync",
+      "markdownDescription": "The files and file paths to include or exclude in the bundle. See [link](https://docs.databricks.com/dev-tools/bundles/)"
     },
     "targets": {
+      "description": "Defines deployment targets for the bundle.",
       "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Target"
     },
     "variables": {
+      "description": "A Map that defines the custom variables for the bundle, where each key is the name of the variable, and the value is a Map that defines the variable.",
       "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config/variable.Variable"
     },
     "workspace": {
+      "description": "Defines the Databricks workspace for the bundle.",
       "$ref": "#/$defs/github.com/databricks/cli/bundle/config.Workspace"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": {}
 }


### PR DESCRIPTION
Hi, I'm an engineer at Databricks who owns and maintains the Databricks Asset Bundles schema. 

We recently updated the JSON schema to include several new doc strings. This PR updates the JSON schema in Schemastore to the latest version. 

This schema corresponds to the Databricks CLI version `0.239.1`.

Similar PR I made before for ref: https://github.com/SchemaStore/schemastore/pull/4157