### PR TITLE
github-workflow: workflow_call.secrets.*.required is not required

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1574,7 +1574,6 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["required"],
                       "additionalProperties": false
                     }
                   },


### PR DESCRIPTION
Hi SchemaStore maintainers! Thank you for all the hard work you've done here.

This removes `required` from the `required` set, since GitHub Actions does not actually require this field to be set.

Corroborating evidence:

* `required` is not documented as required in the workflow syntax documentation: <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretssecret_idrequired>
* Empirically, GitHub Actions happily runs `workflow_call` triggers that don't include a `required` field under their secret definitions: https://github.com/woodruffw/github-actions-models/pull/40
    * Example: https://github.com/woodruffw-experiments/actions-experiments/blob/main/.github/workflows/zizmor-issue-646.yml?rgh-link-date=2025-04-06T14%3A18%3A49Z
    * Example run: https://github.com/woodruffw-experiments/actions-experiments/actions/runs/14293382119/job/40057493277

See https://github.com/woodruffw/zizmor/issues/646 for additional context as well.