### PR TITLE
add schema for k1LoW/deck

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1309,6 +1309,17 @@
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_yml_files-latest.json"
     },
     {
+      "name": "Deck config",
+      "description": "Deck is a tool for creating presentation using Markdown and Google Slides",
+      "fileMatch": [
+        "**/.config/deck/config.yml",
+        "**/.config/deck/config.yaml",
+        "**/.config/deck/config-*.yml",
+        "**/.config/deck/config-*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/k1LoW/deck/refs/heads/main/schema.yml"
+    },
+    {
       "name": "Dein Config",
       "description": "Dein.vim, a Vim/Neovim plugin manager",
       "fileMatch": ["dein.toml"],


### PR DESCRIPTION
Add a schema for validating config files for [k1LoW/deck](https://github.com/k1LoW/deck), a presentation-generating tool with over 500 stars.