### PR TITLE
Add the "source" key as option to hatch.version

### DIFF
--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -733,6 +733,16 @@
             }
           },
           "type": "string"
+        },
+        "source": {
+          "title": "Source",
+          "description": "A source to use for retrieving and updating the version.",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/latest/version/#configuration"
+            }
+          },
+          "type": "string"
         }
       }
     },

--- a/src/test/hatch/version-source.toml
+++ b/src/test/hatch/version-source.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/hatch.json
+[version]
+source = "uv-dynamic-versioning"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Hi all,
I noticed that the `hatch.version.source` option used by tools like uv-dynamic-versioning is not recognized by the json, even if it stated in the hatch documentation.
Hope this fix is the way you want it to be. :)