### PR TITLE
Add support for PEP 770 to pyproject.toml

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -375,6 +375,22 @@
             }
           }
         },
+        "sbom-files": {
+          "$comment": "Still provisional under PEP 770",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "License files",
+          "description": "Relative paths or globs to paths of Software Bill-of-Materials files. Can be an empty list.",
+          "markdownDescription": "Relative paths or globs to paths of Software Bill-of-Materials files. Can be an empty list.",
+          "x-intellij-html-description": "<p>Relative paths or globs to paths of Software Bill-of-Materials files. Can be an empty list.</p>",
+          "x-taplo": {
+            "links": {
+              "key": "https://peps.python.org/pep-0770/#add-sbom-files-key"
+            }
+          }
+        }
         "authors": {
           "type": "array",
           "items": {
@@ -591,6 +607,7 @@
               "requires-python",
               "license",
               "license-files",
+              "sbom-files",
               "authors",
               "maintainers",
               "keywords",


### PR DESCRIPTION
This pull request adds support for [PEP 770](https://peps.python.org/pep-0770/#project-source-metadata) which will become provisional soon.