### PR TITLE
Add `typo3-vendor-bundler` config schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5732,6 +5732,16 @@
       "url": "https://json.schemastore.org/typo3.json"
     },
     {
+      "name": "TYPO3 Vendor Bundler config",
+      "description": "Configuration for TYPO3 Vendor Bundler, a Composer library to bundle vendor libraries for TYPO3 extensions in classic mode",
+      "fileMatch": [
+        "typo3-vendor-bundler.json",
+        "typo3-vendor-bundler.yaml",
+        "typo3-vendor-bundler.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/eliashaeussler/typo3-vendor-bundler/refs/heads/main/res/typo3-vendor-bundler.schema.json"
+    },
+    {
       "name": "Typst Manifest",
       "description": "Typst package manifest file (typst.toml)",
       "fileMatch": ["typst.toml"],


### PR DESCRIPTION
This PR adds the config file schema of [`typo3-vendor-bundler`](https://github.com/eliashaeussler/typo3-vendor-bundler) to the schema catalog.