### PR TITLE
feat: Add support for uv executor in partial-poe.json

### DIFF
--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -491,8 +491,8 @@
         },
         "type": {
           "default": "auto",
-          "description": "Specifies the executor type. 'auto' uses the most appropriate executor, 'poetry' uses the poetry environment, 'virtualenv' specifies a virtual environment, and 'simple' runs tasks without any specific environment setup.",
-          "enum": ["auto", "poetry", "virtualenv", "simple"],
+          "description": "Specifies the executor type. 'auto' uses the most appropriate executor, 'poetry' uses the poetry environment, 'uv' uses `uv run` to run tasks, 'virtualenv' specifies a virtual environment, and 'simple' runs tasks without any specific environment setup.",
+          "enum": ["auto", "poetry", "uv", "virtualenv", "simple"],
           "type": "string"
         }
       },


### PR DESCRIPTION
The uv executor is supported by poethepoet since version [0.33.0](https://github.com/nat-n/poethepoet/releases/tag/v0.33.0).