### PR TITLE
feat(tsconfig): Add `ESNext.Iterator` lib item

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -963,6 +963,7 @@
                       "ESNext.BigInt",
                       "ESNext.Collection",
                       "ESNext.Intl",
+                      "ESNext.Iterator",
                       "ESNext.Object",
                       "ESNext.Promise",
                       "ESNext.Regexp",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -967,6 +967,7 @@
                       "ESNext.BigInt",
                       "ESNext.Collection",
                       "ESNext.Intl",
+                      "ESNext.Iterator",
                       "ESNext.Object",
                       "ESNext.Promise",
                       "ESNext.Regexp",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Refs: 
- https://unpkg.com/browse/typescript@5.8.2/lib/lib.esnext.d.ts
- https://node.green/#ES2025-features-Iterator-Helpers

In order to use the new iterator helpers, currently you have to add `ESNext.Iterator` into tsconfig's `lib`, but vscode shows a validation error there.

Feel free to ignore/close if this is supposed to become simply `ES2025` target, but that's not the case with typescript currently.