### PR TITLE
Add schema for PEP 723 script metadata

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7623,6 +7623,12 @@
       "description": "Tyk Gateway Open Source Configuration File",
       "fileMatch": ["tyk.conf"],
       "url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/refs/heads/main/JSON/draft-07/schema_tyk.oss.conf"
+    },
+    {
+      "name": "Python script metadata",
+      "description": "Metadata of a Python script, as defined by PEP 723",
+      "fileMatch": [],
+      "url": "https://json.schemastore.org/pep-723.json"
     }
   ]
 }

--- a/src/negative_test/pep-723/1.toml
+++ b/src/negative_test/pep-723/1.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/pep-723.json
+foobar = "lorem-ipsum"

--- a/src/negative_test/pep-723/2.toml
+++ b/src/negative_test/pep-723/2.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/pep-723.json
+dependencies = {}

--- a/src/negative_test/pep-723/3.toml
+++ b/src/negative_test/pep-723/3.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/pep-723.json
+[tool.pyright]
+strict = 42

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -247,6 +247,7 @@
     "lsdlschema.json",
     "nodemon.json",
     "partial-pyright.json",
+    "pep-723.json",
     "pyproject.json",
     "sarif-2.1.0-rtm.0.json",
     "sarif-2.1.0-rtm.1.json",
