### PR TITLE
add Railway config as code schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4457,6 +4457,12 @@
       "url": "https://www.qgoda.net/schemas/qgoda.json"
     },
     {
+      "name": "Railway",
+      "description": "Use Railway config as code to define settings for building and deploying your services",
+      "fileMatch": ["railway.toml", "railway.json"],
+      "url": "https://railway.com/railway.schema.json"
+    },
+    {
       "name": "Rattler-build",
       "description": "Rattler-build recipe",
       "fileMatch": ["recipe.yaml", "recipe.yml"],


### PR DESCRIPTION
This PR adds Railway's [config as code](https://docs.railway.com/guides/config-as-code) schema to the catalog