### PR TITLE
feat: add `pnpm.ignoredBuiltDependencies` to `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -984,6 +984,13 @@
           "description": "Specifies a JSON file that lists the only packages permitted to run installation scripts during the pnpm install process.",
           "type": "string"
         },
+        "ignoredBuiltDependencies": {
+          "description": "A list of package names that should not be built during installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "allowedDeprecatedVersions": {
           "description": "A list of deprecated versions that the warnings are suppressed.",
           "type": "object"

--- a/src/test/package/pnpm-fields.json
+++ b/src/test/package/pnpm-fields.json
@@ -17,6 +17,7 @@
     "neverBuiltDependencies": ["fsevents"],
     "onlyBuiltDependencies": ["level"],
     "onlyBuiltDependenciesFile": "node_modules/@my-org/policy/onlyBuiltDependencies.json",
+    "ignoredBuiltDependencies": ["fsevents"],
     "overrides": {
       "bar@^2.1.0": "3.0.0",
       "foo": "^1.0.0",

--- a/src/test/package/pnpm-fields.json
+++ b/src/test/package/pnpm-fields.json
@@ -13,11 +13,11 @@
     "executionEnv": {
       "nodeVersion": "22"
     },
+    "ignoredBuiltDependencies": ["fsevents"],
     "ignoredOptionalDependencies": ["fsevents"],
     "neverBuiltDependencies": ["fsevents"],
     "onlyBuiltDependencies": ["level"],
     "onlyBuiltDependenciesFile": "node_modules/@my-org/policy/onlyBuiltDependencies.json",
-    "ignoredBuiltDependencies": ["fsevents"],
     "overrides": {
       "bar@^2.1.0": "3.0.0",
       "foo": "^1.0.0",


### PR DESCRIPTION
Added in [pnpm v10.1.0](https://github.com/pnpm/pnpm/releases/tag/v10.1.0).

Docs: https://pnpm.io/package_json#pnpmignoredbuiltdependencies

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
