### PR TITLE
Add `allow_redefinition_new` from mypy 1.16

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -326,6 +326,13 @@
       "default": false,
       "type": "boolean"
     },
+    "allow_redefinition_new": {
+      "description": "By default, mypy won't allow a variable to be redefined with an unrelated type. This experimental flag enables the redefinition of unannotated variables with an arbitrary type. You will also need to enable `local_partial_types` (https://mypy.readthedocs.io/en/stable/config_file.html#confval-local_partial_types).",
+      "markdownDescription": "By default, mypy won't allow a variable to be redefined with an unrelated type. This experimental flag enables the redefinition of unannotated variables with an arbitrary type. You will also need to enable [local_partial_types](https://mypy.readthedocs.io/en/stable/config_file.html#confval-local_partial_types).",
+      "x-intellij-html-description": "By default, mypy won't allow a variable to be redefined with an unrelated type. This experimental flag enables the redefinition of unannotated variables with an arbitrary type. You will also need to enable <a href=\"https://mypy.readthedocs.io/en/stable/config_file.html#confval-local_partial_types\">local_partial_types</a>.",
+      "default": false,
+      "type": "boolean"
+    },
     "allow_redefinition": {
       "description": "Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.",
       "default": false,
@@ -722,6 +729,9 @@
           },
           "allow_untyped_globals": {
             "$ref": "#/properties/allow_untyped_globals"
+          },
+          "allow_redefinition_new": {
+            "$ref": "#/properties/allow_redefinition_new"
           },
           "allow_redefinition": {
             "$ref": "#/properties/allow_redefinition"


### PR DESCRIPTION
Adding the lastly `--allow-redefinition-new` flag from mypy 1.16 https://mypy.readthedocs.io/en/stable/config_file.html#confval-allow_redefinition_new