### PR TITLE
feat: add "x-tombi-table-keys-order-by" to pyproject.toml

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -1066,6 +1066,7 @@
         "x-taplo",
         "x-taplo-info",
         "x-tombi-toml-version",
+        "x-tombi-table-keys-order-by",
         "x-intellij-html-description",
         "x-intellij-language-injection"
       ]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -111,6 +111,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#arbitrary-tool-configuration-the-tool-table"
         }
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "properties": {
         "black": {
           "$ref": "https://json.schemastore.org/partial-black.json"
@@ -567,6 +568,7 @@
         },
         "optional-dependencies": {
           "type": "object",
+          "x-tombi-table-keys-order-by": "ascending",
           "patternProperties": {
             "^([a-z\\d]|[a-z\\d]([a-z\\d-](?!--))*[a-z\\d])$": {
               "type": "array",
@@ -871,6 +873,7 @@
       "description": "Named groups of dependencies, similar to `requirements.txt` files, which launchers, IDEs, and other tools can find and identify by name. Each item in `[dependency-groups]` is defined as mapping of group name to list of [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).",
       "markdownDescription": "Named groups of dependencies, similar to `requirements.txt` files, which launchers, IDEs, and other tools can find and identify by name. Each item in `[dependency-groups]` is defined as mapping of group name to list of [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).",
       "x-intellij-html-description": "<p>Named groups of dependencies, similar to <code>requirements.txt</code> files, which launchers, IDEs, and other tools can find and identify by name. Each item in <code>[dependency-groups]</code> is defined as mapping of group name to list of <a href=\"https://packaging.python.org/en/latest/specifications/dependency-specifiers/\">dependency specifiers</a>.</p>",
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://peps.python.org/pep-0735/"


### PR DESCRIPTION
Add ["x-tombi-table-keys-order-by"](https://tombi-toml.github.io/tombi/docs/json-schema) to pyproject.