### PR TITLE
github-workflow: trigger types can be an array or a scalar string

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -491,8 +491,15 @@
     "types": {
       "$comment": "https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onevent_nametypes",
       "description": "Selects the types of activity that will trigger a workflow run. Most GitHub events are triggered by more than one type of activity. For example, the event for the release resource is triggered when a release is published, unpublished, created, edited, deleted, or prereleased. The types keyword enables you to narrow down activity that causes the workflow to run. When only one activity type triggers a webhook event, the types keyword is unnecessary.\nYou can use an array of event types. For more information about each event and their activity types, see https://help.github.com/en/articles/events-that-trigger-workflows#webhook-events.",
-      "type": "array",
-      "minItems": 1
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "working-directory": {
       "$comment": "https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun",


### PR DESCRIPTION
Hello again!

This is another small bug in the `github-workflow.json` schema: `types` is currently defined as an array of one or more items, but GitHub Actions also allows it to be a single scalar string value.

Example well-formed workflow here: https://github.com/woodruffw-experiments/actions-experiments/pull/4

See https://github.com/woodruffw/zizmor/issues/650 for some more context.