### PR TITLE
fix: use official schema for AWS CloudFormation

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1530,7 +1530,7 @@
         "cloudformation.yml",
         "cloudformation.yaml"
       ],
-      "url": "https://cfn-resource-specifications-us-east-1-prod.s3.us-east-1.amazonaws.com/latest/gzip/CloudFormationResourceSpecification.json"
+      "url": "https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json"
     },
     {
       "name": "AWS CloudFormation Serverless Application Model (SAM)",


### PR DESCRIPTION
Update the JSON schema for AWS CloudFormation with the official one. 
Moreover, the current one (awslabs/goformation) is deprecated and archived.