### PR TITLE
feat: add "x-tombi-table-keys-order-by" to Cargo.toml

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -588,7 +588,7 @@
     "cargo.json": {
       "externalSchema": ["base.json"],
       "unknownFormat": ["uint32", "semver", "semver-requirement"],
-      "unknownKeywords": ["x-taplo", "x-taplo-info", "x-tombi-toml-version"]
+      "unknownKeywords": ["x-taplo", "x-taplo-info", "x-tombi-toml-version", "x-tombi-table-keys-order-by"]
     },
     "cheatsheets.json": {
       "externalSchema": ["base.json"]

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -1748,6 +1748,7 @@
           "type": "string"
         }
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section"
@@ -1796,6 +1797,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
@@ -1811,6 +1813,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "hidden": true
       }
@@ -1827,6 +1830,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
@@ -1839,6 +1843,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
@@ -1854,6 +1859,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
+      "x-tombi-table-keys-order-by": "ascending",
       "x-taplo": {
         "hidden": true
       }
@@ -1955,6 +1961,7 @@
     },
     "replace": {
       "type": "object",
+      "x-tombi-table-keys-order-by": "ascending",
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
@@ -1964,6 +1971,7 @@
     },
     "target": {
       "type": "object",
+      "x-tombi-table-keys-order-by": "ascending",
       "additionalProperties": {
         "$ref": "#/definitions/Platform"
       }


### PR DESCRIPTION
Add ["x-tombi-table-keys-order-by"](https://tombi-toml.github.io/tombi/docs/json-schema) to Cargo.toml