### PR TITLE
kustomization: add images.tagSuffix and var.objref.namespace

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -193,6 +193,10 @@
         },
         "newTag": {
           "type": "string"
+        },
+        "tagSuffix": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
         }
       },
       "additionalProperties": false,
@@ -950,6 +954,10 @@
         },
         "name": {
           "type": "string"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "UNDOCUMENTED."
         },
         "version": {
           "type": "string"


### PR DESCRIPTION
These options are not present in the documentation pages, but can be found in the code: [images.tagSuffix](https://github.com/kubernetes-sigs/kustomize/blob/3be1af679874e3921ebfc6b9e72f7194cff3d888/api/types/image.go#L17) and [vars.objRef.namespace](https://github.com/kubernetes-sigs/kustomize/blob/3be1af679874e3921ebfc6b9e72f7194cff3d888/api/types/var.go#L43).