### PR TITLE
change: tombi keyword

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -594,7 +594,7 @@
         "x-taplo",
         "x-taplo-info",
         "x-tombi-toml-version",
-        "x-tombi-table-keys-order-by"
+        "x-tombi-table-keys-order"
       ]
     },
     "cheatsheets.json": {
@@ -982,7 +982,7 @@
       "unknownKeywords": ["x-taplo"]
     },
     "partial-poetry.json": {
-      "unknownKeywords": ["x-tombi-table-keys-order-by"],
+      "unknownKeywords": ["x-tombi-table-keys-order"],
       "externalSchema": ["base.json"]
     },
     "partial-pyright.json": {
@@ -1009,7 +1009,7 @@
       ]
     },
     "partial-taskipy.json": {
-      "unknownKeywords": ["x-tombi-table-keys-order-by"]
+      "unknownKeywords": ["x-tombi-table-keys-order"]
     },
     "pdm.json": {
       "unknownKeywords": ["x-taplo", "x-taplo-info"]
@@ -1054,7 +1054,7 @@
         "x-taplo",
         "x-taplo-info",
         "x-tombi-toml-version",
-        "x-tombi-table-keys-order-by",
+        "x-tombi-table-keys-order",
         "x-intellij-html-description",
         "x-intellij-language-injection"
       ]
