### PR TITLE
Add cargo-mutants config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -547,6 +547,12 @@
       "url": "https://json.schemastore.org/buf.work.json"
     },
     {
+      "name": "cargo-mutants-config.yaml",
+      "description": "cargo-mutants configuration file",
+      "fileMatch": ["**/.cargo/mutants.toml"],
+      "url": "https://json.schemastore.org/cargo-mutants-config.json"
+    },
+    {
       "name": "Cinnamon Spice info.json",
       "description": "The 'info.json' metadata file used in Cinnamon Spice components",
       "fileMatch": [],

--- a/src/schemas/json/cargo-mutants-config.json
+++ b/src/schemas/json/cargo-mutants-config.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/cargo-mutants-config.json",
+  "additionalProperties": true,
+  "title": "cargo-mutants config",
+  "description": "cargo-mutants configuration, read by default from `.cargo/mutants.toml`.\n\nSee <https://mutants.rs/>.",
+  "type": "object",
+  "properties": {
+    "additional_cargo_args": {
+      "description": "Pass extra args to every cargo invocation.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additional_cargo_test_args": {
+      "description": "Pass extra args to cargo test.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "build_timeout_multiplier": {
+      "description": "Build timeout multiplier, relative to the baseline 'cargo build'.",
+      "default": null,
+      "type": ["number", "null"],
+      "format": "double"
+    },
+    "cap_lints": {
+      "description": "Pass `--cap-lints` to rustc.",
+      "default": false,
+      "type": "boolean"
+    },
+    "copy_vcs": {
+      "description": "Copy `.git` and other VCS directories to the build directory.",
+      "default": null,
+      "type": ["boolean", "null"]
+    },
+    "error_values": {
+      "description": "Generate these error values from functions returning Result.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "examine_globs": {
+      "description": "Generate mutants from source files matching these globs.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "examine_re": {
+      "description": "Examine only mutants matching these regexps.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclude_globs": {
+      "description": "Exclude mutants from source files matching these globs.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "exclude_re": {
+      "description": "Exclude mutants from source files matches these regexps.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "minimum_test_timeout": {
+      "description": "Minimum test timeout, in seconds, as a floor on the autoset value.",
+      "default": null,
+      "type": ["number", "null"],
+      "format": "double"
+    },
+    "output": {
+      "description": "Output directory.",
+      "default": null,
+      "type": ["string", "null"]
+    },
+    "profile": {
+      "description": "Cargo profile.",
+      "default": null,
+      "type": ["string", "null"]
+    },
+    "skip_calls": {
+      "description": "Skip calls to functions or methods with these names.\n\nThis is combined with values from the --skip-calls argument.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "skip_calls_defaults": {
+      "description": "Use built-in defaults for `skip_calls` in addition to any explicit values.",
+      "default": null,
+      "type": ["boolean", "null"]
+    },
+    "test_package": {
+      "description": "Run tests from these packages for all mutants.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "test_tool": {
+      "description": "Choice of test tool: cargo or nextest.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TestTool"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "test_workspace": {
+      "description": "Run tests from all packages in the workspace, not just the mutated package.\n\nOverrides `test_package`.",
+      "default": null,
+      "type": ["boolean", "null"]
+    },
+    "timeout_multiplier": {
+      "description": "Timeout multiplier, relative to the baseline 'cargo test'.",
+      "default": null,
+      "type": ["number", "null"],
+      "format": "double"
+    }
+  },
+  "definitions": {
+    "TestTool": {
+      "description": "Choice of tool to use to run tests.",
+      "oneOf": [
+        {
+          "description": "Use `cargo test`, the default.",
+          "type": "string",
+          "enum": ["cargo"]
+        },
+        {
+          "description": "Use `cargo nextest`.",
+          "type": "string",
+          "enum": ["nextest"]
+        }
+      ]
+    }
+  }
+}

--- a/src/test/cargo-mutants-config/mutants.toml
+++ b/src/test/cargo-mutants-config/mutants.toml
@@ -1,0 +1,14 @@
+#:schema ../../schemas/json/cargo-mutants-config.json
+# cargo-mutants configuration
+
+copy_vcs = true
+error_values = ["::anyhow::anyhow!(\"mutated!\")"]
+exclude_globs = ["src/console.rs"]
+profile = "mutants"                                # Build without debug symbols
+output = "custom-mutants-out"
+skip_calls = ["boring", "uninteresting"]
+skip_calls_defaults = true
+test_tool = "nextest"
+timeout_multiplier = 4.23
+build_timeout_multiplier = 2.1
+test_workspace = true


### PR DESCRIPTION
This adds a schema for the config file of https://mutants.rs/

I've tried to follow the contribution guidelines including running `cli.js check` locally.