### PR TITLE
Add an entry for convex.json schemas for Convex.dev projects

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1037,9 +1037,9 @@
     },
     {
       "name": "Convex",
-      "description": "Configuration schema for Convex project settings",
+      "description": "Configuration for Convex project settings",
       "fileMatch": ["convex.json"],
-      "url": "https://json.schemastore.org/convex.json"
+      "url": "https://raw.githubusercontent.com/get-convex/convex-backend/refs/heads/main/npm-packages/convex/schemas/convex.schema.json"
     },
     {
       "name": "Conjure",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1036,6 +1036,12 @@
       "url": "https://raw.githubusercontent.com/conda-forge/conda-smithy/main/conda_smithy/data/conda-forge.json"
     },
     {
+      "name": "Convex",
+      "description": "Configuration schema for Convex project settings",
+      "fileMatch": ["convex.json"],
+      "url": "https://json.schemastore.org/convex.json"
+    },
+    {
       "name": "Conjure",
       "description": "Conjure Human-Readable Format",
       "fileMatch": ["**/conjure/**.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1039,7 +1039,7 @@
       "name": "Convex",
       "description": "Configuration for Convex project settings",
       "fileMatch": ["convex.json"],
-      "url": "https://raw.githubusercontent.com/get-convex/convex-backend/refs/heads/main/npm-packages/convex/schemas/convex.schema.json"
+      "url": "https://json.schemastore.org/convex.json"
     },
     {
       "name": "Conjure",

--- a/src/schemas/json/convex.json
+++ b/src/schemas/json/convex.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/convex.json",
-  "description": "Configuration schema for Convex project settings.\n\nDocumentation: https://docs.convex.dev/production/project-configuration#convexjson",
+  "description": "Configuration for Convex project settings.\n\nDocumentation: https://docs.convex.dev/production/project-configuration#convexjson",
   "type": "object",
   "properties": {
     "$schema": {

--- a/src/schemas/json/convex.json
+++ b/src/schemas/json/convex.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/convex.json",
+  "description": "Configuration schema for Convex project settings.\n\nDocumentation: https://docs.convex.dev/production/project-configuration#convexjson",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "node": {
+      "type": "object",
+      "description": "Configuration for the Convex Node.js runtime, where your actions run that have 'use node' at the top of the file.",
+      "properties": {
+        "externalPackages": {
+          "type": ["array"],
+          "description": "List of packages that should be installed on the server instead of being bundled by the CLI. Use this for packages that can't be bundled or need to be installed directly on the server.\n\nIf you want to mark all dependencies as external, you can use the string '*' instead of an array.\n\nhttps://docs.convex.dev/functions/bundling#external-packages",
+          "items": {
+            "type": "string"
+          },
+          "default": ["*"],
+          "oneOf": [
+            {
+              "contains": {
+                "const": "*"
+              },
+              "maxItems": 1
+            },
+            {
+              "not": {
+                "contains": {
+                  "const": "*"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "generateCommonJSApi": {
+      "type": "boolean",
+      "description": "When true, generates CommonJS-compatible API files for projects not using ES modules. Enable this if your project uses require() syntax instead of ES modules.\n\nhttps://docs.convex.dev/client/javascript/node#javascript-with-commonjs-require-syntax",
+      "default": false
+    },
+    "functions": {
+      "type": "string",
+      "description": "Path to the directory containing Convex functions. You can customize this to use a different location than the default 'convex/' directory.\n\nhttps://docs.convex.dev/production/project-configuration#changing-the-convex-folder-name-or-location",
+      "default": "convex/"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/convex/convex.json
+++ b/src/test/convex/convex.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/convex.json",
+  "functions": "convex/",
+  "generateCommonJSApi": false,
   "node": {
     "externalPackages": ["*"]
-  },
-  "generateCommonJSApi": false,
-  "functions": "convex/"
+  }
 }

--- a/src/test/convex/convex.json
+++ b/src/test/convex/convex.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/convex.json",
+  "node": {
+    "externalPackages": ["*"]
+  },
+  "generateCommonJSApi": false,
+  "functions": "convex/"
+}


### PR DESCRIPTION
Convex.dev projects use a convex.json file in the root of the project if they need some configuration that can't live in code. 
Add a schema for it, and a test
https://docs.convex.dev/production/project-configuration#convexjson