### PR TITLE
Issue #4465: Update metricshub.json

### DIFF
--- a/src/schemas/json/metricshub.json
+++ b/src/schemas/json/metricshub.json
@@ -276,8 +276,8 @@
                   },
                   "authType": {
                     "type": "string",
-                    "enum": ["NO_AUTH", "MD5", "SHA"],
-                    "description": "Sets the SNMPv3 authentication type. (MD5, SHA or NO_AUTH)."
+                    "enum": ["NO_AUTH", "MD5", "SHA", "SHA256", "SHA512", "SHA224", "SHA384"],
+                    "description": "Sets the SNMPv3 authentication type. (MD5, SHA, SHA256, SHA512, SHA384, SHA224 or NO_AUTH)."
                   },
                   "privacy": {
                     "type": "string",
@@ -1425,8 +1425,15 @@
       "default": "5m"
     },
     "hostname": {
-      "type": "string",
-      "description": "The hostname to which the query is sent."
+      "description": "The hostname to which the query is sent.",
+      "oneOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "retryIntervals": {
       "type": "array",

--- a/src/schemas/json/metricshub.json
+++ b/src/schemas/json/metricshub.json
@@ -276,7 +276,15 @@
                   },
                   "authType": {
                     "type": "string",
-                    "enum": ["NO_AUTH", "MD5", "SHA", "SHA256", "SHA512", "SHA224", "SHA384"],
+                    "enum": [
+                      "NO_AUTH",
+                      "MD5",
+                      "SHA",
+                      "SHA256",
+                      "SHA512",
+                      "SHA224",
+                      "SHA384"
+                    ],
                     "description": "Sets the SNMPv3 authentication type. (MD5, SHA, SHA256, SHA512, SHA384, SHA224 or NO_AUTH)."
                   },
                   "privacy": {

--- a/src/test/metricshub/metricshub.yaml
+++ b/src/test/metricshub/metricshub.yaml
@@ -377,7 +377,7 @@ resourceGroups:
             timeout: 120
 
       #═══════════════════════════════════════════════════
-      # SNMP v3 protocol configuration
+      # SNMP v3 protocol configuration with SHA1
       #═══════════════════════════════════════════════════
 
       server-13:
@@ -400,7 +400,7 @@ resourceGroups:
               - 300
 
       #═══════════════════════════════════════════════════
-      # JDBC Configuration
+      # SNMP v3 protocol configuration with SHA256
       #═══════════════════════════════════════════════════
 
       server-14:
@@ -408,11 +408,126 @@ resourceGroups:
           host.name: server-14
           host.type: linux
         protocols:
+          snmpv3:
+            port: 161
+            timeout: 120s
+            contextName: myContext
+            authType: SHA256
+            privacy: DES
+            username: myUser
+            privacyPassword: myPrivacyPassword
+            password: myAuthPassword
+            retryIntervals:
+            - 100
+            - 200
+            - 300
+
+      #═══════════════════════════════════════════════════
+      # SNMP v3 protocol configuration with SHA224
+      #═══════════════════════════════════════════════════
+
+      server-15:
+        attributes:
+          host.name: server-15
+          host.type: linux
+        protocols:
+          snmpv3:
+            port: 161
+            timeout: 120s
+            contextName: myContext
+            authType: SHA224
+            privacy: none
+            username: myUser
+            password: myAuthPassword
+            retryIntervals:
+            - 100
+            - 200
+            - 300
+      #═══════════════════════════════════════════════════
+      # SNMP v3 protocol configuration with SHA512
+      #═══════════════════════════════════════════════════
+
+      server-16:
+        attributes:
+          host.name: server-16
+          host.type: linux
+        protocols:
+          snmpv3:
+            port: 161
+            timeout: 120s
+            contextName: myContext
+            authType: SHA512
+            privacy: DES
+            privacyPassword: myPrivacyPassword
+            username: myUser
+            password: myAuthPassword
+            retryIntervals:
+            - 100
+            - 200
+            - 300
+      
+      #═══════════════════════════════════════════════════
+      # SNMP v3 protocol configuration with SHA384
+      #═══════════════════════════════════════════════════
+
+      server-17:
+        attributes:
+          host.name: server-17
+          host.type: linux
+        protocols:
+          snmpv3:
+            port: 161
+            timeout: 120s
+            contextName: myContext
+            authType: SHA384
+            privacy: DES
+            privacyPassword: myPrivacyPassword
+            username: myUser
+            password: myAuthPassword
+            hostname: server-17
+            retryIntervals:
+            - 100
+            - 200
+            - 300
+      
+      #═══════════════════════════════════════════════════
+      # SNMP v3 protocol configuration with MD5
+      #═══════════════════════════════════════════════════
+
+      server-18:
+        attributes:
+          host.name: server-18
+          host.type: linux
+        protocols:
+          snmpv3:
+            port: 161
+            timeout: 120s
+            contextName: myContext
+            authType: MD5
+            privacy: DES
+            privacyPassword: myPrivacyPassword
+            username: myUser
+            password: myAuthPassword
+            hostname: [ server-15, server-16 ]
+            retryIntervals:
+            - 100
+            - 200
+            - 300
+
+      #═══════════════════════════════════════════════════
+      # JDBC Configuration
+      #═══════════════════════════════════════════════════
+
+      server-19:
+        attributes:
+          host.name: server-19
+          host.type: linux
+        protocols:
           jdbc:
-            hostname: server-14
+            hostname: server-19
             username: dbuser
             password: dbpassword
-            url: jdbc:mysql://server-14:3306/mydatabase
+            url: jdbc:mysql://server-19:3306/mydatabase
             timeout: 120s
             type: mysql
             port: 3306

--- a/src/test/metricshub/metricshub.yaml
+++ b/src/test/metricshub/metricshub.yaml
@@ -418,9 +418,9 @@ resourceGroups:
             privacyPassword: myPrivacyPassword
             password: myAuthPassword
             retryIntervals:
-            - 100
-            - 200
-            - 300
+              - 100
+              - 200
+              - 300
 
       #═══════════════════════════════════════════════════
       # SNMP v3 protocol configuration with SHA224
@@ -440,9 +440,9 @@ resourceGroups:
             username: myUser
             password: myAuthPassword
             retryIntervals:
-            - 100
-            - 200
-            - 300
+              - 100
+              - 200
+              - 300
       #═══════════════════════════════════════════════════
       # SNMP v3 protocol configuration with SHA512
       #═══════════════════════════════════════════════════
@@ -462,10 +462,10 @@ resourceGroups:
             username: myUser
             password: myAuthPassword
             retryIntervals:
-            - 100
-            - 200
-            - 300
-      
+              - 100
+              - 200
+              - 300
+
       #═══════════════════════════════════════════════════
       # SNMP v3 protocol configuration with SHA384
       #═══════════════════════════════════════════════════
@@ -486,10 +486,10 @@ resourceGroups:
             password: myAuthPassword
             hostname: server-17
             retryIntervals:
-            - 100
-            - 200
-            - 300
-      
+              - 100
+              - 200
+              - 300
+
       #═══════════════════════════════════════════════════
       # SNMP v3 protocol configuration with MD5
       #═══════════════════════════════════════════════════
@@ -508,11 +508,11 @@ resourceGroups:
             privacyPassword: myPrivacyPassword
             username: myUser
             password: myAuthPassword
-            hostname: [ server-15, server-16 ]
+            hostname: [server-15, server-16]
             retryIntervals:
-            - 100
-            - 200
-            - 300
+              - 100
+              - 200
+              - 300
 
       #═══════════════════════════════════════════════════
       # JDBC Configuration


### PR DESCRIPTION
- Add the authentication protocols `SHA256, SHA224, SHA512, SHA384` to the enum `authType` which is under `snmpv3`.

- Update the field `hostname` used in `snmp` and `snmpv3` fields to support both String and Array types.