### PR TITLE
fix: readme properties.

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -216,9 +216,7 @@
             {
               "additionalProperties": false,
               "type": "object",
-              "required": [
-                "content-type"
-              ],
+              "required": ["content-type"],
               "properties": {
                 "content-type": {
                   "title": "README content-type",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -180,47 +180,53 @@
               "type": "string"
             },
             {
+              "additionalProperties": false,
               "type": "object",
-              "required": ["content-type"],
+              "required": ["file"],
               "properties": {
+                "file": {
+                  "title": "README file path",
+                  "type": "string"
+                },
                 "content-type": {
-                  "title": "README text content-type",
+                  "title": "README content-type",
                   "description": "RFC 1341 compliant content-type (with optional charset, defaulting to UTF-8)",
                   "type": "string"
                 }
               },
-              "oneOf": [
-                {
-                  "additionalProperties": false,
-                  "required": ["file"],
-                  "properties": {
-                    "file": {
-                      "title": "README file path",
-                      "type": "string"
-                    },
-                    "content-type": {
-                      "title": "README content-type",
-                      "type": "string"
-                    }
-                  },
-                  "x-tombi-table-keys-order": "schema"
+              "x-tombi-table-keys-order": "schema"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": ["text"],
+              "properties": {
+                "text": {
+                  "title": "README text",
+                  "type": "string"
                 },
-                {
-                  "additionalProperties": false,
-                  "required": ["text"],
-                  "properties": {
-                    "text": {
-                      "title": "README text",
-                      "type": "string"
-                    },
-                    "content-type": {
-                      "title": "README content-type",
-                      "type": "string"
-                    }
-                  },
-                  "x-tombi-table-keys-order": "schema"
+                "content-type": {
+                  "title": "README content-type",
+                  "description": "RFC 1341 compliant content-type (with optional charset, defaulting to UTF-8)",
+                  "type": "string"
                 }
-              ]
+              },
+              "x-tombi-table-keys-order": "schema"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "content-type"
+              ],
+              "properties": {
+                "content-type": {
+                  "title": "README content-type",
+                  "description": "RFC 1341 compliant content-type (with optional charset, defaulting to UTF-8)",
+                  "type": "string"
+                }
+              },
+              "x-tombi-table-keys-order": "schema"
             }
           ],
           "examples": [


### PR DESCRIPTION
Because the `oneOf` and `object` instructions are mixed, we have flattened them out.