### PR TITLE
fix(pytest): add string as valid option for all string arrays

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -25,10 +25,17 @@
       "type": "object",
       "properties": {
         "addopts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Extra command line options to be added by default.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -58,10 +65,17 @@
           "description": "Sets default encoding for doctest files."
         },
         "doctest_optionflags": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Specifies doctest flag names from the `doctest` module.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -76,10 +90,17 @@
           "description": "Sets timeout in seconds for dumping the traceback of all threads if a test takes too long."
         },
         "filterwarnings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Sets action to take for matching warnings. Each item is a warning specification string.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -173,10 +194,17 @@
           "description": "Sets minimum log level for captured logging. Can be level name or integer value."
         },
         "markers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Allows registering additional markers for test functions.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -200,10 +228,17 @@
           "x-tombi-array-values-order": "ascending"
         },
         "python_classes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Specifies name prefixes or glob patterns for identifying test classes.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -224,35 +259,63 @@
           "x-tombi-array-values-order": "ascending"
         },
         "python_functions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Specifies name prefixes or glob patterns for identifying test functions and methods.",
           "default": ["test_*"],
           "x-tombi-array-values-order": "ascending"
         },
         "pythonpath": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Sets list of directories to be added to the Python search path. Paths are relative to root directory.",
           "x-tombi-array-values-order": "ascending"
         },
         "required_plugins": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Space-separated list of plugins required to run pytest. Can include version specifiers.",
           "x-tombi-array-values-order": "ascending"
         },
         "testpaths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "Sets directories to search for tests when no specific paths are given on the command line. Paths are relative to root directory. Shell-style wildcards can be used.",
           "x-tombi-array-values-order": "ascending"
         },
@@ -268,10 +331,17 @@
           "default": "all"
         },
         "usefixtures": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ],
           "description": "List of fixtures that will be applied to all test functions.",
           "x-tombi-array-values-order": "ascending"
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
This makes string a valid options in every place a string array can be used. Fixes #4572. 

From some tests I made, it seem to me that this is valid to emulate the .ini file behavior. Let me know if you think anything needs changing. Thanks!