@@ -1063,7 +1063,7 @@
       "unknownFormat": ["iri"]
     },
     "poetry.json": {
-      "unknownKeywords": ["x-tombi-table-keys-order-by"],
+      "unknownKeywords": ["x-tombi-table-keys-order"],
       "externalSchema": ["partial-poetry.json", "base.json"]
     },
     "pre-commit-config.json": {
@@ -1124,8 +1124,8 @@
         "x-taplo",
         "x-taplo-info",
         "x-tombi-toml-version",
-        "x-tombi-table-keys-order-by",
-        "x-tombi-array-values-order-by",
+        "x-tombi-table-keys-order",
+        "x-tombi-array-values-order",
         "x-intellij-html-description",
         "x-intellij-language-injection"
       ]

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -13,10 +13,7 @@
         },
         {
           "type": "boolean",
-          "enum": [
-            true,
-            false
-          ],
+          "enum": [true, false],
           "x-taplo": {
             "docs": {
               "enumValues": [
@@ -117,9 +114,7 @@
               "links": {
                 "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features"
               },
-              "plugins": [
-                "crates"
-              ],
+              "plugins": ["crates"],
               "crates": {
                 "schemas": "feature"
               }
@@ -222,9 +217,7 @@
       "minProperties": 1,
       "additionalProperties": false,
       "x-taplo": {
-        "initFields": [
-          "version"
-        ]
+        "initFields": ["version"]
       }
     },
     "DetailedLint": {
@@ -249,12 +242,7 @@
       "title": "Edition",
       "description": "The `edition` key affects which edition your package is compiled with. Cargo\nwill always generate packages via [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html) with the `edition` key set to the\nlatest edition. Setting the `edition` key in `[package]` will affect all\ntargets/crates in the package, including test suites, benchmarks, binaries,\nexamples, etc.",
       "type": "string",
-      "enum": [
-        "2015",
-        "2018",
-        "2021",
-        "2024"
-      ],
+      "enum": ["2015", "2018", "2021", "2024"],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/stable/edition-guide/introduction.html"
@@ -276,12 +264,7 @@
       "title": "Lint Level",
       "description": "Specify the [lint level](https://doc.rust-lang.org/rustc/lints/levels.html) for a lint or lint group.",
       "type": "string",
-      "enum": [
-        "forbid",
-        "deny",
-        "warn",
-        "allow"
-      ],
+      "enum": ["forbid", "deny", "warn", "allow"],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -326,13 +309,7 @@
     "Lto": {
       "title": "Lto",
       "description": "The `lto` setting controls the [`-C lto` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto) which controls LLVM's [link time optimizations](https://llvm.org/docs/LinkTimeOptimization.html). LTO can produce better optimized code, using\nwhole-program analysis, at the cost of longer linking time.\n                    \nSee also the [`-C linker-plugin-lto`](https://doc.rust-lang.org/rustc/codegen-options/index.html#linker-plugin-lto) `rustc` flag for cross-language LTO.",
-      "enum": [
-        "fat",
-        "thin",
-        "off",
-        true,
-        false
-      ],
+      "enum": ["fat", "thin", "off", true, false],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -359,11 +336,7 @@
       "title": "Resolver",
       "description": "A different feature resolver algorithm can be used by specifying the resolver version in Cargo.toml like this:\n\n[package]\nname = \"my-package\"\nversion = \"1.0.0\"\nresolver = \"2\"\n\nThe version \"1\" resolver is the original resolver that shipped with Cargo up to version 1.50. The default is \"2\" if the root package specifies edition = \"2021\" or a newer edition. Otherwise the default is \"1\".\n\nThe version \"2\" resolver introduces changes in feature unification. See the features chapter for more details.\n\nThe resolver is a global option that affects the entire workspace. The resolver version in dependencies is ignored, only the value in the top-level package will be used. If using a virtual workspace, the version should be specified in the [workspace] table, for example:\n\n[workspace]\nmembers = [\"member1\", \"member2\"]\nresolver = \"2\"",
       "type": "string",
-      "enum": [
-        "1",
-        "2",
-        "3"
-      ],
+      "enum": ["1", "2", "3"],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions"
@@ -373,14 +346,7 @@
     "OptLevel": {
       "title": "Optimization Level",
       "description": "The `opt-level` setting controls the [`-C opt-level` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#opt-level) which controls the level\nof optimization. Higher optimization levels may produce faster runtime code at\nthe expense of longer compiler times. Higher levels may also change and\nrearrange the compiled code which may make it harder to use with a debugger.\n\nIt is recommended to experiment with different levels to find the right\nbalance for your project. There may be surprising results, such as level `3`\nbeing slower than `2`, or the `\"s\"` and `\"z\"` levels not being necessarily\nsmaller. You may also want to reevaluate your settings over time as newer\nversions of `rustc` changes optimization behavior.\n\nSee also [Profile Guided Optimization](https://doc.rust-lang.org/rustc/profile-guided-optimization.html) for more advanced optimization\ntechniques.",
-      "enum": [
-        0,
-        1,
-        2,
-        3,
-        "s",
-        "z"
-      ],
+      "enum": [0, 1, 2, 3, "s", "z"],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -401,9 +367,7 @@
       "title": "Package",
       "description": "The only field required by Cargo is [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field).\n If publishing to a registry, the registry may\nrequire additional fields. See the notes below and [the publishing chapter](https://doc.rust-lang.org/cargo/reference/publishing.html) for requirements for publishing to [crates.io](https://crates.io/).",
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "authors": {
           "title": "Authors",
@@ -726,10 +690,7 @@
       "title": "Panic",
       "description": "The `panic` setting controls the [`-C panic` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#panic) which controls which panic\nstrategy to use.\n\nWhen set to `\"unwind\"`, the actual value depends on the default of the target\nplatform. For example, the NVPTX platform does not support unwinding, so it\nalways uses `\"abort\"`.\n\nTests, benchmarks, build scripts, and proc macros ignore the `panic` setting.\nThe `rustc` test harness currently requires `unwind` behavior. See the\n[`panic-abort-tests`](https://doc.rust-lang.org/cargo/reference/unstable.html#panic-abort-tests) unstable flag which enables `abort` behavior.\n\nAdditionally, when using the `abort` strategy and building a test, all of the\ndependencies will also be forced to built with the `unwind` strategy.",
       "type": "string",
-      "enum": [
-        "unwind",
-        "abort"
-      ],
+      "enum": ["unwind", "abort"],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -757,9 +718,7 @@
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
             },
-            "plugins": [
-              "crates"
-            ],
+            "plugins": ["crates"],
             "crates": {
               "schemas": "dependencies"
             }
@@ -799,9 +758,7 @@
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
             },
-            "plugins": [
-              "crates"
-            ],
+            "plugins": ["crates"],
             "crates": {
               "schemas": "dependencies"
             }
@@ -975,10 +932,7 @@
         {
           "description": "A boolean indicating whether the package can be published.",
           "type": "boolean",
-          "enum": [
-            true,
-            false
-          ],
+          "enum": [true, false],
           "default": true,
           "x-taplo": {
             "docs": {
@@ -1013,10 +967,7 @@
         },
         {
           "type": "boolean",
-          "enum": [
-            true,
-            false
-          ],
+          "enum": [true, false],
           "x-taplo": {
             "docs": {
               "enumValues": [
@@ -1055,9 +1006,7 @@
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
         },
-        "plugins": [
-          "crates"
-        ],
+        "plugins": ["crates"],
         "crates": {
           "schemas": "version"
         }
@@ -1557,23 +1506,17 @@
           "title": "Workspace",
           "description": "The `workspace` field allow keys to be inherited by defining them in the member package with `{key}.workspace = true`",
           "type": "boolean",
-          "enum": [
-            true
-          ]
+          "enum": [true]
         }
       },
-      "required": [
-        "workspace"
-      ],
+      "required": ["workspace"],
       "additionalProperties": false
     },
     "PlaydateMetadata": {
       "title": "Playdate Package Metadata",
       "description": "Metadata and build configuration.",
       "type": "object",
-      "required": [
-        "bundle-id"
-      ],
+      "required": ["bundle-id"],
       "properties": {
         "bundle-id": {
           "type": "string",
@@ -1707,9 +1650,7 @@
         }
       },
       "x-taplo-info": {
-        "authors": [
-          "Alex Koz. (https://github.com/boozook)"
-        ]
+        "authors": ["Alex Koz. (https://github.com/boozook)"]
       }
     },
     "PlaydateMetadataAssetsArray": {
@@ -1772,10 +1713,7 @@
         },
         "method": {
           "type": "string",
-          "enum": [
-            "copy",
-            "link"
-          ]
+          "enum": ["copy", "link"]
         },
         "dependencies": {
           "type": "boolean",
@@ -1870,9 +1808,7 @@
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
         },
-        "plugins": [
-          "crates"
-        ],
+        "plugins": ["crates"],
         "crates": {
           "schemas": "dependencies"
         }
@@ -1918,9 +1854,7 @@
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
         },
-        "plugins": [
-          "crates"
-        ],
+        "plugins": ["crates"],
         "crates": {
           "schemas": "dependencies"
         }
@@ -1994,9 +1928,7 @@
               "description": "Inherit lints from the workspace manifest."
             }
           },
-          "required": [
-            "workspace"
-          ],
+          "required": ["workspace"],
           "additionalProperties": false
         }
       ],
@@ -2075,11 +2007,7 @@
   "title": "Cargo.toml",
   "type": "object",
   "x-taplo-info": {
-    "authors": [
-      "tamasfe (https://github.com/tamasfe)"
-    ],
-    "patterns": [
-      "^(.*(/|\\\\)Cargo\\.toml|Cargo\\.toml)$"
-    ]
+    "authors": ["tamasfe (https://github.com/tamasfe)"],
+    "patterns": ["^(.*(/|\\\\)Cargo\\.toml|Cargo\\.toml)$"]
   }
 }

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -13,7 +13,10 @@
         },
         {
           "type": "boolean",
-          "enum": [true, false],
+          "enum": [
+            true,
+            false
+          ],
           "x-taplo": {
             "docs": {
               "enumValues": [
@@ -114,7 +117,9 @@
               "links": {
                 "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features"
               },
-              "plugins": ["crates"],
+              "plugins": [
+                "crates"
+              ],
               "crates": {
                 "schemas": "feature"
               }
@@ -217,7 +222,9 @@
       "minProperties": 1,
       "additionalProperties": false,
       "x-taplo": {
-        "initFields": ["version"]
+        "initFields": [
+          "version"
+        ]
       }
     },
     "DetailedLint": {
@@ -242,7 +249,12 @@
       "title": "Edition",
       "description": "The `edition` key affects which edition your package is compiled with. Cargo\nwill always generate packages via [`cargo new`](https://doc.rust-lang.org/cargo/commands/cargo-new.html) with the `edition` key set to the\nlatest edition. Setting the `edition` key in `[package]` will affect all\ntargets/crates in the package, including test suites, benchmarks, binaries,\nexamples, etc.",
       "type": "string",
-      "enum": ["2015", "2018", "2021", "2024"],
+      "enum": [
+        "2015",
+        "2018",
+        "2021",
+        "2024"
+      ],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/stable/edition-guide/introduction.html"
@@ -264,7 +276,12 @@
       "title": "Lint Level",
       "description": "Specify the [lint level](https://doc.rust-lang.org/rustc/lints/levels.html) for a lint or lint group.",
       "type": "string",
-      "enum": ["forbid", "deny", "warn", "allow"],
+      "enum": [
+        "forbid",
+        "deny",
+        "warn",
+        "allow"
+      ],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -309,7 +326,13 @@
     "Lto": {
       "title": "Lto",
       "description": "The `lto` setting controls the [`-C lto` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto) which controls LLVM's [link time optimizations](https://llvm.org/docs/LinkTimeOptimization.html). LTO can produce better optimized code, using\nwhole-program analysis, at the cost of longer linking time.\n                    \nSee also the [`-C linker-plugin-lto`](https://doc.rust-lang.org/rustc/codegen-options/index.html#linker-plugin-lto) `rustc` flag for cross-language LTO.",
-      "enum": ["fat", "thin", "off", true, false],
+      "enum": [
+        "fat",
+        "thin",
+        "off",
+        true,
+        false
+      ],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -336,7 +359,11 @@
       "title": "Resolver",
       "description": "A different feature resolver algorithm can be used by specifying the resolver version in Cargo.toml like this:\n\n[package]\nname = \"my-package\"\nversion = \"1.0.0\"\nresolver = \"2\"\n\nThe version \"1\" resolver is the original resolver that shipped with Cargo up to version 1.50. The default is \"2\" if the root package specifies edition = \"2021\" or a newer edition. Otherwise the default is \"1\".\n\nThe version \"2\" resolver introduces changes in feature unification. See the features chapter for more details.\n\nThe resolver is a global option that affects the entire workspace. The resolver version in dependencies is ignored, only the value in the top-level package will be used. If using a virtual workspace, the version should be specified in the [workspace] table, for example:\n\n[workspace]\nmembers = [\"member1\", \"member2\"]\nresolver = \"2\"",
       "type": "string",
-      "enum": ["1", "2", "3"],
+      "enum": [
+        "1",
+        "2",
+        "3"
+      ],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions"
@@ -346,7 +373,14 @@
     "OptLevel": {
       "title": "Optimization Level",
       "description": "The `opt-level` setting controls the [`-C opt-level` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#opt-level) which controls the level\nof optimization. Higher optimization levels may produce faster runtime code at\nthe expense of longer compiler times. Higher levels may also change and\nrearrange the compiled code which may make it harder to use with a debugger.\n\nIt is recommended to experiment with different levels to find the right\nbalance for your project. There may be surprising results, such as level `3`\nbeing slower than `2`, or the `\"s\"` and `\"z\"` levels not being necessarily\nsmaller. You may also want to reevaluate your settings over time as newer\nversions of `rustc` changes optimization behavior.\n\nSee also [Profile Guided Optimization](https://doc.rust-lang.org/rustc/profile-guided-optimization.html) for more advanced optimization\ntechniques.",
-      "enum": [0, 1, 2, 3, "s", "z"],
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        "s",
+        "z"
+      ],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -367,7 +401,9 @@
       "title": "Package",
       "description": "The only field required by Cargo is [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field).\n If publishing to a registry, the registry may\nrequire additional fields. See the notes below and [the publishing chapter](https://doc.rust-lang.org/cargo/reference/publishing.html) for requirements for publishing to [crates.io](https://crates.io/).",
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "authors": {
           "title": "Authors",
@@ -690,7 +726,10 @@
       "title": "Panic",
       "description": "The `panic` setting controls the [`-C panic` flag](https://doc.rust-lang.org/rustc/codegen-options/index.html#panic) which controls which panic\nstrategy to use.\n\nWhen set to `\"unwind\"`, the actual value depends on the default of the target\nplatform. For example, the NVPTX platform does not support unwinding, so it\nalways uses `\"abort\"`.\n\nTests, benchmarks, build scripts, and proc macros ignore the `panic` setting.\nThe `rustc` test harness currently requires `unwind` behavior. See the\n[`panic-abort-tests`](https://doc.rust-lang.org/cargo/reference/unstable.html#panic-abort-tests) unstable flag which enables `abort` behavior.\n\nAdditionally, when using the `abort` strategy and building a test, all of the\ndependencies will also be forced to built with the `unwind` strategy.",
       "type": "string",
-      "enum": ["unwind", "abort"],
+      "enum": [
+        "unwind",
+        "abort"
+      ],
       "x-taplo": {
         "docs": {
           "enumValues": [
@@ -713,12 +752,14 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
             },
-            "plugins": ["crates"],
+            "plugins": [
+              "crates"
+            ],
             "crates": {
               "schemas": "dependencies"
             }
@@ -729,7 +770,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "hidden": true
           }
@@ -740,7 +781,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
@@ -753,12 +794,14 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
             },
-            "plugins": ["crates"],
+            "plugins": [
+              "crates"
+            ],
             "crates": {
               "schemas": "dependencies"
             }
@@ -769,7 +812,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "hidden": true
           }
@@ -932,7 +975,10 @@
         {
           "description": "A boolean indicating whether the package can be published.",
           "type": "boolean",
-          "enum": [true, false],
+          "enum": [
+            true,
+            false
+          ],
           "default": true,
           "x-taplo": {
             "docs": {
@@ -967,7 +1013,10 @@
         },
         {
           "type": "boolean",
-          "enum": [true, false],
+          "enum": [
+            true,
+            false
+          ],
           "x-taplo": {
             "docs": {
               "enumValues": [
@@ -1006,7 +1055,9 @@
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
         },
-        "plugins": ["crates"],
+        "plugins": [
+          "crates"
+        ],
         "crates": {
           "schemas": "version"
         }
@@ -1204,7 +1255,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/Dependency"
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "x-taplo": {
             "links": {
               "key": "https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section"
@@ -1506,17 +1557,23 @@
           "title": "Workspace",
           "description": "The `workspace` field allow keys to be inherited by defining them in the member package with `{key}.workspace = true`",
           "type": "boolean",
-          "enum": [true]
+          "enum": [
+            true
+          ]
         }
       },
-      "required": ["workspace"],
+      "required": [
+        "workspace"
+      ],
       "additionalProperties": false
     },
     "PlaydateMetadata": {
       "title": "Playdate Package Metadata",
       "description": "Metadata and build configuration.",
       "type": "object",
-      "required": ["bundle-id"],
+      "required": [
+        "bundle-id"
+      ],
       "properties": {
         "bundle-id": {
           "type": "string",
@@ -1650,7 +1707,9 @@
         }
       },
       "x-taplo-info": {
-        "authors": ["Alex Koz. (https://github.com/boozook)"]
+        "authors": [
+          "Alex Koz. (https://github.com/boozook)"
+        ]
       }
     },
     "PlaydateMetadataAssetsArray": {
@@ -1713,7 +1772,10 @@
         },
         "method": {
           "type": "string",
-          "enum": ["copy", "link"]
+          "enum": [
+            "copy",
+            "link"
+          ]
         },
         "dependencies": {
           "type": "boolean",
@@ -1754,7 +1816,7 @@
           "type": "string"
         }
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section"
@@ -1803,12 +1865,14 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies"
         },
-        "plugins": ["crates"],
+        "plugins": [
+          "crates"
+        ],
         "crates": {
           "schemas": "dependencies"
         }
@@ -1819,7 +1883,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "hidden": true
       }
@@ -1836,7 +1900,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html"
@@ -1849,12 +1913,14 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies"
         },
-        "plugins": ["crates"],
+        "plugins": [
+          "crates"
+        ],
         "crates": {
           "schemas": "dependencies"
         }
@@ -1865,7 +1931,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "hidden": true
       }
@@ -1928,7 +1994,9 @@
               "description": "Inherit lints from the workspace manifest."
             }
           },
-          "required": ["workspace"],
+          "required": [
+            "workspace"
+          ],
           "additionalProperties": false
         }
       ],
@@ -1967,7 +2035,7 @@
     },
     "replace": {
       "type": "object",
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "additionalProperties": {
         "$ref": "#/definitions/Dependency"
       },
@@ -1977,7 +2045,7 @@
     },
     "target": {
       "type": "object",
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "additionalProperties": {
         "$ref": "#/definitions/Platform"
       }
@@ -2007,7 +2075,11 @@
   "title": "Cargo.toml",
   "type": "object",
   "x-taplo-info": {
-    "authors": ["tamasfe (https://github.com/tamasfe)"],
-    "patterns": ["^(.*(/|\\\\)Cargo\\.toml|Cargo\\.toml)$"]
+    "authors": [
+      "tamasfe (https://github.com/tamasfe)"
+    ],
+    "patterns": [
+      "^(.*(/|\\\\)Cargo\\.toml|Cargo\\.toml)$"
+    ]
   }
 }

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -40,10 +40,7 @@
     },
     "poetry-package-format": {
       "type": "string",
-      "enum": [
-        "sdist",
-        "wheel"
-      ],
+      "enum": ["sdist", "wheel"],
       "description": "A Python packaging format."
     },
     "poetry-package-formats": {
@@ -94,9 +91,7 @@
     },
     "poetry-long-dependency": {
       "type": "object",
-      "required": [
-        "version"
-      ],
+      "required": ["version"],
       "additionalProperties": false,
       "properties": {
         "version": {
@@ -141,9 +136,7 @@
     },
     "poetry-git-dependency": {
       "type": "object",
-      "required": [
-        "git"
-      ],
+      "required": ["git"],
       "additionalProperties": false,
       "properties": {
         "git": {
@@ -213,9 +206,7 @@
     },
     "poetry-file-dependency": {
       "type": "object",
-      "required": [
-        "file"
-      ],
+      "required": ["file"],
       "additionalProperties": false,
       "properties": {
         "file": {
@@ -249,9 +240,7 @@
     },
     "poetry-path-dependency": {
       "type": "object",
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false,
       "properties": {
         "path": {
@@ -289,9 +278,7 @@
     },
     "poetry-url-dependency": {
       "type": "object",
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "additionalProperties": false,
       "properties": {
         "url": {
@@ -376,10 +363,7 @@
         "type": {
           "description": "Value can be either file or console.",
           "type": "string",
-          "enum": [
-            "file",
-            "console"
-          ]
+          "enum": ["file", "console"]
         },
         "extras": {
           "type": "array",
@@ -389,10 +373,7 @@
           }
         }
       },
-      "required": [
-        "reference",
-        "type"
-      ]
+      "required": ["reference", "type"]
     },
     "poetry-extra-script-legacy": {
       "type": "object",
@@ -517,9 +498,7 @@
         "type": "object",
         "description": "Information about where the package resides.",
         "additionalProperties": false,
-        "required": [
-          "include"
-        ],
+        "required": ["include"],
         "properties": {
           "include": {
             "$ref": "#/definitions/poetry-include-path"
@@ -549,9 +528,7 @@
           {
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "path"
-            ],
+            "required": ["path"],
             "properties": {
               "path": {
                 "$ref": "#/definitions/poetry-include-path"
@@ -612,9 +589,7 @@
         "^[a-zA-Z-_.0-9]+$": {
           "type": "object",
           "description": "This represents a single dependency group",
-          "required": [
-            "dependencies"
-          ],
+          "required": ["dependencies"],
           "properties": {
             "optional": {
               "type": "boolean",
@@ -703,9 +678,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string",
@@ -742,9 +715,7 @@
           }
         },
         "else": {
-          "required": [
-            "url"
-          ],
+          "required": ["url"],
           "properties": {
             "url": true
           }

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -701,24 +701,14 @@
           }
         },
         "if": {
-          "properties": {
-            "name": {
-              "const": "pypi"
-            }
-          }
+          "properties": { "name": { "const": "pypi" } }
         },
         "then": {
-          "propertyNames": {
-            "not": {
-              "const": "url"
-            }
-          }
+          "propertyNames": { "not": { "const": "url" } }
         },
         "else": {
           "required": ["url"],
-          "properties": {
-            "url": true
-          }
+          "properties": { "url": true }
         }
       }
     }

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -40,7 +40,10 @@
     },
     "poetry-package-format": {
       "type": "string",
-      "enum": ["sdist", "wheel"],
+      "enum": [
+        "sdist",
+        "wheel"
+      ],
       "description": "A Python packaging format."
     },
     "poetry-package-formats": {
@@ -91,7 +94,9 @@
     },
     "poetry-long-dependency": {
       "type": "object",
-      "required": ["version"],
+      "required": [
+        "version"
+      ],
       "additionalProperties": false,
       "properties": {
         "version": {
@@ -136,7 +141,9 @@
     },
     "poetry-git-dependency": {
       "type": "object",
-      "required": ["git"],
+      "required": [
+        "git"
+      ],
       "additionalProperties": false,
       "properties": {
         "git": {
@@ -206,7 +213,9 @@
     },
     "poetry-file-dependency": {
       "type": "object",
-      "required": ["file"],
+      "required": [
+        "file"
+      ],
       "additionalProperties": false,
       "properties": {
         "file": {
@@ -240,7 +249,9 @@
     },
     "poetry-path-dependency": {
       "type": "object",
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false,
       "properties": {
         "path": {
@@ -278,7 +289,9 @@
     },
     "poetry-url-dependency": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "additionalProperties": false,
       "properties": {
         "url": {
@@ -363,7 +376,10 @@
         "type": {
           "description": "Value can be either file or console.",
           "type": "string",
-          "enum": ["file", "console"]
+          "enum": [
+            "file",
+            "console"
+          ]
         },
         "extras": {
           "type": "array",
@@ -373,7 +389,10 @@
           }
         }
       },
-      "required": ["reference", "type"]
+      "required": [
+        "reference",
+        "type"
+      ]
     },
     "poetry-extra-script-legacy": {
       "type": "object",
@@ -498,7 +517,9 @@
         "type": "object",
         "description": "Information about where the package resides.",
         "additionalProperties": false,
-        "required": ["include"],
+        "required": [
+          "include"
+        ],
         "properties": {
           "include": {
             "$ref": "#/definitions/poetry-include-path"
@@ -528,7 +549,9 @@
           {
             "type": "object",
             "additionalProperties": false,
-            "required": ["path"],
+            "required": [
+              "path"
+            ],
             "properties": {
               "path": {
                 "$ref": "#/definitions/poetry-include-path"
@@ -558,7 +581,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/poetry-dependency-any"
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "dev-dependencies": {
       "type": "object",
@@ -568,7 +591,7 @@
           "$ref": "#/definitions/poetry-dependency-any"
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "extras": {
       "type": "object",
@@ -580,7 +603,7 @@
           }
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "group": {
       "type": "object",
@@ -589,7 +612,9 @@
         "^[a-zA-Z-_.0-9]+$": {
           "type": "object",
           "description": "This represents a single dependency group",
-          "required": ["dependencies"],
+          "required": [
+            "dependencies"
+          ],
           "properties": {
             "optional": {
               "type": "boolean",
@@ -604,13 +629,13 @@
                 }
               },
               "additionalProperties": false,
-              "x-tombi-table-keys-order-by": "ascending"
+              "x-tombi-table-keys-order": "ascending"
             }
           },
           "additionalProperties": false
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "build": {
       "$ref": "#/definitions/poetry-build-section"
@@ -630,7 +655,7 @@
           ]
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "plugins": {
       "type": "object",
@@ -660,7 +685,7 @@
           }
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "urls": {
       "type": "object",
@@ -670,7 +695,7 @@
           "description": "The full url of the custom url."
         }
       },
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "source": {
       "$comment": "The unique 'pypi' source constraint is not implemented yet.",
@@ -678,7 +703,9 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -701,14 +728,26 @@
           }
         },
         "if": {
-          "properties": { "name": { "const": "pypi" } }
+          "properties": {
+            "name": {
+              "const": "pypi"
+            }
+          }
         },
         "then": {
-          "propertyNames": { "not": { "const": "url" } }
+          "propertyNames": {
+            "not": {
+              "const": "url"
+            }
+          }
         },
         "else": {
-          "required": ["url"],
-          "properties": { "url": true }
+          "required": [
+            "url"
+          ],
+          "properties": {
+            "url": true
+          }
         }
       }
     }

--- a/src/schemas/json/partial-taskipy.json
+++ b/src/schemas/json/partial-taskipy.json
@@ -15,7 +15,7 @@
         }
       },
       "additionalProperties": false,
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "variables": {
       "title": "variables",
@@ -36,7 +36,7 @@
         }
       },
       "additionalProperties": false,
-      "x-tombi-table-keys-order-by": "ascending"
+      "x-tombi-table-keys-order": "ascending"
     },
     "settings": {
       "$ref": "#/definitions/Settings"
@@ -66,7 +66,9 @@
               "$ref": "#/definitions/Cwd"
             }
           },
-          "required": ["cmd"]
+          "required": [
+            "cmd"
+          ]
         }
       ]
     },

--- a/src/schemas/json/partial-taskipy.json
+++ b/src/schemas/json/partial-taskipy.json
@@ -66,9 +66,7 @@
               "$ref": "#/definitions/Cwd"
             }
           },
-          "required": [
-            "cmd"
-          ]
+          "required": ["cmd"]
         }
       ]
     },

--- a/src/schemas/json/pep-723.json
+++ b/src/schemas/json/pep-723.json
@@ -15,7 +15,9 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python"
         }
       },
-      "examples": [">= 3.7"]
+      "examples": [
+        ">= 3.7"
+      ]
     },
     "dependencies": {
       "type": "array",
@@ -31,7 +33,12 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies"
         }
       },
-      "examples": [["attrs", "requests ~= 2.28"]]
+      "examples": [
+        [
+          "attrs",
+          "requests ~= 2.28"
+        ]
+      ]
     },
     "tool": {
       "type": "object",
@@ -47,7 +54,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#arbitrary-tool-configuration-the-tool-table"
         }
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "properties": {
         "black": {
           "$ref": "https://json.schemastore.org/partial-black.json"

--- a/src/schemas/json/pep-723.json
+++ b/src/schemas/json/pep-723.json
@@ -15,9 +15,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python"
         }
       },
-      "examples": [
-        ">= 3.7"
-      ]
+      "examples": [">= 3.7"]
     },
     "dependencies": {
       "type": "array",
@@ -33,12 +31,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies"
         }
       },
