### PR TITLE
Add AWS Copilot schema to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8296,9 +8296,7 @@
     {
       "name": "AWS Copilot Manifest",
       "description": "Manifest YAML files for AWS Copilot services, environments, and pipelines. Documentation: https://aws.github.io/copilot-cli/docs/manifest/overview/",
-      "fileMatch": [
-        "**/copilot/**/manifest.yml"
-      ],
+      "fileMatch": ["**/copilot/**/manifest.yml"],
       "url": "https://sootyowl.github.io/aws-copilot-schemas/copilot-schema.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8292,6 +8292,14 @@
       "description": "Jujutsu (jj) configuration file",
       "fileMatch": ["**/.jj/repo/config.toml", "**/jj/config.toml"],
       "url": "https://jj-vcs.github.io/jj/latest/config-schema.json"
+    },
+    {
+      "name": "AWS Copilot Manifest",
+      "description": "Manifest YAML files for AWS Copilot services, environments, and pipelines. Documentation: https://aws.github.io/copilot-cli/docs/manifest/overview/",
+      "fileMatch": [
+        "**/copilot/**/manifest.yml"
+      ],
+      "url": "https://sootyowl.github.io/aws-copilot-schemas/copilot-schema.json"
     }
   ]
 }


### PR DESCRIPTION
I've created and hosted schema for [AWS Copilot](https://aws.github.io/copilot-cli/) `manifest.yml` files - thought it would be nice to add them to the SchemaStore so others could use them more easily.