### PR TITLE
Update uv schema to include "all" as a valid option for default-groups

### DIFF
--- a/src/schemas/json/uv.json
+++ b/src/schemas/json/uv.json
@@ -87,10 +87,21 @@
     },
     "default-groups": {
       "description": "The list of `dependency-groups` to install by default.",
-      "type": ["array", "null"],
-      "items": {
-        "$ref": "#/definitions/GroupName"
-      }
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupName"
+          }
+        },
+        {
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "dependency-metadata": {
       "description": "Pre-defined static metadata for dependencies of the project (direct or transitive). When provided, enables the resolver to use the specified metadata instead of querying the registry or building the relevant package from source.\n\nMetadata should be provided in adherence with the [Metadata 2.3](https://packaging.python.org/en/latest/specifications/core-metadata/) standard, though only the following fields are respected:\n\n- `name`: The name of the package. - (Optional) `version`: The version of the package. If omitted, the metadata will be applied to all versions of the package. - (Optional) `requires-dist`: The dependencies of the package (e.g., `werkzeug>=0.14`). - (Optional) `requires-python`: The Python version required by the package (e.g., `>=3.10`). - (Optional) `provides-extras`: The extras provided by the package.",


### PR DESCRIPTION
Update `uv`'s configuration schema/sub-schema to allow setting the bare string "all" for `default-groups`; this is permitted as of v0.6.8 (see changelog [here](https://github.com/astral-sh/uv/releases/tag/0.6.8) and pull request [here](https://github.com/astral-sh/uv/pull/12289))

I went with changing this to an `anyOf` and adding the specific `all` string match as one of the valid options since that seems more in line with the rest of the schema's style, but just changing line 90 to `"type": ["array", "string", "null"],` would work as well. I don't think it's likely that this field will get any other string options in the future, though, so probably constraining to the specific value is the way to go?