### PR TITLE
Fix a typo in `partial-pyright.json`

### DIFF
--- a/src/schemas/json/partial-pyright.json
+++ b/src/schemas/json/partial-pyright.json
@@ -100,7 +100,7 @@
     "enableReachabilityAnalysis": {
       "type": "boolean",
       "title": "Identify code determined to be unreachable through type analysis",
-      "description": "If enabled, code that is determined to be unreachable by type analysis is reported using a tagged hint. This setting does not affect code that is determined to be unreachable regardless of type analysis; such code is always reported as unreachable. This setting also has no effect when when using the command-line version of pyright because it never emits tagged hints for unreachable code.",
+      "description": "If enabled, code that is determined to be unreachable by type analysis is reported using a tagged hint. This setting does not affect code that is determined to be unreachable regardless of type analysis; such code is always reported as unreachable. This setting also has no effect when using the command-line version of pyright because it never emits tagged hints for unreachable code.",
       "default": true
     },
     "deprecateTypingAliases": {


### PR DESCRIPTION
Diff:

```diff
-when when using the command-line version
+when using the command-line version
```