### PR TITLE
Update clangd schema to v20, improve `cli.js`, and schema fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 'v3.5.2'
     hooks:
       - id: 'prettier'
-        types_or: ['yaml', 'json', 'javascript', 'css', 'markdown']
+        types_or: ['yaml', 'json', 'jsonc', 'javascript', 'css', 'markdown']
         always_run: true
         additional_dependencies:
           - 'prettier@3.4.2'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,15 @@ repos:
     rev: 'v3.5.2'
     hooks:
       - id: 'prettier'
-        types_or: ['yaml', 'json', 'jsonc', 'javascript', 'css', 'markdown']
+        types_or:
+          [
+            'yaml',
+            'json',
+            'javascript',
+            'css',
+            'markdown',
+            'src/schema-validation.jsonc',
+          ]
         always_run: true
         additional_dependencies:
           - 'prettier@3.4.2'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,5 +22,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,Delimeters',
           ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,9 @@ repos:
     rev: 'v3.5.2'
     hooks:
       - id: 'prettier'
-        types_or:
-          [
-            'yaml',
-            'json',
-            'javascript',
-            'css',
-            'markdown',
-            'src/schema-validation.jsonc',
-          ]
+        # TODO: Add 'jsonc' so 'src/schema-validation.jsonc' is checked in CI
+        # Error: "Type tag 'jsonc' is not recognized.  Try upgrading identify and pre-commit?"
+        types_or: ['yaml', 'json', 'javascript', 'css', 'markdown']
         always_run: true
         additional_dependencies:
           - 'prettier@3.4.2'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
   - [Ajv non-strict mode](#ajv-non-strict-mode)
   - [SchemaSafe](#schemasafe)
 - [About `catalog.json`](#about-catalogjson)
-  - [Avoiding Generic Names](#avoiding-generic-names)
+  - [Avoiding Generic `fileMatch` patterns](#avoid-generic-filematch-patterns)
 - [Compatible Language Servers and Tools](#compatible-language-servers-and-tools)
   - [`redhat-developer/yaml-language-server`](#redhat-developeryaml-language-server)
   - [`tamasfe/taplo`](#tamasfetaplo)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "minimist": "^1.2.8",
         "node-fetch": "^3.3.2",
         "ora": "^8.1.1",
-        "prettier": "^3.5.0",
+        "prettier": "^3.5.2",
         "prettier-plugin-sort-json": "^4.0.0",
         "prettier-plugin-toml": "^2.0.1",
         "smol-toml": "^1.3.1",
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "minimist": "^1.2.8",
     "node-fetch": "^3.3.2",
     "ora": "^8.1.1",
-    "prettier": "^3.5.0",
+    "prettier": "^3.5.2",
     "prettier-plugin-sort-json": "^4.0.0",
     "prettier-plugin-toml": "^2.0.1",
     "smol-toml": "^1.3.1",

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -2,7 +2,7 @@
   "$schema": "./schema-validation.schema.json",
   "ajvNotStrictMode": [
     "anywork-ac-1.0.json",
-    "anywork-ac-1.1.json",
+      "anywork-ac-1.1.json",
     "apibuilder.json",
     "appsettings.json",
     "appveyor.json",

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -2,7 +2,7 @@
   "$schema": "./schema-validation.schema.json",
   "ajvNotStrictMode": [
     "anywork-ac-1.0.json",
-      "anywork-ac-1.1.json",
+    "anywork-ac-1.1.json",
     "apibuilder.json",
     "appsettings.json",
     "appveyor.json",
@@ -589,7 +589,12 @@
     "cargo.json": {
       "externalSchema": ["base.json"],
       "unknownFormat": ["uint32", "semver", "semver-requirement"],
-      "unknownKeywords": ["x-taplo", "x-taplo-info", "x-tombi-toml-version", "x-tombi-table-keys-order-by"]
+      "unknownKeywords": [
+        "x-taplo",
+        "x-taplo-info",
+        "x-tombi-toml-version",
+        "x-tombi-table-keys-order-by"
+      ]
     },
     "cheatsheets.json": {
       "externalSchema": ["base.json"]

--- a/src/schemas/json/clangd.json
+++ b/src/schemas/json/clangd.json
@@ -531,6 +531,20 @@
           "items": {
             "type": "string"
           }
+        },
+        "QuotedHeaders": {
+          "description": "A list of regexes. Headers whose path matches one of these regexes are inserted using \"\" syntax\nhttps://clangd.llvm.org/config#quotedheaders",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AngledHeaders": {
+          "description": "A list of regexes. Headers whose path matches one of these regexes are inserted using <> syntax.\nhttps://clangd.llvm.org/config#angledheaders",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -637,6 +651,18 @@
         "AllScopes": {
           "description": "Whether to include suggestions from scopes that are not visible\nhttps://clangd.llvm.org/config.html#allscopes",
           "type": "boolean"
+        },
+        "ArgumentLists": {
+          "description": "Determines what is inserted in argument list position when completing a call to a function\nhttps://clangd.llvm.org/config#argumentlists",
+          "type": "string",
+          "enum": ["None", "OpenDelimeter", "Delimeters", "FullPlaceholders"],
+          "enumDescriptions": [
+            "`fo^` completes to `foo`",
+            "`fo^` completes to `foo(^`",
+            "`fo^` completes to `foo(^)`",
+            "`fo^` completes to `foo(int arg)`, with `int arg` selected"
+          ],
+          "default": "FullPlaceholders"
         }
       },
       "additionalProperties": false
@@ -664,6 +690,10 @@
         },
         "BlockEnd": {
           "description": "A boolean that enables/disables inlay-hints for block end comments\nhttps://clangd.llvm.org/config.html#blockend",
+          "type": "boolean"
+        },
+        "DefaultArguments": {
+          "description": "A boolean that enables/disables inlay hints for default arguments\nhttps://clangd.llvm.org/config#defaultarguments",
           "type": "boolean"
         },
         "TypeNameLimit": {

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -996,7 +996,7 @@
           "additionalProperties": false
         },
         "neverBuiltDependencies": {
-          "description": "A list of dependencies to skip the builds.",
+          "description": "A list of dependencies to run builds for.",
           "type": "array",
           "items": {
             "type": "string"

--- a/src/test/package/exports-test8.json
+++ b/src/test/package/exports-test8.json
@@ -1,0 +1,17 @@
+{
+  "exports": {
+    ".": {
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/esm/index.d.ts",
+        "types@>=5.0": "./ts-5/index.v5.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/index.cjs",
+        "types": "./dist/cjs/index.d.cts",
+        "types@>=5.0": "./ts-5/index.v5.d.cts"
+      }
+    },
+    "./package.json": "./package.json"
+  }
+}


### PR DESCRIPTION
- Add note about error when attempting to automatically formatting `.jsonc` files in `pre-commit.ci`
- Improve maintenance task of checking for valid URLs by attempting parse in JSON, then YAML (if cannot parse either, print as error)  (related to #2247, related to #4403)
- Fix typo. Closes #4324
- Update clangd schema to v20. Closes #4459
- Add a test for issue #4249
- Other miscellaneous fixes