### PR TITLE
fix(schema): resolve linting issues in abc-inventory-module-data-2.0.0

### DIFF
--- a/src/schemas/json/abc-inventory-module-data-2.0.0.json
+++ b/src/schemas/json/abc-inventory-module-data-2.0.0.json
@@ -57,7 +57,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -143,7 +143,7 @@
                     "type": "number"
                   }
                 },
-                "required": [ "lotID", "quantity" ],
+                "required": ["lotID", "quantity"],
                 "additionalProperties": false
               }
             },
@@ -178,12 +178,12 @@
               }
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "upstreamProductIDs": {
               "type": "array",
               "items": {
-                "type": [ "string", "null" ]
+                "type": ["string", "null"]
               }
             },
             "notes": {
@@ -258,7 +258,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -323,7 +323,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -385,7 +385,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -403,7 +403,7 @@
           "additionalProperties": false
         }
       },
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryDestroyTransaction": {
@@ -434,7 +434,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -451,7 +451,7 @@
           "additionalProperties": false
         }
       },
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventorySellTransaction": {
@@ -485,7 +485,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -503,7 +503,7 @@
           "additionalProperties": false
         }
       },
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryAdjustTransaction": {
@@ -540,7 +540,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -559,7 +559,7 @@
           "additionalProperties": false
         }
       },
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryChangeExpiryTransaction": {
@@ -593,7 +593,7 @@
               "type": "string"
             },
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "notes": {
               "type": "string"
@@ -611,7 +611,7 @@
           "additionalProperties": false
         }
       },
-      "required": [ "uid", "timestamp", "transactionType", "transactionData" ],
+      "required": ["uid", "timestamp", "transactionType", "transactionData"],
       "additionalProperties": false
     },
     "ABCInventoryTransaction": {
@@ -655,7 +655,7 @@
           "type": "string"
         },
         "productID": {
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "quantity": {
           "type": "number"
@@ -716,7 +716,7 @@
           "type": "string"
         },
         "productID": {
-          "type": [ "string", "null" ]
+          "type": ["string", "null"]
         },
         "quantity": {
           "type": "number"
@@ -817,7 +817,7 @@
               "type": "boolean"
             }
           },
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "additionalProperties": false
         }
       },
@@ -836,7 +836,7 @@
               "type": "boolean"
             }
           },
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "additionalProperties": false
         }
       },
@@ -858,7 +858,7 @@
               "type": "boolean"
             }
           },
-          "required": [ "name", "isActive", "prefix" ],
+          "required": ["name", "isActive", "prefix"],
           "additionalProperties": false
         }
       },
@@ -871,10 +871,10 @@
           "type": "object",
           "properties": {
             "productID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "vendorID": {
-              "type": [ "string", "null" ]
+              "type": ["string", "null"]
             },
             "materialCategoryID": {
               "type": "string"
@@ -923,7 +923,7 @@
               "type": "boolean"
             }
           },
-          "required": [ "name", "isActive" ],
+          "required": ["name", "isActive"],
           "additionalProperties": false
         }
       },
@@ -945,7 +945,7 @@
               "type": "boolean"
             }
           },
-          "required": [ "code", "description", "isActive" ],
+          "required": ["code", "description", "isActive"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
### Description

This PR addresses the following linting issues in the `abc-inventory-module-data-2.0.0.json` schema:

- Replaced `enum` with `const` for single-value enumerations.
- Removed `type` alongside `enum` to avoid anti-patterns.

### Screenshots

Before and after:

https://github.com/user-attachments/assets/1d9c3945-aaed-4c91-85ad-2d5b696c2ec0


### Note

I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. We have recently added many rules `prefixing unknown keywords with x-` which will be introduced in the newer JSON Schema drafts
If beneficial to the project, I suggest integrating the linter with it to write the best schemas and catch any errors and follow best practices.
