### PR TITLE
Add 'node:20' as a supported apiRuntime option for Azure Static Web Apps

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -609,6 +609,7 @@
             "node:14",
             "node:16",
             "node:18",
+            "node:20",
             "python:3.8",
             "python:3.9",
             "python:3.10"


### PR DESCRIPTION
This PR adds `node:20` as one of the available options for the `apiRuntime` of a `staticwebapp.config.json`.

[As per official documentation, this option is supported.](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#select-the-api-language-runtime-version)