### PR TITLE
Remove extra match

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7752,7 +7752,7 @@
     {
       "name": "Open Know-How",
       "description": "Open Source Hardware project metadata",
-      "fileMatch": ["okh.{json,toml,yml,yaml}", "*.okh.{json,toml,yml,yaml}"],
+      "fileMatch": ["okh.{json,toml,yml,yaml}"],
       "url": "https://json.schemastore.org/okh.json"
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

I [received a report](https://github.com/SchemaStore/schemastore/commit/a3ff09cf4a55fc143fcaf7afccc5ea036d663243#commitcomment-153993289) that #4578 broke JetBrains. This falls in line with similar reports that JetBrains does not behave correctly when there are more than one elements in `fileMatch` that have a glob pattern.

This patch fixes that, preventing any breakages in JetBrains IDE.