### PR TITLE
Use lowercase for TypeScript module / target options

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -401,20 +401,20 @@
               "anyOf": [
                 {
                   "enum": [
-                    "CommonJS",
-                    "AMD",
-                    "System",
-                    "UMD",
-                    "ES6",
-                    "ES2015",
-                    "ES2020",
-                    "ESNext",
-                    "None",
-                    "ES2022",
-                    "Node16",
-                    "Node18",
-                    "NodeNext",
-                    "Preserve"
+                    "commonjs",
+                    "amd",
+                    "system",
+                    "umd",
+                    "es6",
+                    "es2015",
+                    "es2020",
+                    "esnext",
+                    "none",
+                    "es2022",
+                    "node16",
+                    "node18",
+                    "nodenext",
+                    "preserve"
                   ]
                 },
                 {
@@ -657,24 +657,24 @@
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
-              "default": "ES3",
+              "default": "es3",
               "anyOf": [
                 {
                   "enum": [
-                    "ES3",
-                    "ES5",
-                    "ES6",
-                    "ES2015",
-                    "ES2016",
-                    "ES2017",
-                    "ES2018",
-                    "ES2019",
-                    "ES2020",
-                    "ES2021",
-                    "ES2022",
-                    "ES2023",
-                    "ES2024",
-                    "ESNext"
+                    "es3",
+                    "es5",
+                    "es6",
+                    "es2015",
+                    "es2016",
+                    "es2017",
+                    "es2018",
+                    "es2019",
+                    "es2020",
+                    "es2021",
+                    "es2022",
+                    "es2023",
+                    "es2024",
+                    "esnext"
                   ]
                 },
                 {

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -404,20 +404,20 @@
               "anyOf": [
                 {
                   "enum": [
-                    "CommonJS",
-                    "AMD",
-                    "System",
-                    "UMD",
-                    "ES6",
-                    "ES2015",
-                    "ES2020",
-                    "ESNext",
-                    "None",
-                    "ES2022",
-                    "Node16",
-                    "Node18",
-                    "NodeNext",
-                    "Preserve"
+                    "commonjs",
+                    "amd",
+                    "system",
+                    "umd",
+                    "es6",
+                    "es2015",
+                    "es2020",
+                    "esnext",
+                    "none",
+                    "es2022",
+                    "node16",
+                    "node18",
+                    "nodenext",
+                    "preserve"
                   ]
                 },
                 {
@@ -661,24 +661,24 @@
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
-              "default": "ES3",
+              "default": "es3",
               "anyOf": [
                 {
                   "enum": [
-                    "ES3",
-                    "ES5",
-                    "ES6",
-                    "ES2015",
-                    "ES2016",
-                    "ES2017",
-                    "ES2018",
-                    "ES2019",
-                    "ES2020",
-                    "ES2021",
-                    "ES2022",
-                    "ES2023",
-                    "ES2024",
-                    "ESNext"
+                    "es3",
+                    "es5",
+                    "es6",
+                    "es2015",
+                    "es2016",
+                    "es2017",
+                    "es2018",
+                    "es2019",
+                    "es2020",
+                    "es2021",
+                    "es2022",
+                    "es2023",
+                    "es2024",
+                    "esnext"
                   ]
                 },
                 {


### PR DESCRIPTION
Follow up to https://github.com/SchemaStore/schemastore/pull/4210

This PR changes the enum values of `module` and `target` options of TypeScript to use lowercase instead of PascalCase.

I also made a PR to update the TypeScript website to use lowercase consistently (https://github.com/microsoft/TypeScript-Website/pull/3396), so maybe good to wait for that PR to be merged.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
