### PR TITLE
Add Expo v53 schema and test

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2319,7 +2319,7 @@
       "name": "Expo SDK",
       "description": "Expo SDK app manifest",
       "fileMatch": ["app.json"],
-      "url": "https://www.schemastore.org/expo-52.0.0.json",
+      "url": "https://www.schemastore.org/expo-53.0.0.json",
       "versions": {
         "37.0.0": "https://www.schemastore.org/expo-37.0.0.json",
         "38.0.0": "https://www.schemastore.org/expo-38.0.0.json",
@@ -2329,7 +2329,8 @@
         "42.0.0": "https://www.schemastore.org/expo-42.0.0.json",
         "46.0.0": "https://www.schemastore.org/expo-46.0.0.json",
         "50.0.0": "https://www.schemastore.org/expo-50.0.0.json",
-        "52.0.0": "https://www.schemastore.org/expo-52.0.0.json"
+        "52.0.0": "https://www.schemastore.org/expo-52.0.0.json",
+        "53.0.0": "https://www.schemastore.org/expo-53.0.0.json"
       }
     },
     {

--- a/src/schemas/json/expo-53.0.0.json
+++ b/src/schemas/json/expo-53.0.0.json
@@ -1,0 +1,1401 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/expo-53.0.0.json",
+  "title": "JSON schema for Expo SDK 53 app manifest",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "expo": {
+      "description": "Expo SDK 53 app manifest",
+      "type": "object",
+      "required": ["name", "slug"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name of your app as it appears both within Expo Go and on your home screen as a standalone app.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A short description of what your app is and why it is great.",
+          "type": "string"
+        },
+        "slug": {
+          "description": "A URL-friendly name for your project that is unique across your account.",
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_\\-]+$"
+        },
+        "owner": {
+          "description": "The name of the Expo account that owns the project. This is useful for teams collaborating on a project. If not provided, the owner defaults to the username of the current user.",
+          "type": "string",
+          "minLength": 1
+        },
+        "currentFullName": {
+          "description": "The auto generated Expo account name and slug used for display purposes. It is not meant to be set directly. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value may change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "originalFullName": {
+          "description": "The auto generated Expo account name and slug used for services like Notifications and AuthSession proxy. It is not meant to be set directly. Formatted like `@username/slug`. When unauthenticated, the username is `@anonymous`. For published projects, this value will not change when a project is transferred between accounts or renamed.",
+          "type": "string"
+        },
+        "sdkVersion": {
+          "description": "The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.",
+          "type": "string",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+)|(UNVERSIONED)$"
+        },
+        "runtimeVersion": {
+          "description": "Property indicating compatibility between a build's native code and an OTA update.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z\\d][a-zA-Z\\d._+()-]{0,254}$"
+            },
+            {
+              "type": "string",
+              "pattern": "^exposdk:((\\d+\\.\\d+\\.\\d+)|(UNVERSIONED))$"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "policy": {
+                  "type": "string",
+                  "enum": [
+                    "nativeVersion",
+                    "sdkVersion",
+                    "appVersion",
+                    "fingerprint"
+                  ]
+                }
+              },
+              "required": ["policy"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "version": {
+          "description": "Your app version. In addition to this field, you'll also use `ios.buildNumber` and `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). On iOS this corresponds to `CFBundleShortVersionString`, and on Android, this corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).",
+          "type": "string"
+        },
+        "platforms": {
+          "description": "Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["android", "ios", "web"]
+          }
+        },
+        "githubUrl": {
+          "description": "If you would like to share the source code of your app on Github, enter the URL for the repository here and it will be linked to from your Expo project page.",
+          "pattern": "^https://github\\.com/",
+          "type": ["string"]
+        },
+        "orientation": {
+          "description": "Locks your app to a specific orientation with portrait or landscape. Defaults to no lock. Valid values: `default`, `portrait`, `landscape`",
+          "enum": ["default", "portrait", "landscape"],
+          "type": "string"
+        },
+        "userInterfaceStyle": {
+          "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`. Requires `expo-system-ui` be installed in your project to work on Android.",
+          "type": "string",
+          "enum": ["light", "dark", "automatic"],
+          "default": "light"
+        },
+        "backgroundColor": {
+          "description": "The background color for your app, behind any of your React views. This is also known as the root view background color. Requires `expo-system-ui` be installed in your project to work on iOS.",
+          "type": "string",
+          "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+        },
+        "primaryColor": {
+          "description": "On Android, this will determine the color of your app in the multitasker. Currently this is not used on iOS, but it may be used for other purposes in the future.",
+          "type": "string",
+          "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+        },
+        "icon": {
+          "description": "Local path or remote URL to an image to use for your app's icon. We recommend that you use a 1024x1024 png file. This icon will appear on the home screen and within the Expo Go app.",
+          "type": "string"
+        },
+        "notification": {
+          "description": "Configuration for remote (push) notifications.",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "description": "(Android only) Local path or remote URL to an image to use as the icon for push notifications. 96x96 png grayscale with transparency. We recommend following [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles). If not provided, defaults to your app icon.",
+              "type": "string"
+            },
+            "color": {
+              "description": "(Android only) Tint color for the push notification image when it appears in the notification tray. Defaults to `#ffffff`",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "iosDisplayInForeground": {
+              "description": "Whether or not to display notifications when the app is in the foreground on iOS. `_displayInForeground` option in the individual push notification message overrides this option. [Learn more.](https://docs.expo.dev/push-notifications/receiving-notifications/#foreground-notification-behavior) Defaults to `false`.",
+              "type": "boolean"
+            },
+            "androidMode": {
+              "description": "Show each push notification individually (`default`) or collapse into one (`collapse`).",
+              "enum": ["default", "collapse"],
+              "type": "string"
+            },
+            "androidCollapsedTitle": {
+              "description": "If `androidMode` is set to `collapse`, this title is used for the collapsed notification message. For example, `'#{unread_notifications} new interactions'`.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "androidStatusBar": {
+          "description": "Configuration for the status bar on Android. For more details navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).",
+          "type": "object",
+          "properties": {
+            "barStyle": {
+              "description": "Configures the status bar icons to have a light or dark color. Valid values: `light-content`, `dark-content`. Defaults to `dark-content`",
+              "type": "string",
+              "enum": ["light-content", "dark-content"]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the status bar. Defaults to `#00000000` (transparent) for `dark-content` bar style and `#00000088` (semi-transparent black) for `light-content` bar style",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "hidden": {
+              "description": "Instructs the system whether the status bar should be visible or not. Defaults to `false`",
+              "type": "boolean"
+            },
+            "translucent": {
+              "description": "When false, the system status bar pushes the content of your app down (similar to `position: relative`). When true, the status bar floats above the content in your app (similar to `position: absolute`). Defaults to `true` to match the iOS status bar behavior (which can only float above content). Explicitly setting this property to `true` will add `android:windowTranslucentStatus` to `styles.xml` and may cause unexpected keyboard behavior on Android when using the `softwareKeyboardLayoutMode` set to `resize`. In this case you will have to use `KeyboardAvoidingView` to manage the keyboard layout.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "androidNavigationBar": {
+          "description": "Configuration for the bottom navigation bar on Android. Can be used to configure the `expo-navigation-bar` module in EAS Build.",
+          "type": "object",
+          "properties": {
+            "visible": {
+              "description": "Determines how and when the navigation bar is shown. [Learn more](https://developer.android.com/training/system-ui/immersive). Requires `expo-navigation-bar` be installed in your project. Valid values: `leanback`, `immersive`, `sticky-immersive` \n\n `leanback` results in the navigation bar being hidden until the first touch gesture is registered. \n\n `immersive` results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden. \n\n `sticky-immersive` is identical to `'immersive'` except that the navigation bar will be semi-transparent and will be hidden again after a short period of time.",
+              "type": "string",
+              "enum": ["leanback", "immersive", "sticky-immersive"]
+            },
+            "barStyle": {
+              "description": "Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer. Valid values: `'light-content'`, `'dark-content'`",
+              "type": "string",
+              "enum": ["light-content", "dark-content"]
+            },
+            "backgroundColor": {
+              "description": "Specifies the background color of the navigation bar.",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "developmentClient": {
+          "description": "Settings that apply specifically to running this app in a development client",
+          "type": "object",
+          "properties": {
+            "silentLaunch": {
+              "description": "If true, the app will launch in a development client with no additional dialogs or progress indicators, just like in a standalone app.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "scheme": {
+          "description": "URL scheme(s) to link into your app. For example, if we set this to `'demo'`, then demo:// URLs would open your app when tapped. This is a build-time configuration, it has no effect in Expo Go.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9+.-]*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9+.-]*$"
+              }
+            }
+          ]
+        },
+        "extra": {
+          "description": "Any extra fields you want to pass to your experience. Values are accessible via `Constants.expoConfig.extra` ([Learn more](https://docs.expo.dev/versions/latest/sdk/constants/#constantsmanifest))",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": true
+        },
+        "updates": {
+          "description": "Configuration for the expo-updates library",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether the updates system will run. Defaults to true. If set to false, builds will only use code and assets bundled at time of build.",
+              "type": "boolean"
+            },
+            "checkAutomatically": {
+              "description": "By default, expo-updates will check for updates every time the app is loaded. Set this to `ON_ERROR_RECOVERY` to disable automatic checking unless recovering from an error. Set this to `NEVER` to disable automatic checking. Valid values: `ON_LOAD` (default value), `ON_ERROR_RECOVERY`, `WIFI_ONLY`, `NEVER`",
+              "enum": ["ON_ERROR_RECOVERY", "ON_LOAD", "WIFI_ONLY", "NEVER"],
+              "type": "string"
+            },
+            "useEmbeddedUpdate": {
+              "description": "Whether to load the embedded update. Defaults to true. If set to false, an update will be fetched at launch. When set to false, ensure that `checkAutomatically` is set to `ON_LOAD` and `fallbackToCacheTimeout` is large enough for the initial remote update to download. This should not be used in production.",
+              "type": "boolean"
+            },
+            "fallbackToCacheTimeout": {
+              "description": "How long (in ms) to wait for the app to check for and fetch a new update upon launch before falling back to the most recent update already present on the device. Defaults to 0. Must be between 0 and 300000 (5 minutes). If the startup update check takes longer than this value, any update downloaded during the check will be applied upon the next app launch.",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 300000
+            },
+            "url": {
+              "description": "URL from which expo-updates will fetch update manifests",
+              "type": "string"
+            },
+            "codeSigningCertificate": {
+              "description": "Local path of a PEM-formatted X.509 certificate used for verifying codesigned updates. When provided, all updates downloaded by expo-updates must be signed.",
+              "type": "string"
+            },
+            "codeSigningMetadata": {
+              "description": "Metadata for `codeSigningCertificate`",
+              "type": "object",
+              "properties": {
+                "alg": {
+                  "description": "Algorithm used to generate manifest code signing signature. Valid values: `rsa-v1_5-sha256`",
+                  "enum": ["rsa-v1_5-sha256"],
+                  "type": "string"
+                },
+                "keyid": {
+                  "description": "Identifier for the key in the certificate. Used to instruct signing mechanisms when signing or verifying signatures.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "requestHeaders": {
+              "description": "Extra HTTP headers to include in HTTP requests made by `expo-updates` when fetching manifests or assets. These may override preset headers.",
+              "type": "object",
+              "additionalProperties": true
+            },
+            "assetPatternsToBeBundled": {
+              "description": "Array of glob patterns specifying which files should be included in updates. Glob patterns are relative to the project root. A value of `['**']` will match all asset files within the project root. When not supplied all asset files will be included. Example: Given a value of `['app/images/**/*.png', 'app/fonts/**/*.woff']` all `.png` files in all subdirectories of `app/images` and all `.woff` files in all subdirectories of `app/fonts` will be included in updates.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "disableAntiBrickingMeasures": {
+              "description": "Whether to disable the built-in expo-updates anti-bricking measures. Defaults to false. If set to true, this will allow overriding certain configuration options from the JS API, which is liable to leave an app in a bricked state if not done carefully. This should not be used in production.",
+              "type": "boolean"
+            },
+            "useNativeDebug": {
+              "description": "Enable debugging of native code with updates enabled. Defaults to false. If set to true, the EX_UPDATES_NATIVE_DEBUG environment variable will be set in Podfile.properties.json and gradle.properties. This causes Xcode and Android Studio debug builds to be built with expo-updates enabled, and JS debugging (with dev client or packager) disabled. This should not be used in production.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "locales": {
+          "description": "Provide overrides by locale for System Dialog prompts like Permissions Boxes",
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "assetBundlePatterns": {
+          "description": "@deprecated Follow [the guide to select and exclude assets](https://docs.expo.dev/eas-update/asset-selection/) for EAS Update instead. An array of file glob strings which point to assets that will be bundled within your standalone app binary. Read more in the [Offline Support guide](https://docs.expo.dev/guides/offline-support/)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "deprecated": true
+        },
+        "plugins": {
+          "description": "Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.dev/guides/config-plugins/).",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": ["string"]
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "minItems": 1,
+                "maxItems": 1
+              },
+              {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
+                  }
+                ],
+                "minItems": 2,
+                "maxItems": 2
+              }
+            ]
+          }
+        },
+        "splash": {
+          "description": "Configuration for loading and splash screen for standalone apps.",
+          "type": "object",
+          "properties": {
+            "backgroundColor": {
+              "description": "Color to fill the loading screen background",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "resizeMode": {
+              "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+              "enum": ["cover", "contain"],
+              "type": "string"
+            },
+            "image": {
+              "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+              "type": "string"
+            }
+          }
+        },
+        "jsEngine": {
+          "description": "@deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.",
+          "type": "string",
+          "enum": ["hermes", "jsc"],
+          "deprecated": true
+        },
+        "newArchEnabled": {
+          "description": "A Boolean value that indicates whether the app should use the new architecture. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "ios": {
+          "description": "Configuration that is specific to the iOS platform.",
+          "type": "object",
+          "properties": {
+            "appleTeamId": {
+              "description": "The Apple development team ID to use for all native targets. You can find your team ID in [the Apple Developer Portal](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/).",
+              "type": "string"
+            },
+            "publishManifestPath": {
+              "description": "The manifest for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the iOS version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "bundleIdentifier": {
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See [this StackOverflow question](http://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-the-ios-project).",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9.-]+$"
+            },
+            "buildNumber": {
+              "description": "Build number for your iOS standalone app. Corresponds to `CFBundleVersion` and must match Apple's [specified format](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion). (Note: Transporter will pull the value for `Version Number` from `expo.version` and NOT from `expo.ios.buildNumber`.)",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9\\.]+$"
+            },
+            "backgroundColor": {
+              "description": "The background color for your iOS app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present. Requires `expo-system-ui` be installed in your project to work on iOS.",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "scheme": {
+              "description": "URL scheme(s) to link into your iOS app. Schemes added to this field will be merged with the schemes in the `scheme` key at the top level of the config.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9+.-]*$"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[a-z][a-z0-9+.-]*$"
+                  }
+                }
+              ]
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on iOS. Alternatively, an object specifying different icons for various system appearances (e.g., dark, tinted) can be provided. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency.\n\nExpo will generate the other required sizes. This icon will appear on the home screen and within the Expo Go app.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "description": "Configuration that is specific to the iOS platform icons.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "light": {
+                      "description": "The light icon. It will appear when neither dark nor tinted icons are used, or if they are not provided.",
+                      "type": "string"
+                    },
+                    "dark": {
+                      "description": "The dark icon. It will appear for the app when the user's system appearance is dark. See Apple's [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS) for more information.",
+                      "type": "string"
+                    },
+                    "tinted": {
+                      "description": "The tinted icon. It will appear for the app when the user's system appearance is tinted. See Apple's [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons#iOS-iPadOS) for more information.",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            },
+            "appStoreUrl": {
+              "description": "URL to your app on the Apple App Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://(itunes|apps)\\.apple\\.com/.*?\\d+",
+              "type": ["string"]
+            },
+            "bitcode": {
+              "description": "Enable iOS Bitcode optimizations in the native build. Accepts the name of an iOS build configuration to enable for a single configuration and disable for all others, e.g. Debug, Release. Not available in Expo Go. Defaults to `undefined` which uses the template's predefined settings.",
+              "anyOf": [
+                {
+                  "type": ["boolean"]
+                },
+                {
+                  "type": ["string"]
+                }
+              ]
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "usesNonExemptEncryption": {
+                  "description": "Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.",
+                  "type": "boolean"
+                },
+                "googleMapsApiKey": {
+                  "description": "[Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.",
+                  "type": "string"
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.",
+              "type": "string"
+            },
+            "supportsTablet": {
+              "description": "Whether your standalone iOS app supports tablet screen sizes. Defaults to `false`.",
+              "type": "boolean"
+            },
+            "isTabletOnly": {
+              "description": "If true, indicates that your standalone iOS app does not support handsets, and only supports tablets.",
+              "type": "boolean"
+            },
+            "requireFullScreen": {
+              "description": "If true, indicates that your standalone iOS app does not support Slide Over and Split View on iPad. Defaults to `false`",
+              "type": "boolean"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
+              "type": "string",
+              "enum": ["light", "dark", "automatic"],
+              "default": "light"
+            },
+            "infoPlist": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "entitlements": {
+              "description": "Dictionary of arbitrary configuration to add to your standalone app's native *.entitlements (plist). Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "privacyManifests": {
+              "description": "Dictionary of privacy manifest definitions to add to your app's native PrivacyInfo.xcprivacy file. [Learn more](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files)",
+              "type": "object",
+              "properties": {
+                "NSPrivacyAccessedAPITypes": {
+                  "type": "array",
+                  "description": "A list of required reasons of why your app uses restricted API categories. [Learn more](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "NSPrivacyAccessedAPIType",
+                      "NSPrivacyAccessedAPITypeReasons"
+                    ],
+                    "properties": {
+                      "NSPrivacyAccessedAPIType": {
+                        "type": "string",
+                        "description": "A string that identifies the category of required reason APIs your app uses"
+                      },
+                      "NSPrivacyAccessedAPITypeReasons": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "description": "A list of reasons for a specific category.",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "NSPrivacyTrackingDomains": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "description": "A list of domains that your app uses for tracking.",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "NSPrivacyTracking": {
+                  "type": "boolean",
+                  "description": "A Boolean that indicates whether your app or third-party SDK uses data for tracking."
+                },
+                "NSPrivacyCollectedDataTypes": {
+                  "description": "A list of collected data types that your app uses.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "NSPrivacyCollectedDataType",
+                      "NSPrivacyCollectedDataTypeLinked",
+                      "NSPrivacyCollectedDataTypeTracking",
+                      "NSPrivacyCollectedDataTypePurposes"
+                    ],
+                    "properties": {
+                      "NSPrivacyCollectedDataType": {
+                        "type": "string"
+                      },
+                      "NSPrivacyCollectedDataTypeLinked": {
+                        "type": "boolean"
+                      },
+                      "NSPrivacyCollectedDataTypeTracking": {
+                        "type": "boolean"
+                      },
+                      "NSPrivacyCollectedDataTypePurposes": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "associatedDomains": {
+              "description": "An array that contains Associated Domains for the standalone app. [Learn more](https://developer.apple.com/documentation/safariservices/supporting_associated_domains).",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "usesIcloudStorage": {
+              "description": "A boolean indicating if the app uses iCloud Storage for `DocumentPicker`. See `DocumentPicker` docs for details.",
+              "type": "boolean"
+            },
+            "usesAppleSignIn": {
+              "description": "A boolean indicating if the app uses Apple Sign-In. See `AppleAuthentication` docs for details.",
+              "type": "boolean",
+              "default": false
+            },
+            "usesBroadcastPushNotifications": {
+              "description": " A boolean indicating if the app uses Push Notifications Broadcast option for Push Notifications capability. If true, EAS CLI will use the value during capability syncing. If EAS CLI is not used, this configuration will not have any effect unless another tool is used to operate on it, so enable the capability manually on the Apple Developer Portal in that case.",
+              "type": "boolean",
+              "default": false
+            },
+            "accessesContactNotes": {
+              "description": "A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.",
+              "type": "boolean",
+              "default": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for standalone iOS apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": ["cover", "contain"],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "tabletImage": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "dark": {
+                  "description": "Configuration for loading and splash screen for standalone iOS apps in dark mode.",
+                  "type": "object",
+                  "properties": {
+                    "backgroundColor": {
+                      "description": "Color to fill the loading screen background",
+                      "type": "string",
+                      "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                    },
+                    "resizeMode": {
+                      "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                      "enum": ["cover", "contain"],
+                      "type": "string"
+                    },
+                    "image": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                      "type": "string"
+                    },
+                    "tabletImage": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "jsEngine": {
+              "description": "@deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for iOS apps. Not supported in Expo Go. Defaults to `hermes`. Valid values: `hermes`, `jsc`.",
+              "type": "string",
+              "enum": ["hermes", "jsc"],
+              "deprecated": true
+            },
+            "newArchEnabled": {
+              "description": "A Boolean value that indicates whether the iOS app should use the new architecture.",
+              "type": "boolean"
+            },
+            "runtimeVersion": {
+              "description": "Property indicating compatibility between an iOS build's native code and an OTA update for the iOS platform. If provided, this will override the value of the top level `runtimeVersion` key on iOS.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z\\d][a-zA-Z\\d._+()-]{0,254}$"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^exposdk:((\\d+\\.\\d+\\.\\d+)|(UNVERSIONED))$"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "policy": {
+                      "type": "string",
+                      "enum": [
+                        "nativeVersion",
+                        "sdkVersion",
+                        "appVersion",
+                        "fingerprint"
+                      ]
+                    }
+                  },
+                  "required": ["policy"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "version": {
+              "description": "Your iOS app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `ios.buildNumber` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `CFBundleShortVersionString`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "android": {
+          "description": "Configuration that is specific to the Android platform.",
+          "type": "object",
+          "properties": {
+            "publishManifestPath": {
+              "description": "The manifest for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "publishBundlePath": {
+              "description": "The bundle for the Android version of your app will be written to this path during publish.",
+              "type": "string"
+            },
+            "package": {
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See [this StackOverflow question](http://stackoverflow.com/questions/6273892/android-package-name-convention).",
+              "type": "string",
+              "pattern": "^(?!.*\\bnative\\b)[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$"
+            },
+            "versionCode": {
+              "description": "Version number required by Google Play. Increment by one for each release. Must be a positive integer. [Learn more](https://developer.android.com/studio/publish/versioning.html)",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2100000000
+            },
+            "backgroundColor": {
+              "description": "The background color for your Android app, behind any of your React views. Overrides the top-level `backgroundColor` key if it is present.",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "userInterfaceStyle": {
+              "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`. Requires `expo-system-ui` be installed in your project to work on Android.",
+              "type": "string",
+              "enum": ["light", "dark", "automatic"],
+              "default": "light"
+            },
+            "scheme": {
+              "description": "URL scheme(s) to link into your Android app. Schemes added to this field will be merged with the schemes in the `scheme` key at the top level of the config.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9+.-]*$"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[a-z][a-z0-9+.-]*$"
+                  }
+                }
+              ]
+            },
+            "icon": {
+              "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo Go app.",
+              "type": "string"
+            },
+            "adaptiveIcon": {
+              "description": "Settings for an Adaptive Launcher Icon on Android. [Learn more](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive)",
+              "type": "object",
+              "properties": {
+                "foregroundImage": {
+                  "description": "Local path or remote URL to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` and the `android.icon` keys. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen.",
+                  "type": "string"
+                },
+                "monochromeImage": {
+                  "description": "Local path or remote URL to an image representing the Android 13+ monochromatic icon. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive). This icon will appear on the home screen when the user enables 'Themed icons' in system settings on a device running Android 13+.",
+                  "type": "string"
+                },
+                "backgroundImage": {
+                  "description": "Local path or remote URL to a background image for your app's Adaptive Icon on Android. If specified, this overrides the `backgroundColor` key. Must have the same dimensions as `foregroundImage`, and has no effect if `foregroundImage` is not specified. Should follow the [specified guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).",
+                  "type": "string"
+                },
+                "backgroundColor": {
+                  "description": "Color to use as the background for your app's Adaptive Icon on Android. Defaults to white, `#FFFFFF`. Has no effect if `foregroundImage` is not specified.",
+                  "type": "string",
+                  "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "playStoreUrl": {
+              "description": "URL to your app on the Google Play Store, if you have deployed it there. This is used to link to your store page from your Expo project page if your app is public.",
+              "pattern": "^https://play\\.google\\.com/",
+              "type": ["string"]
+            },
+            "permissions": {
+              "description": "A list of permissions to add to the app `AndroidManifest.xml` during prebuild. For example: `['android.permission.SCHEDULE_EXACT_ALARM']`",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blockedPermissions": {
+              "description": "List of permissions to block in the final `AndroidManifest.xml`. This is useful for removing permissions that are added by native package `AndroidManifest.xml` files which are merged into the final manifest. Internally this feature uses the `tools:node=\"remove\"` XML attribute to remove permissions. Not available in Expo Go.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "googleServicesFile": {
+              "description": "[Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `google-services.json` file for configuring Firebase. Including this key automatically enables FCM in your standalone app.",
+              "type": "string"
+            },
+            "config": {
+              "type": "object",
+              "description": "Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.",
+              "properties": {
+                "branch": {
+                  "description": "[Branch](https://branch.io/) key to hook up Branch linking services.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Branch API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMaps": {
+                  "description": "[Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.",
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "description": "Your Google Maps Android SDK API key",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "googleMobileAdsAppId": {
+                  "description": "[Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID. ",
+                  "type": "string"
+                },
+                "googleMobileAdsAutoInit": {
+                  "description": "A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "splash": {
+              "description": "Configuration for loading and splash screen for managed and standalone Android apps.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                  "enum": ["cover", "contain", "native"],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                },
+                "mdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                  "type": "string"
+                },
+                "hdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                  "type": "string"
+                },
+                "xhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                  "type": "string"
+                },
+                "xxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                  "type": "string"
+                },
+                "xxxhdpi": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                  "type": "string"
+                },
+                "dark": {
+                  "description": "Configuration for loading and splash screen for managed and standalone Android apps in dark mode.",
+                  "type": "object",
+                  "properties": {
+                    "backgroundColor": {
+                      "description": "Color to fill the loading screen background",
+                      "type": "string",
+                      "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                    },
+                    "resizeMode": {
+                      "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
+                      "enum": ["cover", "contain", "native"],
+                      "type": "string"
+                    },
+                    "image": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                      "type": "string"
+                    },
+                    "mdpi": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Natural sized image (baseline)`",
+                      "type": "string"
+                    },
+                    "hdpi": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 1.5x`",
+                      "type": "string"
+                    },
+                    "xhdpi": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 2x`",
+                      "type": "string"
+                    },
+                    "xxhdpi": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 3x`",
+                      "type": "string"
+                    },
+                    "xxxhdpi": {
+                      "description": "Local path or remote URL to an image to fill the background of the loading screen in \"native\" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities) \n\n `Scale 4x`",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "intentFilters": {
+              "description": "Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "autoVerify": {
+                    "description": "You may also use an intent filter to set your app as the default handler for links (without showing the user a dialog with options). To do so use `true` and then configure your server to serve a JSON file verifying that you own the domain. [Learn more](https://developer.android.com/training/app-links)",
+                    "type": "boolean"
+                  },
+                  "action": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "description": "Scheme of the URL, e.g. `https`",
+                            "type": "string"
+                          },
+                          "host": {
+                            "description": "Hostname, e.g. `myapp.io`",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "Port, e.g. `3000`",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Exact path for URLs that should be matched by the filter, e.g. `/records`",
+                            "type": "string"
+                          },
+                          "pathPattern": {
+                            "description": "Pattern for paths that should be matched by the filter, e.g. `.*`. Must begin with `/`",
+                            "type": "string"
+                          },
+                          "pathPrefix": {
+                            "description": "Prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                            "type": "string"
+                          },
+                          "mimeType": {
+                            "description": "MIME type for URLs that should be matched by the filter",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": ["array"],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "scheme": {
+                              "description": "Scheme of the URL, e.g. `https`",
+                              "type": "string"
+                            },
+                            "host": {
+                              "description": "Hostname, e.g. `myapp.io`",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Port, e.g. `3000`",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "Exact path for URLs that should be matched by the filter, e.g. `/records`",
+                              "type": "string"
+                            },
+                            "pathPattern": {
+                              "description": "Pattern for paths that should be matched by the filter, e.g. `.*`. Must begin with `/`",
+                              "type": "string"
+                            },
+                            "pathPrefix": {
+                              "description": "Prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`",
+                              "type": "string"
+                            },
+                            "mimeType": {
+                              "description": "MIME type for URLs that should be matched by the filter",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    ]
+                  },
+                  "category": {
+                    "anyOf": [
+                      {
+                        "type": ["string"]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["action"]
+              }
+            },
+            "allowBackup": {
+              "description": "Allows your user's app data to be automatically backed up to their Google Drive. If this is set to false, no backup or restore of the application will ever be performed (this is useful if your app deals with sensitive information). Defaults to the Android default, which is `true`.",
+              "type": "boolean",
+              "default": true
+            },
+            "softwareKeyboardLayoutMode": {
+              "description": "Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.",
+              "enum": ["resize", "pan"],
+              "type": "string",
+              "default": "resize"
+            },
+            "jsEngine": {
+              "description": "@deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.",
+              "type": "string",
+              "enum": ["hermes", "jsc"],
+              "deprecated": true
+            },
+            "newArchEnabled": {
+              "description": "A Boolean value that indicates whether the Android app should use the new architecture.",
+              "type": "boolean"
+            },
+            "runtimeVersion": {
+              "description": "Property indicating compatibility between a Android build's native code and an OTA update for the Android platform. If provided, this will override the value of top level `runtimeVersion` key on Android.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z\\d][a-zA-Z\\d._+()-]{0,254}$"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^exposdk:((\\d+\\.\\d+\\.\\d+)|(UNVERSIONED))$"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "policy": {
+                      "type": "string",
+                      "enum": [
+                        "nativeVersion",
+                        "sdkVersion",
+                        "appVersion",
+                        "fingerprint"
+                      ]
+                    }
+                  },
+                  "required": ["policy"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "version": {
+              "description": "Your android app version. Takes precedence over the root `version` field. In addition to this field, you'll also use `android.versionCode` — read more about how to version your app [here](https://docs.expo.dev/distribution/app-stores/#versioning-your-app). This corresponds to `versionName`. The required format can be found [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring).",
+              "type": "string"
+            },
+            "edgeToEdgeEnabled": {
+              "description": "Enable your app to run in [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode. Default to false.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "web": {
+          "description": "Configuration that is specific to the web platform.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "output": {
+              "description": "Sets the export method for the web app for both `expo start` and `expo export`. `static` statically renders HTML files for every route in the `app/` directory, which is available only in Expo Router apps. `single` outputs a Single Page Application (SPA), with a single `index.html` in the output folder, and has no statically indexable HTML. `server` outputs static HTML, and API Routes for hosting with a custom Node.js server. Defaults to `single`.",
+              "enum": ["single", "static", "server"],
+              "type": "string"
+            },
+            "favicon": {
+              "description": "Relative path of an image to use for your app's favicon.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Defines the title of the document, defaults to the outer level name",
+              "type": "string"
+            },
+            "shortName": {
+              "description": "A short version of the app's name, 12 characters or fewer. Used in app launcher and new tab pages. Maps to `short_name` in the PWA manifest.json. Defaults to the `name` property.",
+              "type": "string"
+            },
+            "lang": {
+              "description": "Specifies the primary language for the values in the name and short_name members. This value is a string containing a single language tag.",
+              "type": "string",
+              "default": "en"
+            },
+            "scope": {
+              "description": "Defines the navigation scope of this website's context. This restricts what web pages can be viewed while the manifest is applied. If the user navigates outside the scope, it returns to a normal web page inside a browser tab/window. If the scope is a relative URL, the base URL will be the URL of the manifest.",
+              "type": "string"
+            },
+            "themeColor": {
+              "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "description": {
+              "description": "Provides a general description of what the pinned website does.",
+              "type": "string"
+            },
+            "dir": {
+              "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
+              "enum": ["auto", "ltr", "rtl"],
+              "type": "string"
+            },
+            "display": {
+              "description": "Defines the developers’ preferred display mode for the website.",
+              "enum": ["fullscreen", "standalone", "minimal-ui", "browser"],
+              "type": "string"
+            },
+            "startUrl": {
+              "description": "The URL that loads when a user launches the application (e.g., when added to home screen), typically the index. Note: This has to be a relative URL, relative to the manifest URL.",
+              "type": "string"
+            },
+            "orientation": {
+              "description": "Defines the default orientation for all the website's top level browsing contexts.",
+              "enum": [
+                "any",
+                "natural",
+                "landscape",
+                "landscape-primary",
+                "landscape-secondary",
+                "portrait",
+                "portrait-primary",
+                "portrait-secondary"
+              ],
+              "type": "string"
+            },
+            "backgroundColor": {
+              "description": "Defines the expected “background color” for the website. This value repeats what is already available in the site’s CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
+              "type": "string",
+              "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+            },
+            "barStyle": {
+              "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
+              "enum": ["default", "black", "black-translucent"],
+              "type": "string",
+              "default": "black-translucent"
+            },
+            "preferRelatedApplications": {
+              "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
+              "type": "boolean",
+              "default": true
+            },
+            "dangerous": {
+              "description": "Experimental features. These will break without deprecation notice.",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            },
+            "splash": {
+              "description": "Configuration for PWA splash screens.",
+              "type": "object",
+              "properties": {
+                "backgroundColor": {
+                  "description": "Color to fill the loading screen background",
+                  "type": "string",
+                  "pattern": "^(#|&#x23;)[0-9a-fA-F]{6,8}$"
+                },
+                "resizeMode": {
+                  "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
+                  "enum": ["cover", "contain"],
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "description": "Firebase web configuration. Used by the expo-firebase packages on both web and native. [Learn more](https://firebase.google.com/docs/reference/js/firebase.html#initializeapp)",
+              "type": "object",
+              "properties": {
+                "firebase": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "authDomain": {
+                      "type": "string"
+                    },
+                    "databaseURL": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "storageBucket": {
+                      "type": "string"
+                    },
+                    "messagingSenderId": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    },
+                    "measurementId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "bundler": {
+              "description": "Sets the bundler to use for the web platform. Only supported in the local CLI `npx expo`. Defaults to `webpack` if the `@expo/webpack-config` package is installed, if not, it defaults to `metro`.",
+              "enum": ["webpack", "metro"],
+              "default": "metro"
+            }
+          }
+        },
+        "experiments": {
+          "description": "Enable experimental features that may be unstable, unsupported, or removed without deprecation notices.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "baseUrl": {
+              "description": "Export a website relative to a subpath of a domain. The path will be prepended as-is to links to all bundled resources. Prefix the path with a `/` (recommended) to load all resources relative to the server root. If the path **does not** start with a `/` then resources will be loaded relative to the code that requests them, this could lead to unexpected behavior. Example '/subpath'. Defaults to '' (empty string).",
+              "type": "string",
+              "default": ""
+            },
+            "buildCacheProvider": {
+              "description": "Experimentally enable downloading cached builds from remote.",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["eas"]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "plugin": {
+                      "type": "string"
+                    },
+                    "options": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["plugin"]
+                }
+              ]
+            },
+            "supportsTVOnly": {
+              "description": "If true, indicates that this project does not support tablets or handsets, and only supports Apple TV and Android TV",
+              "type": "boolean",
+              "default": false
+            },
+            "tsconfigPaths": {
+              "description": "Enable tsconfig/jsconfig `compilerOptions.paths` and `compilerOptions.baseUrl` support for import aliases in Metro.",
+              "type": "boolean",
+              "default": true
+            },
+            "typedRoutes": {
+              "description": "Enable support for statically typed links in Expo Router. This feature requires TypeScript be set up in your Expo Router v2 project.",
+              "type": "boolean",
+              "default": false
+            },
+            "turboModules": {
+              "description": "Enables Turbo Modules, which are a type of native modules that use a different way of communicating between JS and platform code. When installing a Turbo Module you will need to enable this experimental option (the library still needs to be a part of Expo SDK already, like react-native-reanimated v2). Turbo Modules do not support remote debugging and enabling this option will disable remote debugging.",
+              "type": "boolean",
+              "default": false
+            },
+            "reactCanary": {
+              "description": "Experimentally use a vendored canary build of React for testing upcoming features.",
+              "type": "boolean",
+              "default": false
+            },
+            "reactCompiler": {
+              "description": "Experimentally enable React Compiler.",
+              "type": "boolean",
+              "default": false
+            },
+            "reactServerComponentRoutes": {
+              "description": "Experimentally enable React Server Components by default in Expo Router and concurrent routing for transitions.",
+              "type": "boolean",
+              "default": false
+            },
+            "reactServerFunctions": {
+              "description": "Experimentally enable React Server Functions support in Expo CLI and Expo Router.",
+              "type": "boolean",
+              "default": false
+            },
+            "remoteBuildCache": {
+              "description": "@deprecated Experimentally enable downloading cached builds from remote.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "provider": {
+                  "description": "Service provider for remote builds.",
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": ["eas"]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "plugin": {
+                          "type": "string"
+                        },
+                        "options": {
+                          "type": "object"
+                        }
+                      },
+                      "required": ["plugin"]
+                    }
+                  ]
+                }
+              },
+              "deprecated": true
+            }
+          }
+        },
+        "_internal": {
+          "description": "Internal properties for developer tools",
+          "type": "object",
+          "properties": {
+            "pluginHistory": {
+              "description": "List of plugins already run on the config",
+              "type": "object",
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/src/test/expo-53.0.0/hotdog-app.json
+++ b/src/test/expo-53.0.0/hotdog-app.json
@@ -1,0 +1,139 @@
+{
+  "expo": {
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#1185FE",
+        "backgroundImage": "./assets/icon-android-background.png",
+        "foregroundImage": "./assets/icon-android-foreground.png",
+        "monochromeImage": "./assets/icon-android-foreground.png"
+      },
+      "edgeToEdgeEnabled": true,
+      "googleServicesFile": "./google-services.json",
+      "icon": "./assets/app-icons/android_icon_default_light.png",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "category": ["BROWSABLE", "DEFAULT"],
+          "data": [
+            {
+              "host": "hotdog.app",
+              "scheme": "https"
+            }
+          ]
+        }
+      ],
+      "package": "xyz.hotdog.app"
+    },
+    "androidNavigationBar": {
+      "barStyle": "light-content"
+    },
+    "androidStatusBar": {
+      "barStyle": "light-content"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "00000000-0000-0000-0000-000000000000"
+      }
+    },
+    "icon": "./assets/app-icons/ios_icon_default_light.png",
+    "ios": {
+      "associatedDomains": ["applinks:test.app"],
+      "bundleIdentifier": "xyz.hotdog.app",
+      "config": {
+        "usesNonExemptEncryption": false
+      },
+      "entitlements": {
+        "com.apple.developer.kernel.extended-virtual-addressing": true,
+        "com.apple.developer.kernel.increased-memory-limit": true,
+        "com.apple.security.application-groups": "group.app.hotdog"
+      },
+      "infoPlist": {
+        "CFBundleLocalizations": ["en"],
+        "CFBundleSpokenName": "Hotdog",
+        "NSCameraUsageDescription": "Used for profile pictures, posts, and other kinds of content.",
+        "NSMicrophoneUsageDescription": "Used for posts and other kinds of content.",
+        "NSPhotoLibraryAddUsageDescription": "Used to save images to your library.",
+        "NSPhotoLibraryUsageDescription": "Used for profile pictures, posts, and other kinds of content",
+        "UIBackgroundModes": ["remote-notification"]
+      },
+      "privacyManifests": {
+        "NSPrivacyAccessedAPITypes": [
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
+            "NSPrivacyAccessedAPITypeReasons": ["C617.1", "3B52.1", "0A2A.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
+            "NSPrivacyAccessedAPITypeReasons": ["E174.1", "85F4.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
+            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1", "1C8F.1"]
+          }
+        ]
+      },
+      "supportsTablet": false
+    },
+    "name": "Hotdog",
+    "owner": "hotdog-team",
+    "plugins": [
+      "expo-video",
+      "expo-localization",
+      "expo-web-browser",
+      [
+        "react-native-edge-to-edge",
+        { "android": { "enforceNavigationBarContrast": false } }
+      ],
+      [
+        "@sentry/react-native/expo",
+        {
+          "organization": "",
+          "project": "app",
+          "url": "https://sentry.io"
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "buildToolsVersion": "35.0.0",
+            "compileSdkVersion": 35,
+            "newArchEnabled": false,
+            "targetSdkVersion": 35
+          },
+          "ios": {
+            "deploymentTarget": "15.1",
+            "newArchEnabled": false
+          }
+        }
+      ]
+    ],
+    "primaryColor": "#1083fe",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "scheme": "hotdog",
+    "slug": "hotdog",
+    "updates": {
+      "checkAutomatically": "NEVER",
+      "codeSigningCertificate": "./code-signing/certificate.pem",
+      "codeSigningMetadata": {
+        "alg": "rsa-v1_5-sha256",
+        "keyid": "main"
+      },
+      "enabled": true,
+      "fallbackToCacheTimeout": 30000,
+      "url": "https://updates.hotdog.app/manifest"
+    },
+    "userInterfaceStyle": "automatic",
+    "version": "1.0.0",
+    "web": {
+      "favicon": "./assets/favicon.png"
+    }
+  }
+}


### PR DESCRIPTION
Hello,

This adds the Expo SDK 53 app manifest schema, along with a generic test schema inspired by the [Bluesky app.json](https://github.com/bluesky-social/social-app/blob/main/app.config.js) as a real-world use case.

For reference, the following script was used to transform the Expo partial JSON schema into a complete JSON schema:
 
<details>
<summary>script.js</summary>

 ```javascript
 import fs from "node:fs/promises"

function cleanProperties(obj) {
  if ("meta" in obj) delete obj["meta"]
  if ("example" in obj) delete obj["example"]
  if ("exampleString" in obj) delete obj["exampleString"]
  if ("tsType" in obj) delete obj["tsType"]
  if ("fallback" in obj) {
    obj["default"] = obj["fallback"]
    delete obj["fallback"]
  }
  if (
    typeof obj["description"] === "string" &&
    obj["description"].startsWith("@deprecated ")
  ) {
    obj["deprecated"] = true
  }
  if (Array.isArray(obj["type"]) && obj["type"].length > 1) {
    obj["anyOf"] = obj["type"].map((v) => ({ type: v }))
    delete obj["type"]
  }

  for (const key in obj) {
    if (obj[key] && typeof obj[key] === "object") cleanProperties(obj[key])
  }
}

async function main() {
  const version = parseInt(process.argv[2], 10)
  const source = await fetch(
    `https://raw.githubusercontent.com/expo/expo/refs/heads/main/docs/public/static/schemas/v${version}.0.0/app-config-schema.json`
  )
  const data = await source.json()
  // Global converstion
  cleanProperties(data)

  // Version specific converstion
  if (version === 53) {
    data.plugins.items.anyOf[1] = {
      type: "array",
      items: [{ type: "string" }],
      minItems: 1,
      maxItems: 1,
    }
    data.plugins.items.anyOf[2] = {
      type: "array",
      items: [{ type: "string" }, { type: "object" }],
      minItems: 2,
      maxItems: 2,
    }
    delete data.experiments.properties.buildCacheProvider.additionalProperties
    data.android.properties.package.pattern =
      data.android.properties.package.pattern.replaceAll("\\_", "_")
  }

  await fs.writeFile(
    `expo-${version}.0.0.json`,
    `{
  "$id": "https://json.schemastore.org/expo-${version}.0.0.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "JSON schema for Expo SDK ${version} app manifest",
  "type": "object",
  "additionalProperties": true,
  "properties": {
    "expo": {
      "description": "Expo SDK ${version} app manifest",
      "type": "object",
      "required": ["name", "slug"],
      "additionalProperties": false,
      "properties": ${JSON.stringify(data, undefined, 2).replaceAll("\n", "\n      ")}
    }
  }
}`,
    { encoding: "utf-8" }
  )
}

await main()
 ```

</details>

 Have a great day!