### PR TITLE
Add peerDependencyRules missing type

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -973,6 +973,7 @@
           "additionalProperties": false
         },
         "peerDependencyRules": {
+          "type": "object",
           "properties": {
             "ignoreMissing": {
               "description": "pnpm will not print warnings about missing peer dependencies from this list.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
It seems a bit strange that a missing `type` field in `pnpm-workspace.json` will cause ci errors, but a missing `package.json` will not.