### PR TITLE
Add info to rev property in cargo manifest

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -184,11 +184,11 @@
           }
         },
         "rev": {
-          "description": "Specify the Git revision to use in case of a [Git dependency](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories).",
+          "description": "Specify the Git revision to use in case of a [Git dependency](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choice-of-commit).\n\nThis can be a commit hash, or a named reference exposed by the remote repository. GitHub Pull Requests may be specified using the `refs/pull/ID/head` format.",
           "type": "string",
           "x-taplo": {
             "links": {
-              "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories"
+              "key": "https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choice-of-commit"
             }
           }
         },


### PR DESCRIPTION
When I infrequently want to patch a dependency to point at a github PR, I always have to read the docs to find the exact format of the rev field. This commit adds a bit more detail to the field covering this use case, and corrects the direct link to the section of the cargo reference docs where this field is defined

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
