### PR TITLE
Add 'helm' ecosystem to dependabot-2.0 schema

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -660,6 +660,7 @@
         "github-actions",
         "gomod",
         "gradle",
+        "helm",
         "maven",
         "mix",
         "npm",


### PR DESCRIPTION
Dependabot recently added support for Helm charts, with the identifier "helm". For details, see:

https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories

The change is quite recent, looks like it was released on April 9: https://github.blog/changelog/2025-04-09-dependabot-version-updates-now-support-helm/

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
