### PR TITLE
Added schema for shadcn/ui

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8455,6 +8455,12 @@
       "description": "Manifest YAML files for AWS Copilot services, environments, and pipelines. Documentation: https://aws.github.io/copilot-cli/docs/manifest/overview/",
       "fileMatch": ["**/copilot/**/manifest.yml"],
       "url": "https://sootyowl.github.io/aws-copilot-schemas/copilot-schema.json"
+    },
+    {
+      "name": "shadcn/ui components.json",
+      "description": "Config file for shadcn/ui. Documentation: https://ui.shadcn.com/docs/components-json",
+      "fileMatch": ["components.json"],
+      "url": "https://ui.shadcn.com/schema.json"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds a new entry to the `catalog.json` file to support the `shadcn/ui` components.json configuration file.
