### PR TITLE
feat: Support Apple App Site later versions

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -529,9 +529,6 @@
     "app-config.json": {
       "externalSchema": ["base.json"]
     },
-    "apple-app-site-association.json": {
-      "externalSchema": ["base-04.json"]
-    },
     "appsscript.json": {
       "externalSchema": ["base.json"]
     },

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -1,9 +1,50 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/apple-app-site-association.json",
-  "required": [
-    "applinks"
-  ],
+  "$defs": {
+    "app_id": {
+      "type": "string",
+      "pattern": "^[A-Z0-9]{10}\\.([A-Za-z]{1}[A-Za-z\\d_]*\\.)+[A-Za-z][A-Za-z\\d_]*$",
+      "title": "TeamID And AppID",
+      "description": "10 character TeamID followed by AppID"
+    },
+    "component": {
+      "type": "object",
+      "title": "AppID component",
+      "description": "A component for uri matching",
+      "additionalProperties": false,
+      "properties": {
+        "/": {
+          "type": "string",
+          "title": "Path component",
+          "description": "Define path matching"
+        },
+        "#": {
+          "type": "string",
+          "title": "Fragment component",
+          "description": "Define fragment matching"
+        },
+        "?": {
+          "title": "Query component",
+          "description": "Define Query matching",
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "exclude": {
+          "type": "boolean",
+          "title": "Exclusion flag",
+          "description": "Whether to exclude a specific match"
+        }
+      }
+    }
+  },
+  "required": ["applinks"],
   "title": "Apple Universal Links Config",
   "description": "Apple Universal Links Config Schema",
   "type": "object",
@@ -14,9 +55,7 @@
       "title": "Universalink Configurations",
       "description": "Universalink Configurations Schema",
       "additionalProperties": false,
-      "required": [
-        "details"
-      ],
+      "required": ["details"],
       "properties": {
         "apps": {
           "description": "Always empty [] for UniversaLink, can be omitted in later versions",
@@ -69,49 +108,6 @@
               }
             }
           }
-        }
-      }
-    }
-  },
-  "$defs": {
-    "app_id": {
-      "type": "string",
-      "pattern": "^[A-Z0-9]{10}\\.([A-Za-z]{1}[A-Za-z\\d_]*\\.)+[A-Za-z][A-Za-z\\d_]*$",
-      "title": "TeamID And AppID",
-      "description": "10 character TeamID followed by AppID"
-    },
-    "component": {
-      "type": "object",
-      "title": "AppID component",
-      "description": "A component for uri matching",
-      "additionalProperties": false,
-      "properties": {
-        "/": {
-          "type": "string",
-          "title": "Path component",
-          "description": "Define path matching"
-        },
-        "#": {
-          "type": "string",
-          "title": "Fragment component",
-          "description": "Define fragment matching"
-        },
-        "?": {
-          "title": "Query component",
-          "description": "Define Query matching",
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "exclude": {
-          "type": "boolean",
-          "title": "Exclusion flag",
-          "description": "Whether to exclude a specific match"
         }
       }
     }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -44,7 +44,9 @@
       }
     }
   },
-  "required": ["applinks"],
+  "required": [
+    "applinks"
+  ],
   "title": "Apple Universal Links Config",
   "description": "Apple Universal Links Config Schema",
   "type": "object",
@@ -55,7 +57,9 @@
       "title": "Universalink Configurations",
       "description": "Universalink Configurations Schema",
       "additionalProperties": false,
