### PR TITLE
Match .renovaterc.json5

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4939,7 +4939,8 @@
         "**/.gitlab/renovate.json",
         "**/.gitlab/renovate.json5",
         ".renovaterc",
-        ".renovaterc.json"
+        ".renovaterc.json",
+        ".renovaterc.json5"
       ],
       "url": "https://docs.renovatebot.com/renovate-schema.json"
     },


### PR DESCRIPTION
Add matching for `.renovaterc.json5` files to Renovate.

I also checked against the list of supported file names in the [Renovate docs](https://docs.renovatebot.com/configuration-options/). This appears to be the only one missing.