### PR TITLE
feat: :sparkles: allowed experimental options to be an object in boyka config

### DIFF
--- a/src/schemas/json/boyka-config.json
+++ b/src/schemas/json/boyka-config.json
@@ -904,6 +904,9 @@
                     },
                     {
                       "type": "boolean"
+                    },
+                    {
+                      "type": "object"
                     }
                   ]
                 },

--- a/src/schemas/json/partial-repo-review.json
+++ b/src/schemas/json/partial-repo-review.json
@@ -1,6 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/partial-repo-review.json",
+  "$defs": {
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z]+[0-9]*$"
+      }
+    }
+  },
   "description": "Repo-review's settings.",
   "type": "object",
   "additionalProperties": false,
@@ -21,15 +30,6 @@
           "additionalProperties": false
         }
       ]
-    }
-  },
-  "$defs": {
-    "checks": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^[A-Z]+[0-9]*$"
-      }
     }
   }
 }

--- a/src/test/boyka-config/boyka-config-web-experimental-options.json
+++ b/src/test/boyka-config/boyka-config-web-experimental-options.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json.schemastore.org/boyka-config",
+  "listeners_package": "io.github.boykaframework.testng.listeners",
+  "ui": {
+    "logging": {
+      "exclude_logs": ["bugreport"]
+    },
+    "screenshot": {
+      "enabled": true,
+      "extension": "jpeg",
+      "path": "./screenshots",
+      "prefix": "SCR"
+    },
+    "timeout": {
+      "explicit_wait": 30,
+      "highlight_delay": 100,
+      "implicit_wait": 10,
+      "page_load_timeout": 30,
+      "script_timeout": 10
+    },
+    "web": {
+      "test_local_chrome": {
+        "base_url": "https://the-internet.herokuapp.com/",
+        "browser": "CHROME",
+        "browser_options": [
+          "use-fake-device-for-media-stream",
+          "use-fake-ui-for-media-stream"
+        ],
+        "custom_size": {
+          "height": 1080,
+          "width": 1580
+        },
+        "experimental_options": {
+          "prefs": {
+            "download.default_directory": "${sys:user.home}/Downloads",
+            "download.prompt_for_download": false,
+            "safebrowsing.enabled": true
+          }
+        },
+        "headless": true,
+        "highlight": false,
+        "page_load_strategy": "NORMAL",
+        "resize": "CUSTOM"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Updated `bouka-config.json` schema to allow `experimental_option` to also have an object.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
