### PR TITLE
Infrahub: Schema file locations

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3049,6 +3049,12 @@
       "url": "https://schema.infrahub.app/python-sdk/repository-config/latest.json"
     },
     {
+      "name": "Infrahub Schemas",
+      "description": "Infrahub Schema files",
+      "fileMatch": ["schemas/*.yml", "models/*.yaml"],
+      "url": "https://schema.infrahub.app/infrahub/schema/latest.json"
+    },
+    {
       "name": "ioBroker Configuration",
       "description": "The configuration file of an ioBroker installation",
       "fileMatch": ["iobroker.json", "iobroker-dist.json"],

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -400,7 +400,8 @@
     "https://json.schemastore.org/lsdlschema.json",
     "https://json.schemastore.org/BizTalkServerApplicationSchema.json",
     "https://json.schemastore.org/metaschema-draft-07-unofficial-strict.json",
-    "https://json.schemastore.org/schema-draft-v4.json"
+    "https://json.schemastore.org/schema-draft-v4.json",
+    "https://schema.infrahub.app/infrahub/schema/latest.json"
   ],
   "options": {
     "abc-supply-plan-1.0.0.json": {


### PR DESCRIPTION
Add models/*.yml and schemas/*.yml for OpsMill's Infrahub schema file locations.
