### PR TITLE
Update GitLab Agent configuration file location

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7452,7 +7452,7 @@
       "name": "GitLab Agent for Kubernetes configuration",
       "description": "GitLab Agent for Kubernetes configuration file",
       "fileMatch": ["**/.gitlab/agents/*/config.yaml"],
-      "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/ConfigurationFile.json"
+      "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/gitlab.agent.agentcfg.ConfigurationFile.jsonschema.bundle.json"
     },
     {
       "name": "IVMS101 by CODE Protocol",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->


We've updated the location of the agent configuration file due to how it's being generated. 

See https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/merge_requests/1642