### PR TITLE
feat: add uv to dependabot 2.0 schema

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -666,7 +666,8 @@
         "pip",
         "pub",
         "swift",
-        "terraform"
+        "terraform",
+        "uv"
       ]
     },
     "schedule-day": {


### PR DESCRIPTION
Adds `uv` as a valid schema to `dependabot-2.0.json`.

## Purpose

This corrects an invalid schema warning as seen below, since `uv` is now supported by Dependabot.

![Screenshot 2025-03-13 at 18 13 42](https://github.com/user-attachments/assets/51300616-d6d5-4e16-8248-655cf946cb09)


Ref: https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/
Ref: https://github.com/dependabot/dependabot-core/issues/10478

## Validation

```bash
$ node ./cli.js check --schema-name=dependabot-2.0.json | pbcopy
===== VALIDATE PRECONDITIONS =====
✔️ Directory structure conforms to expected layout
✔️ catalog.json validates against its schema
✔️ catalog.json has no fields that break guidelines
✔️ catalog.json has no duplicate "fileMatch" values
✔️ catalog.json has no invalid schema URLs
✔️ catalog.json has all local entries that exist in file total
✔️ schema-validation.jsonc validates against its schema
✔️ schema-validation.jsonc has no invalid schema names
✔️ schema-validation.jsonc has no invalid schema URLs
✔️ schema-validation.jsonc has no invalid skiptest[] entries
===== VALIDATE SCHEMAS =====
✔️ Completed "pre-checks"
✔️ Completed "Ajv validation"
===== REPORT =====
Out of 1525 TOTAL schemas:
- 686 (45%) are SchemaStore URLs
- 839 (55%) are External URLs

Out of 685 TESTED schemas:
- 278 (41%) are validated with Ajv's strict mode
- 185 (27%) do not have tests.
- 567 (83%) do not have negative tests.

Out of 1 TESTED schemas:
- Total  2020-12: 0
- Total  2019-09: 0
- Total draft-07: 1
- Total draft-06: 0
- Total draft-04: 0
- Total draft-03: 0
```
