### PR TITLE
docs: encourage use of simple catalog fileMatch patterns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,6 +407,13 @@ This would not be accepted because the file detection would have too many false 
 - Omit `fileMatch` or set it to an empty array (which still allows the user to manually select it)
 - Prepend a directory name to the pattern (e.g. `"**/micro/runtime/syntax/*.yaml"`)
 
+### Use Simple `fileMatch` Patterns
+
+Glob implementations vary in their support of various pattern constructs.
+Lean towards keeping it simple rather than concise.
+
+For example, `{...}` alternations and some extended glob constructs can be written as multiple "simple" patterns instead.
+
 ## Compatible Language Servers and Tools
 
 ### [`redhat-developer/yaml-language-server`](https://github.com/redhat-developer/yaml-language-server)


### PR DESCRIPTION
As the PR's I submitted for this topic got a favorable response, I thought maybe a note in docs would keep future additions/changes on the simpler side.

Refs
* https://github.com/redhat-developer/yaml-language-server/issues/422
* https://github.com/SchemaStore/schemastore/pull/4590
* https://github.com/SchemaStore/schemastore/pull/4608

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
