### PR TITLE
Add Air to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -90,6 +90,12 @@
       }
     },
     {
+      "name": "Air",
+      "description": "R formatter and language server",
+      "fileMatch": ["air.toml", ".air.toml"],
+      "url": "https://github.com/posit-dev/air/releases/latest/download/air.schema.json"
+    },
+    {
       "name": ".aiproj.json",
       "description": "Settings for project analysis by the Application Inspector",
       "fileMatch": [".aiproj.json"],


### PR DESCRIPTION
Adds Air to the catalog, a new R code formatter.

We publish updated schema on every release, i.e. https://github.com/posit-dev/air/releases/tag/0.3.0, so this URL should always pull the latest release (similar to a few others in the catalog, like FlexGet)