### PR TITLE
Support for Bitol’s ODCS and ODPS

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4114,12 +4114,23 @@
     },
     {
       "name": "Open Data Contract Standard (ODCS)",
-      "description": "Open Data Contract Standard contract file",
+      "description": "Open Data Contract Standard contract file, from the Bitol project at The Linux Foundation",
       "fileMatch": ["*.odcs.yaml", "*.odcs.yml"],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-contract-standard/main/schema/odcs-json-schema-latest.json",
       "versions": {
+        "v3.0.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.2.json",
+        "v3.0.1": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.1.json",
         "v3.0.0": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.0.json",
         "v2.2.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v2.2.2.json"
+      }
+    },
+    {
+      "name": "Open Data Product Standard (ODPS)",
+      "description": "Open Data Product Standard descriptor file, from the Bitol project at The Linux Foundation",
+      "fileMatch": ["*.odps.yaml", "*.odps.yml"],
+      "url": "https://raw.githubusercontent.com/bitol-io/open-data-product-standard/main/schema/odps-json-schema-latest.json",
+      "versions": {
+        "v0.9.0": "https://github.com/bitol-io/open-data-product-standard/blob/main/schema/odps-json-schema-v0.9.0.json"
       }
     },
     {


### PR DESCRIPTION
Adding additional versions for ODCS and the new ODPS. 

Those are open standards from The Linux Foundation. 
