### PR TITLE
Add Spack package manager schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5362,6 +5362,114 @@
       "url": "https://www.schemastore.org/sourcery_yaml_schema.json"
     },
     {
+      "name": "Spack bootstrap.yaml",
+      "description": "Spack package manager bootstrap.yaml config file",
+      "fileMatch": ["**/*spack/**/bootstrap.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/bootstrap.json"
+    },
+    {
+      "name": "Spack cdash.yaml",
+      "description": "Spack package manager cdash.yaml config file",
+      "fileMatch": ["**/*spack/**/cdash.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/cdash.json"
+    },
+    {
+      "name": "Spack ci.yaml",
+      "description": "Spack package manager ci.yaml config file",
+      "fileMatch": ["**/*spack/**/ci.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/ci.json"
+    },
+    {
+      "name": "Spack compilers.yaml",
+      "description": "Spack package manager compilers.yaml config file",
+      "fileMatch": ["**/*spack/**/compilers.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/compilers.json"
+    },
+    {
+      "name": "Spack concretizer.yaml",
+      "description": "Spack package manager concretizer.yaml config file",
+      "fileMatch": ["**/*spack/**/concretizer.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/concretizer.json"
+    },
+    {
+      "name": "Spack config.yaml",
+      "description": "Spack package manager config.yaml file",
+      "fileMatch": ["**/*spack/**/config.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/config.json"
+    },
+    {
+      "name": "Spack definitions.yaml",
+      "description": "Spack package manager definitions.yaml config",
+      "fileMatch": ["**/*spack/**/definitions.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/definitions.json"
+    },
+    {
+      "name": "Spack develop.yaml",
+      "description": "Spack package manager develop.yaml config file",
+      "fileMatch": ["**/*spack/**/develop.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/develop.json"
+    },
+    {
+      "name": "Spack env_vars.yaml",
+      "description": "Spack package manager env_vars.yaml config file",
+      "fileMatch": ["**/*spack/**/env_vars.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/env_vars.json"
+    },
+    {
+      "name": "Spack include.yaml",
+      "description": "Spack package manager include.yaml config file",
+      "fileMatch": ["**/*spack/**/include.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/include.json"
+    },
+    {
+      "name": "Spack mirrors.yaml",
+      "description": "Spack package manager mirrors.yaml config file",
+      "fileMatch": ["**/*spack/**/mirrors.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/mirrors.json"
+    },
+    {
+      "name": "Spack modules.yaml",
+      "description": "Spack package manager modules.yaml config file",
+      "fileMatch": ["**/*spack/**/modules.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/modules.json"
+    },
+    {
+      "name": "Spack packages.yaml",
+      "description": "Spack package manager packages.yaml config file",
+      "fileMatch": ["**/*spack/**/packages.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/packages.json"
+    },
+    {
+      "name": "Spack repos.yaml",
+      "description": "Spack package manager repos.yaml config file",
+      "fileMatch": ["**/*spack/**/repos.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/repos.json"
+    },
+    {
+      "name": "Spack environment",
+      "description": "Spack package manager environment file",
+      "fileMatch": ["spack.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/spack.json"
+    },
+    {
+      "name": "Spack toolchains.yaml",
+      "description": "Spack package manager toolchains.yaml config file",
+      "fileMatch": ["**/*spack/**/toolchains.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/toolchains.json"
+    },
+    {
+      "name": "Spack upstreams.yaml",
+      "description": "Spack package manager upstreams.yaml config file",
+      "fileMatch": ["**/*spack/**/upstreams.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/upstreams.json"
+    },
+    {
+      "name": "Spack view.yaml",
+      "description": "Spack package manager view.yaml config file",
+      "fileMatch": ["**/*spack/**/view.yaml"],
+      "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/view.json"
+    },
+    {
       "name": "Speakeasy Lint Configuration File",
       "description": "Configuration file for Speakeasy's OpenAPI document linting. Find out more at https://www.speakeasy.com/docs/linting",
       "fileMatch": ["**/.speakeasy/lint.yaml"],


### PR DESCRIPTION
We're hosting schemas for [Spack](https://github.com/spack/spack) at https://github.com/spack/schemas

Would be nice to add them to this project.

For file matching I've picked `spack.yaml` as the only literal file match, all others are too generic and should have `.../*spack/...` as a path component, so it matches:

* `/path/to/spack/etc/config.yaml`
* `~/.spack/config.yaml`

