### PR TITLE
Update host.json schema for functions extension bundle default

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -616,7 +616,7 @@
       "type": "object",
       "properties": {
         "extensionBundle": {
-          "description": "Configuration settings for extension bundle",
+          "description": "Configuration settings for extension bundle - a predefined set of compatible binding extensions to a function app",
           "type": "object",
           "properties": {
             "id": {
@@ -627,14 +627,18 @@
             "version": {
               "description": "The version of the extension bundle.",
               "type": "string",
-              "examples": ["[1.*, 2.0.0)", "[2.*, 3.0.0)"],
-              "default": "[2.*, 3.0.0)"
+              "examples": ["[3.3.0, 4.0.0)", "[4.*, 5.0.0)"],
+              "default": "[4.*, 5.0.0)"
             }
           },
           "examples": [
             {
               "id": "Microsoft.Azure.Functions.ExtensionBundle",
-              "version": "[2.*, 3.0.0)"
+              "version": "[4.*, 5.0.0)"
+            },
+            {
+              "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+              "version": "[4.*, 5.0.0)"
             }
           ],
           "additionalProperties": false
@@ -1521,7 +1525,7 @@
           },
           "extensionBundle": {
             "id": "Microsoft.Azure.Functions.ExtensionBundle",
-            "version": "[2.*, 3.0.0)"
+            "version": "[4.*, 5.0.0)"
           }
         }
       ],


### PR DESCRIPTION
This pull request updates the `extensionBundle` configuration in the `host.json` schema to reflect newer version ranges and provide clearer documentation. The main focus is on aligning the schema with the latest supported extension bundle versions and improving the description for better clarity.

**Schema documentation and version updates:**

* Updated the `extensionBundle` property description to clarify that it refers to a predefined set of compatible binding extensions for a function app.
* Changed the example and default values for the `extensionBundle.version` property to use the new version range `[4.*, 5.0.0)` and updated examples to include both the standard and preview extension bundles.
* Updated the example usage of `extensionBundle` in the schema to use the `[4.*, 5.0.0)` version range.