### PR TITLE
Relax Buf lint/breaking rules

### DIFF
--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -6,7 +6,7 @@
     "lint-rule": {
       "type": "string",
       "description": "https://buf.build/docs/lint/rules",
-      "enum": [
+      "examples": [
         "STANDARD",
         "DEFAULT",
         "BASIC",
@@ -64,7 +64,7 @@
     "breaking-rule": {
       "type": "string",
       "description": "https://buf.build/docs/breaking/rules",
-      "enum": [
+      "examples": [
         "FILE",
         "PACKAGE",
         "WIRE_JSON",
@@ -141,10 +141,9 @@
       ]
     },
     "lint-ignore-only": {
-      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore_only - All of the #/$defs/lint-rule values can be keys",
+      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#ignore_only - All of the #/$defs/lint-rule values can be keys, plus custom lint rules",
       "description": "Optional. Allows directories or files to be excluded from specific lint categories or rules. As with ignore, the paths must be relative to buf.yaml.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "STANDARD": {
           "type": "array",
@@ -461,10 +460,9 @@
       }
     },
     "breaking-ignore-only": {
-      "$comment": "All of the #/$defs/breaking-rule values can be keys.",
-      "description": "The ignore_only key is optional, and allows directories or files to be excluded from specific breaking rules when running buf breaking by taking a map from breaking rule ID or category to path. As with ignore, the paths must be relative to the buf.yaml. We do not recommend this option in general.",
+      "$comment": "https://buf.build/docs/configuration/v2/buf-yaml/#ignore_only_1 - All of the #/$defs/breaking-rule values can be keys, plus custom breaking rules.",
+      "description": "Optional. Allows directories or files to be excluded from specific breaking change detection categories or rules. As with ignore, the paths must be relative to buf.yaml. We do not recommend this option in general.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "FILE": {
           "type": "array",
@@ -916,6 +914,7 @@
           "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#use",
           "description": "Optional. Lists the categories and/or specific rules to use. The STANDARD category is used if lint is unset.",
           "type": "array",
+          "default": ["STANDARD"],
           "items": {
             "$ref": "#/$defs/lint-rule"
           }
@@ -983,6 +982,7 @@
           "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#use-1",
           "description": "Optional. Lists the rules or categories to use for breaking change detection. The FILE category is used if breaking is unset, which is conservative and appropriate for most teams.",
           "type": "array",
+          "default": ["FILE"],
           "items": {
             "$ref": "#/$defs/breaking-rule"
           }


### PR DESCRIPTION
Now that users can create [custom lint / breaking plugins][1], we no longer can constrict these values to only defined values. Flip the enums to be examples, and relax the values for the ignore-only objects.

Also add default values where appropriate.

[1]: https://buf.build/blog/buf-custom-lint-breaking-change-plugins

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
