### PR TITLE
fix: mypy missing strict_bytes

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -276,6 +276,13 @@
       "default": false,
       "type": "boolean"
     },
+    "strict_bytes": {
+      "description": "Disable treating `bytearray` and `memoryview` as subtypes of `bytes`. This will be enabled by default in mypy 2.0.",
+      "markdownDescription": "Disable treating `bytearray` and `memoryview` as subtypes of `bytes`. This will be enabled by default in *mypy 2.0*.",
+      "x-intellij-html-description": "Disable treating <code>bytearray</code> and <code>memoryview</code> as subtypes of `bytes`. This will be enabled by default in mypy 2.0.",
+      "default": false,
+      "type": "boolean"
+    },
     "strict_optional": {
       "description": "Enables or disables strict `Optional` checks. If `False`, mypy treats `None` as compatible with every type.",
       "x-intellij-html-description": "Enables or disables strict <code>Optional</code> checks. If <code>False</code>, mypy treats <code>None</code> as compatible with every type.",
@@ -728,6 +735,9 @@
           "enable_error_code": {
             "$ref": "#/properties/enable_error_code"
           },
+          "extra_checks": {
+            "$ref": "#/properties/extra_checks"
+          },
           "implicit_reexport": {
             "$ref": "#/properties/implicit_reexport"
           },
@@ -737,6 +747,9 @@
           "strict_equality": {
             "$ref": "#/properties/strict_equality"
           },
+          "strict_bytes": {
+            "$ref": "#/properties/strict_bytes"
+          },
           "strict": {
             "$ref": "#/properties/strict"
           },
@@ -745,6 +758,9 @@
           },
           "show_column_numbers": {
             "$ref": "#/properties/show_column_numbers"
+          },
+          "show_error_code_links": {
+            "$ref": "#/properties/show_error_code_links"
           },
           "hide_error_codes": {
             "$ref": "#/properties/hide_error_codes"


### PR DESCRIPTION
Adding a new missing field (`strict_bytes`), as well as a few recent additions that didn't get added to `[[overrides]]`.


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
