### PR TITLE
Allow `pnpm-workspace.yaml` with no `packages` field

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -267,6 +267,5 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false,
-  "required": ["packages"]
+  "additionalProperties": false
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
This PR removes `packages` as a required filed for `pnpm-workspace.yaml`.

### Refs:

- https://github.com/pnpm/pnpm/pull/8969#issuecomment-2614324388