-      "examples": [
-        [
-          "attrs",
-          "requests ~= 2.28"
-        ]
-      ]
+      "examples": [["attrs", "requests ~= 2.28"]]
     },
     "tool": {
       "type": "object",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -3,7 +3,7 @@
   "$id": "https://json.schemastore.org/pyproject.json",
   "$comment": "there are multiple resources describing pyproject.toml. The canonical reference is at https://packaging.python.org/en/latest/specifications/declaring-project-metadata/, which refers to multiple proposals such as PEP 517, PEP 518 and PEP 621",
   "x-tombi-toml-version": "v1.0.0",
-  "x-tombi-table-keys-order-by": "schema",
+  "x-tombi-table-keys-order": "schema",
   "additionalProperties": false,
   "definitions": {
     "projectAuthor": {
@@ -11,13 +11,17 @@
       "additionalProperties": false,
       "anyOf": [
         {
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "properties": {
             "name": true
           }
         },
         {
-          "required": ["email"],
+          "required": [
+            "email"
+          ],
           "properties": {
             "email": true
           }
@@ -32,12 +36,14 @@
           "format": "email"
         }
       },
-      "x-tombi-table-keys-order-by": "schema"
+      "x-tombi-table-keys-order": "schema"
     },
     "BuildSystem": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["requires"],
+      "required": [
+        "requires"
+      ],
       "title": "Project build system configuration",
       "description": "Declares any Python level dependencies that must be installed in order to run the project’s build system successfully.",
       "markdownDescription": "Declares any Python level dependencies that must be installed in order to run the project’s build system successfully.",
@@ -47,7 +53,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-build-system-dependencies-the-build-system-table"
         }
       },
