### PR TITLE
add Revel Digital gadget definition schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8271,6 +8271,15 @@
         "*.hecate.json"
       ],
       "url": "https://raw.githubusercontent.com/ShaitanLyss/these/main/hecate/hecate-json-schema.json"
+    },
+    {
+      "name": "Revel Digital Gadget Definition File",
+      "description": "Revel Digital gadget definition file. See https://developer.reveldigital.com/gadgets for more information",
+      "fileMatch": [
+        "gadget.yml",
+        "gadget.yaml"
+      ],
+      "url": "https://www.schemastore.org/gadget-yaml.json"
     }
   ]
 }

--- a/src/schemas/json/gadget-yaml.json
+++ b/src/schemas/json/gadget-yaml.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/gadget-yaml.json",
+  "title": "gadget.yaml",
+  "description": "Schema for Revel Digital gadget.yaml files. See https://developer.reveldigital.com/gadgets for more information.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "title_url": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "string"
+    },
+    "background": {
+      "type": "string"
+    },
+    "requirements": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "locales": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Locale"
+      }
+    },
+    "prefs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Pref"
+      }
+    }
+  },
+  "required": [
+    "author",
+    "background",
+    "description",
+    "locales",
+    "prefs",
+    "requirements",
+    "title",
+    "title_url"
+  ],
+  "definitions": {
+    "Locale": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "messages": {
+          "type": "string",
+          "format": "uri"
+        },
+        "lang": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "messages"
+      ],
+      "title": "Locale"
+    },
+    "Pref": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "datatype": {
+          "type": "string"
+        },
+        "default_value": {
+          "$ref": "#/definitions/DefaultValue"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Option"
+          }
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Depend"
+          }
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "multiline": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "datatype",
+        "default_value",
+        "display_name",
+        "name",
+        "required"
+      ],
+      "title": "Pref"
+    },
+    "Depend": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "any_of": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnyOf"
+          }
+        },
+        "all_of": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AllOf"
+          }
+        },
+        "none_of": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NoneOf"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Depend"
+    },
+    "AnyOf": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "AnyOf"
+    },
+    "AllOf": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "AllOf"
+    },
+    "NoneOf": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "values"
+      ],
+      "title": "NoneOf"
+    },
+    "Option": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display_value": {
+          "type": "string"
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "display_value"
+      ],
+      "title": "Option"
+    },
+    "DefaultValue": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "title": "DefaultValue"
+    }
+  }
+}