-      "required": ["details"],
+      "required": [
+        "details"
+      ],
       "properties": {
         "apps": {
           "description": "Always empty [] for UniversaLink, can be omitted in later versions",
@@ -94,7 +98,7 @@
                 "items": {
                   "type": "string",
                   "title": "Path",
-                  "description": "Single unique path to be matched againts"
+                  "description": "Single unique path to be matched against"
                 }
               },
               "components": {

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -2,6 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/apple-app-site-association.json",
   "$defs": {
+    "app_ids": {
+      "type": "array",
+      "title": "AppIDs",
+      "description": "Array of multiple AppIDs",
+      "items": {
+        "$ref": "#/$defs/app_id"
+      }
+    },
     "app_id": {
       "type": "string",
       "pattern": "^[A-Z0-9]{10}\\.([A-Za-z]{1}[A-Za-z\\d_]*\\.)+[A-Za-z][A-Za-z\\d_]*$",
@@ -44,18 +52,42 @@
       }
     }
   },
-  "required": ["applinks"],
+  "required": [
+    "applinks"
+  ],
   "title": "Apple Universal Links Config",
   "description": "Apple Universal Links Config Schema",
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "webcredentials": {
+      "type": "object",
+      "title": "Webcredentials Config",
+      "description": "Apple Webcredentials Config Schema",
+      "properties": {
+        "apps": {
+          "$ref": "#/$defs/app_ids"
+        }
+      }
+    },
+    "appclips": {
+      "type": "object",
+      "title": "AppClip Config",
+      "description": "Apple AppClip Config Schema",
+      "properties": {
+        "apps": {
+          "$ref": "#/$defs/app_ids"
+        }
+      }
+    },
     "applinks": {
       "type": "object",
       "title": "Universalink Configurations",
       "description": "Universalink Configurations Schema",
       "additionalProperties": false,
-      "required": ["details"],
+      "required": [
+        "details"
+      ],
       "properties": {
         "apps": {
           "description": "Always empty [] for UniversaLink, can be omitted in later versions",

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -44,9 +44,7 @@
       }
     }
   },
-  "required": [
-    "applinks"
-  ],
+  "required": ["applinks"],
   "title": "Apple Universal Links Config",
   "description": "Apple Universal Links Config Schema",
   "type": "object",
@@ -57,9 +55,7 @@
       "title": "Universalink Configurations",
       "description": "Universalink Configurations Schema",
       "additionalProperties": false,
-      "required": [
-        "details"
-      ],
+      "required": ["details"],
       "properties": {
         "apps": {
           "description": "Always empty [] for UniversaLink, can be omitted in later versions",

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -1,38 +1,70 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "An Apple Universal Link config schema",
-  "id": "https://json.schemastore.org/apple-app-site-association.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/apple-app-site-association.json",
+  "required": [
+    "applinks"
+  ],
+  "title": "Apple Universal Links Config",
+  "description": "Apple Universal Links Config Schema",
+  "type": "object",
+  "additionalProperties": false,
   "properties": {
     "applinks": {
-      "title": "application links",
-      "description": "Application links",
       "type": "object",
-      "required": ["apps", "details"],
+      "title": "Universalink Configurations",
+      "description": "Universalink Configurations Schema",
+      "additionalProperties": false,
+      "required": [
+        "details"
+      ],
       "properties": {
         "apps": {
-          "description": "Applications",
+          "description": "Always empty [] for UniversaLink, can be omitted in later versions",
           "type": "array",
-          "enum": [[]]
+          "const": []
         },
         "details": {
-          "description": "Details",
           "type": "array",
+          "description": "AppIDs's Universalink URI Matching Configuration",
+          "minItems": 1,
           "items": {
-            "title": "detail",
-            "description": "A detail",
+            "title": "AppID's matching details",
+            "description": "Details of specific AppIDs uri matching configuration",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-              "appID": {
-                "description": "An appID key or app ID prefix, followed by the bundle ID",
-                "type": "string"
-              },
-              "paths": {
-                "description": "Paths",
+              "appIDs": {
+                "title": "AppIDs",
+                "description": "Array of AppIDs",
                 "type": "array",
                 "uniqueItems": true,
+                "minItems": 1,
                 "items": {
-                  "$ref": "https://json.schemastore.org/base-04.json#/definitions/path",
-                  "description": "Path to open in the mobile app"
+                  "$ref": "#/$defs/app_id"
+                }
+              },
+              "appID": {
+                "$ref": "#/$defs/app_id"
+              },
+              "paths": {
+                "title": "Paths",
+                "description": "Array of paths to be matched against",
+                "type": "array",
+                "uniqueItems": true,
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "title": "Path",
+                  "description": "Single unique path to be matched againts"
+                }
+              },
+              "components": {
+                "type": "array",
+                "title": "URI Components",
+                "description": "Array of path components to be matched, available in later versions",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/component"
                 }
               }
             }
@@ -41,7 +73,47 @@
       }
     }
   },
-  "required": ["applinks"],
-  "title": "Apple Universal Link config",
-  "type": "object"
+  "$defs": {
+    "app_id": {
+      "type": "string",
+      "pattern": "^[A-Z0-9]{10}\\.([A-Za-z]{1}[A-Za-z\\d_]*\\.)+[A-Za-z][A-Za-z\\d_]*$",
+      "title": "TeamID And AppID",
+      "description": "10 character TeamID followed by AppID"
+    },
+    "component": {
+      "type": "object",
+      "title": "AppID component",
+      "description": "A component for uri matching",
+      "additionalProperties": false,
+      "properties": {
+        "/": {
+          "type": "string",
+          "title": "Path component",
+          "description": "Define path matching"
+        },
+        "#": {
+          "type": "string",
+          "title": "Fragment component",
+          "description": "Define fragment matching"
+        },
+        "?": {
+          "title": "Query component",
+          "description": "Define Query matching",
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "exclude": {
+          "type": "boolean",
+          "title": "Exclusion flag",
+          "description": "Whether to exclude a specific match"
+        }
+      }
+    }
+  }
 }

--- a/src/schemas/json/apple-app-site-association.json
+++ b/src/schemas/json/apple-app-site-association.json
@@ -52,9 +52,7 @@
       }
     }
   },
