### PR TITLE
Add styles and script to GitHub pages website directory

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-node@v4'
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: './package-lock.json'
       - run: 'npm clean-install'

--- a/cli.js
+++ b/cli.js
@@ -1153,8 +1153,11 @@ async function taskBuildWebsite() {
     './src/api/json/catalog.json',
     './website/api/json/catalog.json',
   )
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   await fs.cp('./src/css', './website/css', { recursive: true })
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   await fs.cp('./src/img', './website/img', { recursive: true })
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   await fs.cp('./src/js', './website/js', { recursive: true })
 }
 

--- a/cli.js
+++ b/cli.js
@@ -1082,8 +1082,8 @@ async function taskBuildWebsite() {
 <html>
 <head prefix="og: http://ogp.me/ns#">
 	<title>${pageTitle}</title>
+	<!-- Generated from cli.js -->
 
-	<base href="https://www.schemastore.org/" />
 	<meta charset="utf-8" />
 	<meta name="description" content="${pageDescription}" />
 	<meta name="viewport" content="initial-scale=1.0" />
@@ -1153,6 +1153,9 @@ async function taskBuildWebsite() {
     './src/api/json/catalog.json',
     './website/api/json/catalog.json',
   )
+  await fs.cp('./src/css', './website/css', { recursive: true })
+  await fs.cp('./src/img', './website/img', { recursive: true })
+  await fs.cp('./src/js', './website/js', { recursive: true })
 }
 
 async function assertFileSystemIsValid() {

--- a/cli.js
+++ b/cli.js
@@ -1137,7 +1137,7 @@ async function taskBuildWebsite() {
 	<div role="main" id="main" class="container">
 		${body}
 	</div>
-	
+
 	<footer role="contentinfo" class="container">
 		<p>Open source on <a href="https://github.com/schemastore/schemastore/">GitHub</a></p>
 	</footer>
@@ -1146,6 +1146,12 @@ async function taskBuildWebsite() {
 </body>
 </html>
 `,
+  )
+
+  await fs.mkdir('./website/api/json', { recursive: true })
+  await fs.copyFile(
+    './src/api/json/catalog.json',
+    './website/api/json/catalog.json',
   )
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

- Fixes styling and css on website
- Bumps `github-pages.yml` publishing to `v22` because that's when `fs.cp` is no longer experimental. Later, look into replacing with something both stable and supporting v18 to prevent potential issues stemming from version mismatches