### PR TITLE
Don't match GitHub issue config when matching GitHub issue forms

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2635,8 +2635,8 @@
       "name": "GitHub Issue Template forms",
       "description": "YAML GitHub issue forms",
       "fileMatch": [
-        "**/.github/ISSUE_TEMPLATE/**.yml",
-        "**/.github/ISSUE_TEMPLATE/**.yaml"
+        "**/.github/ISSUE_TEMPLATE/!(config).yml",
+        "**/.github/ISSUE_TEMPLATE/!(config).yaml"
       ],
       "url": "https://www.schemastore.org/github-issue-forms.json"
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Update the fileMatch for GitHub issue forms to match all YAML files except for `config.yml`/`config.yaml`. This is because these files use a different schema (already defined immediately above).

This prevents IDEs from matching both schemas to config.yml, and potentially applying the wrong one.

See the docs from GitHub at https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms