### PR TITLE
Add Power Pages configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8177,12 +8177,6 @@
       "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
       "fileMatch": ["powerpages.config.json"],
       "url": "https://json.schemastore.org/powerpages.config.json"
-    },
-    {
-      "name": "powerpages.config.json",
-      "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
-      "fileMatch": ["powerpages.config.json"],
-      "url": "https://json.schemastore.org/powerpages.config.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8171,6 +8171,12 @@
         "openstatus.toml"
       ],
       "url": "https://github.com/openstatusHQ/json-schema/releases/download/v1.0.0/schema.json"
+    },
+    {
+      "name": "powerpages.config.json",
+      "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
+      "fileMatch": ["powerpages.config.json"],
+      "url": "https://json.schemastore.org/powerpages.config.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8173,7 +8173,7 @@
       "url": "https://github.com/openstatusHQ/json-schema/releases/download/v1.0.0/schema.json"
     },
     {
-      "name": "powerpages.config.json",
+      "name": "Power Pages Configuration",
       "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
       "fileMatch": ["powerpages.config.json"],
       "url": "https://json.schemastore.org/powerpages.config.json"

--- a/src/schemas/json/powerpages.config.json
+++ b/src/schemas/json/powerpages.config.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://json.schemastore.org/powerpages.config.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "title": "JSON schema for the Power Pages configuration file",
+  "properties": {
+    "siteName": {
+      "type": "string",
+      "description": "The name of the website"
+    },
+    "defaultLandingPage": {
+      "type": "string",
+      "description": "The default HTML page to load when opening the website",
+      "pattern": "^[\\w.-]+\\.html$"
+    },
+    "compiledPath": {
+      "type": "string",
+      "description": "The path of the compiled output directory relative to powerpages.config.json file"
+    }
+  },
+  "type": "object"
+}

--- a/src/test/powerpages.config/powerpages.config.json
+++ b/src/test/powerpages.config/powerpages.config.json
@@ -1,0 +1,5 @@
+{
+  "siteName": "Website Name",
+  "defaultLandingPage": "foo.html",
+  "compiledPath": "C:\\path\\to\\compiled\\folder"
+}


### PR DESCRIPTION
Introduce a JSON schema for the Power Pages configuration file, including properties for site name, default landing page, and compiled output path. A test configuration file is also provided for validation.