### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -687,6 +687,12 @@
         "preview": {
           "description": "Whether to enable preview mode. When preview mode is enabled, Ruff will expose unstable commands.",
           "type": ["boolean", "null"]
+        },
+        "string-imports-min-dots": {
+          "description": "The minimum number of dots in a string to consider it a valid import.\n\nThis setting is only relevant when [`detect-string-imports`](#detect-string-imports) is enabled. For example, if this is set to `2`, then only strings with at least two dots (e.g., `\"path.to.module\"`) would be considered valid imports.",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false
@@ -1852,6 +1858,10 @@
               "type": "null"
             }
           ]
+        },
+        "future-annotations": {
+          "description": "Whether to allow rules to add `from __future__ import annotations` in cases where this would simplify a fix or enable a new diagnostic.\n\nFor example, `TC001`, `TC002`, and `TC003` can move more imports into `TYPE_CHECKING` blocks if `__future__` annotations are enabled.\n\nThis setting is currently in [preview](https://docs.astral.sh/ruff/preview/) and requires preview mode to be enabled to have any effect.",
+          "type": ["boolean", "null"]
         },
         "ignore": {
           "description": "A list of rule codes or prefixes to ignore. Prefixes can specify exact rules (like `F841`), entire categories (like `F`), or anything in between.\n\nWhen breaking ties between enabled and disabled rules (via `select` and `ignore`, respectively), more specific prefixes override less specific prefixes. `ignore` takes precedence over `select` if the same prefix appears in both.",


### PR DESCRIPTION
This updates ruff's JSON schema to [c5ac998892a339be0304c7f9e69a5318b371deb8](https://github.com/astral-sh/ruff/commit/c5ac998892a339be0304c7f9e69a5318b371deb8)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
