### PR TITLE
Add "CfxLua" Syntax to Stylua

### DIFF
--- a/src/schemas/json/stylua.json
+++ b/src/schemas/json/stylua.json
@@ -9,7 +9,7 @@
       "description": "Specify a disambiguation for the style of Lua syntax being formatted.",
       "type": "string",
       "default": "All",
-      "enum": ["All", "Lua51", "Lua52", "Lua53", "Lua54", "LuaJIT", "Luau"]
+      "enum": ["All", "Lua51", "Lua52", "Lua53", "Lua54", "LuaJIT", "Luau", "CfxLua"]
     },
     "column_width": {
       "description": "Approximate line length for printing.\nUsed as a guide for line wrapping - this is not a hard requirement: lines may fall under or over the limit.",

--- a/src/schemas/json/stylua.json
+++ b/src/schemas/json/stylua.json
@@ -9,7 +9,16 @@
       "description": "Specify a disambiguation for the style of Lua syntax being formatted.",
       "type": "string",
       "default": "All",
-      "enum": ["All", "Lua51", "Lua52", "Lua53", "Lua54", "LuaJIT", "Luau", "CfxLua"]
+      "enum": [
+        "All",
+        "Lua51",
+        "Lua52",
+        "Lua53",
+        "Lua54",
+        "LuaJIT",
+        "Luau",
+        "CfxLua"
+      ]
     },
     "column_width": {
       "description": "Approximate line length for printing.\nUsed as a guide for line wrapping - this is not a hard requirement: lines may fall under or over the limit.",


### PR DESCRIPTION
Hi there, it's been quite some weeks since we've introduced a new syntax called "Cfxlua" to Stylua as seen in the following PR.
https://github.com/JohnnyMorganz/StyLua/pull/972

I've just now found out that Even Better TOML is using this database, and the Syntax field is missing this option.
The PR is adding the missing option to the stylua source.