### PR TITLE
Add Taplo config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7935,6 +7935,12 @@
       "description": "Stylua configuration",
       "fileMatch": [".stylua.toml", "stylua.toml"],
       "url": "https://json.schemastore.org/stylua.json"
+    },
+    {
+      "name": "Taplo",
+      "description": "Taplo configuration file",
+      "fileMatch": [".taplo.toml", "taplo.toml"],
+      "url": "https://json.schemastore.org/taplo.json"
     }
   ]
 }

--- a/src/schemas/json/taplo.json
+++ b/src/schemas/json/taplo.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/taplo.json",
+  "title": "Taplo Configuration Schema",
+  "type": "object",
+  "properties": {
+    "exclude": {
+      "description": "Files to exclude (ignore).\n\nA list of Unix-like [glob](https://en.wikipedia.org/wiki/Glob_(programming)) path patterns. Globstars (`**`) are supported.\n\nRelative paths are **not** relative to the configuration file, but rather depends on the tool using the configuration.\n\nThis has priority over `include`.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "formatting": {
+      "description": "Formatting options.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OptionsIncomplete"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "include": {
+      "description": "Files to include.\n\nA list of Unix-like [glob](https://en.wikipedia.org/wiki/Glob_(programming)) path patterns. Globstars (`**`) are supported.\n\nRelative paths are **not** relative to the configuration file, but rather depends on the tool using the configuration.\n\nOmitting this property includes all files, **however an empty array will include none**.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "plugins": {
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "$ref": "#/definitions/Plugin"
+      }
+    },
+    "rule": {
+      "description": "Rules are used to override configurations by path and keys.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Rule"
+      }
+    },
+    "schema": {
+      "description": "Schema validation options.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SchemaOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "OptionsIncomplete": {
+      "description": "All the formatting options.",
+      "type": "object",
+      "properties": {
+        "align_comments": {
+          "description": "Align consecutive comments after entries and items vertically.\n\nThis applies to comments that are after entries or array items.",
+          "type": ["boolean", "null"]
+        },
+        "align_entries": {
+          "description": "Align entries vertically.\n\nEntries that have table headers, comments, or blank lines between them are not aligned.",
+          "type": ["boolean", "null"]
+        },
+        "align_single_comments": {
+          "description": "If `align_comments` is true, apply the alignment in cases where there's only one comment.",
+          "type": ["boolean", "null"]
+        },
+        "allowed_blank_lines": {
+          "description": "The maximum amount of consecutive blank lines allowed.",
+          "type": ["integer", "null"],
+          "minimum": 0.0
+        },
+        "array_auto_collapse": {
+          "description": "Automatically collapse arrays if they fit in one line.\n\nThe array won't be collapsed if it contains a comment.",
+          "type": ["boolean", "null"]
+        },
+        "array_auto_expand": {
+          "description": "Automatically expand arrays to multiple lines once they exceed the configured `column_width`.",
+          "type": ["boolean", "null"]
+        },
+        "array_trailing_comma": {
+          "description": "Put trailing commas for multiline arrays.",
+          "type": ["boolean", "null"]
+        },
+        "column_width": {
+          "description": "Target maximum column width after which arrays are expanded into new lines.\n\nThis is best-effort and might not be accurate.",
+          "type": ["integer", "null"],
+          "minimum": 0.0
+        },
+        "compact_arrays": {
+          "description": "Omit whitespace padding inside single-line arrays.",
+          "type": ["boolean", "null"]
+        },
+        "compact_entries": {
+          "description": "Omit whitespace around `=`.",
+          "type": ["boolean", "null"]
+        },
+        "compact_inline_tables": {
+          "description": "Omit whitespace padding inside inline tables.",
+          "type": ["boolean", "null"]
+        },
+        "crlf": {
+          "description": "Use CRLF line endings",
+          "type": ["boolean", "null"]
+        },
+        "indent_entries": {
+          "description": "Indent entries under tables.",
+          "type": ["boolean", "null"]
+        },
+        "indent_string": {
+          "description": "Indentation to use, should be tabs or spaces but technically could be anything.",
+          "type": ["string", "null"]
+        },
+        "indent_tables": {
+          "description": "Indent subtables if they come in order.",
+          "type": ["boolean", "null"]
+        },
+        "inline_table_expand": {
+          "description": "Expand values (e.g.) inside inline tables where possible.",
+          "type": ["boolean", "null"]
+        },
+        "reorder_arrays": {
+          "description": "Alphabetically reorder array values that are not separated by blank lines.",
+          "type": ["boolean", "null"]
+        },
+        "reorder_keys": {
+          "description": "Alphabetically reorder keys that are not separated by blank lines.",
+          "type": ["boolean", "null"]
+        },
+        "trailing_newline": {
+          "description": "Add trailing newline to the source.",
+          "type": ["boolean", "null"]
+        }
+      }
+    },
+    "Plugin": {
+      "description": "A plugin to extend Taplo's capabilities.",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Optional settings for the plugin.",
+          "default": null
+        }
+      }
+    },
+    "Rule": {
+      "description": "A rule to override options by either name or file.",
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "description": "Files that are excluded from this rule.\n\nA list of Unix-like [glob](https://en.wikipedia.org/wiki/Glob_(programming)) path patterns.\n\nRelative paths are **not** relative to the configuration file, but rather depends on the tool using the configuration.\n\nThis has priority over `include`.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "formatting": {
+          "description": "Formatting options.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OptionsIncomplete"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "description": "Files this rule is valid for.\n\nA list of Unix-like [glob](https://en.wikipedia.org/wiki/Glob_(programming)) path patterns.\n\nRelative paths are **not** relative to the configuration file, but rather depends on the tool using the configuration.\n\nOmitting this property includes all files, **however an empty array will include none**.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "keys": {
+          "description": "Keys the rule is valid for in a document.\n\nA list of Unix-like [glob](https://en.wikipedia.org/wiki/Glob_(programming)) dotted key patterns.\n\nThis allows enabling the rule for specific paths in the document.\n\nFor example:\n\n- `package.metadata` will enable the rule for everything inside the `package.metadata` table, including itself.\n\nIf omitted, the rule will always be valid for all keys.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "The name of the rule.\n\nUsed in `taplo::<name>` comments.",
+          "type": ["string", "null"]
+        },
+        "schema": {
+          "description": "Schema validation options.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SchemaOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SchemaOptions": {
+      "description": "Options for schema validation and completion.\n\nSchemas in rules with defined keys are ignored.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether the schema should be enabled or not.\n\nDefaults to true if omitted.",
+          "type": ["boolean", "null"]
+        },
+        "path": {
+          "description": "A local file path to the schema, overrides `url` if set.\n\nURLs are also accepted here, but it's not a guarantee and might change in newer releases. Please use the `url` field instead whenever possible.",
+          "type": ["string", "null"]
+        },
+        "url": {
+          "description": "A full absolute URL to the schema.\n\nThe url of the schema, supported schemes are `http`, `https`, `file` and `taplo`.",
+          "type": ["string", "null"],
+          "format": "uri"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/test/taplo/config.toml
+++ b/src/test/taplo/config.toml
@@ -1,0 +1,35 @@
+#:schema ../../schemas/json/taplo.json
+include = ["Cargo.toml", "directory/**/*.toml"]
+exclude = ["excluded.toml"]
+
+[formatting]
+align_entries = false
+align_comments = true
+array_trailing_comma = true
+array_auto_expand = true
+array_auto_collapse = true
+compact_arrays = true
+compact_inline_tables = false
+inline_table_expand = true
+compact_entries = false
+column_width = 80
+indent_tables = false
+indent_entries = false
+indent_string = "  "
+trailing_newline = true
+reorder_keys = false
+reorder_arrays = false
+reorder_inline_tables = false
+allowed_blank_lines = 2
+crlf = false
+
+[[rule]]
+include = ["Cargo.toml"]
+keys = ["dependencies"]
+
+[rule.formatting]
+reorder_keys = true
+
+[schema]
+path = "some-external-schema.json"
+enabled = true


### PR DESCRIPTION
Adds configuration file for [Taplo](https://github.com/tamasfe/taplo).

File obtained using the `taplo config schema` command, and slightly modified to pass the checks/tests.