### PR TITLE
Use boolean as type of StandardLibrary key in clangd schema

### DIFF
--- a/src/schemas/json/clangd.json
+++ b/src/schemas/json/clangd.json
@@ -515,7 +515,8 @@
         },
         "StandardLibrary": {
           "description": "Whether to index a standard library\nhttps://clangd.llvm.org/config.html#standardlibrary",
-          "enum": ["Yes", "No"]
+          "type": "boolean",
+          "default": true
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The example in the clangd documentation uses Yes/No because clangd uses a YAML 1.1 parser which accepts Yes/No for booleans, but we're looking to move away from that. All other boolean keys are specified as `"boolean"` in the schema, so for consistency, `StandardLibrary` should be too.