### PR TITLE
Allow use of `raw.githubusercontent.com` links

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -853,7 +853,7 @@
       "name": "partial-black.json",
       "description": "black, a Python formatter",
       "fileMatch": [],
-      "url": "https://json.schemastore.org/partial-black.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-black.json"
     },
     {
       "name": "bozr.suite.json",
@@ -1094,7 +1094,7 @@
       "name": "cibuildwheel",
       "description": "cibuildwheel, a Python redistributable wheel builder",
       "fileMatch": ["cibuildwheel.toml", ".cibuildwheel.toml"],
-      "url": "https://json.schemastore.org/cibuildwheel.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/cibuildwheel.json"
     },
     {
       "name": "CityJSON",
@@ -5769,7 +5769,7 @@
       "name": "uv",
       "description": "uv, a fast Python package installer",
       "fileMatch": ["uv.toml"],
-      "url": "https://json.schemastore.org/uv.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/uv.json"
     },
     {
       "name": "Vector",
@@ -6277,7 +6277,7 @@
       "name": "Hatch",
       "description": "Python package build tool",
       "fileMatch": ["hatch.toml"],
-      "url": "https://json.schemastore.org/hatch.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/hatch.json"
     },
     {
       "name": "helmfile",
@@ -7985,7 +7985,7 @@
       "name": "Python script metadata",
       "description": "Metadata of a Python script, as defined by PEP 723",
       "fileMatch": [],
-      "url": "https://json.schemastore.org/pep-723.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pep-723.json"
     },
     {
       "name": "vtcfg",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4670,7 +4670,7 @@
       "name": "PyProject",
       "description": "Python project metadata and configuration",
       "fileMatch": ["pyproject.toml"],
-      "url": "https://json.schemastore.org/pyproject.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pyproject.json"
     },
     {
       "name": "Pyright",
@@ -4681,7 +4681,7 @@
     {
       "name": "pytest",
       "description": "pytest configuration",
-      "url": "https://json.schemastore.org/partial-pytest.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-pytest.json"
     },
     {
       "name": "Qgoda",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

- Modify `cli.js` to allow `https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/*` URLs in both `catalog.json` and `"$ref"`'s

This will be a big change, so changing only a few at first, and then change everything else after it's clear there are no issues.

Also before I change everything else, I'll make a PR to VSCode so that [caching does not break](https://github.com/microsoft/vscode/blob/747d0bd66a4699a53e720cf7a61dcd10f664e667/extensions/json-language-features/client/src/node/jsonClientMain.ts#L161)

cc @madskristensen 