### PR TITLE
Update Bitbucket Pipelines schema URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -765,7 +765,7 @@
       "name": "bitbucket-pipelines",
       "description": "Bitbucket Pipelines CI/CD manifest",
       "fileMatch": ["bitbucket-pipelines.yml"],
-      "url": "https://bitbucket.org/atlassianlabs/intellij-bitbucket-references-plugin/raw/master/src/main/resources/schemas/bitbucket-pipelines.schema.json"
+      "url": "https://api.bitbucket.org/schemas/pipelines-configuration"
     },
     {
       "name": "bitrise",


### PR DESCRIPTION
The JSON schema for Bitbucket Pipelines configuration file is now officially provided by Bitbucket.