### PR TITLE
Remove redundant `ignoredBuiltDependencies`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -980,13 +980,6 @@
             "type": "string"
           }
         },
-        "ignoredBuiltDependencies": {
-          "description": "A list of package names that should not be built during installation.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "onlyBuiltDependenciesFile": {
           "description": "Specifies a JSON file that lists the only packages permitted to run installation scripts during the pnpm install process.",
           "type": "string"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Sorry, I didn't notice that part #4445 overlapped with #4435, which caused the check error.
