### PR TITLE
fix(qtype): Use raw gitub url for qtype

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4773,7 +4773,7 @@
       "name": "QType AI DSL",
       "description": "A DSL for rapid prototyping of AI applications",
       "fileMatch": ["qtype.config.yaml", "*.qtype.yaml"],
-      "url": "https://github.com/lou-k/qtype/blob/main/schema/qtype.schema.json"
+      "url": "https://raw.githubusercontent.com/lou-k/qtype/refs/heads/main/schema/qtype.schema.json"
     },
     {
       "name": "Railway",


### PR DESCRIPTION
This doesn't work in vscode without the raw github url.
My apologies for not doing this properly in #4804