### PR TITLE
feat(dependabot): add support for the new cooldown feature

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -758,6 +758,49 @@
           ],
           "additionalProperties": false
         },
+        "cooldown": {
+          "description": "Defines a cooldown period for dependency updates, allowing updates to be delayed for a configurable number of days. This feature enables users to customize how often Dependabot generates new version updates, offering greater control over update frequency.",
+          "type": "object",
+          "properties": {
+            "default-days": {
+              "description": "Default cooldown period for dependencies without specific rules (optional).",
+              "type": "integer",
+              "minimum": 0
+            },
+            "semver-major-days": {
+              "description": "Cooldown period for major version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 0
+            },
+            "semver-minor-days": {
+              "description": "Cooldown period for minor version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 0
+            },
+            "semver-patch-days": {
+              "description": "Cooldown period for patch version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 0
+            },
+            "include": {
+              "description": "List of dependencies to apply cooldown (up to 150 items). Supports wildcards (`*`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 150
+            },
+            "exclude": {
+              "description": "List of dependencies excluded from cooldown (up to 150 items). Supports wildcards (`*`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 150
+            }
+          },
+          "additionalProperties": false
+        },
         "directories": {
           "description": "Locations of package manifests",
           "type": "array",


### PR DESCRIPTION
Ref:
 - <https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/>
 - <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown->