### PR TITLE
fix(schema): replace single-value enums with const and remove redundant type for better lint compliance

### DIFF
--- a/src/schemas/json/abc-inventory-module-data-1.0.0.json
+++ b/src/schemas/json/abc-inventory-module-data-1.0.0.json
@@ -34,7 +34,7 @@
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "properties": {
             "isActive": {
               "type": "boolean"
@@ -53,7 +53,7 @@
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "required": [ "name", "isActive", "prefix" ],
+          "required": ["name", "isActive", "prefix"],
           "properties": {
             "isActive": {
               "type": "boolean"
@@ -102,13 +102,13 @@
               "type": "number"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "unitOfMeasure": {
               "type": "string"
             },
             "vendorID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false
@@ -121,7 +121,7 @@
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "properties": {
             "isActive": {
               "type": "boolean"
@@ -140,7 +140,7 @@
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "required": [ "code", "description", "isActive" ],
+          "required": ["code", "description", "isActive"],
           "properties": {
             "description": {
               "type": "string"
@@ -168,7 +168,7 @@
       "patternProperties": {
         "^[a-zA-Z0-9_-]+$": {
           "type": "object",
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "properties": {
             "isActive": {
               "type": "boolean"
@@ -187,7 +187,7 @@
   "definitions": {
     "ABCInventoryAdjustTransaction": {
       "type": "object",
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "properties": {
         "timestamp": {
           "type": "number"
@@ -224,7 +224,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "reasonCodeID": {
               "type": "string"
@@ -307,7 +307,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"
@@ -342,7 +342,7 @@
             "upstreamProductIDs": {
               "type": "array",
               "items": {
-                "type": [ "string", "null" ]
+                "type": ["string", "null"]
               }
             },
             "upstreamQuantities": {
@@ -355,7 +355,7 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "required": [ "lotID", "quantity" ],
+                "required": ["lotID", "quantity"],
                 "properties": {
                   "lotID": {
                     "type": "string"
@@ -381,7 +381,7 @@
     },
     "ABCInventoryChangeExpiryTransaction": {
       "type": "object",
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "properties": {
         "timestamp": {
           "type": "number"
@@ -417,7 +417,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false
@@ -433,7 +433,7 @@
     },
     "ABCInventoryDestroyTransaction": {
       "type": "object",
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "properties": {
         "timestamp": {
           "type": "number"
@@ -465,7 +465,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false
@@ -481,7 +481,7 @@
     },
     "ABCInventoryDistributeTransaction": {
       "type": "object",
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "properties": {
         "timestamp": {
           "type": "number"
@@ -514,7 +514,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"
@@ -592,7 +592,7 @@
           "type": "string"
         },
         "productID": {
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "quantity": {
           "type": "number"
@@ -675,7 +675,7 @@
           "type": "string"
         },
         "productID": {
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "quantity": {
           "type": "number"
@@ -751,7 +751,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"
@@ -773,7 +773,7 @@
     },
     "ABCInventorySellTransaction": {
       "type": "object",
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "properties": {
         "timestamp": {
           "type": "number"
@@ -810,7 +810,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"
@@ -875,7 +875,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"
@@ -971,7 +971,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "quantity": {
               "type": "number"

--- a/src/schemas/json/abc-inventory-module-data-1.0.0.json
+++ b/src/schemas/json/abc-inventory-module-data-1.0.0.json
@@ -4,89 +4,245 @@
   "title": "ABCInventoryModuleData JSON Schema",
   "description": "Schema defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module.",
   "type": "object",
-  "definitions": {
-    "ABCStatus": {
-      "type": "string",
-      "enum": [
-        "RELEASED",
-        "CONDITIONAL_RELEASED",
-        "QUARANTINE",
-        "ON_HOLD",
-        "EXPIRED",
-        "DAMAGED"
-      ]
+  "required": [
+    "$schema",
+    "ABCProducts",
+    "ABCVendors",
+    "ABCMaterialCategories",
+    "ABCMaterialNumbers",
+    "ABCLocations",
+    "ABCReasonCodes",
+    "ABCTransactions",
+    "ABCInventoryEntries"
+  ],
+  "properties": {
+    "$schema": {
+      "description": "Link to https://www.schemastore.org/abc-inventory-module-data-1.0.0.json",
+      "const": "https://www.schemastore.org/abc-inventory-module-data-1.0.0.json"
     },
-    "ABCInventoryReceiveTransaction": {
+    "ABCInventoryEntries": {
       "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "$ref": "#/definitions/ABCInventoryEntry"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCLocations": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [ "name", "isActive" ],
+          "properties": {
+            "isActive": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialCategories": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [ "name", "isActive", "prefix" ],
+          "properties": {
+            "isActive": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCMaterialNumbers": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [
+            "productID",
+            "vendorID",
+            "materialCategoryID",
+            "number",
+            "name",
+            "description",
+            "unitOfMeasure",
+            "isActive"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            },
+            "materialCategoryID": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "number": {
+              "type": "number"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            },
+            "vendorID": {
+              "type": [ "string", "null" ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCProducts": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [ "name", "isActive" ],
+          "properties": {
+            "isActive": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCReasonCodes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [ "code", "description", "isActive" ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            },
+            "isActive": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCTransactions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ABCInventoryTransaction"
+      }
+    },
+    "ABCVendors": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "type": "object",
+          "required": [ "name", "isActive" ],
+          "properties": {
+            "isActive": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "ABCInventoryAdjustTransaction": {
+      "type": "object",
+      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
       "properties": {
-        "uid": {
-          "type": "string"
-        },
         "timestamp": {
           "type": "number"
         },
-        "transactionType": {
-          "type": "string",
-          "enum": ["receive"]
-        },
         "transactionData": {
           "type": "object",
+          "required": [
+            "lotID",
+            "newQuantity",
+            "reasonCodeID",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "properties": {
+            "locationID": {
+              "type": "string"
+            },
+            "lotID": {
+              "type": "string"
+            },
             "lotNumber": {
               "type": "string"
             },
             "materialNumberID": {
               "type": "string"
             },
-            "quantity": {
+            "newQuantity": {
               "type": "number"
-            },
-            "dateOfExpiry": {
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfManufacture": {
-              "type": "string",
-              "format": "date"
-            },
-            "poNumber": {
-              "type": "string"
-            },
-            "statusID": {
-              "$ref": "#/definitions/ABCStatus"
-            },
-            "locationID": {
-              "type": "string"
-            },
-            "cost": {
-              "type": "number"
-            },
-            "productID": {
-              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "reasonCodeID": {
+              "type": "string"
             }
           },
-          "required": [
-            "lotNumber",
-            "materialNumberID",
-            "quantity",
-            "dateOfExpiry",
-            "dateOfManufacture",
-            "poNumber",
-            "statusID",
-            "locationID",
-            "cost",
-            "productID",
-            "notes"
-          ],
           "additionalProperties": false
         },
-        "targetLotID": {
+        "transactionType": {
+          "const": "adjust"
+        },
+        "uid": {
           "type": "string"
         }
       },
+      "additionalProperties": false
+    },
+    "ABCInventoryBuildTransaction": {
+      "type": "object",
       "required": [
         "uid",
         "timestamp",
@@ -94,112 +250,15 @@
         "transactionData",
         "targetLotID"
       ],
-      "additionalProperties": false
-    },
-    "ABCInventoryBuildTransaction": {
-      "type": "object",
       "properties": {
-        "uid": {
+        "targetLotID": {
           "type": "string"
         },
         "timestamp": {
           "type": "number"
         },
-        "transactionType": {
-          "type": "string",
-          "enum": ["build"]
-        },
         "transactionData": {
           "type": "object",
-          "properties": {
-            "lotNumber": {
-              "type": "string"
-            },
-            "materialNumberID": {
-              "type": "string"
-            },
-            "quantity": {
-              "type": "number"
-            },
-            "dateOfExpiry": {
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfManufacture": {
-              "type": "string",
-              "format": "date"
-            },
-            "poNumber": {
-              "type": "string"
-            },
-            "statusID": {
-              "$ref": "#/definitions/ABCStatus"
-            },
-            "locationID": {
-              "type": "string"
-            },
-            "cost": {
-              "type": "number"
-            },
-            "upstreams": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "lotID": {
-                    "type": "string"
-                  },
-                  "quantity": {
-                    "type": "number"
-                  }
-                },
-                "required": ["lotID", "quantity"],
-                "additionalProperties": false
-              }
-            },
-            "upstreamIDs": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "upstreamLotNumbers": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "upstreamQuantities": {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            "upstreamMaterialNumberIDs": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "upstreamLocationIDs": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "productID": {
-              "type": ["string", "null"]
-            },
-            "upstreamProductIDs": {
-              "type": "array",
-              "items": {
-                "type": ["string", "null"]
-              }
-            },
-            "notes": {
-              "type": "string"
-            }
-          },
           "required": [
             "lotNumber",
             "materialNumberID",
@@ -220,45 +279,20 @@
             "upstreamProductIDs",
             "notes"
           ],
-          "additionalProperties": false
-        },
-        "targetLotID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "uid",
-        "timestamp",
-        "transactionType",
-        "transactionData",
-        "targetLotID"
-      ],
-      "additionalProperties": false
-    },
-    "ABCInventoryTransferTransaction": {
-      "type": "object",
-      "properties": {
-        "uid": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "number"
-        },
-        "transactionType": {
-          "type": "string",
-          "enum": ["transfer"]
-        },
-        "transactionData": {
-          "type": "object",
           "properties": {
-            "lotID": {
-              "type": "string"
-            },
-            "newLocationID": {
-              "type": "string"
-            },
-            "quantity": {
+            "cost": {
               "type": "number"
+            },
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "locationID": {
+              "type": "string"
             },
             "lotNumber": {
               "type": "string"
@@ -266,128 +300,109 @@
             "materialNumberID": {
               "type": "string"
             },
-            "locationID": {
+            "notes": {
+              "type": "string"
+            },
+            "poNumber": {
               "type": "string"
             },
             "productID": {
-              "type": ["string", "null"]
+              "type": [ "string", "null" ]
             },
-            "notes": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "lotID",
-            "newLocationID",
-            "quantity",
-            "lotNumber",
-            "materialNumberID",
-            "locationID",
-            "productID",
-            "notes"
-          ],
-          "additionalProperties": false
-        },
-        "targetLotID": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "uid",
-        "timestamp",
-        "transactionType",
-        "transactionData",
-        "targetLotID"
-      ],
-      "additionalProperties": false
-    },
-    "ABCInventoryStatusChangeTransaction": {
-      "type": "object",
-      "properties": {
-        "uid": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "number"
-        },
-        "transactionType": {
-          "type": "string",
-          "enum": ["statusChange"]
-        },
-        "transactionData": {
-          "type": "object",
-          "properties": {
-            "lotID": {
-              "type": "string"
+            "quantity": {
+              "type": "number"
             },
-            "newStatusID": {
+            "statusID": {
               "$ref": "#/definitions/ABCStatus"
             },
-            "quantity": {
-              "type": "number"
+            "upstreamIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "lotNumber": {
-              "type": "string"
+            "upstreamLocationIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "materialNumberID": {
-              "type": "string"
+            "upstreamLotNumbers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "locationID": {
-              "type": "string"
+            "upstreamMaterialNumberIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "productID": {
-              "type": ["string", "null"]
+            "upstreamProductIDs": {
+              "type": "array",
+              "items": {
+                "type": [ "string", "null" ]
+              }
             },
-            "notes": {
-              "type": "string"
+            "upstreamQuantities": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "upstreams": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [ "lotID", "quantity" ],
+                "properties": {
+                  "lotID": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              }
             }
           },
-          "required": [
-            "lotID",
-            "newStatusID",
-            "quantity",
-            "lotNumber",
-            "materialNumberID",
-            "locationID",
-            "productID",
-            "notes"
-          ],
           "additionalProperties": false
         },
-        "targetLotID": {
+        "transactionType": {
+          "const": "build"
+        },
+        "uid": {
           "type": "string"
         }
       },
-      "required": [
-        "uid",
-        "timestamp",
-        "transactionType",
-        "transactionData",
-        "targetLotID"
-      ],
       "additionalProperties": false
     },
-    "ABCInventoryDistributeTransaction": {
+    "ABCInventoryChangeExpiryTransaction": {
       "type": "object",
+      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
       "properties": {
-        "uid": {
-          "type": "string"
-        },
         "timestamp": {
           "type": "number"
         },
-        "transactionType": {
-          "type": "string",
-          "enum": ["distribute"]
-        },
         "transactionData": {
           "type": "object",
+          "required": [
+            "lotID",
+            "newDateOfExpiry",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "properties": {
-            "lotID": {
+            "locationID": {
               "type": "string"
             },
-            "quantity": {
-              "type": "number"
+            "lotID": {
+              "type": "string"
             },
             "lotNumber": {
               "type": "string"
@@ -395,66 +410,36 @@
             "materialNumberID": {
               "type": "string"
             },
-            "locationID": {
+            "newDateOfExpiry": {
               "type": "string"
-            },
-            "productID": {
-              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
             }
           },
-          "required": [
-            "lotID",
-            "quantity",
-            "lotNumber",
-            "materialNumberID",
-            "locationID",
-            "productID",
-            "notes"
-          ],
           "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "changeExpiry"
+        },
+        "uid": {
+          "type": "string"
         }
       },
-      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryDestroyTransaction": {
       "type": "object",
+      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
       "properties": {
-        "uid": {
-          "type": "string"
-        },
         "timestamp": {
           "type": "number"
         },
-        "transactionType": {
-          "type": "string",
-          "enum": ["destroy"]
-        },
         "transactionData": {
           "type": "object",
-          "properties": {
-            "lotID": {
-              "type": "string"
-            },
-            "lotNumber": {
-              "type": "string"
-            },
-            "materialNumberID": {
-              "type": "string"
-            },
-            "locationID": {
-              "type": "string"
-            },
-            "productID": {
-              "type": ["string", "null"]
-            },
-            "notes": {
-              "type": "string"
-            }
-          },
           "required": [
             "lotID",
             "lotNumber",
@@ -463,36 +448,12 @@
             "productID",
             "notes"
           ],
-          "additionalProperties": false
-        }
-      },
-      "required": ["uid", "timestamp", "transactionType", "transactionData"],
-      "additionalProperties": false
-    },
-    "ABCInventorySellTransaction": {
-      "type": "object",
-      "properties": {
-        "uid": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "number"
-        },
-        "transactionType": {
-          "type": "string",
-          "enum": ["sell"]
-        },
-        "transactionData": {
-          "type": "object",
           "properties": {
-            "lotID": {
+            "locationID": {
               "type": "string"
             },
-            "quantity": {
-              "type": "number"
-            },
-            "cost": {
-              "type": "number"
+            "lotID": {
+              "type": "string"
             },
             "lotNumber": {
               "type": "string"
@@ -500,16 +461,325 @@
             "materialNumberID": {
               "type": "string"
             },
-            "locationID": {
+            "notes": {
               "type": "string"
             },
             "productID": {
-              "type": ["string", "null"]
+              "type": [ "string", "null" ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "destroy"
+        },
+        "uid": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCInventoryDistributeTransaction": {
+      "type": "object",
+      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "properties": {
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionData": {
+          "type": "object",
+          "required": [
+            "lotID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
+          "properties": {
+            "locationID": {
+              "type": "string"
+            },
+            "lotID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
             },
             "notes": {
               "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "quantity": {
+              "type": "number"
             }
           },
+          "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "distribute"
+        },
+        "uid": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCInventoryEntry": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams"
+        },
+        {
+          "$ref": "#/definitions/ABCInventoryEntryWithUpstreams"
+        }
+      ]
+    },
+    "ABCInventoryEntryWithUpstreams": {
+      "type": "object",
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "cost",
+        "hasUpstreams",
+        "upstreamIDs",
+        "upstreamQuantities",
+        "upstreamLotNumbers",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "properties": {
+        "cost": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "hasUpstreams": {
+          "const": true
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "lotNumber": {
+          "type": "string"
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "productID": {
+          "type": [ "string", "null" ]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "transactionNotes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upstreamIDs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upstreamLotNumbers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "upstreamQuantities": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCInventoryEntryWithoutUpstreams": {
+      "type": "object",
+      "required": [
+        "lotNumber",
+        "materialNumberID",
+        "productID",
+        "quantity",
+        "dateOfExpiry",
+        "dateOfManufacture",
+        "poNumber",
+        "statusID",
+        "locationID",
+        "cost",
+        "hasUpstreams",
+        "transactionNotes",
+        "lotNumberLowercase"
+      ],
+      "properties": {
+        "cost": {
+          "type": "number"
+        },
+        "dateOfExpiry": {
+          "type": "string",
+          "format": "date"
+        },
+        "dateOfManufacture": {
+          "type": "string",
+          "format": "date"
+        },
+        "hasUpstreams": {
+          "const": false
+        },
+        "locationID": {
+          "type": "string"
+        },
+        "lotNumber": {
+          "type": "string"
+        },
+        "lotNumberLowercase": {
+          "type": "string"
+        },
+        "materialNumberID": {
+          "type": "string"
+        },
+        "poNumber": {
+          "type": "string"
+        },
+        "productID": {
+          "type": [ "string", "null" ]
+        },
+        "quantity": {
+          "type": "number"
+        },
+        "statusID": {
+          "$ref": "#/definitions/ABCStatus"
+        },
+        "transactionNotes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCInventoryReceiveTransaction": {
+      "type": "object",
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
+      "properties": {
+        "targetLotID": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionData": {
+          "type": "object",
+          "required": [
+            "lotNumber",
+            "materialNumberID",
+            "quantity",
+            "dateOfExpiry",
+            "dateOfManufacture",
+            "poNumber",
+            "statusID",
+            "locationID",
+            "cost",
+            "productID",
+            "notes"
+          ],
+          "properties": {
+            "cost": {
+              "type": "number"
+            },
+            "dateOfExpiry": {
+              "type": "string",
+              "format": "date"
+            },
+            "dateOfManufacture": {
+              "type": "string",
+              "format": "date"
+            },
+            "locationID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            },
+            "poNumber": {
+              "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "quantity": {
+              "type": "number"
+            },
+            "statusID": {
+              "$ref": "#/definitions/ABCStatus"
+            }
+          },
+          "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "receive"
+        },
+        "uid": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ABCInventorySellTransaction": {
+      "type": "object",
+      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "properties": {
+        "timestamp": {
+          "type": "number"
+        },
+        "transactionData": {
+          "type": "object",
           "required": [
             "lotID",
             "quantity",
@@ -520,35 +790,14 @@
             "productID",
             "notes"
           ],
-          "additionalProperties": false
-        }
-      },
-      "required": ["uid", "timestamp", "transactionType", "transactionData"],
-      "additionalProperties": false
-    },
-    "ABCInventoryAdjustTransaction": {
-      "type": "object",
-      "properties": {
-        "uid": {
-          "type": "string"
-        },
-        "timestamp": {
-          "type": "number"
-        },
-        "transactionType": {
-          "type": "string",
-          "enum": ["adjust"]
-        },
-        "transactionData": {
-          "type": "object",
           "properties": {
-            "lotID": {
-              "type": "string"
-            },
-            "newQuantity": {
+            "cost": {
               "type": "number"
             },
-            "reasonCodeID": {
+            "locationID": {
+              "type": "string"
+            },
+            "lotID": {
               "type": "string"
             },
             "lotNumber": {
@@ -557,52 +806,60 @@
             "materialNumberID": {
               "type": "string"
             },
-            "locationID": {
+            "notes": {
               "type": "string"
             },
             "productID": {
-              "type": ["string", "null"]
+              "type": [ "string", "null" ]
             },
-            "notes": {
-              "type": "string"
+            "quantity": {
+              "type": "number"
             }
           },
-          "required": [
-            "lotID",
-            "newQuantity",
-            "reasonCodeID",
-            "lotNumber",
-            "materialNumberID",
-            "locationID",
-            "productID",
-            "notes"
-          ],
           "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "sell"
+        },
+        "uid": {
+          "type": "string"
         }
       },
-      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
-    "ABCInventoryChangeExpiryTransaction": {
+    "ABCInventoryStatusChangeTransaction": {
       "type": "object",
+      "required": [
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
+      ],
       "properties": {
-        "uid": {
+        "targetLotID": {
           "type": "string"
         },
         "timestamp": {
           "type": "number"
         },
-        "transactionType": {
-          "type": "string",
-          "enum": ["changeExpiry"]
-        },
         "transactionData": {
           "type": "object",
+          "required": [
+            "lotID",
+            "newStatusID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
+            "productID",
+            "notes"
+          ],
           "properties": {
-            "lotID": {
+            "locationID": {
               "type": "string"
             },
-            "newDateOfExpiry": {
+            "lotID": {
               "type": "string"
             },
             "lotNumber": {
@@ -611,29 +868,28 @@
             "materialNumberID": {
               "type": "string"
             },
-            "locationID": {
-              "type": "string"
-            },
-            "productID": {
-              "type": ["string", "null"]
+            "newStatusID": {
+              "$ref": "#/definitions/ABCStatus"
             },
             "notes": {
               "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "quantity": {
+              "type": "number"
             }
           },
-          "required": [
-            "lotID",
-            "newDateOfExpiry",
-            "lotNumber",
-            "materialNumberID",
-            "locationID",
-            "productID",
-            "notes"
-          ],
           "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "statusChange"
+        },
+        "uid": {
+          "type": "string"
         }
       },
-      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryTransaction": {
@@ -667,351 +923,80 @@
         }
       ]
     },
-    "ABCInventoryEntryWithoutUpstreams": {
+    "ABCInventoryTransferTransaction": {
       "type": "object",
-      "properties": {
-        "lotNumber": {
-          "type": "string"
-        },
-        "materialNumberID": {
-          "type": "string"
-        },
-        "productID": {
-          "type": ["string", "null"]
-        },
-        "quantity": {
-          "type": "number"
-        },
-        "dateOfExpiry": {
-          "type": "string",
-          "format": "date"
-        },
-        "dateOfManufacture": {
-          "type": "string",
-          "format": "date"
-        },
-        "poNumber": {
-          "type": "string"
-        },
-        "statusID": {
-          "$ref": "#/definitions/ABCStatus"
-        },
-        "locationID": {
-          "type": "string"
-        },
-        "cost": {
-          "type": "number"
-        },
-        "hasUpstreams": {
-          "type": "boolean",
-          "enum": [false]
-        },
-        "transactionNotes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "lotNumberLowercase": {
-          "type": "string"
-        }
-      },
       "required": [
-        "lotNumber",
-        "materialNumberID",
-        "productID",
-        "quantity",
-        "dateOfExpiry",
-        "dateOfManufacture",
-        "poNumber",
-        "statusID",
-        "locationID",
-        "cost",
-        "hasUpstreams",
-        "transactionNotes",
-        "lotNumberLowercase"
+        "uid",
+        "timestamp",
+        "transactionType",
+        "transactionData",
+        "targetLotID"
       ],
-      "additionalProperties": false
-    },
-    "ABCInventoryEntryWithUpstreams": {
-      "type": "object",
       "properties": {
-        "lotNumber": {
+        "targetLotID": {
           "type": "string"
         },
-        "materialNumberID": {
-          "type": "string"
-        },
-        "productID": {
-          "type": ["string", "null"]
-        },
-        "quantity": {
+        "timestamp": {
           "type": "number"
         },
-        "dateOfExpiry": {
-          "type": "string",
-          "format": "date"
-        },
-        "dateOfManufacture": {
-          "type": "string",
-          "format": "date"
-        },
-        "poNumber": {
-          "type": "string"
-        },
-        "statusID": {
-          "$ref": "#/definitions/ABCStatus"
-        },
-        "locationID": {
-          "type": "string"
-        },
-        "cost": {
-          "type": "number"
-        },
-        "hasUpstreams": {
-          "type": "boolean",
-          "enum": [true]
-        },
-        "upstreamIDs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "upstreamQuantities": {
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "upstreamLotNumbers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "transactionNotes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "lotNumberLowercase": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "lotNumber",
-        "materialNumberID",
-        "productID",
-        "quantity",
-        "dateOfExpiry",
-        "dateOfManufacture",
-        "poNumber",
-        "statusID",
-        "locationID",
-        "cost",
-        "hasUpstreams",
-        "upstreamIDs",
-        "upstreamQuantities",
-        "upstreamLotNumbers",
-        "transactionNotes",
-        "lotNumberLowercase"
-      ],
-      "additionalProperties": false
-    },
-    "ABCInventoryEntry": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ABCInventoryEntryWithoutUpstreams"
-        },
-        {
-          "$ref": "#/definitions/ABCInventoryEntryWithUpstreams"
-        }
-      ]
-    }
-  },
-  "properties": {
-    "$schema": {
-      "description": "Link to https://www.schemastore.org/abc-inventory-module-data-1.0.0.json",
-      "type": "string",
-      "enum": [
-        "https://www.schemastore.org/abc-inventory-module-data-1.0.0.json"
-      ]
-    },
-    "ABCProducts": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
+        "transactionData": {
           "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "isActive": {
-              "type": "boolean"
-            }
-          },
-          "required": ["name", "isActive"],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ABCVendors": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "isActive": {
-              "type": "boolean"
-            }
-          },
-          "required": ["name", "isActive"],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ABCMaterialCategories": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "prefix": {
-              "type": "string"
-            },
-            "isActive": {
-              "type": "boolean"
-            }
-          },
-          "required": ["name", "isActive", "prefix"],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ABCMaterialNumbers": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
-          "properties": {
-            "productID": {
-              "type": ["string", "null"]
-            },
-            "vendorID": {
-              "type": ["string", "null"]
-            },
-            "materialCategoryID": {
-              "type": "string"
-            },
-            "number": {
-              "type": "number"
-            },
-            "name": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "unitOfMeasure": {
-              "type": "string"
-            },
-            "isActive": {
-              "type": "boolean"
-            }
-          },
           "required": [
+            "lotID",
+            "newLocationID",
+            "quantity",
+            "lotNumber",
+            "materialNumberID",
+            "locationID",
             "productID",
-            "vendorID",
-            "materialCategoryID",
-            "number",
-            "name",
-            "description",
-            "unitOfMeasure",
-            "isActive"
+            "notes"
           ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ABCLocations": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
           "properties": {
-            "name": {
+            "locationID": {
               "type": "string"
             },
-            "isActive": {
-              "type": "boolean"
+            "lotID": {
+              "type": "string"
+            },
+            "lotNumber": {
+              "type": "string"
+            },
+            "materialNumberID": {
+              "type": "string"
+            },
+            "newLocationID": {
+              "type": "string"
+            },
+            "notes": {
+              "type": "string"
+            },
+            "productID": {
+              "type": [ "string", "null" ]
+            },
+            "quantity": {
+              "type": "number"
             }
           },
-          "required": ["name", "isActive"],
           "additionalProperties": false
+        },
+        "transactionType": {
+          "const": "transfer"
+        },
+        "uid": {
+          "type": "string"
         }
       },
       "additionalProperties": false
     },
-    "ABCReasonCodes": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "type": "object",
-          "properties": {
-            "code": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "isActive": {
-              "type": "boolean"
-            }
-          },
-          "required": ["code", "description", "isActive"],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "ABCTransactions": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ABCInventoryTransaction"
-      }
-    },
-    "ABCInventoryEntries": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
-          "$ref": "#/definitions/ABCInventoryEntry"
-        }
-      },
-      "additionalProperties": false
+    "ABCStatus": {
+      "enum": [
+        "RELEASED",
+        "CONDITIONAL_RELEASED",
+        "QUARANTINE",
+        "ON_HOLD",
+        "EXPIRED",
+        "DAMAGED"
+      ]
     }
-  },
-  "required": [
-    "$schema",
-    "ABCProducts",
-    "ABCVendors",
-    "ABCMaterialCategories",
-    "ABCMaterialNumbers",
-    "ABCLocations",
-    "ABCReasonCodes",
-    "ABCTransactions",
-    "ABCInventoryEntries"
-  ],
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
### Description

This PR addresses warnings from the JSON schema linter.
- Replaced all single-value `enum` properties with `const`
- Removed redundant `type` when used with `enum`/`const`

### Screenshots

Before and after:

[Screencast from 2025-07-06 23-04-40.webm](https://github.com/user-attachments/assets/2e6cbe83-7ea0-4bb5-9499-d55de1e1ab3a)

### Note

I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. If beneficial to the project, I suggest integrating the linter with it to write the best schemas and catch any errors and follow best practices.
