### PR TITLE
Allow and document new options introduced in jekyll-sass-converter 3.1.0

### DIFF
--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -927,8 +927,28 @@
           },
           "default": []
         },
-        "silence_deprecations": {
+        "fatal_deprecations": {
+          "description": "An array of deprecations or versions to treat as fatal.\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },        
+        "future_deprecations": {
           "description": "An array of active deprecations to ignore.\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "silence_deprecations": {
+          "description": "An array of future deprecations to opt into early.\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -927,6 +927,16 @@
           },
           "default": []
         },
+        "silence_deprecations": {
+          "description": "An array of active deprecations to ignore.\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
         "sourcemap": {
           "description": "Control when source maps shall be generated\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
           "type": "string",

--- a/src/schemas/json/jekyll.json
+++ b/src/schemas/json/jekyll.json
@@ -936,7 +936,7 @@
             "minLength": 1
           },
           "default": []
-        },        
+        },
         "future_deprecations": {
           "description": "An array of active deprecations to ignore.\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
           "type": "array",


### PR DESCRIPTION
Title says it all.

Configured VSCode locally to link to the raw file in my fork and can confirm these changes work as expected: 

![grafik](https://github.com/user-attachments/assets/e2c34144-598d-4566-82ad-8856f08d81cf)