### PR TITLE
tmuxinator/962: add named window/pane support

### DIFF
--- a/src/schemas/json/tmuxinator.json
+++ b/src/schemas/json/tmuxinator.json
@@ -43,8 +43,8 @@
                 "type": "string"
               },
               {
-                "type": "object",
-                "$ref": "#/definitions/command"
+                "$ref": "#/definitions/command",
+                "type": "object"
               }
             ]
           }
@@ -53,9 +53,7 @@
     },
     "window": {
       "type": "object",
-      "required": [
-        "panes"
-      ],
+      "required": ["panes"],
       "properties": {
         "pre": {
           "type": "array",


### PR DESCRIPTION
This is a contribution to tmuxinator, cc @hschne, following [issue 962](https://github.com/tmuxinator/tmuxinator/issues/962)

In essence, Current schema does not recognize named windows / panes, only anonymous ones
This branch attempts to
- generalizing the Window and Pane objects
- introduce their discovery with named objects
  `{windows: [{$wname: <window>{panes: [{$pname: <pane>}, ...]}}, ...]}`
- versus the current schema that's using
  `{ windows: [ <window>{panes: <pane>{}}] }`



Current [tmuxinator testsuite](https://github.com/SchemaStore/schemastore/tree/master/src/test/tmuxinator) already uses this configuration variant
But this setup should allow for completion to work correctly aswell