### PR TITLE
feat: add schema for `lakefile.toml`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8475,6 +8475,12 @@
       "description": "Terrateam configuration file",
       "fileMatch": ["**/.terrateam/config.yaml", "**/.terrateam/config.yml"],
       "url": "https://raw.githubusercontent.com/terrateamio/terrateam/refs/heads/main/api_schemas/terrat/config-schema.json"
+    },
+    {
+      "name": "Lake configuration file",
+      "description": "Schema for `lakefile.toml`, the .toml configuration file for Lake, the package manager of the Lean programming language and theorem prover",
+      "fileMatch": ["lakefile.toml"],
+      "url": "https://raw.githubusercontent.com/leanprover/lean4/refs/heads/master/src/lake/schemas/lakefile-toml-schema.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a catalog schema entry for the `lakefile.toml` config format, which is used by the Lake package manager of the Lean programming language and theorem prover. The schema is intended to be used with Taplo.