### PR TITLE
Update bitrise.yml schema with "last commit" option

### DIFF
--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -495,29 +495,29 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "PushTriggerMapItemModelCommitsCondition": { 
-        "oneOf": [
-          {     
-              "required": ["pattern"],
-              "properties": {
-                "pattern": {
-                  "type": "string"
-                },
-                "last_commit": {
-                  "type": "boolean"
-                }
+    "PushTriggerMapItemModelCommitsCondition": {
+      "oneOf": [
+        {
+          "required": ["pattern"],
+          "properties": {
+            "pattern": {
+              "type": "string"
+            },
+            "last_commit": {
+              "type": "boolean"
             }
-          },
-          {
-            "required": ["regex"],
-            "properties": {
-              "regex": {
-                "type": "string"
-              },
-              "last_commit": {
-                "type": "boolean"
-              }
+          }
+        },
+        {
+          "required": ["regex"],
+          "properties": {
+            "regex": {
+              "type": "string"
+            },
+            "last_commit": {
+              "type": "boolean"
             }
+          }
         }
       ],
       "additionalProperties": false,

--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -495,6 +495,34 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "PushTriggerMapItemModelCommitsCondition": { 
+        "oneOf": [
+          {     
+              "required": ["pattern"],
+              "properties": {
+                "pattern": {
+                  "type": "string"
+                },
+                "last_commit": {
+                  "type": "boolean"
+                }
+            }
+          },
+          {
+            "required": ["regex"],
+            "properties": {
+              "regex": {
+                "type": "string"
+              },
+              "last_commit": {
+                "type": "boolean"
+              }
+            }
+        }]
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "PushTriggerModel": {
       "properties": {
         "enabled": {
@@ -511,13 +539,13 @@
         },
         "commit_message": {
           "oneOf": [
-            { "$ref": "#/definitions/TriggerMapItemModelRegexCondition" },
+            { "$ref": "#/definitions/PushTriggerMapItemModelCommitsCondition" },
             { "type": "string" }
           ]
         },
         "changed_files": {
           "oneOf": [
-            { "$ref": "#/definitions/TriggerMapItemModelRegexCondition" },
+            { "$ref": "#/definitions/PushTriggerMapItemModelCommitsCondition" },
             { "type": "string" }
           ]
         }

--- a/src/schemas/json/bitrise.json
+++ b/src/schemas/json/bitrise.json
@@ -518,8 +518,8 @@
                 "type": "boolean"
               }
             }
-        }]
-      },
+        }
+      ],
       "additionalProperties": false,
       "type": "object"
     },


### PR DESCRIPTION
This change allows specifying the last_commit flag for commit message and changed files filters in push triggers.
Related PR [here](https://github.com/bitrise-io/bitrise/pull/1081).