### PR TITLE
fix: change usage of minItems in assetlinks.json

### DIFF
--- a/src/schemas/json/assetlinks.json
+++ b/src/schemas/json/assetlinks.json
@@ -1,12 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/assetlinks.json",
+  "additionalProperties": false,
   "$defs": {
     "android_app": {
       "description": "The target asset belong to an android application",
       "type": "object",
       "additionalProperties": false,
-      "required": ["namespace", "package_name", "sha256_cert_fingerprints"],
+      "required": [
+        "namespace",
+        "package_name",
+        "sha256_cert_fingerprints"
+      ],
       "properties": {
         "namespace": {
           "description": "Must be android_app for Android apps",
@@ -22,9 +27,9 @@
           "description": "SHA256s from keystore",
           "type": "array",
           "uniqueItems": true,
+          "minItems": 1,
           "items": {
             "type": "string",
-            "minItems": 1,
             "pattern": "^(?:[A-F0-9]{2}:){31}[A-F0-9]{2}$"
           }
         }
@@ -34,7 +39,10 @@
       "description": "The target asset belong to a web application",
       "type": "object",
       "additionalProperties": false,
-      "required": ["namespace", "site"],
+      "required": [
+        "namespace",
+        "site"
+      ],
       "properties": {
         "namespace": {
           "description": "Must be web for websites",
@@ -50,8 +58,8 @@
     "relation": {
       "description": "Describe the relation being declared about the target",
       "type": "array",
+      "minItems": 1,
       "items": {
-        "minItems": 1,
         "oneOf": [
           {
             "const": "delegate_permission/common.handle_all_urls",
@@ -73,7 +81,6 @@
     "description": "Website or app statements as JSON objects",
     "type": "object",
     "additionalProperties": false,
-    "minItems": 1,
     "properties": {
       "relation": {
         "$ref": "#/$defs/relation"

--- a/src/schemas/json/assetlinks.json
+++ b/src/schemas/json/assetlinks.json
@@ -1,17 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/assetlinks.json",
-  "additionalProperties": false,
   "$defs": {
     "android_app": {
       "description": "The target asset belong to an android application",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "namespace",
-        "package_name",
-        "sha256_cert_fingerprints"
-      ],
+      "required": ["namespace", "package_name", "sha256_cert_fingerprints"],
       "properties": {
         "namespace": {
           "description": "Must be android_app for Android apps",
@@ -39,10 +34,7 @@
       "description": "The target asset belong to a web application",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "namespace",
-        "site"
-      ],
+      "required": ["namespace", "site"],
       "properties": {
         "namespace": {
           "description": "Must be web for websites",
@@ -73,6 +65,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "title": "Google Digital Assetlinks",
   "description": "Google Digital Assetlinks Schema",
   "type": "array",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Following https://github.com/SchemaStore/schemastore/pull/4598

This aimed to correct the use of `minItems`