### PR TITLE
Add theme to vsix-publish.json

### DIFF
--- a/src/schemas/json/vsix-publish.json
+++ b/src/schemas/json/vsix-publish.json
@@ -182,6 +182,7 @@
               "start pages",
               "team development",
               "testing",
+              "theme",
               "visual studio extensions",
               "wcf",
               "web",


### PR DESCRIPTION
Add `theme` to the list of allowed categories.

Fixes https://github.com/microsoft/vsmarketplace/issues/459