-      "x-tombi-table-keys-order-by": "schema",
+      "x-tombi-table-keys-order": "schema",
       "properties": {
         "requires": {
           "type": "array",
@@ -63,8 +69,10 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-build-system-dependencies-the-build-system-table"
             }
           },
-          "x-tombi-array-values-order-by": "ascending",
-          "examples": ["setuptools >= 64.0"]
+          "x-tombi-array-values-order": "ascending",
+          "examples": [
+            "setuptools >= 64.0"
+          ]
         },
         "build-backend": {
           "type": "string",
@@ -77,7 +85,10 @@
               "key": "https://peps.python.org/pep-0517/#source-trees"
             }
           },
-          "examples": ["setuptools.build_meta", "my_build_backend:backend"]
+          "examples": [
+            "setuptools.build_meta",
+            "my_build_backend:backend"
+          ]
         },
         "backend-path": {
           "type": "array",
@@ -93,7 +104,7 @@
               "key": "https://peps.python.org/pep-0517/#in-tree-build-backends"
             }
           },
-          "x-tombi-table-keys-order-by": "ascending"
+          "x-tombi-table-keys-order": "ascending"
         }
       }
     }
@@ -102,7 +113,9 @@
     "project": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "title": "Project core metadata",
       "description": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
       "markdownDescription": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
