### PR TITLE
update compose spec url to compose-go

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6689,7 +6689,7 @@
         "**/compose.*.yml",
         "**/compose.*.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json"
+      "url": "https://raw.githubusercontent.com/compose-spec/compose-go/master/schema/compose-spec.json"
     },
     {
       "name": "devinit",


### PR DESCRIPTION
The compose spec url (for docker compose) seems out of date. This updates to the url they recommend.

The compose-spec/compose-spec repository has a warning for the schena file curently used in schemastore https://github.com/compose-spec/compose-spec/tree/main/schema 

> This file is a copy, maintained for backward compatibility. ** Do not edit ** See https://github.com/compose-spec/compose-go/blob/main/schema/compose-spec.json for the original file and to propose changes to the compose specification

This PR updates the URL to the recommended link in the official repository: `compose-spec/compose-go` instead of `compose-spec/compose-spec`