### PR TITLE
feat: Change depencendies.poetry to optional.

### DIFF
--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -548,16 +548,8 @@
     "dependencies": {
       "type": "object",
       "description": "This is a hash of package name (keys) and version constraints (values) that are required to run this package.",
-      "required": ["python"],
-      "properties": {
-        "python": {
-          "$ref": "#/definitions/poetry-dependency",
-          "type": "string",
-          "description": "The Python versions the package is compatible with."
-        }
-      },
       "patternProperties": {
-        "^(?!python$)[a-zA-Z-_.0-9]+$": {
+        "^[a-zA-Z-_.0-9]+$": {
           "$ref": "#/definitions/poetry-dependency-any"
         }
       }


### PR DESCRIPTION
In poetry v2, the python version is now specified in [project.requires-python](https://python-poetry.org/docs/pyproject/#requires-python),

so `tool.poetry.dependencies.python` is no longer required.