### PR TITLE
fix: prettier config inconsistencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         types_or: ['yaml', 'json', 'javascript', 'css', 'markdown']
         always_run: true
         additional_dependencies:
-          - 'prettier@3.4.2'
+          - 'prettier@3.5.2'
           - 'prettier-plugin-sort-json@4.0.0'
           - 'prettier-plugin-toml@2.0.1'
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,14 @@ repos:
           - 'prettier-plugin-sort-json@4.0.0'
           - 'prettier-plugin-toml@2.0.1'
         pass_filenames: true
-        args: ['--no-color', '--log-level=warn', '--write']
+        args:
+          [
+            '--no-color',
+            '--log-level=warn',
+            '--write',
+            '--config=.prettierrc.cjs',
+            '--ignore-path=.gitignore',
+          ]
   - repo: 'https://github.com/codespell-project/codespell'
     rev: 'v2.4.1'
     hooks:

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -992,7 +992,10 @@
       "unknownKeywords": ["markdownDescription", "x-intellij-html-description"]
     },
     "partial-pytest.json": {
-      "unknownKeywords": ["x-tombi-array-values-order", "x-tombi-table-keys-order"]
+      "unknownKeywords": [
+        "x-tombi-array-values-order",
+        "x-tombi-table-keys-order"
+      ]
     },
     "partial-setuptools.json": {
       "unknownFormat": [

--- a/src/test/pep-723/2.toml
+++ b/src/test/pep-723/2.toml
@@ -1,8 +1,6 @@
 #:schema ../../schemas/json/pep-723.json
 requires-python = ""
-dependencies = [
-  "a-n-plus-b>=0.0.1"
-]
+dependencies = ["a-n-plus-b>=0.0.1"]
 
 [tool.ruff]
 select = ["RUF001"]

--- a/src/test/prettierrc/.prettierrc.yml
+++ b/src/test/prettierrc/.prettierrc.yml
@@ -6,11 +6,11 @@ tabWidth: 4
 semi: false
 singleQuote: true
 overrides:
-    - files: '*.test.js'
-      options:
-          semi: true
-    - files:
-          - '*.html'
-          - 'legacy/**/*.js'
-      options:
-          tabWidth: 4
+  - files: '*.test.js'
+    options:
+      semi: true
+  - files:
+      - '*.html'
+      - 'legacy/**/*.js'
+    options:
+      tabWidth: 4

--- a/src/test/prettierrc/prettierrc.json
+++ b/src/test/prettierrc/prettierrc.json
@@ -1,32 +1,32 @@
 {
-    "arrowParens": "always",
-    "bracketSameLine": false,
-    "bracketSpacing": true,
-    "htmlWhitespaceSensitivity": "css",
-    "insertPragma": false,
-    "jsxBracketSameLine": false,
-    "jsxSingleQuote": false,
-    "overrides": [
-        {
-            "files": ["*/*.Rmd"],
-            "options": {
-                "parser": "markdown"
-            }
-        },
-        {
-            "files": ["*/*.type"],
-            "options": {
-                "parser": "custom"
-            }
-        }
-    ],
-    "printWidth": 80,
-    "proseWrap": "preserve",
-    "quoteProps": "as-needed",
-    "requirePragma": false,
-    "semi": true,
-    "singleQuote": false,
-    "tabWidth": 2,
-    "trailingComma": "all",
-    "useTabs": false
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "overrides": [
+    {
+      "files": ["*/*.Rmd"],
+      "options": {
+        "parser": "markdown"
+      }
+    },
+    {
+      "files": ["*/*.type"],
+      "options": {
+        "parser": "custom"
+      }
+    }
+  ],
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
 }

--- a/src/test/pyproject/poetry-dependencies-no-python.toml
+++ b/src/test/pyproject/poetry-dependencies-no-python.toml
@@ -3,9 +3,7 @@
 name = "dependencies-no-python"
 version = "0.1.0"
 description = ""
-authors = [
-    {name = "Elvis Presley",email = "theking@example.com"}
-]
+authors = [{ name = "Elvis Presley", email = "theking@example.com" }]
 requires-python = ">=3.8"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Update version of prettier version in `.pre-commit-config.yaml` with that from `package.json`.

Sync the config of prettier in the pre commit hook with that of `npm` so we don't get conflicts between the two.

Run prettier fix across the code base to ensure formatting abides by the standard.
