### PR TITLE
feat: add x-tombi-table-keys-order-by to Cargo.toml

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -713,6 +713,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
@@ -728,6 +729,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "hidden": true
           }
@@ -738,6 +740,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
@@ -750,6 +753,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
@@ -765,6 +769,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "hidden": true
           }
@@ -1199,6 +1204,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
+          "x-tombi-table-keys-order-by": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section"


### PR DESCRIPTION
Add [x-tombi-table-keys-order-by](https://tombi-toml.github.io/tombi/docs/json-schema)
