### PR TITLE
cibuildwheel: update for 3.1

### DIFF
--- a/src/schemas/json/partial-cibuildwheel.json
+++ b/src/schemas/json/partial-cibuildwheel.json
@@ -21,7 +21,7 @@
     "description": "A Python version or flavor to enable."
   },
   "additionalProperties": false,
-  "description": "cibuildwheel's settings.",
+  "description": "cibuildwheel's settings. Generated with ./bin/generate_schema.py --schemastore from cibuildwheel.",
   "type": "object",
   "properties": {
     "archs": {
@@ -102,7 +102,7 @@
     },
     "build-frontend": {
       "default": "default",
-      "description": "Set the tool to use to build, either \"pip\" (default for now), \"build\", or \"build[uv]\"",
+      "description": "Set the tool to use to build, either \"build\" (default), \"build[uv]\", or \"pip\"",
       "oneOf": [
         {
           "enum": ["pip", "build", "build[uv]", "default"]
@@ -980,6 +980,66 @@
       }
     },
     "pyodide": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "archs": {
+          "$ref": "#/properties/archs"
+        },
+        "before-all": {
+          "$ref": "#/properties/before-all"
+        },
+        "before-build": {
+          "$ref": "#/properties/before-build"
+        },
+        "before-test": {
+          "$ref": "#/properties/before-test"
+        },
+        "build-frontend": {
+          "$ref": "#/properties/build-frontend"
+        },
+        "build-verbosity": {
+          "$ref": "#/properties/build-verbosity"
+        },
+        "config-settings": {
+          "$ref": "#/properties/config-settings"
+        },
+        "dependency-versions": {
+          "$ref": "#/properties/dependency-versions"
+        },
+        "environment": {
+          "$ref": "#/properties/environment"
+        },
+        "xbuild-tools": {
+          "$ref": "#/properties/xbuild-tools"
+        },
+        "pyodide-version": {
+          "$ref": "#/properties/pyodide-version"
+        },
+        "repair-wheel-command": {
+          "$ref": "#/properties/repair-wheel-command"
+        },
+        "test-command": {
+          "$ref": "#/properties/test-command"
+        },
+        "test-extras": {
+          "$ref": "#/properties/test-extras"
+        },
+        "test-sources": {
+          "$ref": "#/properties/test-sources"
+        },
+        "test-groups": {
+          "$ref": "#/properties/test-groups"
+        },
+        "test-requires": {
+          "$ref": "#/properties/test-requires"
+        },
+        "test-environment": {
+          "$ref": "#/properties/test-environment"
+        }
+      }
+    },
+    "android": {
       "type": "object",
       "additionalProperties": false,
       "properties": {


### PR DESCRIPTION
Notice this was missing due to `android` not being allowed, I must have forgotten it after 3.1.
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
