### PR TITLE
Assorted `cli.js` and schema fixes

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v4'
       - name: 'Run Codeowners check'
-        uses: 'fox-forks/code-owner-self-merge@d085674edba4207f478ff08ff91c7ecf9cbaf767'
+        uses: 'OSS-Docs-Tools/code-owner-self-merge@d085674edba4207f478ff08ff91c7ecf9cbaf767'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import node from 'eslint-plugin-n'
 import prettier from 'eslint-config-prettier'
 import globals from 'globals'
 
-/** @type {import('eslint').Linter.FlatConfig} */
+/** @type {import('eslint').Linter.Config} */
 export default [
   {
     ignores: ['**/schema.json.translated.to.js'],
@@ -27,6 +27,7 @@ export default [
       'no-unused-vars': 'off',
       'object-shorthand': ['error', 'always'],
       'n/no-process-exit': 'off',
+      'promise/always-return': ['error', { ignoreLastCallback: true }],
     },
   },
 ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6023,6 +6023,11 @@
       "url": "https://json.schemastore.org/winget-pkgs-locale-1.0.0.json"
     },
     {
+      "name": "Winutil",
+      "description": "Configuration for files in \"ChrisTitusTech/winutil\"",
+      "url": "https://json.schemastore.org/winutil-presets.json"
+    },
+    {
       "name": "commitlint (.commitlintrc)",
       "description": "commitlint configuration files",
       "fileMatch": [".commitlintrc", ".commitlintrc.json"],
@@ -7341,13 +7346,13 @@
       "name": "Settings for a Cinnamon spice",
       "description": "Settings for a Cinnamon spice",
       "fileMatch": ["**/*@*/**/settings-schema.json"],
-      "url": "https://raw.githubusercontent.com/cinnamon-spice-settings.json"
+      "url": "https://json.schemastore.org/cinnamon-spice-settings.json"
     },
     {
       "name": "Metadata for a Cinnamon spice",
       "description": "Metadata for a Cinnamon spice",
       "fileMatch": ["**/*@*/**/metadata.json"],
-      "url": "https://raw.githubusercontent.com/cinnamon-spice-metadata.json"
+      "url": "https://json.schemastore.org/cinnamon-spice-metadata.json"
     },
     {
       "name": "Yandex Workflow Language",

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -353,7 +353,9 @@
     "json-api-1.0.json",
     "licenses.1.json",
     "toolinfo.1.1.0.json",
-    "npm-link-up.json"
+    "npm-link-up.json",
+    "gematik-test-insurances.json",
+    "lefthook.json"
   ],
   "skiptest": [
     // Add JSON schema to skiptest[] to skip the whole validation process

--- a/src/schemas/json/pantsbuild-2.24.0.json
+++ b/src/schemas/json/pantsbuild-2.24.0.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://json.schemastore.org/pantsbuild-2.24.0.json",
   "additionalProperties": true,
   "description": "Pants configuration file schema: https://www.pantsbuild.org/",
   "properties": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

- Fix `uses` to point to correct ref
- Fix `assertCatalogJsonLocalUrlsMustRefFile` (now `assertCatalogJsonLocalURLsAreOneToOne`) to correctly run to completion (replace incorrect `return` with `continue`)
  - And fix schemas/catalog that actually had errors stemming from that bug fix
- Fix other small things 
