### PR TITLE
Add LangGraph Configuration JSON Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7717,6 +7717,17 @@
       "url": "https://www.schemastore.org/language-configuration.json"
     },
     {
+      "name": "LangGraph Platform configuration",
+      "description": "LangGraph Platform configuration file",
+      "fileMatch": [
+        "langgraph.json",
+        "langgraph.*.json",
+        ".langgraph.json",
+        ".langgraph.*.json"
+      ],
+      "url": "https://raw.githubusercontent.com/langchain-ai/langgraph/main/libs/cli/schemas/version.schema.json"
+    },
+    {
       "name": "Any",
       "description": "Valid for any JSON file",
       "fileMatch": [],


### PR DESCRIPTION
We have schemas hosted for langgraph config files in our [github repo](https://github.com/langchain-ai/langgraph/blob/main/libs/cli/schemas/version.schema.json), but it would be great to have them picked up automatically.

Thanks for this project!