### PR TITLE
fix: `pnpm-workspace` allow packages array to be empty

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -67,7 +67,6 @@
     "packages": {
       "description": "Workspace package paths. Glob patterns are supported",
       "type": "array",
-      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
refs https://github.com/SchemaStore/schemastore/pull/4525

The `packages` field is optional and should also allow an empty array.

https://github.com/pnpm/pnpm/blob/43bd37f504a003ac0b751c711c967422d72fe992/config/config/test/fixtures/settings-in-workspace-yaml/pnpm-workspace.yaml#L1