### PR TITLE
Add remotely hosted schemas for tach.toml, tach.domain.toml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5139,6 +5139,18 @@
       "url": "https://raw.githubusercontent.com/synadia-io/connect/main/schemas/component.json"
     },
     {
+      "name": "Tach",
+      "description": "Tach configuration file",
+      "fileMatch": ["tach.toml"],
+      "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-toml-schema.json"
+    },
+    {
+      "name": "Tach Domain",
+      "description": "Tach domain configuration file",
+      "fileMatch": ["tach.domain.toml"],
+      "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-domain-toml-schema.json"
+    },
+    {
       "name": "task.json",
       "description": "VSCode Task file",
       "fileMatch": ["task.json", "tasks.json"],


### PR DESCRIPTION
Hello! :wave: 

I'd like to add configuration to the Catalog for `tach.toml` and `tach.domain.toml` schemas.

These are used in https://github.com/gauge-sh/tach
[Docs here](https://docs.gauge.sh)
