### PR TITLE
fix: enable prettier pre commit check on jsonc files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
         pass_filenames: true
         args:
           [
-            '--no-color',
             '--log-level=warn',
             '--check',
             '--config=.prettierrc.cjs',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,7 @@ repos:
     rev: 'v3.5.3'
     hooks:
       - id: 'prettier'
-        # TODO: Add 'jsonc' so 'src/schema-validation.jsonc' is checked in CI
-        # Error: "Type tag 'jsonc' is not recognized.  Try upgrading identify and pre-commit?"
-        types_or: ['yaml', 'json', 'javascript', 'css', 'markdown']
-        always_run: true
+        types: [text]
         additional_dependencies:
           - 'prettier@3.5.2'
           - 'prettier-plugin-sort-json@4.0.0'
@@ -17,7 +14,7 @@ repos:
           [
             '--no-color',
             '--log-level=warn',
-            '--write',
+            '--check',
             '--config=.prettierrc.cjs',
             '--ignore-path=.gitignore',
           ]


### PR DESCRIPTION
Enable the pre commit prettier check on jsonc files by enabling it for all files which identify as text.

Disable always run as passing no files would just error.

Enable color in pre commit hook as it has no impact on action but when run locally allows the user to see the issue more readily.