### PR TITLE
Fix missing includes parameter for buf.yaml modules

### DIFF
--- a/src/schemas/json/buf.json
+++ b/src/schemas/json/buf.json
@@ -1196,6 +1196,14 @@
               "description": "Optional. A Buf Schema Registry (BSR) path that uniquely identifies this directory. The name must be a valid module name and it defines the BSR repository that contains the commit and label history and generated artifacts for the Protobuf files in the directory.",
               "type": "string"
             },
+            "includes": {
+              "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#includes",
+              "description": "Optional. Lists directories within this directory to include in Protobuf file discovery. Only directories added to this list are included in Buf operations.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "excludes": {
               "$comment": "https://buf.build/docs/configuration/v2/buf-yaml#excludes",
               "description": "Optional. Lists directories within this directory to exclude from Protobuf file discovery. Any directories added to this list are completely skipped and excluded from Buf operations. We don't recommend using this option, but in some situations it's unavoidable.",


### PR DESCRIPTION
This adds a missing includes field for the `buf.yaml` json schema. The field `includes` is valid, similar to the field `excludes` already present below.