### PR TITLE
clangd: Fix "Delimiters" typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,5 +22,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,Delimeters',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl',
           ]

--- a/src/schemas/json/clangd.json
+++ b/src/schemas/json/clangd.json
@@ -655,7 +655,7 @@
         "ArgumentLists": {
           "description": "Determines what is inserted in argument list position when completing a call to a function\nhttps://clangd.llvm.org/config#argumentlists",
           "type": "string",
-          "enum": ["None", "OpenDelimeter", "Delimeters", "FullPlaceholders"],
+          "enum": ["None", "OpenDelimiter", "Delimiters", "FullPlaceholders"],
           "enumDescriptions": [
             "`fo^` completes to `foo`",
             "`fo^` completes to `foo(^`",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This fixes a typo, [which existed](https://github.com/SchemaStore/schemastore/issues/4459#issuecomment-2686941086) in the clangd documentation.