@@ -123,7 +136,7 @@
           ]
         }
       },
-      "x-tombi-table-keys-order-by": "schema",
+      "x-tombi-table-keys-order": "schema",
       "properties": {
         "name": {
           "title": "Project name",
@@ -150,7 +163,10 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#version"
             }
           },
-          "examples": ["42.0.1", "0.3.9rc7.post0.dev5"]
+          "examples": [
+            "42.0.1",
+            "0.3.9rc7.post0.dev5"
+          ]
         },
         "description": {
           "type": "string",
@@ -181,7 +197,9 @@
             },
             {
               "type": "object",
-              "required": ["content-type"],
+              "required": [
+                "content-type"
+              ],
               "properties": {
                 "content-type": {
                   "title": "README text content-type",
@@ -192,7 +210,9 @@
               "oneOf": [
                 {
                   "additionalProperties": false,
-                  "required": ["file"],
+                  "required": [
+                    "file"
+                  ],
                   "properties": {
                     "file": {
                       "title": "README file path",
@@ -203,11 +223,13 @@
                       "type": "string"
                     }
                   },
-                  "x-tombi-table-keys-order-by": "schema"
+                  "x-tombi-table-keys-order": "schema"
                 },
                 {
                   "additionalProperties": false,
-                  "required": ["text"],
+                  "required": [
+                    "text"
+                  ],
                   "properties": {
                     "text": {
                       "title": "README text",
@@ -218,7 +240,7 @@
                       "type": "string"
                     }
                   },
-                  "x-tombi-table-keys-order-by": "schema"
+                  "x-tombi-table-keys-order": "schema"
                 }
               ]
             }
@@ -246,7 +268,9 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python"
             }
           },