-  "required": [
-    "applinks"
-  ],
+  "required": ["applinks"],
   "title": "Apple Universal Links Config",
   "description": "Apple Universal Links Config Schema",
   "type": "object",
@@ -85,9 +83,7 @@
       "title": "Universalink Configurations",
       "description": "Universalink Configurations Schema",
       "additionalProperties": false,
-      "required": [
-        "details"
-      ],
+      "required": ["details"],
       "properties": {
         "apps": {
           "description": "Always empty [] for UniversaLink, can be omitted in later versions",

--- a/src/test/apple-app-site-association/apple-app-site-association-new-format.json
+++ b/src/test/apple-app-site-association/apple-app-site-association-new-format.json
@@ -3,7 +3,9 @@
     "apps": [],
     "details": [
       {
-        "appIDs": ["ABCDE12345.com.example.lunch"],
+        "appIDs": [
+          "ABCDE12345.com.example.lunch"
+        ],
         "components": [
           {
             "/": "*/order/"
@@ -27,7 +29,10 @@
       },
       {
         "appID": "ABCDE12345.com.example.app",
-        "appIDs": ["ABCDE12345.com.example.app", "9JA89QQLNQ.com.example.app2"],
+        "appIDs": [
+          "ABCDE12345.com.example.app",
+          "9JA89QQLNQ.com.example.app2"
+        ],
         "components": [
           {
             "/": "/path/*/filename"
@@ -39,8 +44,20 @@
             "?": "widget=?*"
           }
         ],
-        "paths": ["/path/*/filename"]
+        "paths": [
+          "/path/*/filename"
+        ]
       }
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "ABCDE12345.com.example.app"
+    ]
+  },
+  "appclips": {
+    "apps": [
+      "ABCDE12345.com.example.MyApp.Clip"
     ]
   }
 }

--- a/src/test/apple-app-site-association/apple-app-site-association-new-format.json
+++ b/src/test/apple-app-site-association/apple-app-site-association-new-format.json
@@ -1,0 +1,53 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": [
+          "ABCDE12345.com.example.lunch"
+        ],
+        "components": [
+          {
+            "/": "*/order/"
+          },
+          {
+            "/": "/taco/*",
+            "?": {
+              "cheese": "?*",
+              "taco": "???"
+            }
+          },
+          {
+            "#": "coupon-1???",
+            "exclude": true
+          },
+          {
+            "/": "",
+            "#": "coupon-????"
+          }
+        ]
+      },
+      {
+        "appID": "ABCDE12345.com.example.app",
+        "appIDs": [
+          "ABCDE12345.com.example.app",
+          "9JA89QQLNQ.com.example.app2"
+        ],
+        "paths": [
+          "/path/*/filename"
+        ],
+        "components": [
+          {
+            "/": "/path/*/filename"
+          },
+          {
+            "#": "*fragment"
+          },
+          {
+            "?": "widget=?*"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/apple-app-site-association/apple-app-site-association-new-format.json
+++ b/src/test/apple-app-site-association/apple-app-site-association-new-format.json
@@ -1,11 +1,12 @@
 {
+  "appclips": {
+    "apps": ["ABCDE12345.com.example.MyApp.Clip"]
+  },
   "applinks": {
     "apps": [],
     "details": [
       {
-        "appIDs": [
-          "ABCDE12345.com.example.lunch"
-        ],
+        "appIDs": ["ABCDE12345.com.example.lunch"],
         "components": [
           {
             "/": "*/order/"
@@ -29,10 +30,7 @@
       },
       {
         "appID": "ABCDE12345.com.example.app",
-        "appIDs": [
-          "ABCDE12345.com.example.app",
-          "9JA89QQLNQ.com.example.app2"
-        ],
+        "appIDs": ["ABCDE12345.com.example.app", "9JA89QQLNQ.com.example.app2"],
         "components": [
           {
             "/": "/path/*/filename"
@@ -44,20 +42,11 @@
             "?": "widget=?*"
           }
         ],
-        "paths": [
-          "/path/*/filename"
-        ]
+        "paths": ["/path/*/filename"]
       }
     ]
   },
   "webcredentials": {
-    "apps": [
-      "ABCDE12345.com.example.app"
-    ]
-  },
-  "appclips": {
-    "apps": [
-      "ABCDE12345.com.example.MyApp.Clip"
-    ]
+    "apps": ["ABCDE12345.com.example.app"]
   }
 }

--- a/src/test/apple-app-site-association/apple-app-site-association-new-format.json
+++ b/src/test/apple-app-site-association/apple-app-site-association-new-format.json
@@ -3,9 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appIDs": [
-          "ABCDE12345.com.example.lunch"
-        ],
+        "appIDs": ["ABCDE12345.com.example.lunch"],
         "components": [
           {
             "/": "*/order/"
@@ -22,20 +20,14 @@
             "exclude": true
           },
           {
-            "/": "",
-            "#": "coupon-????"
+            "#": "coupon-????",
+            "/": ""
           }
         ]
       },
       {
         "appID": "ABCDE12345.com.example.app",
-        "appIDs": [
-          "ABCDE12345.com.example.app",
-          "9JA89QQLNQ.com.example.app2"
-        ],
-        "paths": [
-          "/path/*/filename"
-        ],
+        "appIDs": ["ABCDE12345.com.example.app", "9JA89QQLNQ.com.example.app2"],
         "components": [
           {
             "/": "/path/*/filename"
@@ -46,7 +38,8 @@
           {
             "?": "widget=?*"
           }
-        ]
+        ],
+        "paths": ["/path/*/filename"]
       }
     ]
   }

--- a/src/test/apple-app-site-association/apple-app-site-association_getting-started.json
+++ b/src/test/apple-app-site-association/apple-app-site-association_getting-started.json
@@ -4,16 +4,11 @@
     "details": [
       {
         "appID": "9JA89QQLNQ.com.apple.wwdc",
-        "paths": [
-          "/wwdc/news/",
-          "/videos/wwdc/2015/*"
-        ]
+        "paths": ["/wwdc/news/", "/videos/wwdc/2015/*"]
       },
       {
         "appID": "ABCD123451.com.apple.wwdc",
-        "paths": [
-          "*"
-        ]
+        "paths": ["*"]
       }
     ]
   }

--- a/src/test/apple-app-site-association/apple-app-site-association_getting-started.json
+++ b/src/test/apple-app-site-association/apple-app-site-association_getting-started.json
@@ -4,11 +4,16 @@
     "details": [
       {
         "appID": "9JA89QQLNQ.com.apple.wwdc",
-        "paths": ["/wwdc/news/", "/videos/wwdc/2015/*"]
+        "paths": [
+          "/wwdc/news/",
+          "/videos/wwdc/2015/*"
+        ]
       },
       {
-        "appID": "ABCD1234.com.apple.wwdc",
-        "paths": ["*"]
+        "appID": "ABCD123451.com.apple.wwdc",
+        "paths": [
+          "*"
+        ]
       }
     ]
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
 close #4600 

With new apple-app-site-association format, we should support validating the new schema, and ensure backward compatibility at the same time 

https://developer.apple.com/videos/play/wwdc2019/717/
https://developer.apple.com/documentation/xcode/supporting-associated-domains

Also migrate this to latest draft-07
