### PR TITLE
fix: update regex pattern for property keys in pyproject.json

### DIFF
--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -513,7 +513,7 @@
           "type": "object",
           "x-tombi-table-keys-order": "ascending",
           "patternProperties": {
-            "^([a-z\\d]|[a-z\\d]([a-z\\d-](?!--))*[a-z\\d])$": {
+            "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9])$": {
               "type": "array",
               "items": {
                 "type": "string"


### PR DESCRIPTION
Fix https://github.com/tombi-toml/tombi/issues/432

Since rust's regex cannot perform lookahead negation, the pattern was modified.