### PR TITLE
Update buf.gen.yaml input for buf 1.51.0 release

### DIFF
--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -96,12 +96,6 @@
                 }
               ]
             },
-            "types": {
-              "$ref": "#/$defs/types"
-            },
-            "exclude_types": {
-              "$ref": "#/$defs/types"
-            },
             "path": {
               "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#path",
               "description": "Optional. Only works with local plugins. Overrides the default location and explicitly specifies where to locate the plugin.",
@@ -143,6 +137,12 @@
                   }
                 }
               ]
+            },
+            "types": {
+              "$ref": "#/$defs/types"
+            },
+            "exclude_types": {
+              "$ref": "#/$defs/exclude_types"
             }
           },
           "required": ["out"],
@@ -557,6 +557,12 @@
               "$comment": "https://buf.build/docs/configuration/v2/buf-gen-yaml#include_wkt",
               "description": "Optional. Generates Well-Known Types. Can't be set without --include-imports. This setting works the same as the --include-wkt flag on buf generate—if they conflict with each other, the flag gets precedence.",
               "type": "boolean"
+            },
+            "types": {
+              "$ref": "#/$defs/types"
+            },
+            "exclude_types": {
+              "$ref": "#/$defs/exclude_types"
             }
           }
         }
@@ -576,7 +582,7 @@
                   "$ref": "#/$defs/types"
                 },
                 "exclude_types": {
-                  "$ref": "#/$defs/types"
+                  "$ref": "#/$defs/exclude_types"
                 },
                 "paths": {
                   "$ref": "#/$defs/paths"
@@ -597,6 +603,9 @@
               "properties": {
                 "types": {
                   "$ref": "#/$defs/types"
+                },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
                 },
                 "paths": {
                   "$ref": "#/$defs/paths"
@@ -622,6 +631,9 @@
               "properties": {
                 "types": {
                   "$ref": "#/$defs/types"
+                },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
                 },
                 "paths": {
                   "$ref": "#/$defs/paths"
@@ -668,6 +680,9 @@
                 "types": {
                   "$ref": "#/$defs/types"
                 },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
+                },
                 "paths": {
                   "$ref": "#/$defs/paths"
                 },
@@ -701,6 +716,9 @@
                 "types": {
                   "$ref": "#/$defs/types"
                 },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
+                },
                 "paths": {
                   "$ref": "#/$defs/paths"
                 },
@@ -727,6 +745,13 @@
               "minProperties": 1,
               "properties": {
                 "types": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "exclude_types": {
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -765,6 +790,9 @@
                 "types": {
                   "$ref": "#/$defs/types"
                 },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
+                },
                 "paths": {
                   "$ref": "#/$defs/paths"
                 },
@@ -789,6 +817,9 @@
               "properties": {
                 "types": {
                   "$ref": "#/$defs/types"
+                },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
                 },
                 "paths": {
                   "$ref": "#/$defs/paths"
@@ -815,6 +846,9 @@
                 "types": {
                   "$ref": "#/$defs/types"
                 },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
+                },
                 "paths": {
                   "$ref": "#/$defs/paths"
                 },
@@ -839,6 +873,9 @@
               "properties": {
                 "types": {
                   "$ref": "#/$defs/types"
+                },
+                "exclude_types": {
+                  "$ref": "#/$defs/exclude_types"
                 },
                 "paths": {
                   "$ref": "#/$defs/paths"

--- a/src/schemas/json/buf.gen.json
+++ b/src/schemas/json/buf.gen.json
@@ -11,6 +11,14 @@
         "type": "string"
       }
     },
+    "exclude_types": {
+      "description": "Exclude the specified types when generating.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
     "paths": {
       "description": "Include only the specified paths when generating.",
       "type": "array",
@@ -87,6 +95,12 @@
                   }
                 }
               ]
+            },
+            "types": {
+              "$ref": "#/$defs/types"
+            },
+            "exclude_types": {
+              "$ref": "#/$defs/types"
             },
             "path": {
               "$comment": "https://buf.build/docs/configuration/v1/buf-gen-yaml#path",
@@ -559,6 +573,9 @@
               "minProperties": 1,
               "properties": {
                 "types": {
+                  "$ref": "#/$defs/types"
+                },
+                "exclude_types": {
                   "$ref": "#/$defs/types"
                 },
                 "paths": {

--- a/src/test/buf.gen/v2.buf.gen.yaml
+++ b/src/test/buf.gen/v2.buf.gen.yaml
@@ -107,6 +107,12 @@ plugins:
     strategy: all
     include_imports: true
     include_wkt: true
+    types:
+      - 'foo.v1.User'
+      - 'foo.v1.UserService'
+    exclude_types:
+      - 'foo.v1.User.Password'
+      - 'foo.v1.User.Email'
 
 inputs:
   # Git repository
@@ -119,6 +125,9 @@ inputs:
     types:
       - 'foo.v1.User'
       - 'foo.v1.UserService'
+    exclude_types:
+      - 'foo.v1.User.Password'
+      - 'foo.v1.User.Email'
     # If empty, include all paths.
     paths:
       - a/b/c


### PR DESCRIPTION
This updates `buf.gen.json` to add support for the improved filtering in buf 1.51.0. Type filter was added to plugins, and the new field exclude_types. See bufbuild/buf [v1.51.0](https://github.com/bufbuild/buf/releases/tag/v1.51.0).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
