### PR TITLE
Allow versioned types condition in exports/imports field of package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -220,13 +220,17 @@
         },
         "types": {
           "$ref": "#/definitions/packageImportsEntryOrFallback",
-          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions."
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "patternProperties": {
         "^[^.0-9]+$": {
           "$ref": "#/definitions/packageImportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
+        },
+        "^types@.+$": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "additionalProperties": false

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -149,13 +149,17 @@
         },
         "types": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
-          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions."
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "patternProperties": {
         "^[^.0-9]+$": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
+        },
+        "^types@.+$": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "additionalProperties": false

--- a/src/test/package/exports-test7.json
+++ b/src/test/package/exports-test7.json
@@ -3,7 +3,8 @@
   "exports": {
     "import": "./main-module.js",
     "require": "./main-require.cjs",
-    "types": "./main-module.d.ts"
+    "types": "./main-module.d.ts",
+    "types@>=5.2": "./ts5.2/main-module.d.ts"
   },
   "name": "my-mod",
   "type": "module"

--- a/src/test/package/imports-test5.json
+++ b/src/test/package/imports-test5.json
@@ -1,0 +1,13 @@
+{
+  "description": "conditions to paths",
+  "imports": {
+    "#foo": {
+      "import": "./main-module.js",
+      "require": "./main-require.cjs",
+      "types": "./main-module.d.ts",
+      "types@>=5.2": "./ts5.2/main-module.d.ts"
+    }
+  },
+  "name": "my-mod",
+  "type": "module"
+}


### PR DESCRIPTION
TypeScript supports versioned types conditions in the exports/imports field.

Example:

```json
{
  "name": "pkg",
  "exports": {
    "./subpath": {
      "types@>=5.2": "./ts5.2/subpath/index.d.ts",
      "types@>=4.6": "./ts4.6/subpath/index.d.ts",
      "types": "./tsold/subpath/index.d.ts",
      "default": "./dist/subpath/index.js"
    }
  }
}
```

Docs: https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports