### PR TITLE
Update URL for ksail-cluster-schema.json to raw GitHub content

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2299,7 +2299,7 @@
         "*.ksail.yaml",
         "*.ksail.yml"
       ],
-      "url": "https://github.com/devantler/ksail/blob/main/schemas/ksail-cluster-schema.json"
+      "url": "https://raw.githubusercontent.com/devantler/ksail/refs/heads/main/schemas/ksail-cluster-schema.json"
     },
     {
       "name": "function.json",


### PR DESCRIPTION
Change the URL to point to the raw content of ksail-cluster-schema.json for direct access.