### PR TITLE
Update Zerops.io yaml schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7549,7 +7549,12 @@
     {
       "name": "Zerops.io import",
       "description": "Zerops.io (https://zerops.io) infrastructure-as-code import YAML file",
-      "fileMatch": ["zerops-import.yaml", "zerops-*-import.yaml", "zerops-import.yml", "zerops-*-import.yml"],
+      "fileMatch": [
+        "zerops-import.yaml",
+        "zerops-*-import.yaml",
+        "zerops-import.yml",
+        "zerops-*-import.yml"
+      ],
       "url": "https://api.app-prg1.zerops.io/api/rest/public/settings/import-project-yml-json-schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7541,15 +7541,15 @@
       "url": "https://json.schemastore.org/any.json"
     },
     {
-      "name": "zerops.yml",
-      "description": "zerops.io, dev-first cloud platform - https://zerops.io, configuration YAML file",
-      "fileMatch": ["zerops.yml"],
+      "name": "Zerops.io config",
+      "description": "Zerops.io (https://zerops.io) configuration YAML file, for setting how to build and deploy your services",
+      "fileMatch": ["zerops.yaml", "zerops.yml"],
       "url": "https://api.app-prg1.zerops.io/api/rest/public/settings/zerops-yml-json-schema.json"
     },
     {
-      "name": "zerops.io import file",
-      "description": "zerops.io, dev-first cloud platform - https://zerops.io, infrastructure-as-code import YAML file",
-      "fileMatch": ["zerops-import.yml", "zerops-*-import.yml"],
+      "name": "Zerops.io import",
+      "description": "Zerops.io (https://zerops.io) infrastructure-as-code import YAML file",
+      "fileMatch": ["zerops-import.yaml", "zerops-*-import.yaml", "zerops-import.yml", "zerops-*-import.yml"],
       "url": "https://api.app-prg1.zerops.io/api/rest/public/settings/import-project-yml-json-schema.json"
     },
     {


### PR DESCRIPTION
Updated Zerops.io schemas, we support both `yaml` and `yml` extensions, plus unified the names and descriptions.