### PR TITLE
fix(dependabot): add support for cargo and pub registries

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1036,7 +1036,7 @@
                 "maven-repository",
                 "npm-registry",
                 "nuget-feed",
-                "pub-registry",
+                "pub-repository",
                 "python-index",
                 "rubygems-server",
                 "terraform-registry"

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1027,6 +1027,7 @@
             "type": {
               "description": "Identifies the type of registry.",
               "enum": [
+                "cargo-registry",
                 "composer-repository",
                 "docker-registry",
                 "git",
@@ -1035,6 +1036,7 @@
                 "maven-repository",
                 "npm-registry",
                 "nuget-feed",
+                "pub-registry",
                 "python-index",
                 "rubygems-server",
                 "terraform-registry"

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -1,6 +1,11 @@
 {
   "enable-beta-ecosystems": true,
   "registries": {
+    "cargo-example": {
+      "token": "${{secrets.MY_CARGO_REGISTRY_TOKEN}}",
+      "type": "cargo-registry",
+      "url": "https://my-registry.example.com"
+    },
     "composer": {
       "password": "${{secrets.MY_PACKAGIST_PASSWORD}}",
       "type": "composer-repository",
@@ -71,6 +76,11 @@
       "type": "python-index",
       "url": "https://example.com/_packaging/my-feed/pypi/example",
       "username": "octocat"
+    },
+    "pub-example": {
+      "token": "${{secrets.MY_PUB_TOKEN}}",
+      "type": "pub-registry",
+      "url": "https://pub.example.com"
     },
     "ruby-example": {
       "password": "${{secrets.MY_RUBYGEMS_PASSWORD}}",

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -66,7 +66,7 @@
     },
     "pub-example": {
       "token": "${{secrets.MY_PUB_TOKEN}}",
-      "type": "pub-registry",
+      "type": "pub-repository",
       "url": "https://pub.example.com"
     },
     "python-azure": {

--- a/src/test/dependabot-2.0/example.json
+++ b/src/test/dependabot-2.0/example.json
@@ -64,6 +64,11 @@
       "url": "https://nuget.example.com/v3/index.json",
       "username": "octocat@example.com"
     },
+    "pub-example": {
+      "token": "${{secrets.MY_PUB_TOKEN}}",
+      "type": "pub-registry",
+      "url": "https://pub.example.com"
+    },
     "python-azure": {
       "replaces-base": true,
       "token": "${{secrets.MY_AZURE_DEVOPS_TOKEN}}",
@@ -76,11 +81,6 @@
       "type": "python-index",
       "url": "https://example.com/_packaging/my-feed/pypi/example",
       "username": "octocat"
-    },
-    "pub-example": {
-      "token": "${{secrets.MY_PUB_TOKEN}}",
-      "type": "pub-registry",
-      "url": "https://pub.example.com"
     },
     "ruby-example": {
       "password": "${{secrets.MY_RUBYGEMS_PASSWORD}}",


### PR DESCRIPTION
GitHub supports 2 (new) registires in Dependabot custom registry yaml configuration.

There were missing from the current V2 schema (all schemas >=V2 support these ones)

According to this [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#type-and-authentication-details)

**EDIT:**
GitHub docs seem to have a typo.
I'm using the custom pub registry, but GitHub returns an error if setting `pub-registry` like in the docs, instead of `pub-repository`.
Here's the sample error: 

> The property '#/registries/pub-jfrog/type' value "pub-registry" did not match one of the following values: cargo-registry, composer-repository, docker-registry, git, helm-registry, hex-organization, hex-repository, maven-repository, npm-registry, nuget-feed, pub-repository, python-index, rubygems-server, terraform-registry

Therefore, I can confirm regarding the error, and local testing, that it should be `pub-repository`.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
