### PR TITLE
feat: add aqua config files to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -235,6 +235,26 @@
       "url": "https://raw.githubusercontent.com/Scandltd/storm-petrel/main/generator/assets/appsettings.StormPetrel.Schema.json"
     },
     {
+      "name": "aqua.yaml",
+      "description": "aqua configuration file",
+      "fileMatch": [
+        ".aqua.yaml",
+        ".aqua.yml",
+        "aqua.yaml",
+        "aqua.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json"
+    },
+    {
+      "name": "aqua-policy.yaml",
+      "description": "aqua policy configuration file",
+      "fileMatch": [
+        ".aqua-policy.yaml",
+        "aqua-policy.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/policy.json"
+    },
+    {
       "name": "arb.json",
       "description": "Application Resource Bundle",
       "fileMatch": ["arb.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -237,21 +237,13 @@
     {
       "name": "aqua.yaml",
       "description": "aqua configuration file",
-      "fileMatch": [
-        ".aqua.yaml",
-        ".aqua.yml",
-        "aqua.yaml",
-        "aqua.yml"
-      ],
+      "fileMatch": [".aqua.yaml", ".aqua.yml", "aqua.yaml", "aqua.yml"],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json"
     },
     {
       "name": "aqua-policy.yaml",
       "description": "aqua policy configuration file",
-      "fileMatch": [
-        ".aqua-policy.yaml",
-        "aqua-policy.yaml"
-      ],
+      "fileMatch": [".aqua-policy.yaml", "aqua-policy.yaml"],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/policy.json"
     },
     {


### PR DESCRIPTION
* https://aquaproj.github.io
* https://aquaproj.github.io/docs/reference/config/
* https://aquaproj.github.io/docs/reference/security/policy-as-code/

There's also [registry config](https://aquaproj.github.io/docs/reference/registry-config/) and its schema but it does not have distinctive enough filenames I think (`registry.yaml`) so I left it out.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
