### PR TITLE
Add 'dotnet-isolated:9.0' to staticwebapp schema

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -605,6 +605,7 @@
             "dotnet-isolated:6.0",
             "dotnet-isolated:7.0",
             "dotnet-isolated:8.0",
+            "dotnet-isolated:9.0",
             "node:12",
             "node:14",
             "node:16",


### PR DESCRIPTION
The staticwebapp.config schema is missing support for the dotnet-isolated:9.0 runtime.
