### PR TITLE
Add extras properties to hugo markup.goldmark.extensions

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -905,7 +905,8 @@
             "strikethrough": true,
             "table": true,
             "taskList": true,
-            "typographer": true
+            "typographer": true,
+            "extras": null
           },
           "parser": {
             "attribute": {
@@ -1204,6 +1205,99 @@
                   "description": "\nhttps://gohugo.io/getting-started/configuration-markup#goldmark",
                   "type": "boolean",
                   "default": true
+                },
+                "extras": {
+                  "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                  "type": "object",
+                  "default": {
+                    "delete": {
+                      "enable": false
+                    },
+                    "insert": {
+                      "enable": false
+                    },
+                    "mark": {
+                      "enable": false
+                    },
+                    "subscript": {
+                      "enable": false
+                    },
+                    "superscript": {
+                      "enable": false
+                    }
+                  },
+                  "properties": {
+                    "delete": {
+                      "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                      "type": "object",
+                      "default": {
+                        "enable": false
+                      },
+                      "properties": {
+                        "enable": {
+                          "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    },
+                    "insert": {
+                      "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                      "type": "object",
+                      "default": {
+                        "enable": false
+                      },
+                      "properties": {
+                        "enable": {
+                          "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    },
+                    "mark": {
+                      "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                      "type": "object",
+                      "default": {
+                        "enable": false
+                      },
+                      "properties": {
+                        "enable": {
+                          "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    },
+                    "subscript": {
+                      "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                      "type": "object",
+                      "default": {
+                        "enable": false
+                      },
+                      "properties": {
+                        "enable": {
+                          "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    },
+                    "superscript": {
+                      "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                      "type": "object",
+                      "default": {
+                        "enable": false
+                      },
+                      "properties": {
+                        "enable": {
+                          "description": "\nhttps://gohugo.io/configuration/markup/#extras",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      }
+                    }
+                  }
                 }
               },
               "additionalProperties": false

--- a/src/test/hugo/example-5.yaml
+++ b/src/test/hugo/example-5.yaml
@@ -1,0 +1,114 @@
+# yaml-language-server: $schema=../../schemas/json/hugo.json
+frontmatter:
+  date:
+    - ':default'
+    - ':fileModTime'
+    - ':filename'
+    - ':git'
+    - 'date'
+    - 'lastmod'
+    - 'modified'
+    - 'pubdate'
+    - 'publishDate'
+  expiryDate: [':default', 'expiryDate', 'unpublishdate']
+  lastmod:
+    [
+      ':default',
+      ':fileModTime',
+      ':filename',
+      ':git',
+      'date',
+      'lastmod',
+      'modified',
+      'pubdate',
+      'publishDate',
+    ]
+  publishDate:
+    [
+      ':default',
+      ':fileModTime',
+      ':filename',
+      ':git',
+      'date',
+      'lastmod',
+      'modified',
+      'pubdate',
+      'publishDate',
+    ]
+
+permalinks:
+  page:
+    articles: '/articles/:slugorfilename'
+  post: '/:slug/'
+
+build:
+  _merge: shallow
+  buildStats:
+    disableClasses: false
+    disableIDs: false
+    disableTags: false
+    enable: true
+  cachebusters:
+    - source: assets/watching/hugo_stats\.json
+      target: styles\.css
+    - source: (postcss|tailwind)\.config\.js
+      target: css
+    - source: assets/.*\.(js|ts|jsx|tsx)
+      target: js
+    - source: assets/.*\.(.*)$
+      target: $1
+  noJSConfigInAssets: false
+  useResourceCacheWhen: fallback
+
+menu:
+  resume:
+    - identifier: education
+      name: Education
+      weight: 1
+      params:
+        count: 1
+
+module:
+  workspace: hugo.work
+
+markup:
+  goldmark:
+    extensions:
+      extras:
+        foo:
+          enable: true
+        mark:
+          enable: true
+
+minify:
+  disableCSS: false
+  disableHTML: false
+  disableJS: false
+  disableJSON: false
+  disableSVG: false
+  disableXML: false
+  minifyOutput: false
+  tdewolff:
+    css:
+      keepCSS2: true
+      precision: 0
+    html:
+      keepComments: false
+      keepConditionalComments: true
+      keepDefaultAttrVals: true
+      keepDocumentTags: true
+      keepEndTags: true
+      keepQuotes: false
+      keepWhitespace: false
+    js:
+      keepVarNames: false
+      precision: 0
+      version: 2022
+    json:
+      keepNumbers: false
+      precision: 0
+    svg:
+      keepComments: false
+      precision: 0
+    xml:
+      keepWhitespace: false


### PR DESCRIPTION
This adds properties for the extras key in markup.goldmark.extensions path.
See https://gohugo.io/configuration/markup/#extensions
