### PR TITLE
Use testing `code-owners-self-merge`

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners check'
-        uses: 'OSS-Docs-Tools/code-owner-self-merge@3d0e2871b850d624a5a433fb7143fe4522ba5486'
+        uses: 'fox-forks/code-owner-self-merge@hyperupcall-review-errors'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:


### PR DESCRIPTION
The bot currently has issues where leaving a review (without comments) causes the workflow to error (see https://github.com/SchemaStore/schemastore/actions/runs/13334280055/job/37245785143?pr=4437 for an example)

Switching to fork of workflow to make investigation and debugging easier.