### PR TITLE
cli: Remove some deprecations, improve console output, improve typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,6 @@
     "prettier:fix": "prettier --config .prettierrc.cjs --ignore-path .gitignore --write .",
     "eslint": "eslint ./cli.js",
     "eslint:fix": "eslint --fix ./cli.js",
-    "new-schema": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node --no-deprecation ./cli.js new-schema",
-    "check": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js check",
-    "check-strict": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js check-strict",
-    "check-remote": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js check-remote",
-    "report": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js report",
-    "maintenance": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js maintenance",
-    "lint": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && node ./cli.js lint",
     "build": "echo \"WARNING: Please use 'node ./cli.js' instead of 'npm run'. This method for execution will be removed.\" && npm run eslint && node ./cli.js check && ./scripts/dirty_repository_check.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
- Improve some deprecated npm run commands/features of `cli.js` (the deprecated ones that have been around longer have not been removed yet)
- Improve console output on error
- Remove no-longer-needed JSDoc typings workaround