### PR TITLE
Add `module-sync` to `package.json#exports`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -160,6 +160,11 @@
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this specifier is imported as an ECMAScript module using an `import` declaration or the dynamic `import(...)` function."
         },
+        "module-sync": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "$comment": "https://nodejs.org/api/packages.html#conditional-exports#:~:text=%22module-sync%22",
+          "description": "The same as `import`, but can be used with require(esm) in Node 20+. This requires the files to not use any top-level awaits."
+        },
         "node": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment is Node.js."


### PR DESCRIPTION
This PR adds a new known field to `package.json`'s `exports`: `module-sync`.

This field is used to indicate to Node that it is an ESM file that doesn't use top-level await, allowing it to be imported via `require(esm)` in Node 20+.

Documentation:
https://nodejs.org/en/blog/release/v22.10.0#new-module-sync-exports-condition
https://nodejs.org/api/packages.html#conditional-exports#:~:text=%22module-sync%22