### PR TITLE
fix: update description for `pnpm.onlyBuiltDependencies` in package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -982,7 +982,7 @@
           }
         },
         "onlyBuiltDependencies": {
-          "description": "A list of dependencies to skip the builds.",
+          "description": "A list of package names that are allowed to be executed during installation.",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
This PR updates the description of the `pnpm.onlyBuiltDependencies` to match what the pnpm site says.
[https://pnpm.io/package_json#pnpmonlybuiltdependencies](https://pnpm.io/package_json#pnpmonlybuiltdependencies)