### PR TITLE
Allow any name for the config file under the .upsun directory

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5,7 +5,7 @@
     {
       "name": "Upsun config",
       "description": "Upsun configuration file",
-      "fileMatch": ["**/.upsun/config.yml", "**/.upsun/config.yaml"],
+      "fileMatch": ["**/.upsun/*.yml", "**/.upsun/*.yaml"],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/upsun.json"
     },
     {


### PR DESCRIPTION
Upsun supports any name for the config file inside the `.upsun` directory, not only `.upsun/config.yaml`.