### PR TITLE
Avoid using groups in `commitlint`'s `fileMatch`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6080,7 +6080,12 @@
     {
       "name": "commitlint (.commitlintrc)",
       "description": "commitlint configuration files",
-      "fileMatch": [".commitlintrc", ".commitlintrc.{json,yaml,yml}"],
+      "fileMatch": [
+        ".commitlintrc",
+        ".commitlintrc.json",
+        ".commitlintrc.yaml",
+        ".commitlintrc.yml"
+      ],
       "url": "https://json.schemastore.org/commitlintrc.json"
     },
     {


### PR DESCRIPTION
[`925f0e4`](https://github.com/SchemaStore/schemastore/commit/925f0e4698fee30747dc2b95a16f5726a67ad324), merged about two hours ago, caused [an uproar](https://youtrack.jetbrains.com/issues?q=Cannot%20nest%20groups%20near%20index%2029) on YouTrack (cc @Kristinita).

The stacktrace boils down to this:

```text
java.util.regex.PatternSyntaxException: Cannot nest groups near index 29
{.commitlintrc,.commitlintrc.{json,yaml,yml}}
                             ^
```

While this might be a client-side problem (Or maybe not? I'm not sure.), I think it is also easier to fix on SchemaStore's side: the group can simply be expanded manually.