### PR TITLE
Fixes: !4875 Resolve issues with JetBrains IDEs and ClaudeCode Settings schema

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -46,7 +46,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule (e.g., 'Bash(ls:*)', 'Read(~/.zshrc)', 'WebFetch(domain:github.com)')",
-      "pattern": "^(Agent|Bash|Edit|Glob|Grep|LS|MultiEdit|NotebookEdit|NotebookRead|Read|TodoRead|TodoWrite|WebFetch|WebSearch|Write)\\(?|^mcp__"
+      "pattern": "^((Agent|Bash|Edit|Glob|Grep|LS|MultiEdit|NotebookEdit|NotebookRead|Read|TodoRead|TodoWrite|WebFetch|WebSearch|Write)\\(?|^mcp__)"
     }
   },
   "description": "Configuration file for Claude Code CLI settings",


### PR DESCRIPTION
Adjust the RegEx for permissions schema to work properly with JetBrains IDEs. There is no way to properly test this change given it is a JetBrains RegEx interpreter issue.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
