### PR TITLE
Add support for wrangler.jsonc

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6288,7 +6288,7 @@
     {
       "name": "Wrangler CLI",
       "description": "Wrangler is a command-line tool for building with Cloudflare developer products",
-      "fileMatch": ["wrangler.json", "wrangler.toml"],
+      "fileMatch": ["wrangler.json", "wrangler.jsonc", "wrangler.toml"],
       "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },
     {


### PR DESCRIPTION
Cloudflare recommends using wrangler.jsonc for new projects (https://developers.cloudflare.com/workers/wrangler/configuration/) so add support for this filename.
