### PR TITLE
Support `devEngines` field in `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -308,7 +308,9 @@
     "devEngineDependency": {
       "description": "Specifies requirements for development environment components such as operating systems, runtimes, or package managers. Used to ensure consistent development environments across the team.",
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -320,7 +322,12 @@
         },
         "onFail": {
           "type": "string",
-          "enum": ["ignore", "warn", "error", "download"],
+          "enum": [
+            "ignore",
+            "warn",
+            "error",
+            "download"
+          ],
           "description": "What action to take if validation fails"
         }
       }
@@ -836,50 +843,70 @@
       "properties": {
         "os": {
           "oneOf": [
-            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
             {
               "type": "array",
-              "items": { "$ref": "#/definitions/devEngineDependency" }
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
             }
           ],
           "description": "Specifies which operating systems are supported for development"
         },
         "cpu": {
           "oneOf": [
-            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
             {
               "type": "array",
-              "items": { "$ref": "#/definitions/devEngineDependency" }
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
             }
           ],
           "description": "Specifies which CPU architectures are supported for development"
         },
         "libc": {
           "oneOf": [
-            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
             {
               "type": "array",
-              "items": { "$ref": "#/definitions/devEngineDependency" }
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
             }
           ],
           "description": "Specifies which C standard libraries are supported for development"
         },
         "runtime": {
           "oneOf": [
-            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
             {
               "type": "array",
-              "items": { "$ref": "#/definitions/devEngineDependency" }
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
             }
           ],
           "description": "Specifies which JavaScript runtimes (like Node.js, Deno, Bun) are supported for development. Values should use WinterCG Runtime Keys (see https://runtime-keys.proposal.wintercg.org/)"
         },
         "packageManager": {
           "oneOf": [
-            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
             {
               "type": "array",
-              "items": { "$ref": "#/definitions/devEngineDependency" }
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
             }
           ],
           "description": "Specifies which package managers are supported for development"

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -304,6 +304,26 @@
       "required": [
         "url"
       ]
+    },
+    "devEngineDependency": {
+      "description": "Specifies requirements for development environment components such as operating systems, runtimes, or package managers. Used to ensure consistent development environments across the team.",
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the dependency, with allowed values depending on the parent field"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version range for the dependency"
+        },
+        "onFail": {
+          "type": "string",
+          "enum": ["ignore", "warn", "error", "download"],
+          "description": "What action to take if validation fails"
+        }
+      }
     }
   },
   "type": "object",
@@ -808,6 +828,62 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "devEngines": {
+      "description": "Define the runtime and package manager for developing the current project.",
+      "type": "object",
+      "properties": {
+        "os": {
+          "oneOf": [
+            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/devEngineDependency" }
+            }
+          ],
+          "description": "Specifies which operating systems are supported for development"
+        },
+        "cpu": {
+          "oneOf": [
+            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/devEngineDependency" }
+            }
+          ],
+          "description": "Specifies which CPU architectures are supported for development"
+        },
+        "libc": {
+          "oneOf": [
+            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/devEngineDependency" }
+            }
+          ],
+          "description": "Specifies which C standard libraries are supported for development"
+        },
+        "runtime": {
+          "oneOf": [
+            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/devEngineDependency" }
+            }
+          ],
+          "description": "Specifies which JavaScript runtimes (like Node.js, Deno, Bun) are supported for development. Values should use WinterCG Runtime Keys (see https://runtime-keys.proposal.wintercg.org/)"
+        },
+        "packageManager": {
+          "oneOf": [
+            { "$ref": "#/definitions/devEngineDependency" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/devEngineDependency" }
+            }
+          ],
+          "description": "Specifies which package managers are supported for development"
+        }
       }
     },
     "preferGlobal": {

--- a/src/test/package/devEngines.json
+++ b/src/test/package/devEngines.json
@@ -1,0 +1,43 @@
+{
+  "devEngines": {
+    "cpu": [
+      {
+        "name": "arm"
+      },
+      {
+        "name": "x86"
+      }
+    ],
+    "libc": {
+      "name": "glibc"
+    },
+    "os": {
+      "name": "darwin",
+      "version": ">= 23.0.0"
+    },
+    "packageManager": [
+      {
+        "name": "bun",
+        "onFail": "ignore",
+        "version": ">= 1.0.0"
+      },
+      {
+        "name": "yarn",
+        "onFail": "download",
+        "version": "3.2.3"
+      }
+    ],
+    "runtime": [
+      {
+        "name": "bun",
+        "onFail": "ignore",
+        "version": ">= 1.0.0"
+      },
+      {
+        "name": "node",
+        "onFail": "error",
+        "version": ">= 20.0.0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
It's a [standardization effort by the OpenJS Foundation](https://github.com/openjs-foundation/package-metadata-interoperability-collab-space/blob/43e31689ae1fff8c46b617548655a3f60e0c9387/devengines-field-proposal.md) and has been implemented in [NPM 10.9.0](https://github.com/npm/cli/pull/7766) and [Corepack 0.32.0](https://github.com/nodejs/corepack/pull/643).