### PR TITLE
feat(circleciconfig): add override-with stanza to job references

### DIFF
--- a/src/schemas/json/circleciconfig.json
+++ b/src/schemas/json/circleciconfig.json
@@ -1166,6 +1166,10 @@
               "type": "string"
             }
           }
+        },
+        "override-with": {
+          "description": "This allows overriding the job to run with a different job definition. The provided job override must be an orb job.",
+          "type": "string"
         }
       }
     },

--- a/src/test/circleciconfig/workflow-job-override.yaml
+++ b/src/test/circleciconfig/workflow-job-override.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../schemas/json/circleciconfig.json
+version: 2.1
+
+orbs:
+  welcome: circleci/welcome-orb@0.4.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+
+workflows:
+  test-workflow:
+    jobs:
+      - test:
+          override-with: welcome/test


### PR DESCRIPTION
This PR updates the schema of job references inside workflows to support a new key `override-with`.