-          "examples": [">= 3.7"]
+          "examples": [
+            ">= 3.7"
+          ]
         },
         "license": {
           "$comment": "PEP 639 specifies current behavior (text / file subkey) will be deprecated, but this PEP is still under provisional status.",
@@ -263,7 +287,9 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": ["file"],
+              "required": [
+                "file"
+              ],
               "properties": {
                 "file": {
                   "title": "License file path",
@@ -274,7 +300,9 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": ["text"],
+              "required": [
+                "text"
+              ],
               "properties": {
                 "text": {
                   "title": "License text",
@@ -314,7 +342,7 @@
               "key": "https://peps.python.org/pep-0639/#add-license-files-key"
             }
           },
-          "x-tombi-array-values-order-by": "ascending"
+          "x-tombi-array-values-order": "ascending"
         },
         "authors": {
           "type": "array",
@@ -360,7 +388,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#keywords"
             }
           },
-          "x-tombi-array-values-order-by": "ascending"
+          "x-tombi-array-values-order": "ascending"
         },
         "classifiers": {
           "type": "array",
@@ -376,7 +404,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#classifiers"
             }
           },
-          "x-tombi-array-values-order-by": "ascending"
+          "x-tombi-array-values-order": "ascending"
         },
         "urls": {
           "type": "object",
@@ -393,7 +421,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#urls"
             }
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "examples": [
             {
               "homepage": "https://example.com/example-project"
@@ -419,7 +447,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts"
             }
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "examples": [
             {
               "mycmd": "package.module:object.function"
@@ -440,7 +468,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts"
             }
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "examples": [
             {
               "mycmd": "package.module:object.function"
@@ -479,7 +507,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/entry-points/#use-for-plugins"
             }
           },
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "examples": [
             {
               "pygments.styles": {
@@ -502,12 +530,17 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dependencies-optional-dependencies"
             }
           },
-          "x-tombi-array-values-order-by": "ascending",
-          "examples": [["attrs", "requests ~= 2.28"]]
+          "x-tombi-array-values-order": "ascending",
+          "examples": [
+            [
+              "attrs",
+              "requests ~= 2.28"
+            ]
+          ]
         },
         "optional-dependencies": {
           "type": "object",
-          "x-tombi-table-keys-order-by": "ascending",
+          "x-tombi-table-keys-order": "ascending",
           "patternProperties": {
             "^([a-z\\d]|[a-z\\d]([a-z\\d-](?!--))*[a-z\\d])$": {
               "type": "array",
@@ -527,7 +560,10 @@
           },
           "examples": [
             {
-              "typing": ["boto3-stubs", "typing-extensions ~= 4.1"]
+              "typing": [
+                "boto3-stubs",
+                "typing-extensions ~= 4.1"
+              ]
             }
           ]
         },
@@ -557,19 +593,25 @@
           "title": "Dynamic metadata values",
           "description": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]`.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
           "markdownDescription": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]`.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
-          "x-tombi-array-values-order-by": "ascending",
+          "x-tombi-array-values-order": "ascending",
           "x-intellij-html-description": "<p>Specifies which keys are intentionally unspecified under <code>[project]</code> table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in <code>dynamic</code> and use the key directly in <code>[project]</code>.</p><p>One of the most common usage is <code>version</code>, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in <code>pyproject.toml</code>.</p>",
           "x-taplo": {
             "links": {
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic"
             }
           },
-          "examples": [["version"]]
+          "examples": [
+            [
+              "version"
+            ]
+          ]
         }
       },
       "oneOf": [
         {
-          "required": ["dynamic"],
+          "required": [
+            "dynamic"
+          ],
           "properties": {
             "dynamic": {
               "type": "array",
@@ -580,7 +622,9 @@
           }
         },
         {
-          "required": ["version"],
+          "required": [
+            "version"
+          ],
           "properties": {
             "version": true
           }
@@ -589,7 +633,9 @@
       "dependencies": {
         "version": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -602,7 +648,9 @@
         },
         "description": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -615,7 +663,9 @@
         },
         "readme": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -628,7 +678,9 @@
         },
         "requires-python": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -641,7 +693,9 @@
         },
         "license": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -656,7 +710,9 @@
           "allOf": [
             {
               "not": {
-                "required": ["dynamic"],
+                "required": [
+                  "dynamic"
+                ],
                 "properties": {
                   "dynamic": {
                     "type": "array",
@@ -678,7 +734,9 @@
         },
         "authors": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -691,7 +749,9 @@
         },
         "maintainers": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -704,7 +764,9 @@
         },
         "keywords": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -717,7 +779,9 @@
         },
         "classifiers": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -730,7 +794,9 @@
         },
         "urls": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -743,7 +809,9 @@
         },
         "scripts": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -756,7 +824,9 @@
         },
         "gui-scripts": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -769,7 +839,9 @@
         },
         "entry-points": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -782,7 +854,9 @@
         },
         "dependencies": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -795,7 +869,9 @@
         },
         "optional-dependencies": {
           "not": {
-            "required": ["dynamic"],
+            "required": [
+              "dynamic"
+            ],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -813,7 +889,7 @@
       "description": "Named groups of dependencies, similar to `requirements.txt` files, which launchers, IDEs, and other tools can find and identify by name. Each item in `[dependency-groups]` is defined as mapping of group name to list of [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).",
       "markdownDescription": "Named groups of dependencies, similar to `requirements.txt` files, which launchers, IDEs, and other tools can find and identify by name. Each item in `[dependency-groups]` is defined as mapping of group name to list of [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).",
       "x-intellij-html-description": "<p>Named groups of dependencies, similar to <code>requirements.txt</code> files, which launchers, IDEs, and other tools can find and identify by name. Each item in <code>[dependency-groups]</code> is defined as mapping of group name to list of <a href=\"https://packaging.python.org/en/latest/specifications/dependency-specifiers/\">dependency specifiers</a>.</p>",
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "x-taplo": {
         "links": {
           "key": "https://peps.python.org/pep-0735/"
@@ -828,7 +904,7 @@
           "description": "Each list item should be either:\n- [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/), or\n- table with a single key `include-group` which specifies another group name to include into this one",
           "markdownDescription": "Each list item should be either:\n- [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/), or\n- table with a single key `include-group` which specifies another group name to include into this one",
           "x-intellij-html-description": "<p>Each list item should be either:</p><ul><li><a href=\"https://packaging.python.org/en/latest/specifications/dependency-specifiers/\">dependency specifiers</a>, or</li><li>table with a single key <code>include-group</code> which specifies another group name to include into this one</li></ul>",
-          "x-tombi-array-values-order-by": "ascending",
+          "x-tombi-array-values-order": "ascending",
           "items": {
             "oneOf": [
               {
@@ -866,7 +942,7 @@
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#arbitrary-tool-configuration-the-tool-table"
         }
       },
-      "x-tombi-table-keys-order-by": "ascending",
+      "x-tombi-table-keys-order": "ascending",
       "properties": {
         "black": {
           "$ref": "https://json.schemastore.org/partial-black.json"
@@ -943,7 +1019,11 @@
   "title": "JSON schema for Python project metadata and configuration",
   "type": "object",
   "x-taplo-info": {
-    "authors": ["zevisert (https://github.com/zevisert)"],
-    "pattern": ["^(.*(/|\\\\)pyproject\\.toml|pyproject\\.toml)$"]
+    "authors": [
+      "zevisert (https://github.com/zevisert)"
+    ],
+    "pattern": [
+      "^(.*(/|\\\\)pyproject\\.toml|pyproject\\.toml)$"
+    ]
   }
 }

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -11,17 +11,13 @@
       "additionalProperties": false,
       "anyOf": [
         {
-          "required": [
-            "name"
-          ],
+          "required": ["name"],
           "properties": {
             "name": true
           }
         },
         {
-          "required": [
-            "email"
-          ],
+          "required": ["email"],
           "properties": {
             "email": true
           }
@@ -41,9 +37,7 @@
     "BuildSystem": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "requires"
-      ],
+      "required": ["requires"],
       "title": "Project build system configuration",
       "description": "Declares any Python level dependencies that must be installed in order to run the project’s build system successfully.",
       "markdownDescription": "Declares any Python level dependencies that must be installed in order to run the project’s build system successfully.",
@@ -70,9 +64,7 @@
             }
           },
           "x-tombi-array-values-order": "ascending",
-          "examples": [
-            "setuptools >= 64.0"
-          ]
+          "examples": ["setuptools >= 64.0"]
         },
         "build-backend": {
           "type": "string",
@@ -85,10 +77,7 @@
               "key": "https://peps.python.org/pep-0517/#source-trees"
             }
           },
-          "examples": [
-            "setuptools.build_meta",
-            "my_build_backend:backend"
-          ]
+          "examples": ["setuptools.build_meta", "my_build_backend:backend"]
         },
         "backend-path": {
           "type": "array",
@@ -113,9 +102,7 @@
     "project": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "title": "Project core metadata",
       "description": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
       "markdownDescription": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
@@ -163,10 +150,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#version"
             }
           },
-          "examples": [
-            "42.0.1",
-            "0.3.9rc7.post0.dev5"
-          ]
+          "examples": ["42.0.1", "0.3.9rc7.post0.dev5"]
         },
         "description": {
           "type": "string",
@@ -197,9 +181,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "content-type"
-              ],
+              "required": ["content-type"],
               "properties": {
                 "content-type": {
                   "title": "README text content-type",
@@ -210,9 +192,7 @@
               "oneOf": [
                 {
                   "additionalProperties": false,
-                  "required": [
-                    "file"
-                  ],
+                  "required": ["file"],
                   "properties": {
                     "file": {
                       "title": "README file path",
@@ -227,9 +207,7 @@
                 },
                 {
                   "additionalProperties": false,
-                  "required": [
-                    "text"
-                  ],
+                  "required": ["text"],
                   "properties": {
                     "text": {
                       "title": "README text",
@@ -268,9 +246,7 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#requires-python"
             }
           },
-          "examples": [
-            ">= 3.7"
-          ]
+          "examples": [">= 3.7"]
         },
         "license": {
           "$comment": "PEP 639 specifies current behavior (text / file subkey) will be deprecated, but this PEP is still under provisional status.",
@@ -287,9 +263,7 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": [
-                "file"
-              ],
+              "required": ["file"],
               "properties": {
                 "file": {
                   "title": "License file path",
@@ -300,9 +274,7 @@
             {
               "type": "object",
               "additionalProperties": false,
-              "required": [
-                "text"
-              ],
+              "required": ["text"],
               "properties": {
                 "text": {
                   "title": "License text",
@@ -531,12 +503,7 @@
             }
           },
           "x-tombi-array-values-order": "ascending",
-          "examples": [
-            [
-              "attrs",
-              "requests ~= 2.28"
-            ]
-          ]
+          "examples": [["attrs", "requests ~= 2.28"]]
         },
         "optional-dependencies": {
           "type": "object",
@@ -560,10 +527,7 @@
           },
           "examples": [
             {
-              "typing": [
-                "boto3-stubs",
-                "typing-extensions ~= 4.1"
-              ]
+              "typing": ["boto3-stubs", "typing-extensions ~= 4.1"]
             }
           ]
         },
@@ -600,18 +564,12 @@
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic"
             }
           },
-          "examples": [
-            [
-              "version"
-            ]
-          ]
+          "examples": [["version"]]
         }
       },
       "oneOf": [
         {
-          "required": [
-            "dynamic"
-          ],
+          "required": ["dynamic"],
           "properties": {
             "dynamic": {
               "type": "array",
@@ -622,9 +580,7 @@
           }
         },
         {
-          "required": [
-            "version"
-          ],
+          "required": ["version"],
           "properties": {
             "version": true
           }
@@ -633,9 +589,7 @@
       "dependencies": {
         "version": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -648,9 +602,7 @@
         },
         "description": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -663,9 +615,7 @@
         },
         "readme": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -678,9 +628,7 @@
         },
         "requires-python": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -693,9 +641,7 @@
         },
         "license": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -710,9 +656,7 @@
           "allOf": [
             {
               "not": {
-                "required": [
-                  "dynamic"
-                ],
+                "required": ["dynamic"],
                 "properties": {
                   "dynamic": {
                     "type": "array",
@@ -734,9 +678,7 @@
         },
         "authors": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -749,9 +691,7 @@
         },
         "maintainers": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -764,9 +704,7 @@
         },
         "keywords": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -779,9 +717,7 @@
         },
         "classifiers": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -794,9 +730,7 @@
         },
         "urls": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -809,9 +743,7 @@
         },
         "scripts": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -824,9 +756,7 @@
         },
         "gui-scripts": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -839,9 +769,7 @@
         },
         "entry-points": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -854,9 +782,7 @@
         },
         "dependencies": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -869,9 +795,7 @@
         },
         "optional-dependencies": {
           "not": {
-            "required": [
-              "dynamic"
-            ],
+            "required": ["dynamic"],
             "properties": {
               "dynamic": {
                 "type": "array",
@@ -1019,11 +943,7 @@
   "title": "JSON schema for Python project metadata and configuration",
   "type": "object",
   "x-taplo-info": {
-    "authors": [
-      "zevisert (https://github.com/zevisert)"
-    ],
-    "pattern": [
-      "^(.*(/|\\\\)pyproject\\.toml|pyproject\\.toml)$"
-    ]
+    "authors": ["zevisert (https://github.com/zevisert)"],
+    "pattern": ["^(.*(/|\\\\)pyproject\\.toml|pyproject\\.toml)$"]
   }
 }


### PR DESCRIPTION
change 'x-tombi-table-keys-order-by' to 'x-tombi-table-keys-order'.

NOTE: Tombi accepts both `x-tombi-table-keys-order-by` and `x-tombi-table-keys-order` now, but in the future `x-tombi-table-keys-order-by` will be used as another feature.