### PR TITLE
Added abc-inventory-module-data-5.1.0.json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -142,12 +142,13 @@
       "name": "ABCInventoryModuleData",
       "description": "ABCInventoryModuleData defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module",
       "fileMatch": ["abc-inventory-module-data-*.json"],
-      "url": "https://json.schemastore.org/abc-inventory-module-data-4.0.0.json",
+      "url": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
       "versions": {
         "1.0.0": "https://json.schemastore.org/abc-inventory-module-data-1.0.0.json",
         "2.0.0": "https://json.schemastore.org/abc-inventory-module-data-2.0.0.json",
         "3.0.0": "https://json.schemastore.org/abc-inventory-module-data-3.0.0.json",
-        "4.0.0": "https://json.schemastore.org/abc-inventory-module-data-4.0.0.json"
+        "4.0.0": "https://json.schemastore.org/abc-inventory-module-data-4.0.0.json",
+        "5.1.0": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json"
       }
     },
     {

--- a/src/negative_test/abc-inventory-module-data-5.1.0/abc-inventory-module-data-missing-schema-property.json
+++ b/src/negative_test/abc-inventory-module-data-5.1.0/abc-inventory-module-data-missing-schema-property.json
@@ -1,0 +1,11 @@
+{
+  "ABCInventoryEntries": {},
+  "ABCLocations": {},
+  "ABCTags": {},
+  "ABCMaterialCategories": {},
+  "ABCMaterialNumbers": {},
+  "ABCProducts": {},
+  "ABCReasonCodes": {},
+  "ABCTransactions": [],
+  "ABCVendors": {}
+}

--- a/src/negative_test/abc-inventory-module-data-5.1.0/abc-inventory-module-data-missing-schema-property.json
+++ b/src/negative_test/abc-inventory-module-data-5.1.0/abc-inventory-module-data-missing-schema-property.json
@@ -1,11 +1,11 @@
 {
   "ABCInventoryEntries": {},
   "ABCLocations": {},
-  "ABCTags": {},
   "ABCMaterialCategories": {},
   "ABCMaterialNumbers": {},
   "ABCProducts": {},
   "ABCReasonCodes": {},
+  "ABCTags": {},
   "ABCTransactions": [],
   "ABCVendors": {}
 }

--- a/src/schemas/json/abc-inventory-module-data-5.1.0.json
+++ b/src/schemas/json/abc-inventory-module-data-5.1.0.json
@@ -1,1118 +1,1126 @@
 {
-    "$id": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "ABCInventoryModuleData JSON Schema",
-    "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module. Version 5.1.0 adds support for Change Attributes transactions.",
-    "type": "object",
-    "definitions": {
-        "ABCStatus": {
-            "type": "string",
-            "enum": [
-                "RELEASED",
-                "CONDITIONAL_RELEASED",
-                "QUARANTINE",
-                "IN_TRANSIT",
-                "ON_HOLD",
-                "EXPIRED",
-                "DAMAGED"
-            ]
-        },
-        "ABCInventoryReceiveTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["receive"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "dateOfExpiry": {
-                            "type": "string",
-                            "format": "date"
-                        },
-                        "dateOfManufacture": {
-                            "type": "string",
-                            "format": "date"
-                        },
-                        "poNumber": {
-                            "type": "string"
-                        },
-                        "statusID": {
-                            "$ref": "#/definitions/ABCStatus"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "tagIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotNumber",
-                        "materialNumberID",
-                        "materialCategoryID",
-                        "quantity",
-                        "dateOfExpiry",
-                        "dateOfManufacture",
-                        "poNumber",
-                        "statusID",
-                        "locationID",
-                        "tagIDs",
-                        "productID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                },
-                "targetLotID": {
-                    "type": "string"
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryBuildTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["build"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "dateOfExpiry": {
-                            "type": "string",
-                            "format": "date"
-                        },
-                        "dateOfManufacture": {
-                            "type": "string",
-                            "format": "date"
-                        },
-                        "poNumber": {
-                            "type": "string"
-                        },
-                        "statusID": {
-                            "$ref": "#/definitions/ABCStatus"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "tagIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "upstreams": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "lotID": {
-                                        "type": "string"
-                                    },
-                                    "quantity": {
-                                        "type": "number"
-                                    }
-                                },
-                                "required": ["lotID", "quantity"],
-                                "additionalProperties": false
-                            }
-                        },
-                        "upstreamIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "upstreamLotNumbers": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "upstreamQuantities": {
-                            "type": "array",
-                            "items": {
-                                "type": "number"
-                            }
-                        },
-                        "upstreamMaterialNumberIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "upstreamMaterialCategoryIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "upstreamLocationIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "upstreamProductIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": ["string", "null"]
-                            }
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotNumber",
-                        "materialNumberID",
-                        "materialCategoryID",
-                        "quantity",
-                        "dateOfExpiry",
-                        "dateOfManufacture",
-                        "poNumber",
-                        "statusID",
-                        "locationID",
-                        "tagIDs",
-                        "upstreams",
-                        "upstreamIDs",
-                        "upstreamLotNumbers",
-                        "upstreamQuantities",
-                        "upstreamMaterialNumberIDs",
-                        "upstreamMaterialCategoryIDs",
-                        "upstreamLocationIDs",
-                        "productID",
-                        "upstreamProductIDs",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                },
-                "targetLotID": {
-                    "type": "string"
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryTransferTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["transfer"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "newLocationID": {
-                            "type": "string"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "newLocationID",
-                        "quantity",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                },
-                "targetLotID": {
-                    "type": "string"
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryStatusChangeTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["statusChange"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "newStatusID": {
-                            "$ref": "#/definitions/ABCStatus"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "newStatusID",
-                        "quantity",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                },
-                "targetLotID": {
-                    "type": "string"
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryDistributeTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["distribute"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "quantity",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryDestroyTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["destroy"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventorySellTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["sell"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "quantity": {
-                            "type": "number"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "quantity",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryAdjustTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["adjust"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "newQuantity": {
-                            "type": "number"
-                        },
-                        "reasonCodeID": {
-                            "type": "string"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "newQuantity",
-                        "reasonCodeID",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                },
-                "oldQuantity": {
-                    "type": "number"
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData", "oldQuantity"],
-            "additionalProperties": false
-        },
-        "ABCInventoryChangeExpiryTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["changeExpiry"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "newDateOfExpiry": {
-                            "type": "string"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "newDateOfExpiry",
-                        "lotNumber",
-                        "materialNumberID",
-                        "locationID",
-                        "productID",
-                        "materialCategoryID",
-                        "notes"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryChangeAttributesTransaction": {
-            "type": "object",
-            "properties": {
-                "uid": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionType": {
-                    "type": "string",
-                    "enum": ["changeAttributes"]
-                },
-                "transactionData": {
-                    "type": "object",
-                    "properties": {
-                        "lotID": {
-                            "type": "string"
-                        },
-                        "lotNumber": {
-                            "type": "string"
-                        },
-                        "materialNumberID": {
-                            "type": "string"
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "locationID": {
-                            "type": "string"
-                        },
-                        "dateOfManufacture": {
-                            "type": "string",
-                            "format": "date"
-                        },
-                        "poNumber": {
-                            "type": "string"
-                        },
-                        "tagIDs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "notes": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "lotID",
-                        "lotNumber",
-                        "materialNumberID",
-                        "materialCategoryID",
-                        "productID",
-                        "locationID"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["uid", "timestamp", "transactionType", "transactionData"],
-            "additionalProperties": false
-        },
-        "ABCInventoryTransaction": {
-            "oneOf": [
-                { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
-                { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
-                { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
-                { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
-                { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
-                { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
-                { "$ref": "#/definitions/ABCInventorySellTransaction" },
-                { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
-                { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" },
-                { "$ref": "#/definitions/ABCInventoryChangeAttributesTransaction" }
-            ]
-        },
-        "ABCInventoryEntryWithoutUpstreams": {
-            "type": "object",
-            "properties": {
-                "lotNumber": {
-                    "type": "string"
-                },
-                "materialNumberID": {
-                    "type": "string"
-                },
-                "materialCategoryID": {
-                    "type": "string"
-                },
-                "productID": {
-                    "type": ["string", "null"]
-                },
-                "quantity": {
-                    "type": "number"
-                },
-                "dateOfExpiry": {
-                    "type": "string",
-                    "format": "date"
-                },
-                "dateOfManufacture": {
-                    "type": "string",
-                    "format": "date"
-                },
-                "poNumber": {
-                    "type": "string"
-                },
-                "statusID": {
-                    "$ref": "#/definitions/ABCStatus"
-                },
-                "locationID": {
-                    "type": "string"
-                },
-                "tagIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hasUpstreams": {
-                    "type": "boolean",
-                    "enum": [false]
-                },
-                "transactionNotes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "lotNumberLowercase": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "lotNumber",
-                "materialNumberID",
-                "materialCategoryID",
-                "productID",
-                "quantity",
-                "dateOfExpiry",
-                "dateOfManufacture",
-                "poNumber",
-                "statusID",
-                "locationID",
-                "tagIDs",
-                "hasUpstreams",
-                "transactionNotes",
-                "lotNumberLowercase"
-            ],
-            "additionalProperties": false
-        },
-        "ABCInventoryEntryWithUpstreams": {
-            "type": "object",
-            "properties": {
-                "lotNumber": {
-                    "type": "string"
-                },
-                "materialNumberID": {
-                    "type": "string"
-                },
-                "materialCategoryID": {
-                    "type": "string"
-                },
-                "productID": {
-                    "type": ["string", "null"]
-                },
-                "quantity": {
-                    "type": "number"
-                },
-                "dateOfExpiry": {
-                    "type": "string",
-                    "format": "date"
-                },
-                "dateOfManufacture": {
-                    "type": "string",
-                    "format": "date"
-                },
-                "poNumber": {
-                    "type": "string"
-                },
-                "statusID": {
-                    "$ref": "#/definitions/ABCStatus"
-                },
-                "locationID": {
-                    "type": "string"
-                },
-                "tagIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hasUpstreams": {
-                    "type": "boolean",
-                    "enum": [true]
-                },
-                "upstreamIDs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "upstreamQuantities": {
-                    "type": "array",
-                    "items": {
-                        "type": "number"
-                    }
-                },
-                "upstreamLotNumbers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "transactionNotes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "lotNumberLowercase": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "lotNumber",
-                "materialNumberID",
-                "materialCategoryID",
-                "productID",
-                "quantity",
-                "dateOfExpiry",
-                "dateOfManufacture",
-                "poNumber",
-                "statusID",
-                "locationID",
-                "tagIDs",
-                "hasUpstreams",
-                "upstreamIDs",
-                "upstreamQuantities",
-                "upstreamLotNumbers",
-                "transactionNotes",
-                "lotNumberLowercase"
-            ],
-            "additionalProperties": false
-        },
-        "ABCInventoryEntry": {
-            "oneOf": [
-                { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
-                { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
-            ]
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
+  "title": "ABCInventoryModuleData JSON Schema",
+  "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module. Version 5.1.0 adds support for Change Attributes transactions.",
+  "type": "object",
+  "definitions": {
+    "ABCStatus": {
+      "type": "string",
+      "enum": [
+        "RELEASED",
+        "CONDITIONAL_RELEASED",
+        "QUARANTINE",
+        "IN_TRANSIT",
+        "ON_HOLD",
+        "EXPIRED",
+        "DAMAGED"
+      ]
     },
-    "properties": {
-        "$schema": {
-            "description": "Link to https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
-            "type": "string",
-            "enum": ["https://json.schemastore.org/abc-inventory-module-data-5.1.0.json"]
+    "ABCInventoryReceiveTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
         },
-        "ABCProducts": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["name", "isActive"],
-                    "additionalProperties": false
-                }
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["receive"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotNumber": {
+              "type": "string"
             },
-            "additionalProperties": false
-        },
-        "ABCVendors": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["name", "isActive"],
-                    "additionalProperties": false
-                }
+            "materialNumberID": {
+              "type": "string"
             },
-            "additionalProperties": false
-        },
-        "ABCMaterialCategories": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "prefix": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["name", "isActive", "prefix"],
-                    "additionalProperties": false
-                }
+            "materialCategoryID": {
+              "type": "string"
             },
-            "additionalProperties": false
-        },
-        "ABCMaterialNumbers": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "productID": {
-                            "type": ["string", "null"]
-                        },
-                        "vendorID": {
-                            "type": ["string", "null"]
-                        },
-                        "materialCategoryID": {
-                            "type": "string"
-                        },
-                        "number": {
-                            "type": "number"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "description": {
-                            "type": "string"
-                        },
-                        "unitOfMeasure": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": [
-                        "productID",
-                        "vendorID",
-                        "materialCategoryID",
-                        "number",
-                        "name",
-                        "description",
-                        "unitOfMeasure",
-                        "isActive"
-                    ],
-                    "additionalProperties": false
-                }
+            "quantity": {
+              "type": "number"
             },
-            "additionalProperties": false
-        },
-        "ABCLocations": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["name", "isActive"],
-                    "additionalProperties": false
-                }
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
             },
-            "additionalProperties": false
-        },
-        "ABCTags": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["name", "isActive"],
-                    "additionalProperties": false
-                }
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
             },
-            "additionalProperties": false
-        },
-        "ABCReasonCodes": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "type": "object",
-                    "properties": {
-                        "code": {
-                            "type": "string"
-                        },
-                        "description": {
-                            "type": "string"
-                        },
-                        "isActive": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": ["code", "description", "isActive"],
-                    "additionalProperties": false
-                }
+            "poNumber": {
+              "type": "string"
             },
-            "additionalProperties": false
-        },
-        "ABCTransactions": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/ABCInventoryTransaction"
+            "statusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "tagIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "notes": {
+              "type": "string"
             }
+          },
+          "required": [
+            "lotNumber",
+            "materialNumberID",
+            "materialCategoryID",
+            "quantity",
+            "dateOfExpiry",
+            "dateOfManufacture",
+            "poNumber",
+            "statusID",
+            "locationID",
+            "tagIDs",
+            "productID",
+            "notes"
+          ],
+          "additionalProperties": false
         },
-        "ABCInventoryEntries": {
-            "type": "object",
-            "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
-                    "$ref": "#/definitions/ABCInventoryEntry"
-                }
-            },
-            "additionalProperties": false
+        "targetLotID": {
+          "type": "string"
         }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
     },
-    "required": [
-        "$schema",
-        "ABCProducts",
-        "ABCVendors",
-        "ABCMaterialCategories",
-        "ABCMaterialNumbers",
-        "ABCLocations",
-        "ABCTags",
-        "ABCReasonCodes",
-        "ABCTransactions",
-        "ABCInventoryEntries"
-    ],
-    "additionalProperties": false
+    "ABCInventoryBuildTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["build"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "poNumber": {
+              "type": "string"
+            },
+            "statusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "tagIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreams": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "lotID": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": ["lotID", "quantity"],
+                "additionalProperties": false
+              }
+            },
+            "upstreamIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamLotNumbers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamQuantities": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "upstreamMaterialNumberIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamMaterialCategoryIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "upstreamLocationIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "upstreamProductIDs": {
+              "type": "array",
+              "items": {
+                "type": ["string", "null"]
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotNumber",
+            "materialNumberID",
+            "materialCategoryID",
+            "quantity",
+            "dateOfExpiry",
+            "dateOfManufacture",
+            "poNumber",
+            "statusID",
+            "locationID",
+            "tagIDs",
+            "upstreams",
+            "upstreamIDs",
+            "upstreamLotNumbers",
+            "upstreamQuantities",
+            "upstreamMaterialNumberIDs",
+            "upstreamMaterialCategoryIDs",
+            "upstreamLocationIDs",
+            "productID",
+            "upstreamProductIDs",
+            "notes"
+          ],
+          "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryTransferTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["transfer"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newLocationID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "newLocationID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryStatusChangeTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["statusChange"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newStatusID": {
+              "$ref": "#/definitions/ABCStatus"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "newStatusID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        },
+        "targetLotID": {
+          "type": "string"
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryDistributeTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["distribute"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryDestroyTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["destroy"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventorySellTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["sell"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryAdjustTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["adjust"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newQuantity": {
+              "type": "number"
+            },
+            "reasonCodeID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "newQuantity",
+            "reasonCodeID",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        },
+        "oldQuantity": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "oldQuantity"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryChangeExpiryTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["changeExpiry"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "newDateOfExpiry": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "newDateOfExpiry",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "materialCategoryID",
+            "notes"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryChangeAttributesTransaction": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionType": {
+          "type": "string",
+          "enum": ["changeAttributes"]
+        },
+        "transactionData": {
+          "type": "object",
+          "properties": {
+            "lotID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "poNumber": {
+              "type": "string"
+            },
+            "tagIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "lotID",
+            "lotNumber",
+            "materialNumberID",
+            "materialCategoryID",
+            "productID",
+            "locationID"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
+      "additionalProperties": false
+    },
+    "ABCInventoryTransaction": {
+      "oneOf": [
+        { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
+        { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
+        { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
+        { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
+        { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
+        { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
+        { "$ref": "#/definitions/ABCInventorySellTransaction" },
+        { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
+        { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" },
+        { "$ref": "#/definitions/ABCInventoryChangeAttributesTransaction" }
+      ]
+    },
+    "ABCInventoryEntryWithoutUpstreams": {
+      "type": "object",
+      "properties": {
+        "lotNumber": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "materialCategoryID": {
+          "type": "string"
+        },
+        "productID": {
+          "type": ["string", "null"]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "tagIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hasUpstreams": {
+          "type": "boolean",
+          "enum": [false]
+        },
+        "transactionNotes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "materialCategoryID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "tagIDs",
+        "hasUpstreams",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryEntryWithUpstreams": {
+      "type": "object",
+      "properties": {
+        "lotNumber": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "materialCategoryID": {
+          "type": "string"
+        },
+        "productID": {
+          "type": ["string", "null"]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "tagIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hasUpstreams": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "upstreamIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upstreamQuantities": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "upstreamLotNumbers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transactionNotes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "materialCategoryID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "tagIDs",
+        "hasUpstreams",
+        "upstreamIDs",
+        "upstreamQuantities",
+        "upstreamLotNumbers",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "additionalProperties": false
+    },
+    "ABCInventoryEntry": {
+      "oneOf": [
+        { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
+        { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
+      ]
+    }
+  },
+  "properties": {
+    "$schema": {
+      "description": "Link to https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
+      "type": "string",
+      "enum": [
+        "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json"
+      ]
+    },
+    "ABCProducts": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCVendors": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialCategories": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive", "prefix"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialNumbers": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "productID": {
+              "type": ["string", "null"]
+            },
+            "vendorID": {
+              "type": ["string", "null"]
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "number": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "productID",
+            "vendorID",
+            "materialCategoryID",
+            "number",
+            "name",
+            "description",
+            "unitOfMeasure",
+            "isActive"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCLocations": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCTags": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["name", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCReasonCodes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "required": ["code", "description", "isActive"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCTransactions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ABCInventoryTransaction"
+      }
+    },
+    "ABCInventoryEntries": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/definitions/ABCInventoryEntry"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "$schema",
+    "ABCProducts",
+    "ABCVendors",
+    "ABCMaterialCategories",
+    "ABCMaterialNumbers",
+    "ABCLocations",
+    "ABCTags",
+    "ABCReasonCodes",
+    "ABCTransactions",
+    "ABCInventoryEntries"
+  ],
+  "additionalProperties": false
 }

--- a/src/schemas/json/abc-inventory-module-data-5.1.0.json
+++ b/src/schemas/json/abc-inventory-module-data-5.1.0.json
@@ -1,0 +1,1118 @@
+{
+    "$id": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ABCInventoryModuleData JSON Schema",
+    "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module. Version 5.1.0 adds support for Change Attributes transactions.",
+    "type": "object",
+    "definitions": {
+        "ABCStatus": {
+            "type": "string",
+            "enum": [
+                "RELEASED",
+                "CONDITIONAL_RELEASED",
+                "QUARANTINE",
+                "IN_TRANSIT",
+                "ON_HOLD",
+                "EXPIRED",
+                "DAMAGED"
+            ]
+        },
+        "ABCInventoryReceiveTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["receive"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "dateOfExpiry": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "dateOfManufacture": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "poNumber": {
+                            "type": "string"
+                        },
+                        "statusID": {
+                            "$ref": "#/definitions/ABCStatus"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "tagIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotNumber",
+                        "materialNumberID",
+                        "materialCategoryID",
+                        "quantity",
+                        "dateOfExpiry",
+                        "dateOfManufacture",
+                        "poNumber",
+                        "statusID",
+                        "locationID",
+                        "tagIDs",
+                        "productID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                },
+                "targetLotID": {
+                    "type": "string"
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryBuildTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["build"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "dateOfExpiry": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "dateOfManufacture": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "poNumber": {
+                            "type": "string"
+                        },
+                        "statusID": {
+                            "$ref": "#/definitions/ABCStatus"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "tagIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "upstreams": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "lotID": {
+                                        "type": "string"
+                                    },
+                                    "quantity": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": ["lotID", "quantity"],
+                                "additionalProperties": false
+                            }
+                        },
+                        "upstreamIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "upstreamLotNumbers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "upstreamQuantities": {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        "upstreamMaterialNumberIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "upstreamMaterialCategoryIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "upstreamLocationIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "upstreamProductIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": ["string", "null"]
+                            }
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotNumber",
+                        "materialNumberID",
+                        "materialCategoryID",
+                        "quantity",
+                        "dateOfExpiry",
+                        "dateOfManufacture",
+                        "poNumber",
+                        "statusID",
+                        "locationID",
+                        "tagIDs",
+                        "upstreams",
+                        "upstreamIDs",
+                        "upstreamLotNumbers",
+                        "upstreamQuantities",
+                        "upstreamMaterialNumberIDs",
+                        "upstreamMaterialCategoryIDs",
+                        "upstreamLocationIDs",
+                        "productID",
+                        "upstreamProductIDs",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                },
+                "targetLotID": {
+                    "type": "string"
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryTransferTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["transfer"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "newLocationID": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "newLocationID",
+                        "quantity",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                },
+                "targetLotID": {
+                    "type": "string"
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryStatusChangeTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["statusChange"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "newStatusID": {
+                            "$ref": "#/definitions/ABCStatus"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "newStatusID",
+                        "quantity",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                },
+                "targetLotID": {
+                    "type": "string"
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryDistributeTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["distribute"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "quantity",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryDestroyTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["destroy"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventorySellTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["sell"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "quantity": {
+                            "type": "number"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "quantity",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryAdjustTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["adjust"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "newQuantity": {
+                            "type": "number"
+                        },
+                        "reasonCodeID": {
+                            "type": "string"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "newQuantity",
+                        "reasonCodeID",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                },
+                "oldQuantity": {
+                    "type": "number"
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData", "oldQuantity"],
+            "additionalProperties": false
+        },
+        "ABCInventoryChangeExpiryTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["changeExpiry"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "newDateOfExpiry": {
+                            "type": "string"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "newDateOfExpiry",
+                        "lotNumber",
+                        "materialNumberID",
+                        "locationID",
+                        "productID",
+                        "materialCategoryID",
+                        "notes"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryChangeAttributesTransaction": {
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionType": {
+                    "type": "string",
+                    "enum": ["changeAttributes"]
+                },
+                "transactionData": {
+                    "type": "object",
+                    "properties": {
+                        "lotID": {
+                            "type": "string"
+                        },
+                        "lotNumber": {
+                            "type": "string"
+                        },
+                        "materialNumberID": {
+                            "type": "string"
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "locationID": {
+                            "type": "string"
+                        },
+                        "dateOfManufacture": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "poNumber": {
+                            "type": "string"
+                        },
+                        "tagIDs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "lotID",
+                        "lotNumber",
+                        "materialNumberID",
+                        "materialCategoryID",
+                        "productID",
+                        "locationID"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["uid", "timestamp", "transactionType", "transactionData"],
+            "additionalProperties": false
+        },
+        "ABCInventoryTransaction": {
+            "oneOf": [
+                { "$ref": "#/definitions/ABCInventoryReceiveTransaction" },
+                { "$ref": "#/definitions/ABCInventoryBuildTransaction" },
+                { "$ref": "#/definitions/ABCInventoryTransferTransaction" },
+                { "$ref": "#/definitions/ABCInventoryStatusChangeTransaction" },
+                { "$ref": "#/definitions/ABCInventoryDistributeTransaction" },
+                { "$ref": "#/definitions/ABCInventoryDestroyTransaction" },
+                { "$ref": "#/definitions/ABCInventorySellTransaction" },
+                { "$ref": "#/definitions/ABCInventoryAdjustTransaction" },
+                { "$ref": "#/definitions/ABCInventoryChangeExpiryTransaction" },
+                { "$ref": "#/definitions/ABCInventoryChangeAttributesTransaction" }
+            ]
+        },
+        "ABCInventoryEntryWithoutUpstreams": {
+            "type": "object",
+            "properties": {
+                "lotNumber": {
+                    "type": "string"
+                },
+                "materialNumberID": {
+                    "type": "string"
+                },
+                "materialCategoryID": {
+                    "type": "string"
+                },
+                "productID": {
+                    "type": ["string", "null"]
+                },
+                "quantity": {
+                    "type": "number"
+                },
+                "dateOfExpiry": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "dateOfManufacture": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "poNumber": {
+                    "type": "string"
+                },
+                "statusID": {
+                    "$ref": "#/definitions/ABCStatus"
+                },
+                "locationID": {
+                    "type": "string"
+                },
+                "tagIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hasUpstreams": {
+                    "type": "boolean",
+                    "enum": [false]
+                },
+                "transactionNotes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lotNumberLowercase": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "lotNumber",
+                "materialNumberID",
+                "materialCategoryID",
+                "productID",
+                "quantity",
+                "dateOfExpiry",
+                "dateOfManufacture",
+                "poNumber",
+                "statusID",
+                "locationID",
+                "tagIDs",
+                "hasUpstreams",
+                "transactionNotes",
+                "lotNumberLowercase"
+            ],
+            "additionalProperties": false
+        },
+        "ABCInventoryEntryWithUpstreams": {
+            "type": "object",
+            "properties": {
+                "lotNumber": {
+                    "type": "string"
+                },
+                "materialNumberID": {
+                    "type": "string"
+                },
+                "materialCategoryID": {
+                    "type": "string"
+                },
+                "productID": {
+                    "type": ["string", "null"]
+                },
+                "quantity": {
+                    "type": "number"
+                },
+                "dateOfExpiry": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "dateOfManufacture": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "poNumber": {
+                    "type": "string"
+                },
+                "statusID": {
+                    "$ref": "#/definitions/ABCStatus"
+                },
+                "locationID": {
+                    "type": "string"
+                },
+                "tagIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hasUpstreams": {
+                    "type": "boolean",
+                    "enum": [true]
+                },
+                "upstreamIDs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "upstreamQuantities": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "upstreamLotNumbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "transactionNotes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "lotNumberLowercase": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "lotNumber",
+                "materialNumberID",
+                "materialCategoryID",
+                "productID",
+                "quantity",
+                "dateOfExpiry",
+                "dateOfManufacture",
+                "poNumber",
+                "statusID",
+                "locationID",
+                "tagIDs",
+                "hasUpstreams",
+                "upstreamIDs",
+                "upstreamQuantities",
+                "upstreamLotNumbers",
+                "transactionNotes",
+                "lotNumberLowercase"
+            ],
+            "additionalProperties": false
+        },
+        "ABCInventoryEntry": {
+            "oneOf": [
+                { "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams" },
+                { "$ref": "#/definitions/ABCInventoryEntryWithUpstreams" }
+            ]
+        }
+    },
+    "properties": {
+        "$schema": {
+            "description": "Link to https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
+            "type": "string",
+            "enum": ["https://json.schemastore.org/abc-inventory-module-data-5.1.0.json"]
+        },
+        "ABCProducts": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["name", "isActive"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCVendors": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["name", "isActive"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCMaterialCategories": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["name", "isActive", "prefix"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCMaterialNumbers": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "productID": {
+                            "type": ["string", "null"]
+                        },
+                        "vendorID": {
+                            "type": ["string", "null"]
+                        },
+                        "materialCategoryID": {
+                            "type": "string"
+                        },
+                        "number": {
+                            "type": "number"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "unitOfMeasure": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "productID",
+                        "vendorID",
+                        "materialCategoryID",
+                        "number",
+                        "name",
+                        "description",
+                        "unitOfMeasure",
+                        "isActive"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCLocations": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["name", "isActive"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCTags": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["name", "isActive"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCReasonCodes": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "isActive": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": ["code", "description", "isActive"],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ABCTransactions": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/ABCInventoryTransaction"
+            }
+        },
+        "ABCInventoryEntries": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "$ref": "#/definitions/ABCInventoryEntry"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "$schema",
+        "ABCProducts",
+        "ABCVendors",
+        "ABCMaterialCategories",
+        "ABCMaterialNumbers",
+        "ABCLocations",
+        "ABCTags",
+        "ABCReasonCodes",
+        "ABCTransactions",
+        "ABCInventoryEntries"
+    ],
+    "additionalProperties": false
+}

--- a/src/test/abc-inventory-module-data-5.1.0/abc-inventory-module-data.json
+++ b/src/test/abc-inventory-module-data-5.1.0/abc-inventory-module-data.json
@@ -6,7 +6,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "SubJul24002",
       "lotNumberLowercase": "subjul24002",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -15,6 +14,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 55,
       "statusID": "QUARANTINE",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -25,7 +25,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "DrugJul24001",
       "lotNumberLowercase": "drugjul24001",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -34,6 +33,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 100,
       "statusID": "ON_HOLD",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["SbQFkyfF8JXdweMDZdlO", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
@@ -44,7 +44,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "S6aXk0Ab7WbVn3VbcumX",
-      "tagIDs": [],
       "lotNumber": "FilJul24002",
       "lotNumberLowercase": "filjul24002",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -53,6 +52,7 @@
       "productID": null,
       "quantity": 400,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""]
     },
     "JhepbvqOsySoYt1pf1H3": {
@@ -60,7 +60,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "S6aXk0Ab7WbVn3VbcumX",
-      "tagIDs": [],
       "lotNumber": "PowJul24002",
       "lotNumberLowercase": "powjul24002",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -69,6 +68,7 @@
       "productID": null,
       "quantity": 300,
       "statusID": "QUARANTINE",
+      "tagIDs": [],
       "transactionNotes": ["received 400 grams of powder @ PCI", ""]
     },
     "Re4OtiGfXMBzsCjZ692M": {
@@ -76,7 +76,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "SubJul24002",
       "lotNumberLowercase": "subjul24002",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -85,6 +84,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 20,
       "statusID": "CONDITIONAL_RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -95,7 +95,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "7OXYrFQz9u5R0BDKSWrt",
-      "tagIDs": [],
       "lotNumber": "RawJul24001",
       "lotNumberLowercase": "rawjul24001",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -104,6 +103,7 @@
       "productID": null,
       "quantity": 395,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""]
     },
     "VBtqZoPSh1OjtKwW1suE": {
@@ -111,7 +111,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "FilJul24001",
       "lotNumberLowercase": "filjul24001",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -120,6 +119,7 @@
       "productID": null,
       "quantity": 100,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": ["received 500 filters immediately released"]
     },
     "aBcF4u4fctf2YZQpb66W": {
@@ -127,7 +127,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "SubJul24002",
       "lotNumberLowercase": "subjul24002",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -136,6 +135,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 25,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -146,7 +146,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "S6aXk0Ab7WbVn3VbcumX",
-      "tagIDs": [],
       "lotNumber": "SubJul24001",
       "lotNumberLowercase": "subjul24001",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -155,6 +154,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 100,
       "statusID": "CONDITIONAL_RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -165,7 +165,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": true,
       "locationID": "S6aXk0Ab7WbVn3VbcumX",
-      "tagIDs": [],
       "lotNumber": "SubJul24001",
       "lotNumberLowercase": "subjul24001",
       "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
@@ -174,6 +173,7 @@
       "productID": "xU0dkyp7LlrEz9lJ7EJk",
       "quantity": 100,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": [""],
       "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
       "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -184,7 +184,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "FdottFSAocWd909F1ZSF",
-      "tagIDs": [],
       "lotNumber": "PowJul24001",
       "lotNumberLowercase": "powjul24001",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -193,6 +192,7 @@
       "productID": null,
       "quantity": 200,
       "statusID": "CONDITIONAL_RELEASED",
+      "tagIDs": [],
       "transactionNotes": ["received 500 grams of powder"]
     },
     "zqE9exfjXOP9caWoNFBh": {
@@ -200,7 +200,6 @@
       "dateOfManufacture": "2024-08-19",
       "hasUpstreams": false,
       "locationID": "S6aXk0Ab7WbVn3VbcumX",
-      "tagIDs": [],
       "lotNumber": "PowJul24002",
       "lotNumberLowercase": "powjul24002",
       "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
@@ -209,6 +208,7 @@
       "productID": null,
       "quantity": 100,
       "statusID": "RELEASED",
+      "tagIDs": [],
       "transactionNotes": ["received 400 grams of powder @ PCI", ""]
     }
   },
@@ -230,7 +230,6 @@
       "name": "Vetter Pharma"
     }
   },
-  "ABCTags": {},
   "ABCMaterialCategories": {
     "CNoJ42aSEn73J5CE9zjF": {
       "isActive": true,
@@ -442,6 +441,7 @@
       "isActive": true
     }
   },
+  "ABCTags": {},
   "ABCTransactions": [
     {
       "targetLotID": "BqRXjMiTSqfJSPDHqgkv",
@@ -450,7 +450,6 @@
         "dateOfExpiry": "2024-09-30",
         "dateOfManufacture": "2024-08-19",
         "locationID": "FdottFSAocWd909F1ZSF",
-        "tagIDs": [],
         "lotNumber": "DrugJul24001",
         "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
         "materialNumberID": "7YufA8lBDOKt6RlNuLlb",
@@ -459,6 +458,7 @@
         "productID": "xU0dkyp7LlrEz9lJ7EJk",
         "quantity": 100,
         "statusID": "ON_HOLD",
+        "tagIDs": [],
         "upstreamIDs": ["SbQFkyfF8JXdweMDZdlO", "VBtqZoPSh1OjtKwW1suE"],
         "upstreamLocationIDs": ["7OXYrFQz9u5R0BDKSWrt", "FdottFSAocWd909F1ZSF"],
         "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
@@ -493,7 +493,6 @@
         "dateOfExpiry": "2024-10-03",
         "dateOfManufacture": "2024-08-19",
         "locationID": "7OXYrFQz9u5R0BDKSWrt",
-        "tagIDs": [],
         "lotNumber": "RawJul24001",
         "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
         "materialNumberID": "GQSMnAe5A4o2CuDMcufH",
@@ -501,7 +500,8 @@
         "poNumber": "XXX",
         "productID": null,
         "quantity": 495,
-        "statusID": "RELEASED"
+        "statusID": "RELEASED",
+        "tagIDs": []
       },
       "transactionType": "receive",
       "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
@@ -564,7 +564,6 @@
         "dateOfExpiry": "2024-10-01",
         "dateOfManufacture": "2024-08-19",
         "locationID": "FdottFSAocWd909F1ZSF",
-        "tagIDs": [],
         "lotNumber": "SubJul24002",
         "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
         "materialNumberID": "EiYVrSraEWKfybV36949",
@@ -573,6 +572,7 @@
         "productID": "xU0dkyp7LlrEz9lJ7EJk",
         "quantity": 100,
         "statusID": "QUARANTINE",
+        "tagIDs": [],
         "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
         "upstreamLocationIDs": ["FdottFSAocWd909F1ZSF", "FdottFSAocWd909F1ZSF"],
         "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -624,7 +624,6 @@
         "dateOfExpiry": "2024-10-01",
         "dateOfManufacture": "2024-08-19",
         "locationID": "S6aXk0Ab7WbVn3VbcumX",
-        "tagIDs": [],
         "lotNumber": "SubJul24001",
         "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
         "materialNumberID": "EiYVrSraEWKfybV36949",
@@ -633,6 +632,7 @@
         "productID": "xU0dkyp7LlrEz9lJ7EJk",
         "quantity": 200,
         "statusID": "CONDITIONAL_RELEASED",
+        "tagIDs": [],
         "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
         "upstreamLocationIDs": ["FdottFSAocWd909F1ZSF", "FdottFSAocWd909F1ZSF"],
         "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
@@ -667,7 +667,6 @@
         "dateOfExpiry": "2027-08-19",
         "dateOfManufacture": "2024-08-19",
         "locationID": "S6aXk0Ab7WbVn3VbcumX",
-        "tagIDs": [],
         "lotNumber": "FilJul24002",
         "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
         "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
@@ -675,7 +674,8 @@
         "poNumber": "XXX",
         "productID": null,
         "quantity": 400,
-        "statusID": "RELEASED"
+        "statusID": "RELEASED",
+        "tagIDs": []
       },
       "transactionType": "receive",
       "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
@@ -687,7 +687,6 @@
         "dateOfExpiry": "2024-10-10",
         "dateOfManufacture": "2024-08-19",
         "locationID": "S6aXk0Ab7WbVn3VbcumX",
-        "tagIDs": [],
         "lotNumber": "PowJul24002",
         "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
         "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
@@ -695,7 +694,8 @@
         "poNumber": "XXX",
         "productID": null,
         "quantity": 400,
-        "statusID": "QUARANTINE"
+        "statusID": "QUARANTINE",
+        "tagIDs": []
       },
       "transactionType": "receive",
       "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
@@ -707,7 +707,6 @@
         "dateOfExpiry": "2027-08-19",
         "dateOfManufacture": "2024-08-19",
         "locationID": "FdottFSAocWd909F1ZSF",
-        "tagIDs": [],
         "lotNumber": "FilJul24001",
         "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
         "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
@@ -715,7 +714,8 @@
         "poNumber": "XXX",
         "productID": null,
         "quantity": 500,
-        "statusID": "RELEASED"
+        "statusID": "RELEASED",
+        "tagIDs": []
       },
       "transactionType": "receive",
       "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
@@ -727,7 +727,6 @@
         "dateOfExpiry": "2025-08-19",
         "dateOfManufacture": "2024-08-19",
         "locationID": "FdottFSAocWd909F1ZSF",
-        "tagIDs": [],
         "lotNumber": "PowJul24001",
         "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
         "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
@@ -735,7 +734,8 @@
         "poNumber": "XXX",
         "productID": null,
         "quantity": 500,
-        "statusID": "CONDITIONAL_RELEASED"
+        "statusID": "CONDITIONAL_RELEASED",
+        "tagIDs": []
       },
       "transactionType": "receive",
       "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"

--- a/src/test/abc-inventory-module-data-5.1.0/abc-inventory-module-data.json
+++ b/src/test/abc-inventory-module-data-5.1.0/abc-inventory-module-data.json
@@ -1,0 +1,782 @@
+{
+  "$schema": "https://json.schemastore.org/abc-inventory-module-data-5.1.0.json",
+  "ABCInventoryEntries": {
+    "AGXfoaDQvtjFUbU43s7U": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "EiYVrSraEWKfybV36949",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 55,
+      "statusID": "QUARANTINE",
+      "transactionNotes": [""],
+      "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "BqRXjMiTSqfJSPDHqgkv": {
+      "dateOfExpiry": "2024-09-30",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "DrugJul24001",
+      "lotNumberLowercase": "drugjul24001",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "7YufA8lBDOKt6RlNuLlb",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 100,
+      "statusID": "ON_HOLD",
+      "transactionNotes": [""],
+      "upstreamIDs": ["SbQFkyfF8JXdweMDZdlO", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "IgS28tuKWkt89UImCsfm": {
+      "dateOfExpiry": "2027-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "S6aXk0Ab7WbVn3VbcumX",
+      "tagIDs": [],
+      "lotNumber": "FilJul24002",
+      "lotNumberLowercase": "filjul24002",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 400,
+      "statusID": "RELEASED",
+      "transactionNotes": [""]
+    },
+    "JhepbvqOsySoYt1pf1H3": {
+      "dateOfExpiry": "2024-10-10",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "S6aXk0Ab7WbVn3VbcumX",
+      "tagIDs": [],
+      "lotNumber": "PowJul24002",
+      "lotNumberLowercase": "powjul24002",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 300,
+      "statusID": "QUARANTINE",
+      "transactionNotes": ["received 400 grams of powder @ PCI", ""]
+    },
+    "Re4OtiGfXMBzsCjZ692M": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "EiYVrSraEWKfybV36949",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 20,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "SbQFkyfF8JXdweMDZdlO": {
+      "dateOfExpiry": "2024-10-03",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "7OXYrFQz9u5R0BDKSWrt",
+      "tagIDs": [],
+      "lotNumber": "RawJul24001",
+      "lotNumberLowercase": "rawjul24001",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "GQSMnAe5A4o2CuDMcufH",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 395,
+      "statusID": "RELEASED",
+      "transactionNotes": [""]
+    },
+    "VBtqZoPSh1OjtKwW1suE": {
+      "dateOfExpiry": "2027-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "FilJul24001",
+      "lotNumberLowercase": "filjul24001",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": ["received 500 filters immediately released"]
+    },
+    "aBcF4u4fctf2YZQpb66W": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "SubJul24002",
+      "lotNumberLowercase": "subjul24002",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "EiYVrSraEWKfybV36949",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 25,
+      "statusID": "RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [100, 100]
+    },
+    "bn5MTamcubWnz4DBPWJX": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "S6aXk0Ab7WbVn3VbcumX",
+      "tagIDs": [],
+      "lotNumber": "SubJul24001",
+      "lotNumberLowercase": "subjul24001",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "EiYVrSraEWKfybV36949",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 100,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [200, 200]
+    },
+    "kqUgI2CCkQtQP6dFfqOw": {
+      "dateOfExpiry": "2024-10-01",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": true,
+      "locationID": "S6aXk0Ab7WbVn3VbcumX",
+      "tagIDs": [],
+      "lotNumber": "SubJul24001",
+      "lotNumberLowercase": "subjul24001",
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "materialNumberID": "EiYVrSraEWKfybV36949",
+      "poNumber": "XXX",
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": [""],
+      "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+      "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+      "upstreamQuantities": [200, 200]
+    },
+    "vLXdbrz75J9q7kGpMzjN": {
+      "dateOfExpiry": "2025-08-19",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "FdottFSAocWd909F1ZSF",
+      "tagIDs": [],
+      "lotNumber": "PowJul24001",
+      "lotNumberLowercase": "powjul24001",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 200,
+      "statusID": "CONDITIONAL_RELEASED",
+      "transactionNotes": ["received 500 grams of powder"]
+    },
+    "zqE9exfjXOP9caWoNFBh": {
+      "dateOfExpiry": "2024-10-10",
+      "dateOfManufacture": "2024-08-19",
+      "hasUpstreams": false,
+      "locationID": "S6aXk0Ab7WbVn3VbcumX",
+      "tagIDs": [],
+      "lotNumber": "PowJul24002",
+      "lotNumberLowercase": "powjul24002",
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+      "poNumber": "XXX",
+      "productID": null,
+      "quantity": 100,
+      "statusID": "RELEASED",
+      "transactionNotes": ["received 400 grams of powder @ PCI", ""]
+    }
+  },
+  "ABCLocations": {
+    "FdottFSAocWd909F1ZSF": {
+      "isActive": true,
+      "name": "Lonza"
+    },
+    "S6aXk0Ab7WbVn3VbcumX": {
+      "isActive": true,
+      "name": "PCI"
+    },
+    "hFGjfKMM4O5ZlslJx8XB": {
+      "isActive": true,
+      "name": "WH001"
+    },
+    "7OXYrFQz9u5R0BDKSWrt": {
+      "isActive": true,
+      "name": "Vetter Pharma"
+    }
+  },
+  "ABCTags": {},
+  "ABCMaterialCategories": {
+    "CNoJ42aSEn73J5CE9zjF": {
+      "isActive": true,
+      "name": "Drug Products",
+      "prefix": "DP"
+    },
+    "L8gyHGgRrN7JfoAY4e2m": {
+      "isActive": true,
+      "name": "Drug Substances",
+      "prefix": "DS"
+    },
+    "divaMPzZP2gSNUE8tMuF": {
+      "isActive": true,
+      "name": "Raw Materials",
+      "prefix": "RM"
+    },
+    "3VNImp3M8qe03RFo8TJz": {
+      "isActive": true,
+      "name": "Finished Goods",
+      "prefix": "FG"
+    }
+  },
+  "ABCMaterialNumbers": {
+    "EWH0Qr8p3LTMEJqER6Oj": {
+      "description": "CDC Powder",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 1",
+      "number": 1,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "Vfp5IcWRqXShMJJpXlMi"
+    },
+    "EiYVrSraEWKfybV36949": {
+      "description": "Drug Substance 1",
+      "isActive": true,
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "name": "Drug Substance 1",
+      "number": 1,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Gram",
+      "vendorID": "Vtx3YhpkPu4Xoq63ELuM"
+    },
+    "GQSMnAe5A4o2CuDMcufH": {
+      "description": "Raw Material 3",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 3",
+      "number": 3,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "Vfp5IcWRqXShMJJpXlMi"
+    },
+    "J1vAOldxpZB9NOeFL0cn": {
+      "description": "Filter",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 2",
+      "number": 2,
+      "productID": null,
+      "unitOfMeasure": "Each",
+      "vendorID": "Vfp5IcWRqXShMJJpXlMi"
+    },
+    "VShtXFll8hlF3jWvXxd3": {
+      "description": "Titanium dioxide",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 6",
+      "number": 6,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "Y7KcYHz1emBvgVT38iQv": {
+      "description": "Ethanol",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 4",
+      "number": 4,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "atqdhbP5veiCzTSG53Ml": {
+      "description": "Drug Product 1",
+      "isActive": true,
+      "materialCategoryID": "CNoJ42aSEn73J5CE9zjF",
+      "name": "Drug Product 1",
+      "number": 1,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Vial",
+      "vendorID": "kjfyttlm297qxHt9yFTi"
+    },
+    "f2tbhOKg3ix7hysZVA8B": {
+      "description": "Finished Goods 2",
+      "isActive": true,
+      "materialCategoryID": "3VNImp3M8qe03RFo8TJz",
+      "name": "Finished Drug Product 2",
+      "number": 2,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Carton",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "gH3LQJbKIB3cVLqJZokk": {
+      "description": "Finished Goods 1",
+      "isActive": true,
+      "materialCategoryID": "3VNImp3M8qe03RFo8TJz",
+      "name": "Finished Drug Product 1",
+      "number": 1,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Carton",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "p2ULkWc5JD3vGwgzBHZu": {
+      "description": "Finished Goods 3",
+      "isActive": true,
+      "materialCategoryID": "3VNImp3M8qe03RFo8TJz",
+      "name": "Finished Drug Product 3",
+      "number": 3,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Carton",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "tUWp1sT4aclPfb0Dk3hW": {
+      "description": "Drug Product 3",
+      "isActive": true,
+      "materialCategoryID": "CNoJ42aSEn73J5CE9zjF",
+      "name": "Drug Product 3",
+      "number": 3,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Vial",
+      "vendorID": "kjfyttlm297qxHt9yFTi"
+    },
+    "15nqWBLasXTU4T8vf5eC": {
+      "description": "Drug Product 2",
+      "isActive": true,
+      "materialCategoryID": "CNoJ42aSEn73J5CE9zjF",
+      "name": "Drug Product 2",
+      "number": 2,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Vial",
+      "vendorID": "kjfyttlm297qxHt9yFTi"
+    },
+    "47ms4wWeZiXQ6fQ02FLG": {
+      "description": "Polyvinylpyrrolidone",
+      "isActive": true,
+      "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+      "name": "Raw Material 5",
+      "number": 5,
+      "productID": null,
+      "unitOfMeasure": "Gram",
+      "vendorID": "EwBedilRF4WdOiHwErJD"
+    },
+    "7YufA8lBDOKt6RlNuLlb": {
+      "description": "Drug Substance 2",
+      "isActive": true,
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "name": "Drug Substance 2",
+      "number": 2,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Gram",
+      "vendorID": "Vtx3YhpkPu4Xoq63ELuM"
+    },
+    "92Bz4vpibxRTqukKtDmi": {
+      "description": "Drug Substance 3",
+      "isActive": true,
+      "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+      "name": "Drug Substance 3",
+      "number": 3,
+      "productID": "xU0dkyp7LlrEz9lJ7EJk",
+      "unitOfMeasure": "Gram",
+      "vendorID": "Vtx3YhpkPu4Xoq63ELuM"
+    }
+  },
+  "ABCProducts": {
+    "VQZxJYMR85qEx9wjGg5M": {
+      "isActive": true,
+      "name": "Cogniva"
+    },
+    "xU0dkyp7LlrEz9lJ7EJk": {
+      "isActive": true,
+      "name": "Cerebrin"
+    }
+  },
+  "ABCReasonCodes": {
+    "ADENo8uncudw1Q7wTeCo": {
+      "code": "RC00002",
+      "description": "Deviation",
+      "isActive": true
+    },
+    "Son4OqrPSssbbQ4eKZfB": {
+      "code": "RC00005",
+      "description": "Better yield",
+      "isActive": true
+    },
+    "tiQ04DKNYklW4OqJ5pX0": {
+      "code": "RC00001",
+      "description": "Material damaged",
+      "isActive": true
+    },
+    "wRHjOamB4R3KMkMTp42f": {
+      "code": "RC00004",
+      "description": "Recount",
+      "isActive": true
+    },
+    "xgSc7Gz2Fx4tgKQkJLG7": {
+      "code": "RC00003",
+      "description": "Temperature excursion",
+      "isActive": true
+    }
+  },
+  "ABCTransactions": [
+    {
+      "targetLotID": "BqRXjMiTSqfJSPDHqgkv",
+      "timestamp": 1724195724040,
+      "transactionData": {
+        "dateOfExpiry": "2024-09-30",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "tagIDs": [],
+        "lotNumber": "DrugJul24001",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "7YufA8lBDOKt6RlNuLlb",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 100,
+        "statusID": "ON_HOLD",
+        "upstreamIDs": ["SbQFkyfF8JXdweMDZdlO", "VBtqZoPSh1OjtKwW1suE"],
+        "upstreamLocationIDs": ["7OXYrFQz9u5R0BDKSWrt", "FdottFSAocWd909F1ZSF"],
+        "upstreamLotNumbers": ["RawJul24001", "FilJul24001"],
+        "upstreamMaterialCategoryIDs": [
+          "divaMPzZP2gSNUE8tMuF",
+          "divaMPzZP2gSNUE8tMuF"
+        ],
+        "upstreamMaterialNumberIDs": [
+          "GQSMnAe5A4o2CuDMcufH",
+          "J1vAOldxpZB9NOeFL0cn"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [100, 100],
+        "upstreams": [
+          {
+            "lotID": "SbQFkyfF8JXdweMDZdlO",
+            "quantity": 100
+          },
+          {
+            "lotID": "VBtqZoPSh1OjtKwW1suE",
+            "quantity": 100
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "SbQFkyfF8JXdweMDZdlO",
+      "timestamp": 1724193323613,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-03",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "7OXYrFQz9u5R0BDKSWrt",
+        "tagIDs": [],
+        "lotNumber": "RawJul24001",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "GQSMnAe5A4o2CuDMcufH",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 495,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "aBcF4u4fctf2YZQpb66W",
+      "timestamp": 1724192190300,
+      "transactionData": {
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "lotID": "AGXfoaDQvtjFUbU43s7U",
+        "lotNumber": "SubJul24002",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "EiYVrSraEWKfybV36949",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 25
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "Re4OtiGfXMBzsCjZ692M",
+      "timestamp": 1724192167647,
+      "transactionData": {
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "lotID": "AGXfoaDQvtjFUbU43s7U",
+        "lotNumber": "SubJul24002",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "EiYVrSraEWKfybV36949",
+        "newStatusID": "CONDITIONAL_RELEASED",
+        "notes": "",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 20
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "kqUgI2CCkQtQP6dFfqOw",
+      "timestamp": 1724092133502,
+      "transactionData": {
+        "locationID": "S6aXk0Ab7WbVn3VbcumX",
+        "lotID": "bn5MTamcubWnz4DBPWJX",
+        "lotNumber": "SubJul24001",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "EiYVrSraEWKfybV36949",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 100
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "AGXfoaDQvtjFUbU43s7U",
+      "timestamp": 1724092097319,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-01",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "tagIDs": [],
+        "lotNumber": "SubJul24002",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "EiYVrSraEWKfybV36949",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 100,
+        "statusID": "QUARANTINE",
+        "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+        "upstreamLocationIDs": ["FdottFSAocWd909F1ZSF", "FdottFSAocWd909F1ZSF"],
+        "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+        "upstreamMaterialCategoryIDs": [
+          "divaMPzZP2gSNUE8tMuF",
+          "divaMPzZP2gSNUE8tMuF"
+        ],
+        "upstreamMaterialNumberIDs": [
+          "EWH0Qr8p3LTMEJqER6Oj",
+          "J1vAOldxpZB9NOeFL0cn"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [100, 100],
+        "upstreams": [
+          {
+            "lotID": "vLXdbrz75J9q7kGpMzjN",
+            "quantity": 100
+          },
+          {
+            "lotID": "VBtqZoPSh1OjtKwW1suE",
+            "quantity": 100
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "zqE9exfjXOP9caWoNFBh",
+      "timestamp": 1724091987560,
+      "transactionData": {
+        "locationID": "S6aXk0Ab7WbVn3VbcumX",
+        "lotID": "JhepbvqOsySoYt1pf1H3",
+        "lotNumber": "PowJul24002",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+        "newStatusID": "RELEASED",
+        "notes": "",
+        "productID": null,
+        "quantity": 100
+      },
+      "transactionType": "statusChange",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "bn5MTamcubWnz4DBPWJX",
+      "timestamp": 1724091965795,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-01",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "S6aXk0Ab7WbVn3VbcumX",
+        "tagIDs": [],
+        "lotNumber": "SubJul24001",
+        "materialCategoryID": "L8gyHGgRrN7JfoAY4e2m",
+        "materialNumberID": "EiYVrSraEWKfybV36949",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": "xU0dkyp7LlrEz9lJ7EJk",
+        "quantity": 200,
+        "statusID": "CONDITIONAL_RELEASED",
+        "upstreamIDs": ["vLXdbrz75J9q7kGpMzjN", "VBtqZoPSh1OjtKwW1suE"],
+        "upstreamLocationIDs": ["FdottFSAocWd909F1ZSF", "FdottFSAocWd909F1ZSF"],
+        "upstreamLotNumbers": ["PowJul24001", "FilJul24001"],
+        "upstreamMaterialCategoryIDs": [
+          "divaMPzZP2gSNUE8tMuF",
+          "divaMPzZP2gSNUE8tMuF"
+        ],
+        "upstreamMaterialNumberIDs": [
+          "EWH0Qr8p3LTMEJqER6Oj",
+          "J1vAOldxpZB9NOeFL0cn"
+        ],
+        "upstreamProductIDs": [null, null],
+        "upstreamQuantities": [200, 200],
+        "upstreams": [
+          {
+            "lotID": "vLXdbrz75J9q7kGpMzjN",
+            "quantity": 200
+          },
+          {
+            "lotID": "VBtqZoPSh1OjtKwW1suE",
+            "quantity": 200
+          }
+        ]
+      },
+      "transactionType": "build",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "IgS28tuKWkt89UImCsfm",
+      "timestamp": 1724091809137,
+      "transactionData": {
+        "dateOfExpiry": "2027-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "S6aXk0Ab7WbVn3VbcumX",
+        "tagIDs": [],
+        "lotNumber": "FilJul24002",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
+        "notes": "",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 400,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "JhepbvqOsySoYt1pf1H3",
+      "timestamp": 1724091750976,
+      "transactionData": {
+        "dateOfExpiry": "2024-10-10",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "S6aXk0Ab7WbVn3VbcumX",
+        "tagIDs": [],
+        "lotNumber": "PowJul24002",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+        "notes": "received 400 grams of powder @ PCI",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 400,
+        "statusID": "QUARANTINE"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "VBtqZoPSh1OjtKwW1suE",
+      "timestamp": 1724091662949,
+      "transactionData": {
+        "dateOfExpiry": "2027-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "tagIDs": [],
+        "lotNumber": "FilJul24001",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "J1vAOldxpZB9NOeFL0cn",
+        "notes": "received 500 filters immediately released",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 500,
+        "statusID": "RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    },
+    {
+      "targetLotID": "vLXdbrz75J9q7kGpMzjN",
+      "timestamp": 1724091626161,
+      "transactionData": {
+        "dateOfExpiry": "2025-08-19",
+        "dateOfManufacture": "2024-08-19",
+        "locationID": "FdottFSAocWd909F1ZSF",
+        "tagIDs": [],
+        "lotNumber": "PowJul24001",
+        "materialCategoryID": "divaMPzZP2gSNUE8tMuF",
+        "materialNumberID": "EWH0Qr8p3LTMEJqER6Oj",
+        "notes": "received 500 grams of powder",
+        "poNumber": "XXX",
+        "productID": null,
+        "quantity": 500,
+        "statusID": "CONDITIONAL_RELEASED"
+      },
+      "transactionType": "receive",
+      "uid": "oqVWAp4OtA3ZhyH1fleb5LXK719U"
+    }
+  ],
+  "ABCVendors": {
+    "EGBgMNcMFz6RHxtUtlmw": {
+      "isActive": true,
+      "name": "XY"
+    },
+    "EwBedilRF4WdOiHwErJD": {
+      "isActive": true,
+      "name": "AbVial"
+    },
+    "Vfp5IcWRqXShMJJpXlMi": {
+      "isActive": true,
+      "name": "FM"
+    },
+    "Vtx3YhpkPu4Xoq63ELuM": {
+      "isActive": true,
+      "name": "Catalent"
+    },
+    "cwTUOcuEoG6Ys4ixYPhn": {
+      "isActive": true,
+      "name": "PCI"
+    },
+    "kjfyttlm297qxHt9yFTi": {
+      "isActive": true,
+      "name": "AGC Biologics"
+    },
+    "opzc5319PnnCDn2HFrbu": {
+      "isActive": true,
+      "name": "Vetter Pharma"
+    },
+    "pMjyCuFtyhtGd8R2ay2v": {
+      "isActive": true,
+      "name": "Lonza"
+    },
+    "2EElWn5CODNCeCxDtyL6": {
+      "isActive": true,
+      "name": "ICS"
+    }
+  }
+}


### PR DESCRIPTION
Highlights:
- Tagging for Build & Receive transactions
- New Change Attributes transaction

Note: We never released abc-inventory-module-data-5.0.0.json because it was internal work.

Migration:
• Transaction migration: Added an empty tagIDs array to BUILD and RECEIVE transactions if missing • Inventory entry migration: Added an empty tagIDs array to inventory entries if missing • Collection migration: Added an empty ABCTags collection object to the inventory module data if missing

Testing:
- `node ./cli.js check` passed (manually confirmed that this command would, in fact, fail if, for example, a negative test case wasn't actually negative)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
