### PR TITLE
feat: add .taskrc schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6204,6 +6204,15 @@
       "url": "https://taskfile.dev/schema.json"
     },
     {
+      "name": ".taskrc.yaml",
+      "description": "Taskfile configuration files",
+      "fileMatch": [
+        ".taskrc.yaml",
+        ".taskrc.yml"
+      ],
+      "url": "https://taskfile.dev/schema-taskrc.json"
+    },
+    {
       "name": "Hammerkit",
       "description": "hammerkit files",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6206,10 +6206,7 @@
     {
       "name": ".taskrc.yaml",
       "description": "Taskfile configuration files",
-      "fileMatch": [
-        ".taskrc.yaml",
-        ".taskrc.yml"
-      ],
+      "fileMatch": [".taskrc.yaml", ".taskrc.yml"],
       "url": "https://taskfile.dev/schema-taskrc.json"
     },
     {


### PR DESCRIPTION
In Taskfile, we recently introduce a new schema for `.taskrc.yaml` or .taskrc.yml`