### PR TITLE
Disallow additional properties for tsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -113,6 +113,7 @@
     "buildOptionsDefinition": {
       "properties": {
         "buildOptions": {
+          "additionalProperties": false,
           "properties": {
             "dry": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -165,6 +166,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
+          "additionalProperties": false,
           "properties": {
             "force": {
               "description": "~",
@@ -224,6 +226,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
+          "additionalProperties": false,
           "properties": {
             "allowArbitraryExtensions": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -533,6 +536,11 @@
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
+            },
+            "out": {
+              "description": "Specify an output for the build. It is recommended to use `outFile` instead.",
+              "type": ["string", "null"],
+              "markdownDescription": "Specify an output for the build. It is recommended to use `outFile` instead.\n\nSee more: https://www.typescriptlang.org/tsconfig/#out"
             },
             "skipDefaultLibCheck": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -1273,6 +1281,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
+          "additionalProperties": false,
           "properties": {
             "enable": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -116,6 +116,7 @@
     "buildOptionsDefinition": {
       "properties": {
         "buildOptions": {
+          "additionalProperties": false,
           "properties": {
             "dry": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -168,6 +169,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
+          "additionalProperties": false,
           "properties": {
             "force": {
               "description": "~",
@@ -227,6 +229,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
+          "additionalProperties": false,
           "properties": {
             "allowArbitraryExtensions": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -537,6 +540,11 @@
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
+            },
+            "out": {
+              "description": "Specify an output for the build. It is recommended to use `outFile` instead.",
+              "type": ["string", "null"],
+              "markdownDescription": "Specify an output for the build. It is recommended to use `outFile` instead.\n\nSee more: https://www.typescriptlang.org/tsconfig/#out"
             },
             "skipDefaultLibCheck": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -1281,6 +1289,7 @@
           "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
+          "additionalProperties": false,
           "properties": {
             "enable": {
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
@@ -1339,6 +1348,7 @@
       "properties": {
         "ts-node": {
           "description": "ts-node options.  See also: https://typestrong.org/ts-node/docs/configuration\n\nts-node offers TypeScript execution and REPL for node.js, with source map support.",
+          "additionalProperties": false,
           "properties": {
             "compiler": {
               "default": "typescript",


### PR DESCRIPTION
Partially addresses #3731

Note that doing this at top-level [requires use of json schema version 2019-09](https://stackoverflow.com/questions/22689900/json-schema-allof-with-additionalproperties). Do not close #3731 until that is addressed.