### PR TITLE
feat: add repo-review to pyproject.toml's tool section

### DIFF
--- a/src/negative_test/pyproject/repo-review-extra-field.toml
+++ b/src/negative_test/pyproject/repo-review-extra-field.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.repo-review]
+other = "hi"

--- a/src/negative_test/pyproject/repo-review-invalid-code.toml
+++ b/src/negative_test/pyproject/repo-review-invalid-code.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.repo-review]
+select = ["100"]

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -309,6 +309,7 @@
     "partial-pdm-dockerize.json", // pyproject.json[tool.pdm.dockerize]
     "partial-poe.json", // pyproject.json[tool.poe]
     "partial-poetry.json", // pyproject.json[tool.poetry]
+    "partial-repo-review.json", // pyproject.json[tool.repo-review]
     "partial-tox.json", // pyproject.json[tool.tox]
     "partial-eslint-plugins.json", // eslintrc.json[rules.*]
     "partial-fusion-pack-metadata.json", // minecraft-pack-mcmeta.json[fusion]
@@ -1009,6 +1010,7 @@
         "partial-poe.json",
         "partial-poetry.json",
         "partial-pyright.json",
+        "partial-repo-review.json",
         "partial-scikit-build.json",
         "partial-setuptools.json",
         "partial-setuptools-scm.json",

--- a/src/schemas/json/partial-repo-review.json
+++ b/src/schemas/json/partial-repo-review.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-repo-review.json",
+  "description": "Repo-review's settings.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "select": {
+      "$ref": "#/$defs/checks"
+    },
+    "ignore": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/checks"
+        },
+        {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Z]+[0-9]*$": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]+[0-9]*$"
+      }
+    }
+  }
+}

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -148,6 +148,9 @@
         "pyright": {
           "$ref": "https://json.schemastore.org/partial-pyright.json"
         },
+        "repo-review": {
+          "$ref": "https://json.schemastore.org/partial-repo-review.json"
+        },
         "tox": {
           "$ref": "https://json.schemastore.org/partial-tox.json"
         },

--- a/src/test/pyproject/repo-review-table.toml
+++ b/src/test/pyproject/repo-review-table.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.repo-review.ignore]
+A = "Not needed"
+B100 = "Also not needed"

--- a/src/test/pyproject/repo-review.toml
+++ b/src/test/pyproject/repo-review.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.repo-review]
+select = ["A", "B100"]
+ignore = ["C", "D100"]


### PR DESCRIPTION
Adding [`tool.repo-review` from scientific-python](https://github.com/scientific-python/repo-review).
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
