### PR TITLE
Fail on update parameters

### DIFF
--- a/src/schemas/json/mta.json
+++ b/src/schemas/json/mta.json
@@ -84,10 +84,18 @@
             "items": {
               "type": "string",
               "enum": [
-                "application.before-stop.live",
-                "application.before-stop.idle",
-                "application.after-stop.live",
-                "application.after-stop.idle"
+                "deploy.application.before-stop",
+                "blue-green.application.before-stop.idle",
+                "blue-green.application.before-stop.live",
+                "deploy.application.after-stop",
+                "blue-green.application.after-stop.idle",
+                "blue-green.application.after-stop.live",
+                "deploy.application.before-unmap-routes",
+                "blue-green.application.before-unmap-routes.live",
+                "blue-green.application.before-unmap-routes.idle",
+                "deploy.application.before-start",
+                "blue-green.application.before-start.idle",
+                "blue-green.application.before-start.live"
               ]
             }
           },

--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -667,11 +667,6 @@
             "items": {
               "type": "string",
               "enum": [
-                "application.before-stop.live",
-                "application.before-stop.idle",
-                "application.after-stop.live",
-                "application.after-stop.idle",
-                "application.before-unmap-routes",
                 "deploy.application.before-stop",
                 "blue-green.application.before-stop.idle",
                 "blue-green.application.before-stop.live",

--- a/src/schemas/json/mtad.json
+++ b/src/schemas/json/mtad.json
@@ -553,6 +553,10 @@
           "$ref": "#/definitions/resource-skip-service-updates",
           "description": "Map value, containing the service components (parameters, plan, tags) to skip when updating a service."
         },
+        "fail-on-service-update": {
+          "$ref": "#/definitions/resource-fail-on-service-update",
+          "description": "Map value specifying which service components (parameters, plan, tags) should cause the deployment to fail if their update fails."
+        },
         "provider-nid": {
           "description": "When used for cross-MTA dependency resolution the provider-nid is always 'mta'.",
           "type": "string",
@@ -590,6 +594,23 @@
         },
         "syslog-drain-url": {
           "description": "URL to which logs for bound applications are streamed.",
+          "type": "boolean"
+        }
+      }
+    },
+    "resource-fail-on-service-update": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "description": "Specifies whether the deployment should fail if updating the service instance parameters fails.",
+          "type": "boolean"
+        },
+        "plan": {
+          "description": "Specifies whether the deployment should fail if updating the service plan fails.",
+          "type": "boolean"
+        },
+        "tags": {
+          "description": "Specifies whether the deployment should fail if updating the service tags fails.",
           "type": "boolean"
         }
       }


### PR DESCRIPTION
Add new parameters that are part of the mtad.yaml file, the so called fail-on-service-update parameter
Remove unsupported hooks from mtad.yaml and mta.yaml