### PR TITLE
Update drupal-links-menu.json metadata to object

### DIFF
--- a/src/schemas/json/drupal-links-menu.json
+++ b/src/schemas/json/drupal-links-menu.json
@@ -62,8 +62,8 @@
         "type": "string"
       },
       "metadata": {
-        "$comment": "@todo Add a title",
-        "type": "array"
+        "$comment": "Any arbitrary metadata for this link.",
+        "type": "object"
       },
       "expanded": {
         "title": "Show the link as expanded",


### PR DESCRIPTION
Change from array to object because Drupal uses this as an associative array, which in JSON Schema must be defined as an object.  @see \token_menu_link_translated_title() for a usage example.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
