### PR TITLE
fix(pytest): asyncio property errors

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -5,7 +5,14 @@
   "type": "object",
   "properties": {
     "ini_options": {
-      "$ref": "#/definitions/IniOptions",
+      "allOf": [
+        {
+          "$ref": "#/definitions/IniOptions"
+        },
+        {
+          "$ref": "#/definitions/IniOptionsAsyncio"
+        }
+      ],
       "title": "Bridge Configuration Options for `pytest.ini` File",
       "description": "The `ini_options` table is used as a bridge between the existing `pytest.ini` configuration system and future configuration formats. `pytest.ini` takes precedence over `[tool.pytest.ini_options]` in `pyproject.toml`."
     }
@@ -14,6 +21,7 @@
   "x-tombi-table-keys-order": "schema",
   "definitions": {
     "IniOptions": {
+      "$comment": "additionalProperties is true because the schema is merged with other schemas",
       "type": "object",
       "properties": {
         "addopts": {
@@ -285,8 +293,47 @@
           "default": false
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "x-tombi-table-keys-order": "schema"
+    },
+    "IniOptionsAsyncio": {
+      "$comment": "additionalProperties is true because the schema is merged with other schemas",
+      "description": "Configuration options for pytest-asyncio.\nhttps://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html",
+      "type": "object",
+      "properties": {
+        "asyncio_default_fixture_loop_scope": {
+          "$ref": "#/definitions/AsyncioScope",
+          "type": "string",
+          "description": "Default event loop scope of asynchronous fixtures. When this configuration option is unset, it defaults to the fixture scope. In future versions of pytest-asyncio, the value will default to function when unset"
+        },
+        "asyncio_default_test_loop_scope": {
+          "$ref": "#/definitions/AsyncioScope",
+          "type": "string",
+          "description": "Default event loop scope of asynchronous tests. When this configuration option is unset, it default to function scope",
+          "default": "function"
+        },
+        "asyncio_mode": {
+          "type": "string",
+          "oneOf": [
+            {
+              "const": "auto",
+              "description": "Automatically handling all async functions by the plugin"
+            },
+            {
+              "const": "strict",
+              "description": "Auto processing disabling (useful if different async frameworks should be tested together, e.g. both pytest-asyncio and pytest-trio are used in the same project"
+            }
+          ],
+          "description": "Sets the asyncio mode for pytest-asyncio.",
+          "default": "strict"
+        }
+      },
+      "additionalProperties": true,
+      "x-tombi-table-keys-order": "schema"
+    },
+    "AsyncioScope": {
+      "type": "string",
+      "enum": ["function", "class", "module", "package", "session"]
     },
     "LogLevel": {
       "type": "string",


### PR DESCRIPTION
Fix errors flagged due to properties in pytest section of pyproject.toml when asyncio options are configured.

The additional properties were defined based off the pytest-asyncio configuration specification here:
https://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html