### PR TITLE
Fix GitHub workflow schema and update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,30 +98,14 @@ The goal of JSON Schemas in this repository is to correctly validate schemas tha
 ### Useful Conventions
 
 - Consider using documentation URLs in `"description"` to improve UX. Most schemas use the format `<description>\n<url>`. For example: `"Whether to ignore a theme configuration for the current site\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration"`
-- Consider using the [`base.json`][base] schema for `draft-07` or [`base-04.json`][base-04] for `draft-04` to use subschemas that are commonly used.
 - When writing `description`, avoid phrases like "there are three possibilities" and "valid values are" in favor of adding the constraints to the schema directly.
 - If you choose to use `title`, we recommend formatting it so that object values look like types in programming languages. This includes:
   - Omitting leading articles and trailing punctuation
   - Beginning it with a lowercase letter
   - Using nouns instead of sentences
 
-**Unofficial Strict Mode**
-
-> [!WARNING]  
-> This "unofficial strict mode" may have bugs or be incomplete.
-
-There is an [unofficial draft-07][draft-07-unofficial-strict] schema that uses JSON Schema to validate your JSON Schema. It checks that:
-
-- `type`, `title`, `description` properties are required
-- There are no empty arrays. For instance, it's impossible to write less than 2 sub-schemas for `allOf`
-- `type` can't be an array, which is intentional, `anyOf`/`oneOf` should be used in this case
-- It links to [understanding-json-schema](https://json-schema.org/understanding-json-schema) for each hint/check
-
-To check your schema against that schema, use `node cli.js check-strict --schema-name=<schemaName.json>`. Note that this is NOT the same as Ajv strict mode.
-
 [base]: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/base.json
 [base-04]: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/base-04.json
-[draft-07-unofficial-strict]: https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json
 
 #### Avoiding Overconstraint
 

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -672,7 +672,7 @@
           "term",
           "rss",
           "sitemap",
-          "robotsTXT",
+          "robotstxt",
           "404"
         ]
       }

--- a/src/test/github-workflow/issue-3208.yaml
+++ b/src/test/github-workflow/issue-3208.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
+on: 'create'
+jobs:
+  ci:
+    runs-on: unknown


### PR DESCRIPTION
Similar to #4749, fixes a validation issue that depends on enum capitalization.

Removes mention of the `metaschema-draft-07-unofficial-strict.json` "unofficial strict mode" schema. It was user-contributed and is no longer maintained (see related open issues below). In my opinion, I think it was too strict in general and I encountered some surprising false positives.

Closes #4031
Closes #4032

Also no longer recommend use of `base.json` (see https://github.com/SchemaStore/schemastore/pull/3519#issuecomment-1920450630) for details. Do not delete schema as consumers downstream may be using it.

Closes #3208
