### PR TITLE
feat: add expanded file types for Codify

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -546,8 +546,12 @@
       "fileMatch": [
         "codify.json",
         "codify.yaml",
+        "codify.json5",
+        "codify.jsonc",
         "*.codify.json",
-        "*.codify.yaml"
+        "*.codify.yaml",
+        "*.codify.json5",
+        "*.codify.jsonc"
       ],
       "url": "https://raw.githubusercontent.com/codifyCLI/codify-schemas/main/src/schemastore/codify-schema.json"
     },


### PR DESCRIPTION
This PR adds additional file types for the Codify schema to match on. It adds support for `.jsonc` and `.json5`.