### PR TITLE
change pnpm-workspace.yaml syncInjectedDepsAfterScripts to be an array of strings instead of a boolean

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -589,7 +589,11 @@
     },
     "syncInjectedDepsAfterScripts": {
       "description": "Injected workspace dependencies are collections of hardlinks, which don't add or remove the files when their sources change.",
-      "type": "boolean"
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
     },
     "preferWorkspacePackages": {
       "description": "If this is enabled, local packages from the workspace are preferred over packages from the registry, even if there is a newer version of the package in the registry.",

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -6,6 +6,10 @@ packages:
 catalog:
   chalk: ^4.1.2
 
+# https://pnpm.io/settings#syncinjecteddepsafterscripts
+syncInjectedDepsAfterScripts:
+  - build
+
 # https://pnpm.io/catalogs
 catalogs:
   react16:


### PR DESCRIPTION
The field is documented here: https://pnpm.io/settings#syncinjecteddepsafterscripts

Here's an example of the failure:

![image](https://github.com/user-attachments/assets/1a46ab83-60f1-47bd-998e-98053b95c90f)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
