### PR TITLE
feat: add docker-compose to to dependabot 2.0 schema

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -653,6 +653,7 @@
         "composer",
         "devcontainers",
         "docker",
+        "docker-compose",
         "dotnet-sdk",
         "elm",
         "gitsubmodule",


### PR DESCRIPTION
Adds docker-compose as a valid schema to dependabot-2.0.json.

## Purpose
`docker-compose` is now supported by Dependabot.

Ref: https://github.blog/changelog/2025-02-25-dependabot-version-updates-now-support-docker-compose-in-general-availability/
Ref: https://docs.github.com/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories

## Validation
```bash
$ node ./cli.js check --schema-name=dependabot-2.0.json | pbcopy
===== VALIDATE PRECONDITIONS =====
✔️ Directory structure conforms to expected layout
✔️ catalog.json validates against its schema
✔️ catalog.json has no fields that break guidelines
✔️ catalog.json has no duplicate "fileMatch" values
✔️ catalog.json has no invalid schema URLs
✔️ catalog.json has all local entries that exist in file total
✔️ schema-validation.jsonc validates against its schema
✔️ schema-validation.jsonc has no invalid schema names
✔️ schema-validation.jsonc has no invalid schema URLs
✔️ schema-validation.jsonc has no invalid skiptest[] entries
===== VALIDATE SCHEMAS =====
✔️ Completed "pre-checks"
✔️ Completed "Ajv validation"
===== REPORT =====
Out of 1528 TOTAL schemas:
- 689 (45%) are SchemaStore URLs
- 839 (55%) are External URLs

Out of 688 TESTED schemas:
- 278 (40%) are validated with Ajv's strict mode
- 188 (27%) do not have tests.
- 570 (83%) do not have negative tests.

Out of 1 TESTED schemas:
- Total  2020-12: 0
- Total  2019-09: 0
- Total draft-07: 1
- Total draft-06: 0
- Total draft-04: 0
- Total draft-03: 0
```