### PR TITLE
Add Jujutsu/jj VCS config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8271,6 +8271,12 @@
         "*.hecate.json"
       ],
       "url": "https://raw.githubusercontent.com/ShaitanLyss/these/main/hecate/hecate-json-schema.json"
+    },
+    {
+      "name": "Jujutsu (jj) VCS config",
+      "description": "Jujutsu (jj) configuration file",
+      "fileMatch": ["**/.jj/repo/config.toml", "**/jj/config.toml"],
+      "url": "https://jj-vcs.github.io/jj/latest/config-schema.json"
     }
   ]
 }


### PR DESCRIPTION
These are updated on every release. The main config maps to the latest stable version.

See also <https://jj-vcs.github.io/jj/latest/config/> and <https://github.com/jj-vcs/jj>.