### PR TITLE
feat: add registry configuration file to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -253,6 +253,12 @@
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/policy.json"
     },
     {
+      "name": "registry.yaml",
+      "description": "aqua registry configuration file",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json"
+    },
+    {
       "name": "arb.json",
       "description": "Application Resource Bundle",
       "fileMatch": ["arb.json"],


### PR DESCRIPTION
Typical filename is `registry.yaml`, which feels a bit generic.

https://aquaproj.github.io/docs/reference/registry-config/

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
