### PR TITLE
Update to latest `code-owner-self-merge` version

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners check'
-        uses: 'fox-forks/code-owner-self-merge@hyperupcall-review-errors'
+        uses: 'fox-forks/code-owner-self-merge@d085674edba4207f478ff08ff91c7ecf9cbaf767'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

The new hash references release `v1.6.7` [here](https://github.com/OSS-Docs-Tools/code-owner-self-merge/releases/tag/1.6.7), which importantly incorporates [this](https://github.com/OSS-Docs-Tools/code-owner-self-merge/commit/6e2286a2cd49b7a5d4b3a8f026b1f67935fd62e4) commit to fix a bug ([described here](https://github.com/OSS-Docs-Tools/code-owner-self-merge/pull/46))