### PR TITLE
feat: add x-tombi-table-keys-order-by to poetry.

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -975,6 +975,7 @@
       "unknownKeywords": ["x-taplo"]
     },
     "partial-poetry.json": {
+      "unknownKeywords": ["x-tombi-table-keys-order-by"],
       "externalSchema": ["base.json"]
     },
     "partial-pyright.json": {
@@ -1007,6 +1008,7 @@
       "unknownFormat": ["iri"]
     },
     "poetry.json": {
+      "unknownKeywords": ["x-tombi-table-keys-order-by"],
       "externalSchema": ["partial-poetry.json", "base.json"]
     },
     "pre-commit-config.json": {

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -557,7 +557,8 @@
       },
       "additionalProperties": {
         "$ref": "#/definitions/poetry-dependency-any"
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "dev-dependencies": {
       "type": "object",
@@ -566,7 +567,8 @@
         "^[a-zA-Z-_.0-9]+$": {
           "$ref": "#/definitions/poetry-dependency-any"
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "extras": {
       "type": "object",
@@ -577,7 +579,8 @@
             "type": "string"
           }
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "group": {
       "type": "object",
@@ -605,7 +608,8 @@
           },
           "additionalProperties": false
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "build": {
       "$ref": "#/definitions/poetry-build-section"
@@ -624,7 +628,8 @@
             }
           ]
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "plugins": {
       "type": "object",
@@ -653,7 +658,8 @@
             }
           }
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "urls": {
       "type": "object",
@@ -662,7 +668,8 @@
           "type": "string",
           "description": "The full url of the custom url."
         }
-      }
+      },
+      "x-tombi-table-keys-order-by": "ascending"
     },
     "source": {
       "$comment": "The unique 'pypi' source constraint is not implemented yet.",


### PR DESCRIPTION
Add [x-tombi-table-keys-order-by](https://tombi-toml.github.io/tombi/docs/json-schema) to [poetry](https://github.com/python-poetry/poetry).