### PR TITLE
Update bunfig.json – add `coveragePathIgnorePatterns`

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -134,6 +134,14 @@
           "type": "boolean",
           "default": false
         },
+        "coveragePathIgnorePatterns": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-coveragepathignorepatterns",
+          "description": "Exclude specific files or file patterns from coverage reports using glob patterns. Can be a single string pattern or an array of patterns.\nhttps://bun.sh/docs/runtime/bunfig#test-coveragepathignorepatterns",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
         "coverageThreshold": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#test-coveragethreshold",
           "description": "To specify a coverage threshold. By default, no threshold is set. If your test suite does not meet or exceed this threshold, `bun test` will exit with a non-zero exit code to indicate the failure\nhttps://bun.sh/docs/runtime/bunfig#test-coveragethreshold",


### PR DESCRIPTION
Update from bun 1.2.19

- https://bun.com/blog/bun-v1.2.19#ignore-files-in-test-coverage-reports-with-test-coveragepathignorepatterns
- https://bun.com/docs/runtime/bunfig#test-coveragepathignorepatterns

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
