### PR TITLE
Improve flexibility in naming of ksail configs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2317,14 +2317,20 @@
       "name": "KSail",
       "description": "Configuration for KSail",
       "fileMatch": [
-        "ksail-cluster.yaml",
-        "ksail-cluster.yml",
-        "ksail-config.yaml",
-        "ksail-config.yml",
-        "ksail.yaml",
-        "ksail.yml",
+        "ksail-*.yaml",
+        "ksail-*.yml",
+        "ksail_*.yaml",
+        "ksail_*.yml",
+        "ksail.*.yaml",
+        "ksail.*.yml",
+        "*-ksail.yaml",
+        "*-ksail.yml",
+        "*_ksail.yaml",
+        "*_ksail.yml",
         "*.ksail.yaml",
-        "*.ksail.yml"
+        "*.ksail.yml",
+        "ksail.yaml",
+        "ksail.yml"
       ],
       "url": "https://raw.githubusercontent.com/devantler/ksail/refs/heads/main/schemas/ksail-cluster-schema.json"
     },


### PR DESCRIPTION
I revised the ksail fileMatches to be a bit more flexible.
