### PR TITLE
feat: add CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,8 @@ src/negative_test/venvironment-* @vectorgrp/canoe-ci-tools @raphael-grimm @Joerg
 # Managed by CTFer.io team:
 src/schemas/json/ctfd.json @pandatix @NicoFgrx
 src/test/ctfd/* @pandatix @NicoFgrx
+
+# Managed by tombi-toml team:
+src/schemas/json/cargo.json @yassun7010
+src/schemas/json/tombi.json @yassun7010
+src/schemas/json/pyproject.json @yassun7010


### PR DESCRIPTION
Throughout the development of [tombi](https://github.com/tombi-toml/tombi), I have made many changes to Cargo.toml/pyproject.toml.

I got a suggestion from @hyperupcall,
I have added codeowner permissions to the toml file that I am supposed to work on.
