### PR TITLE
Make workflow_call.outputs.*.description optional

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1588,7 +1588,7 @@
                           "type": "string"
                         }
                       },
-                      "required": ["description", "value"],
+                      "required": ["value"],
                       "additionalProperties": false
                     }
                   },


### PR DESCRIPTION
Quick follow up on https://github.com/SchemaStore/schemastore/pull/4730 - descriptions are not required