### PR TITLE
fix: remove python as a required property in tool.poetry.dependencies

### DIFF
--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -548,7 +548,6 @@
     "dependencies": {
       "type": "object",
       "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
-      "required": ["python"],
       "properties": {
         "python": {
           "$ref": "#/definitions/poetry-dependency",

--- a/src/test/pyproject/poetry-dependencies-no-python.toml
+++ b/src/test/pyproject/poetry-dependencies-no-python.toml
@@ -1,0 +1,12 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "dependencies-no-python"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "Elvis Presley",email = "theking@example.com"}
+]
+requires-python = ">=3.8"
+
+[tool.poetry.dependencies]
+cleo = "^0.6"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Since poetry v2, the `tool.poetry.dependencies` section no longer requires a version specifier for python.
A PR to update the poetry documents accordingly has been merged [here](https://github.com/python-poetry/poetry/pull/10104). I will mark this PR as ready once the document update is live.

This pull request reflects this by removing `python` as a required property and adds a test example that has a `tool.poetry.dependencies` section without a `python` property.