### PR TITLE
fix(pytest): use correct log level definition

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -420,8 +420,22 @@
       "enum": ["function", "class", "module", "package", "session"]
     },
     "LogLevel": {
-      "type": "string",
-      "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+      "description": "A minimum log level. Can be level name or integer value.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "string",
+          "enum": ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
+        },
+        {
+          "type": "string",
+          "deprecated": true,
+          "enum": ["FATAL", "WARN"]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
The [Pytest documentation](https://docs.pytest.org/en/stable/reference/reference.html#confval-log_level) explains that the `log_level` config variable

> Sets the minimum log message level that should be captured for logging capture. The integer value or the names of the levels can be used.

Furthermore, there are more named levels than the ones listed
previously: https://github.com/python/cpython/blob/ef06508f8ef1d2943b2fb1e310ab115b65e489a8/Lib/logging/__init__.py#L98-L105

Some are deprecated/not recommended (hence marked as such), but there was also the `NOTSET` option missing previously.

Note: I have not added descriptions to the enum. Please let me know if you would like me to do so.