### PR TITLE
feat(commitlint): add valid values for fileMatch key for Commitlint configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6080,7 +6080,7 @@
     {
       "name": "commitlint (.commitlintrc)",
       "description": "commitlint configuration files",
-      "fileMatch": [".commitlintrc", ".commitlintrc.json"],
+      "fileMatch": [".commitlintrc", ".commitlintrc.{json,yaml,yml}"],
       "url": "https://json.schemastore.org/commitlintrc.json"
     },
     {


### PR DESCRIPTION
Similar pull request — **#2965**.

Commitlint [**officially supports configuration filenames `.commitlintrc.yaml` and `.commitlintrc.yml`**](https://commitlint.js.org/reference/configuration.html#config-via-file). Commitlint uses [**Cosmiconfig**](https://github.com/cosmiconfig/cosmiconfig) configuration that allow to use the same properties in configuration files with different markups and extensions. In particular, Cosmiconfig allows using configuration files with extensions `.json`, `.yaml` and `yml`.

Thanks.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->