### PR TITLE
fix: cargo toml.

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -831,7 +831,7 @@
       }
     },
     "ProfileWithBuildOverride": {
-      "allOf": [
+      "anyOf": [
         {
           "$ref": "#/definitions/Profile"
         },


### PR DESCRIPTION
In the case of using `allOf`, all the object's elements. `additionalProperties = “true”` or use `anyOf`.