### PR TITLE
Add `rust-toolchain` as a supported Dependabot ecosystem

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -667,6 +667,7 @@
         "nuget",
         "pip",
         "pub",
+        "rust-toolchain",
         "swift",
         "terraform",
         "uv",


### PR DESCRIPTION
- https://github.com/dependabot/dependabot-core/pull/12492