### PR TITLE
`github-issue-forms.json` - allow string labels

### DIFF
--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -2153,25 +2153,35 @@
     },
     "labels": {
       "description": "An issue template labels\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax",
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "minLength": 1,
-        "examples": [
-          "Sample label",
-          "bug",
-          "documentation",
-          "duplicate",
-          "enhancement",
-          "good first issue",
-          "help wanted",
-          "invalid",
-          "question",
-          "wontfix"
-        ]
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "Sample label",
+              "bug",
+              "documentation",
+              "duplicate",
+              "enhancement",
+              "good first issue",
+              "help wanted",
+              "invalid",
+              "question",
+              "wontfix"
+            ]
+          }
+        },
+        {
+          "description": "Comma-delimited labels",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["Sample label", "bug,documentation,duplicate"]
+        }
+      ]
     },
     "projects": {
       "description": "Projects that any issues created with this template will automatically be added to.",

--- a/src/test/github-issue-forms/labels-comma-separated-string.yml
+++ b/src/test/github-issue-forms/labels-comma-separated-string.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=../../schemas/json/github-issue-forms.json
+name: 🐞 Bug
+description: File a bug/issue
+title: '[BUG] <title>'
+labels: 'Bug,Needs Triage'
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 20.04
+          - **Node**: 13.14.0
+          - **npm**: 7.6.3
+      value: |
+        - OS:
+        - Node:
+        - npm:
+      render: Markdown # markdown lower case is in the official example. But the schema only accept: Markdown
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/src/test/github-issue-forms/labels-single-string.yml
+++ b/src/test/github-issue-forms/labels-single-string.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=../../schemas/json/github-issue-forms.json
+name: 🐞 Bug
+description: File a bug/issue
+title: '[BUG] <title>'
+labels: Bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: Ubuntu 20.04
+          - **Node**: 13.14.0
+          - **npm**: 7.6.3
+      value: |
+        - OS:
+        - Node:
+        - npm:
+      render: Markdown # markdown lower case is in the official example. But the schema only accept: Markdown
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false


### PR DESCRIPTION
According to the [spec](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax

> `labels`: Array or comma-delimited string

But current schema supports only array.

This PR adds support for single string as well.

