### PR TITLE
Add exclude paths to Dependabot json schema

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -817,6 +817,15 @@
           "type": "string",
           "default": "/"
         },
+        "exclude-paths": {
+          "description": "List of file paths to exclude from dependency updates",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "groups": {
           "description": "Configure groups for dependencies. Each 'groups' property is arbitrary will appear in pull request titles and branch names. For example, the code snippet '{\"groups\": {\"NPM dependencies\": {\"patterns\": [\"*\"]}}}' sets the group name to 'NPM dependencies'.",
           "type": "object",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Add a new `exclude-paths` field to `dependabot-2.0.json`. This field allows the user to specify paths of manifest files in subdirectories that should be excluded/ignored during dependency updates.
Related issue - https://github.com/dependabot/dependabot-core/issues/4364