### PR TITLE
Update vtesttree default schema version

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5986,7 +5986,7 @@
       "name": "vtesttree.yaml",
       "description": "Vector test execution tree description",
       "fileMatch": ["*.vtesttree.yaml", "*.vtesttree.yml", "*.vtesttree.json"],
-      "url": "https://json.schemastore.org/vtesttree-schema-v2.3.0.json",
+      "url": "https://json.schemastore.org/vtesttree-schema-v2.4.0.json",
       "versions": {
         "1.0.0": "https://json.schemastore.org/vtesttree-schema-v1.0.0.json",
         "2.0.0": "https://json.schemastore.org/vtesttree-schema-v2.0.0.json",


### PR DESCRIPTION
Update default schema version of vtesttree.yaml to version 2.4.0