@@ -1012,6 +1013,51 @@
     },
     "pdm.json": {
       "unknownKeywords": ["x-taplo", "x-taplo-info"]
+    },
+    "pep-723.json": {
+      "externalSchema": [
+        "hatch.json",
+        "maturin.json",
+        "partial-black.json",
+        "partial-cibuildwheel.json",
+        "partial-mypy.json",
+        "partial-pdm.json",
+        "partial-pdm-dockerize.json",
+        "partial-poe.json",
+        "partial-poetry.json",
+        "partial-pyright.json",
+        "partial-repo-review.json",
+        "partial-scikit-build.json",
+        "partial-setuptools.json",
+        "partial-setuptools-scm.json",
+        "partial-taskipy.json",
+        "partial-tox.json",
+        "poetry.json",
+        "ruff.json",
+        "tombi.json",
+        "uv.json",
+        "base.json"
+      ],
+      "unknownFormat": [
+        "uint16",
+        "uint8",
+        "uint",
+        "int",
+        "python-module-name",
+        "pep508-identifier",
+        "python-qualified-identifier",
+        "python-identifier",
+        "pep561-stub-name"
+      ],
+      "unknownKeywords": [
+        "markdownDescription",
+        "x-taplo",
+        "x-taplo-info",
+        "x-tombi-toml-version",
+        "x-tombi-table-keys-order-by",
+        "x-intellij-html-description",
+        "x-intellij-language-injection"
+      ]
     },
     "pocketmine-plugin.json": {
       "unknownFormat": ["iri"]

--- a/src/schemas/json/pep-723.json
+++ b/src/schemas/json/pep-723.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/pep-723.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requires-python": {
+      "type": "string",
+      "title": "Python version compatibility",
+      "description": "Specifies the Python version(s) that the distribution is compatible with. Must be in the format specified in [Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/).",
+      "markdownDescription": "Specifies the Python version(s) that the distribution is compatible with. Must be in the format specified in [Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/).",
+      "x-intellij-html-description": "<p>Specifies the Python version(s) that the distribution is compatible with. Must be in the format specified in <a href=\"https://packaging.python.org/en/latest/specifications/version-specifiers/\">Version specifiers</a>.</p>",
+      "x-taplo": {
+        "links": {
+          "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python"
+        }
+      },
+      "examples": [">= 3.7"]
+    },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Project mandatory dependency requirements",
+      "description": "An array of [dependency specifier](https://packaging.python.org/en/latest/specifications/dependency-specifiers/) strings, each representing a mandatory dependent package of the project.",
+      "markdownDescription": "An array of [dependency specifier](https://packaging.python.org/en/latest/specifications/dependency-specifiers/) strings, each representing a mandatory dependent package of the project.",
+      "x-intellij-html-description": "<p>An array of <a href=\"https://packaging.python.org/en/latest/specifications/dependency-specifiers/\">dependency specifier</a> strings, each representing a mandatory dependent package of the project.</p>",
+      "x-taplo": {
+        "links": {
+          "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies"
+        }
+      },
+      "examples": [["attrs", "requests ~= 2.28"]]
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object"
+      },
+      "title": "Tool-specific configuration",
+      "description": "Every tool that is used by the project can have users specify configuration data as long as they use a sub-table within `[tool]`. Generally a project can use the subtable `tool.$NAME` if, and only if, they own the entry for `$NAME` in the Cheeseshop/PyPI.",
+      "markdownDescription": "Every tool that is used by the project can have users specify configuration data as long as they use a sub-table within `[tool]`. Generally a project can use the subtable `tool.$NAME` if, and only if, they own the entry for `$NAME` in the Cheeseshop/PyPI.",
+      "x-intellij-html-description": "<p>Every tool that is used by the project can have users specify configuration data as long as they use a sub-table within <code>[tool]</code>. Generally a project can use the subtable <code>tool.$NAME</code> if, and only if, they own the entry for <code>$NAME</code> in the Cheeseshop/PyPI.</p>",
+      "x-taplo": {
+        "links": {
+          "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#arbitrary-tool-configuration-the-tool-table"
+        }
+      },
+      "x-tombi-table-keys-order-by": "ascending",
+      "properties": {
+        "black": {
+          "$ref": "https://json.schemastore.org/partial-black.json"
+        },
+        "cibuildwheel": {
+          "$ref": "https://json.schemastore.org/partial-cibuildwheel.json"
+        },
+        "mypy": {
+          "$ref": "https://json.schemastore.org/partial-mypy.json"
+        },
+        "ruff": {
+          "$ref": "https://json.schemastore.org/ruff.json"
+        },
+        "hatch": {
+          "$ref": "https://json.schemastore.org/hatch.json"
+        },
+        "maturin": {
+          "$ref": "https://json.schemastore.org/maturin.json",
+          "title": "Maturin",
+          "description": "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages"
+        },
+        "scikit-build": {
+          "$ref": "https://json.schemastore.org/partial-scikit-build.json"
+        },
+        "setuptools": {
+          "$ref": "https://json.schemastore.org/partial-setuptools.json"
+        },
+        "setuptools_scm": {
+          "$ref": "https://json.schemastore.org/partial-setuptools-scm.json"
+        },
+        "poe": {
+          "$ref": "https://json.schemastore.org/partial-poe.json"
+        },
+        "poetry": {
+          "$ref": "https://json.schemastore.org/partial-poetry.json"
+        },
+        "pdm": {
+          "$ref": "https://json.schemastore.org/partial-pdm.json"
+        },
+        "pyright": {
+          "$ref": "https://json.schemastore.org/partial-pyright.json"
+        },
+        "repo-review": {
+          "$ref": "https://json.schemastore.org/partial-repo-review.json"
+        },
+        "taskipy": {
+          "$ref": "https://json.schemastore.org/partial-taskipy.json",
+          "title": "Task Runner",
+          "description": "The complementary task runner for python."
+        },
+        "tombi": {
+          "$ref": "https://json.schemastore.org/tombi.json",
+          "title": "TOML Toolkit",
+          "description": "Tombi (鳶) is a toolkit for TOML; providing a formatter/linter and language server"
+        },
+        "tox": {
+          "$ref": "https://json.schemastore.org/partial-tox.json"
+        },
+        "uv": {
+          "$ref": "https://json.schemastore.org/uv.json"
+        }
+      },
+      "examples": [
+        {
+          "tool": {
+            "isort": {
+              "profile": "black"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/pep-723/1.toml
+++ b/src/test/pep-723/1.toml
@@ -1,0 +1,1 @@
+#:schema ../../schemas/json/pep-723.json

--- a/src/test/pep-723/2.toml
+++ b/src/test/pep-723/2.toml
@@ -1,0 +1,8 @@
+#:schema ../../schemas/json/pep-723.json
+requires-python = ""
+dependencies = [
+  "a-n-plus-b>=0.0.1"
+]
+
+[tool.ruff]
+select = ["RUF001"]

--- a/src/test/pep-723/3.toml
+++ b/src/test/pep-723/3.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/pep-723.json
+[tool.foobar]
+lorem-ipsum = "dolor sit amet"


### PR DESCRIPTION
PEP 723 [specifies](https://peps.python.org/pep-0723/#script-type) that:

> This document MAY include top-level fields `dependencies` and `requires-python`, and MAY optionally include a `[tool]` table.
>
> The `[tool]` table MAY be used by any tool, script runner or otherwise, to configure behavior. It has the same semantics as the [tool table](https://peps.python.org/pep-0518/#tool-table) in `pyproject.toml`.

The new `pep-723.json` schema is thus a subset of `pyproject.toml`. It is assumed that no other top-level fields are allowed.

It has no file matchers, as script metadata blocks are embedded within Python files.
