### PR TITLE
Add an alternative name of TSTyche config file

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5864,7 +5864,7 @@
     {
       "name": "TSTyche",
       "description": "TSTyche configuration file",
-      "fileMatch": ["tstyche.config.json"],
+      "fileMatch": ["tstyche.json", "tstyche.config.json"],
       "url": "https://tstyche.org/schemas/config.json"
     },
     {


### PR DESCRIPTION
This adds an alternative name of TSTyche config file. I have noticed that users sometimes keep the config file within a directory like `./config/tstyche.json`. The name is rather distinct so this change helps to recognize the file.
