### PR TITLE
Update prometheus rules file match

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4446,19 +4446,26 @@
       "name": "prometheus.rules.json",
       "description": "Prometheus rules file",
       "fileMatch": [
-        "*.rules.yml",
-        "*.rules.yaml",
-        "*rules.yml",
-        "*rules.yaml",
-        "rules.yml",
-        "rules.yaml"
+        "*.prometheus.rules.yml",
+        "*.prometheus.rules.yaml",
+        "*prometheus-rules.yml",
+        "*prometheus-rules.yaml",
+        "*prometheus_rules.yml",
+        "*prometheus_rules.yaml",
+        "prometheus.rules.yml",
+        "prometheus.rules.yaml"
       ],
       "url": "https://json.schemastore.org/prometheus.rules.json"
     },
     {
       "name": "prometheus.rules.test.json",
       "description": "Prometheus rules test file",
-      "fileMatch": ["*.tests.yml", "*.tests.yaml", "*.test.yml", "*.test.yaml"],
+      "fileMatch": [
+        "*.prometheus.tests.yml",
+        "*.prometheus.tests.yaml",
+        "*.prometheus.test.yml",
+        "*.prometheus.test.yaml"
+      ],
       "url": "https://json.schemastore.org/prometheus.rules.test.json"
     },
     {


### PR DESCRIPTION
This updates the prometheus rules' file matcher config to actually check for "prometheus" in the file name.

These rules were erroneously being applied to our docker config because the file name happened to be for our test CI and had a ".test.yml" in the file name.