### PR TITLE
Add `qtype` schema to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4764,6 +4764,12 @@
       "url": "https://www.qgoda.net/schemas/qgoda.json"
     },
     {
+      "name": "QType AI DSL",
+      "description": "A DSL for rapid prototyping of AI applications",
+      "fileMatch": ["qtype.config.yaml", "*.qtype.yaml"],
+      "url": "https://github.com/lou-k/qtype/blob/main/schema/qtype.schema.json"
+    },
+    {
       "name": "Railway",
       "description": "Use Railway config as code to define settings for building and deploying your services",
       "fileMatch": ["railway.toml", "railway.json"],


### PR DESCRIPTION
Adds a schema for https://github.com/lou-k/qtype.
Note that these mapper schemas are autogenerated on every release and therefore the current master always has all releases.