### PR TITLE
Add Rubocop as a remote schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4836,6 +4836,12 @@
       "url": "https://json.schemastore.org/resjson.json"
     },
     {
+      "name": "Rubocop",
+      "description": "A Ruby code style checker (linter) and formatter",
+      "fileMatch": ["*.rubocop.yml"],
+      "url": "https://www.rubyschema.org/rubocop.json"
+    },
+    {
       "name": "Ruff",
       "description": "Ruff, a fast Python linter",
       "fileMatch": ["ruff.toml", ".ruff.toml"],


### PR DESCRIPTION
This PR adds Rubocop as a remote schema, hosted on [RubySchema](https://github.com/joeldrapper/rubyschema).