### PR TITLE
ci: avoid workflow running in fork

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,6 +23,7 @@ jobs:
   # Build job.
   build:
     runs-on: 'ubuntu-latest'
+    if: ${{ github.repository_owner == 'SchemaStore' }}
     steps:
       - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-node@v4'
@@ -43,6 +44,7 @@ jobs:
       name: 'github-pages'
       url: '${{ steps.deployment.outputs.page_url }}'
     runs-on: 'ubuntu-latest'
+    if: ${{ github.repository_owner == 'SchemaStore' }}
     needs: 'build'
     steps:
       - id: 'deployment'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Every time the forked project synchronizes the upstream code, ci will be executed and an error will be reported.