### PR TITLE
github-workflow: Add `models` permission

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -183,6 +183,10 @@
         "issues": {
           "$ref": "#/definitions/permissions-level"
         },
+        "models": {
+          "type": "string",
+          "enum": ["read", "none"]
+        },
         "packages": {
           "$ref": "#/definitions/permissions-level"
         },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

GitHub Actions now allow users to specify `models` permissions to use GitHub Models.

> ```yaml
> permissions:
>   # ...
>   models: read|none
> ```
> > https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions

> ```yaml
> # ...
> 
> permissions:
>   models: read
> 
> # ...
> ```
> > https://docs.github.com/en/github-models/integrating-ai-models-into-your-development-workflow#writing-your-workflow-file

---

Since ⁠⁠`write` is not a valid option for the ⁠⁠`models` permission, I hardcoded ⁠⁠`read`/⁠⁠`none` instead of using ⁠⁠`#/definitions/permissions-level`(⁠`read`/`⁠write`/`⁠none`).
(When I actually specify ⁠`models: write` in GitHub Actions, it results in an error.)
![image](https://github.com/user-attachments/assets/d9158067-e507-47dc-a09a-1e847b4409d6)