### PR TITLE
Add Homer dashboard schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2796,6 +2796,12 @@
       "url": "https://hazelcast.com/schema/config/hazelcast-config-5.5.json"
     },
     {
+      "name": "Homer dashboard configuration",
+      "description": "Home dashboard configuration file. Documentation: https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/bastienwirtz/homer/main/.schema/config-schema.json"
+    },
+    {
       "name": "host.json",
       "description": "Azure Functions host.json files",
       "fileMatch": ["host.json"],


### PR DESCRIPTION
Homer configuration is documented: https://github.com/bastienwirtz/homer/blob/main/docs/configuration.md

Schema is located here: https://github.com/bastienwirtz/homer/blob/main/.schema/config-schema.json
Documentation on the usage is here: https://github.com/bastienwirtz/homer/blob/main/docs/tips-and-tricks.md#yaml-auto-complete-with-a-yaml-schema
