### PR TITLE
Update schemas according to 🐊Putout v39

### DIFF
--- a/src/schemas/json/putout.json
+++ b/src/schemas/json/putout.json
@@ -57,19 +57,25 @@
       "description": "🐊Putout comes with a large number of rules. You can modify which rules your project uses.",
       "type": "object",
       "properties": {
-        "add-return-await": {
-          "$ref": "#/definitions/rule"
-        },
         "apply-at": {
-          "$ref": "#/definitions/rule"
-        },
-        "apply-await-import": {
           "$ref": "#/definitions/rule"
         },
         "apply-destructuring": {
           "$ref": "#/definitions/rule"
         },
-        "apply-early-return": {
+        "return": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/apply-early": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/simplify-boolean": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/convert-from-break": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/remove-useless": {
           "$ref": "#/definitions/rule"
         },
         "apply-montag": {
@@ -78,19 +84,49 @@
         "apply-nullish-coalescing": {
           "$ref": "#/definitions/rule"
         },
-        "apply-numeric-separators": {
+        "math": {
           "$ref": "#/definitions/rule"
         },
-        "apply-optional-chaining": {
+        "math/apply-numeric-separators": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/apply-exponentiation": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/apply-multiplication": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/convert-sqrt-to-hypot": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/remove-unchanged-zero-declarations": {
           "$ref": "#/definitions/rule"
         },
         "apply-shorthand-properties": {
           "$ref": "#/definitions/rule"
         },
-        "apply-try-catch": {
+        "try-catch": {
           "$ref": "#/definitions/rule"
         },
-        "apply-utility-types": {
+        "try-catch/await": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/async": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/sync": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/args": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/expand-args": {
           "$ref": "#/definitions/rule"
         },
         "browserlist": {
@@ -117,7 +153,6 @@
         "conditions/evaluate": {
           "$ref": "#/definitions/rule"
         },
-
         "conditions/merge-if-statements": {
           "$ref": "#/definitions/rule"
         },
@@ -133,6 +168,15 @@
         "conditions/remove-useless-else": {
           "$ref": "#/definitions/rule"
         },
+        "label": {
+          "$ref": "#/definitions/rule"
+        },
+        "label/convert-to-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "label/remove-unused": {
+          "$ref": "#/definitions/rule"
+        },
         "convert-apply-to-spread": {
           "$ref": "#/definitions/rule"
         },
@@ -140,12 +184,6 @@
           "$ref": "#/definitions/rule"
         },
         "convert-array-copy-to-slice": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-assignment-to-arrow-function": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-assignment-to-comparison": {
           "$ref": "#/definitions/rule"
         },
         "convert-bitwise-to-logical": {
@@ -235,7 +273,10 @@
         "merge-destructuring-properties": {
           "$ref": "#/definitions/rule"
         },
-        "merge-duplicate-imports": {
+        "parens": {
+          "$ref": "#/definitions/rule"
+        },
+        "parens/add-missing": {
           "$ref": "#/definitions/rule"
         },
         "nodejs": {
@@ -293,6 +334,9 @@
           "$ref": "#/definitions/rule"
         },
         "promises/apply-top-level-await": {
+          "$ref": "#/definitions/rule"
+        },
+        "promises/apply-await-import": {
           "$ref": "#/definitions/rule"
         },
         "promises/convert-new-promise-to-async": {
@@ -484,13 +528,49 @@
         "remove-empty/block": {
           "$ref": "#/definitions/rule"
         },
-        "remove-empty/export": {
-          "$ref": "#/definitions/rule"
-        },
-        "remove-empty/import": {
-          "$ref": "#/definitions/rule"
-        },
         "remove-empty/pattern": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-empty-import": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-empty-export": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/convert-assert-to-with": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/group-imports-by-source": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/declare-imports-first": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-quotes-from-import-assertions": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/merge-duplicate-imports": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/sort-imports-by-specifier": {
+          "$ref": "#/definitions/rule"
+        },
+        "optional-chaining": {
+          "$ref": "#/definitions/rule"
+        },
+        "optional-chaining/convert-optional-assign-to-logical": {
+          "$ref": "#/definitions/rule"
+        },
+        "optional-chaining/convert-optional-to-logical": {
+          "$ref": "#/definitions/rule"
+        },
+        "optional-chaining/convert-logical-assign-to-optional": {
+          "$ref": "#/definitions/rule"
+        },
+        "optional-chaining/convert-logical-to-optional": {
           "$ref": "#/definitions/rule"
         },
         "remove-iife": {
@@ -550,9 +630,6 @@
         "remove-useless-operand": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-return": {
-          "$ref": "#/definitions/rule"
-        },
         "remove-useless-spread": {
           "$ref": "#/definitions/rule"
         },
@@ -574,7 +651,22 @@
         "reuse-duplicate-init": {
           "$ref": "#/definitions/rule"
         },
-        "simplify-assignment": {
+        "assignment": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/simplify": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/split": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-arrow-function": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-comparison": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-declaration": {
           "$ref": "#/definitions/rule"
         },
         "simplify-logical-expressions": {


### PR DESCRIPTION
Update schemas according to 🐊[Putout v39](https://github.com/coderaiser/putout/releases/tag/v39.0.0).