### PR TITLE
Added ChordPro config schema to `catalog.json`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1111,6 +1111,19 @@
       "url": "https://raw.githubusercontent.com/canonical/charmcraft/main/schema/charmcraft.json"
     },
     {
+      "name": "ChordPro Configuration",
+      "description": "Configuration files for ChordPro",
+      "fileMatch": [
+        "*.chordpro.json",
+        "chordpro.json",
+        "*.chordpro.yaml",
+        "*.chordpro.yml",
+        "chordpro.yaml",
+        "chordpro.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/ChordPro/chordpro/master/lib/ChordPro/res/config/config.schema"
+    },
+    {
       "name": "Chromia Model",
       "description": "Chromia Model Config File",
       "fileMatch": ["chromia.yml", "chromia.yaml"],


### PR DESCRIPTION
Added new schema for ChordPro configuration files. See [here for their docs](https://www.chordpro.org/chordpro/chordpro-configuration-file/). It's hosted on the `ChordPro/chordpro` GitHub repo.