### PR TITLE
schemas: okh: Re-add support for prefixed files like "my-proj.okh.toml"

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7752,7 +7752,7 @@
     {
       "name": "Open Know-How",
       "description": "Open Source Hardware project metadata",
-      "fileMatch": ["okh.{json,toml,yml,yaml}"],
+      "fileMatch": ["?(*.)okh.{json,toml,yml,yaml}"],
       "url": "https://json.schemastore.org/okh.json"
     },
     {


### PR DESCRIPTION
... vs only plain ones: "okh.toml"


<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->