### PR TITLE
Add CODEOWNERS for Claude Code settings schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,3 +53,7 @@ src/test/pnpm-workspace/ @danielbayley @btea
 # Managed by Power Pages Team:
 src/schemas/json/powerpages.config.json @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
 src/test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
+
+# Managed by Anthropic Team:
+src/schemas/json/claude-code-settings.json @domdomegg @bogini
+src/test/claude-code-settings/ @domdomegg @bogini


### PR DESCRIPTION
## Summary
- Add @domdomegg and @bogini as maintainers for Claude Code settings schema files
- Covers `src/schemas/json/claude-code-settings.json` and `src/test/claude-code-settings/`

🤖 Generated with [Claude Code](https://claude.ai/code)