### PR TITLE
Update catalog.json to support splitting Backstage Catalog Info files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1095,7 +1095,7 @@
     {
       "name": "Catalog Info Backstage",
       "description": "Backstage Catalog Info",
-      "fileMatch": ["catalog-info.yaml"],
+      "fileMatch": ["catalog-info.yaml", "*.catalog-info.yaml"],
       "url": "https://www.schemastore.org/catalog-info.json"
     },
     {


### PR DESCRIPTION
Backstage Catalog Info file format allow including multiple files into one using its Location kind. Adding a prefix to fileMatch to ensure those split files have support to schema validation too.