### PR TITLE
chore: remove pattern.

### DIFF
--- a/src/schemas/json/schema-catalog.json
+++ b/src/schemas/json/schema-catalog.json
@@ -27,8 +27,7 @@
           "url": {
             "description": "An absolute URL to the schema location",
             "type": "string",
-            "format": "uri",
-            "pattern": "^https://"
+            "format": "uri"
           },
           "name": {
             "description": "The name of the schema",
@@ -43,8 +42,7 @@
             "description": "A set of specific version to schema mappings",
             "additionalProperties": {
               "type": "string",
-              "format": "uri",
-              "pattern": "^https://"
+              "format": "uri"
             }
           }
         }


### PR DESCRIPTION
I'm creating a [TOML validation tool](https://github.com/tombi-toml/tombi) using JSON Schema Store.

The JSON Schema fetching is a bottleneck for my tool.

For improvement, I plan to prepare a original URL scheme such as `tombi://json/catalog.json` and embed popular schemas into the tool.

In this PR, I removed the pattern constraint `"pattern": "https://"` and changed it to a constraint that only requires it to be a `"format": "uri"`.
(Since many regular expressions do not support negative lookahead, `^(?!http://).*` cannot be written. So, I removed the pattern)

There may be things I have not considered.
If there are any issues, please let me know.