--- a/src/test/gadget-yaml/good-example.yaml
+++ b/src/test/gadget-yaml/good-example.yaml
@@ -1,0 +1,192 @@
+# yaml-language-server: $schema=../../schemas/json/gadget-yaml.json
+title: Text App
+title_url:
+description: Text zone with support for markdown, emoji, and animations.
+author: Revel Digital
+background: transparent
+
+requirements:
+  - reveldigital
+  - offline
+  - webfont
+
+locales:
+  - messages: https://reveldigital.github.io/reveldigital-gadgets/ALL_ALL.xml
+
+  - lang: ru
+    messages: https://reveldigital.github.io/reveldigital-gadgets/ALL_ALL.xml
+
+prefs:
+  - name: text
+    display_name: Text to Display
+    datatype: string
+    default_value:
+    required: true
+    multiline: true
+
+  - name: style
+    display_name: Font Style
+    datatype: style
+    default_value: font-family:Open Sans;color:rgb(255, 255, 255);font-size:38px;text-align:center;
+    required: true
+
+  - name: ltrSpacing
+    display_name: Letter Spacing
+    datatype: string
+    default_value: 0
+    required: true
+
+  - name: lineHeight
+    display_name: Line Spacing
+    datatype: string
+    default_value: 1.2
+    required: true
+
+  - name: orientation
+    display_name: Orientation
+    datatype: enum
+    default_value: horizontal
+    multiple: false
+    required: true
+    options:
+      - value: horizontal
+        display_value: Horizontal
+      - value: vertical
+        display_value: Vertical
+
+  - name: wrap
+    display_name: Word Wrap
+    datatype: bool
+    default_value: true
+    required: true
+
+  - name: animation
+    display_name: Animation
+    datatype: enum
+    default_value:
+    multiple: false
+    required: false
+    options:
+      - value:
+        display_value: None
+      - value: animate__bounceIn
+        display_value: Bounce In
+      - value: animate__bounceInDown
+        display_value: Bounce In Down
+      - value: animate__bounceInLeft
+        display_value: Bounce In Left
+      - value: animate__bounceInRight
+        display_value: Bounce In Right
+      - value: animate__bounceInUp
+        display_value: Bounce In Up
+      - value: animate__fadeIn
+        display_value: Fade In
+      - value: animate__fadeInDown
+        display_value: Fade In Down
+      - value: animate__fadeInLeft
+        display_value: Fade In Left
+      - value: animate__fadeInRight
+        display_value: Fade In Right
+      - value: animate__fadeInUp
+        display_value: Fade In Up
+      - value: animate__fadeInTopLeft
+        display_value: Fade In Top Left
+      - value: animate__fadeInTopRight
+        display_value: Fade In Top Right
+      - value: animate__fadeInBottomLeft
+        display_value: Fade In Bottom Left
+      - value: animate__fadeInBottomRight
+        display_value: Fade In Bottom Right
+      - value: animate__flipInX
+        display_value: Flip In X
+      - value: animate__flipInY
+        display_value: Flip In Y
+      - value: animate__lightSpeedInRight
+        display_value: Light Speed In Right
+      - value: animate__lightSpeedInLeft
+        display_value: Light Speed In Left
+      - value: animate__rotateIn
+        display_value: Rotate In
+      - value: animate__rotateInDownLeft
+        display_value: Rotate In Down Left
+      - value: animate__rotateInDownRight
+        display_value: Rotate In Down Right
+      - value: animate__rotateInUpLeft
+        display_value: Rotate In Up Left
+      - value: animate__rotateInUpRight
+        display_value: Rotate In Up Right
+      - value: animate__jackInTheBox
+        display_value: Jack In The Box
+      - value: animate__rollIn
+        display_value: Roll In
+      - value: animate__zoomIn
+        display_value: Zoom In
+      - value: animate__zoomInDown
+        display_value: Zoom In Down
+      - value: animate__zoomInLeft
+        display_value: Zoom In Left
+      - value: animate__zoomInRight
+        display_value: Zoom In Right
+      - value: animate__zoomInUp
+        display_value: Zoom In Up
+      - value: animate__slideInDown
+        display_value: Slide In Down
+      - value: animate__slideInLeft
+        display_value: Slide In Left
+      - value: animate__slideInRight
+        display_value: Slide In Right
+      - value: animate__slideInUp
+        display_value: Slide In Up
+
+  - name: confetti
+    display_name: Confetti
+    datatype: enum
+    default_value:
+    required: false
+    options:
+      - value:
+        display_value: None
+      - value: confetti
+        display_value: Confetti
+      - value: fireworks
+        display_value: Fireworks
+      - value: stars
+        display_value: Stars
+      - value: snow
+        display_value: Snow
+      - value: schoolPride
+        display_value: School Pride
+
+  - name: confettiColorPrimary
+    display_name: Primary Confetti Color
+    datatype: color
+    default_value: bb0000
+    required: false
+    depends:
+      - name: confetti
+        any_of:
+          - values:
+            - schoolPride
+    
+  - name: confettiColorSecondary
+    display_name: Secondary Confetti Color
+    datatype: color
+    default_value: ffffff
+    required: false
+    depends:
+      - name: confetti
+        any_of:
+          - values:
+            - schoolPride
+
+  - name: commandName
+    display_name: Command name to use for triggered updates
+    datatype: string
+    default_value:
+    required: false
+
+  - name: commandArgPath
+    display_name: Optional path to argument value for triggered updates
+    datatype: string
+    default_value:
+    required: false


### PR DESCRIPTION

This pull request introduces support for the `gadget.yaml` schema used by Revel Digital gadget definition files. The changes include adding the schema to the catalog, defining the schema itself, and providing an example file for validation.

### Schema Integration:
* Added an entry for the `gadget.yaml` schema in `src/api/json/catalog.json`, enabling schema validation for files named `gadget.yml` or `gadget.yaml`.

### Schema Definition:
* Created `src/schemas/json/gadget-yaml.json`, defining the structure and validation rules for `gadget.yaml` files. The schema includes properties such as `title`, `author`, `prefs`, and nested definitions for `Locale`, `Pref`, `Depend`, and others.

### Example File:
* Added `src/test/gadget-yaml/good-example.yaml` as a test file demonstrating a valid `gadget.yaml` configuration, including examples of preferences, locales, and other schema features.