### PR TITLE
dependabot: Disallow additional properties on `update` objects

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -698,6 +698,7 @@
     },
     "update": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "allow": {
           "description": "Customize which updates are allowed",


### PR DESCRIPTION
We have made mistakes in our `dependabot.yml` files that this would have caught.