### PR TITLE
add allowUnusedPatches to pnpm-workspace.json

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -177,6 +177,10 @@
       "description": "When true, installation won't fail if some of the patches from the \"patchedDependencies\" field were not applied.",
       "type": "boolean"
     },
+    "ignorePatchFailures": {
+      "description": "When true, installation won't fail if some of the patches from the \"patchedDependencies\" field were not applied. (Previously named \"allowNonAppliedPatches\")",
+      "type": "boolean"
+    },
     "updateConfig": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
I wasn't sure of the convention for marking a property as deprecated, so I left `allowNonAppliedPatches` as is.

I was tempted to include in the description the version number in which the property was added, but I didn't see that as a convention. I think it would be helpful though!

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
