### PR TITLE
fix(schema): resolve linting issues in accelerator.json schema

### DIFF
--- a/src/schemas/json/accelerator.json
+++ b/src/schemas/json/accelerator.json
@@ -99,7 +99,7 @@
           "description": "A tooltip to accompany the input"
         },
         "inputType": {
-          "enum": [ "text", "textarea", "checkbox", "select", "radio" ],
+          "enum": ["text", "textarea", "checkbox", "select", "radio"],
           "title": "inputType",
           "description": "The HTML input type used to display the option"
         },
@@ -331,7 +331,7 @@
           "const": "Chain"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Chain-1"
@@ -619,7 +619,7 @@
           "const": "Exclude"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Exclude-1"
@@ -666,7 +666,7 @@
           "const": "Include"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Include-1"
@@ -722,7 +722,7 @@
           "const": "InvokeFragment"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/InvokeFragment-1"
@@ -822,7 +822,7 @@
           "const": "Let"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Let-1"
@@ -974,7 +974,7 @@
           "const": "Loop"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Loop-1"
@@ -1061,7 +1061,7 @@
           "const": "Merge"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Merge-1"
@@ -1109,7 +1109,7 @@
           "const": "OpenRewriteRecipe"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/OpenRewriteRecipe-1"
@@ -1146,7 +1146,7 @@
           "const": "Provenance"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/Provenance-1"
@@ -1230,7 +1230,7 @@
           "const": "ReplaceText"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/ReplaceText-1"
@@ -1286,7 +1286,7 @@
           "const": "RewritePath"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/RewritePath-1"
@@ -1328,7 +1328,7 @@
           "const": "UniquePath"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/UniquePath-1"
@@ -1366,7 +1366,7 @@
           "const": "UseEncoding"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/UseEncoding-1"
@@ -1438,7 +1438,7 @@
           "const": "YTT"
         }
       },
-      "required": [ "type" ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/definitions/YTT-1"

--- a/src/schemas/json/accelerator.json
+++ b/src/schemas/json/accelerator.json
@@ -85,13 +85,11 @@
           "description": "The value used to pre-populate the option"
         },
         "dependsOn": {
+          "title": "dependsOn",
+          "description": "The dependency that controls this options visibility",
           "allOf": [
             {
               "$ref": "#/definitions/DependsOn"
-            },
-            {
-              "title": "dependsOn",
-              "description": "The dependency that controls this options visibility"
             }
           ]
         },
@@ -101,8 +99,7 @@
           "description": "A tooltip to accompany the input"
         },
         "inputType": {
-          "type": "string",
-          "enum": ["text", "textarea", "checkbox", "select", "radio"],
+          "enum": [ "text", "textarea", "checkbox", "select", "radio" ],
           "title": "inputType",
           "description": "The HTML input type used to display the option"
         },
@@ -124,13 +121,11 @@
           "description": "Whether the user is required to enter a value in the UI"
         },
         "validationRegex": {
+          "title": "validationRegex",
+          "description": "A regex that validates the string representation of the option value when set",
           "allOf": [
             {
               "$ref": "#/definitions/Pattern"
-            },
-            {
-              "title": "validationRegex",
-              "description": "A regex that validates the string representation of the option value when set"
             }
           ]
         }
@@ -260,13 +255,11 @@
           }
         },
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -282,13 +275,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Loop-2"
-              },
-              {
                 "$ref": "#/definitions/Chain-2"
               },
               {
-                "$ref": "#/definitions/Provenance-2"
+                "$ref": "#/definitions/Combo-2"
               },
               {
                 "$ref": "#/definitions/Exclude-2"
@@ -297,13 +287,13 @@
                 "$ref": "#/definitions/Include-2"
               },
               {
-                "$ref": "#/definitions/Combo-2"
-              },
-              {
-                "$ref": "#/definitions/ReplaceText-2"
-              },
-              {
                 "$ref": "#/definitions/InvokeFragment-2"
+              },
+              {
+                "$ref": "#/definitions/Let-2"
+              },
+              {
+                "$ref": "#/definitions/Loop-2"
               },
               {
                 "$ref": "#/definitions/Merge-2"
@@ -312,22 +302,22 @@
                 "$ref": "#/definitions/OpenRewriteRecipe-2"
               },
               {
+                "$ref": "#/definitions/Provenance-2"
+              },
+              {
+                "$ref": "#/definitions/ReplaceText-2"
+              },
+              {
                 "$ref": "#/definitions/RewritePath-2"
               },
               {
                 "$ref": "#/definitions/UniquePath-2"
               },
               {
-                "$ref": "#/definitions/YTT-2"
-              },
-              {
-                "$ref": "#/definitions/Let-2"
-              },
-              {
                 "$ref": "#/definitions/UseEncoding-2"
               },
               {
-                "$ref": "#/definitions/InvokeFragment-2"
+                "$ref": "#/definitions/YTT-2"
               }
             ]
           }
@@ -335,18 +325,16 @@
       }
     },
     "Chain-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Chain"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Chain-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Chain"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -372,13 +360,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Loop-2"
-              },
-              {
                 "$ref": "#/definitions/Chain-2"
               },
               {
-                "$ref": "#/definitions/Provenance-2"
+                "$ref": "#/definitions/Combo-2"
               },
               {
                 "$ref": "#/definitions/Exclude-2"
@@ -387,13 +372,13 @@
                 "$ref": "#/definitions/Include-2"
               },
               {
-                "$ref": "#/definitions/Combo-2"
-              },
-              {
-                "$ref": "#/definitions/ReplaceText-2"
-              },
-              {
                 "$ref": "#/definitions/InvokeFragment-2"
+              },
+              {
+                "$ref": "#/definitions/Let-2"
+              },
+              {
+                "$ref": "#/definitions/Loop-2"
               },
               {
                 "$ref": "#/definitions/Merge-2"
@@ -402,34 +387,32 @@
                 "$ref": "#/definitions/OpenRewriteRecipe-2"
               },
               {
+                "$ref": "#/definitions/Provenance-2"
+              },
+              {
+                "$ref": "#/definitions/ReplaceText-2"
+              },
+              {
                 "$ref": "#/definitions/RewritePath-2"
               },
               {
                 "$ref": "#/definitions/UniquePath-2"
               },
               {
-                "$ref": "#/definitions/YTT-2"
-              },
-              {
-                "$ref": "#/definitions/Let-2"
-              },
-              {
                 "$ref": "#/definitions/UseEncoding-2"
               },
               {
-                "$ref": "#/definitions/InvokeFragment-2"
+                "$ref": "#/definitions/YTT-2"
               }
             ]
           }
         },
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -460,12 +443,10 @@
           "description": "A list of additional variables and their values",
           "type": "array",
           "items": {
+            "title": "let",
             "allOf": [
               {
                 "$ref": "#/definitions/DerivedSymbol"
-              },
-              {
-                "title": "let"
               }
             ]
           }
@@ -477,13 +458,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Loop-2"
-              },
-              {
                 "$ref": "#/definitions/Chain-2"
               },
               {
-                "$ref": "#/definitions/Provenance-2"
+                "$ref": "#/definitions/Combo-2"
               },
               {
                 "$ref": "#/definitions/Exclude-2"
@@ -492,13 +470,13 @@
                 "$ref": "#/definitions/Include-2"
               },
               {
-                "$ref": "#/definitions/Combo-2"
-              },
-              {
-                "$ref": "#/definitions/ReplaceText-2"
-              },
-              {
                 "$ref": "#/definitions/InvokeFragment-2"
+              },
+              {
+                "$ref": "#/definitions/Let-2"
+              },
+              {
+                "$ref": "#/definitions/Loop-2"
               },
               {
                 "$ref": "#/definitions/Merge-2"
@@ -507,22 +485,22 @@
                 "$ref": "#/definitions/OpenRewriteRecipe-2"
               },
               {
+                "$ref": "#/definitions/Provenance-2"
+              },
+              {
+                "$ref": "#/definitions/ReplaceText-2"
+              },
+              {
                 "$ref": "#/definitions/RewritePath-2"
               },
               {
                 "$ref": "#/definitions/UniquePath-2"
               },
               {
-                "$ref": "#/definitions/YTT-2"
-              },
-              {
-                "$ref": "#/definitions/Let-2"
-              },
-              {
                 "$ref": "#/definitions/UseEncoding-2"
               },
               {
-                "$ref": "#/definitions/InvokeFragment-2"
+                "$ref": "#/definitions/YTT-2"
               }
             ]
           }
@@ -533,35 +511,30 @@
           "description": "The transform name"
         },
         "onConflict": {
+          "title": "onConflict",
+          "description": "How conflict is handled when an operation produces multiple files at the same path",
           "allOf": [
             {
               "$ref": "#/definitions/ConflictResolution"
-            },
-            {
-              "title": "onConflict",
-              "description": "How conflict is handled when an operation produces multiple files at the same path"
             }
           ]
         }
       }
     },
     "Combo-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Combo"
+        }
+      },
       "allOf": [
         {
           "$ref": "#/definitions/Combo-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Combo"
-            }
-          }
         }
       ]
     },
     "ConflictResolution": {
-      "type": "string",
       "enum": [
         "Fail",
         "UseFirst",
@@ -592,13 +565,11 @@
       "type": "object",
       "properties": {
         "expression": {
+          "title": "expression",
+          "description": "The SpEL expression to evaluate to compute the symbol value",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "expression",
-              "description": "The SpEL expression to evaluate to compute the symbol value"
             }
           ]
         },
@@ -615,13 +586,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -644,18 +613,16 @@
       }
     },
     "Exclude-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Exclude"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Exclude-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Exclude"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -666,13 +633,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -695,18 +660,16 @@
       }
     },
     "Include-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Include"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Include-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Include"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -719,13 +682,11 @@
           "pattern": "^$|^[^/]$|^[^/](.+)[^/]$"
         },
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -733,12 +694,10 @@
           "title": "let",
           "type": "array",
           "items": {
+            "title": "let",
             "allOf": [
               {
                 "$ref": "#/definitions/DerivedSymbol"
-              },
-              {
-                "title": "let"
               }
             ]
           }
@@ -757,18 +716,16 @@
       }
     },
     "InvokeFragment-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "InvokeFragment"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/InvokeFragment-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "InvokeFragment"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -776,26 +733,21 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
         "in": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Loop-2"
-            },
-            {
               "$ref": "#/definitions/Chain-2"
             },
             {
-              "$ref": "#/definitions/Provenance-2"
+              "$ref": "#/definitions/Combo-2"
             },
             {
               "$ref": "#/definitions/Exclude-2"
@@ -804,13 +756,13 @@
               "$ref": "#/definitions/Include-2"
             },
             {
-              "$ref": "#/definitions/Combo-2"
-            },
-            {
-              "$ref": "#/definitions/ReplaceText-2"
-            },
-            {
               "$ref": "#/definitions/InvokeFragment-2"
+            },
+            {
+              "$ref": "#/definitions/Let-2"
+            },
+            {
+              "$ref": "#/definitions/Loop-2"
             },
             {
               "$ref": "#/definitions/Merge-2"
@@ -819,22 +771,22 @@
               "$ref": "#/definitions/OpenRewriteRecipe-2"
             },
             {
+              "$ref": "#/definitions/Provenance-2"
+            },
+            {
+              "$ref": "#/definitions/ReplaceText-2"
+            },
+            {
               "$ref": "#/definitions/RewritePath-2"
             },
             {
               "$ref": "#/definitions/UniquePath-2"
             },
             {
-              "$ref": "#/definitions/YTT-2"
-            },
-            {
-              "$ref": "#/definitions/Let-2"
-            },
-            {
               "$ref": "#/definitions/UseEncoding-2"
             },
             {
-              "$ref": "#/definitions/InvokeFragment-2"
+              "$ref": "#/definitions/YTT-2"
             }
           ]
         },
@@ -853,12 +805,10 @@
           "description": "A list of additional variables and their values",
           "type": "array",
           "items": {
+            "title": "symbols",
             "allOf": [
               {
                 "$ref": "#/definitions/DerivedSymbol"
-              },
-              {
-                "title": "symbols"
               }
             ]
           }
@@ -866,18 +816,16 @@
       }
     },
     "Let-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Let"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Let-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Let"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -885,26 +833,21 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
         "doAsChain": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Loop-2"
-            },
-            {
               "$ref": "#/definitions/Chain-2"
             },
             {
-              "$ref": "#/definitions/Provenance-2"
+              "$ref": "#/definitions/Combo-2"
             },
             {
               "$ref": "#/definitions/Exclude-2"
@@ -913,13 +856,13 @@
               "$ref": "#/definitions/Include-2"
             },
             {
-              "$ref": "#/definitions/Combo-2"
-            },
-            {
-              "$ref": "#/definitions/ReplaceText-2"
-            },
-            {
               "$ref": "#/definitions/InvokeFragment-2"
+            },
+            {
+              "$ref": "#/definitions/Let-2"
+            },
+            {
+              "$ref": "#/definitions/Loop-2"
             },
             {
               "$ref": "#/definitions/Merge-2"
@@ -928,35 +871,32 @@
               "$ref": "#/definitions/OpenRewriteRecipe-2"
             },
             {
+              "$ref": "#/definitions/Provenance-2"
+            },
+            {
+              "$ref": "#/definitions/ReplaceText-2"
+            },
+            {
               "$ref": "#/definitions/RewritePath-2"
             },
             {
               "$ref": "#/definitions/UniquePath-2"
             },
             {
-              "$ref": "#/definitions/YTT-2"
-            },
-            {
-              "$ref": "#/definitions/Let-2"
-            },
-            {
               "$ref": "#/definitions/UseEncoding-2"
             },
             {
-              "$ref": "#/definitions/InvokeFragment-2"
+              "$ref": "#/definitions/YTT-2"
             }
           ]
         },
         "doAsMerge": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Loop-2"
-            },
-            {
               "$ref": "#/definitions/Chain-2"
             },
             {
-              "$ref": "#/definitions/Provenance-2"
+              "$ref": "#/definitions/Combo-2"
             },
             {
               "$ref": "#/definitions/Exclude-2"
@@ -965,13 +905,13 @@
               "$ref": "#/definitions/Include-2"
             },
             {
-              "$ref": "#/definitions/Combo-2"
-            },
-            {
-              "$ref": "#/definitions/ReplaceText-2"
-            },
-            {
               "$ref": "#/definitions/InvokeFragment-2"
+            },
+            {
+              "$ref": "#/definitions/Let-2"
+            },
+            {
+              "$ref": "#/definitions/Loop-2"
             },
             {
               "$ref": "#/definitions/Merge-2"
@@ -980,22 +920,22 @@
               "$ref": "#/definitions/OpenRewriteRecipe-2"
             },
             {
+              "$ref": "#/definitions/Provenance-2"
+            },
+            {
+              "$ref": "#/definitions/ReplaceText-2"
+            },
+            {
               "$ref": "#/definitions/RewritePath-2"
             },
             {
               "$ref": "#/definitions/UniquePath-2"
             },
             {
-              "$ref": "#/definitions/YTT-2"
-            },
-            {
-              "$ref": "#/definitions/Let-2"
-            },
-            {
               "$ref": "#/definitions/UseEncoding-2"
             },
             {
-              "$ref": "#/definitions/InvokeFragment-2"
+              "$ref": "#/definitions/YTT-2"
             }
           ]
         },
@@ -1011,13 +951,11 @@
           "description": "The transform name"
         },
         "on": {
+          "title": "on",
+          "description": "A SpEL expression that evaluates a list that contains the elements to be iterated over",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "on",
-              "description": "A SpEL expression that evaluates a list that contains the elements to be iterated over"
             }
           ]
         },
@@ -1030,18 +968,16 @@
       }
     },
     "Loop-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Loop"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Loop-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Loop"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1049,13 +985,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1071,13 +1005,10 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Loop-2"
-              },
-              {
                 "$ref": "#/definitions/Chain-2"
               },
               {
-                "$ref": "#/definitions/Provenance-2"
+                "$ref": "#/definitions/Combo-2"
               },
               {
                 "$ref": "#/definitions/Exclude-2"
@@ -1086,13 +1017,13 @@
                 "$ref": "#/definitions/Include-2"
               },
               {
-                "$ref": "#/definitions/Combo-2"
-              },
-              {
-                "$ref": "#/definitions/ReplaceText-2"
-              },
-              {
                 "$ref": "#/definitions/InvokeFragment-2"
+              },
+              {
+                "$ref": "#/definitions/Let-2"
+              },
+              {
+                "$ref": "#/definitions/Loop-2"
               },
               {
                 "$ref": "#/definitions/Merge-2"
@@ -1101,22 +1032,22 @@
                 "$ref": "#/definitions/OpenRewriteRecipe-2"
               },
               {
+                "$ref": "#/definitions/Provenance-2"
+              },
+              {
+                "$ref": "#/definitions/ReplaceText-2"
+              },
+              {
                 "$ref": "#/definitions/RewritePath-2"
               },
               {
                 "$ref": "#/definitions/UniquePath-2"
               },
               {
-                "$ref": "#/definitions/YTT-2"
-              },
-              {
-                "$ref": "#/definitions/Let-2"
-              },
-              {
                 "$ref": "#/definitions/UseEncoding-2"
               },
               {
-                "$ref": "#/definitions/InvokeFragment-2"
+                "$ref": "#/definitions/YTT-2"
               }
             ]
           }
@@ -1124,18 +1055,16 @@
       }
     },
     "Merge-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Merge"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Merge-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Merge"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1143,13 +1072,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1176,18 +1103,16 @@
       }
     },
     "OpenRewriteRecipe-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "OpenRewriteRecipe"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/OpenRewriteRecipe-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "OpenRewriteRecipe"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1199,13 +1124,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1217,18 +1140,16 @@
       }
     },
     "Provenance-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Provenance"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/Provenance-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "Provenance"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1236,13 +1157,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1255,24 +1174,20 @@
           "type": "object",
           "properties": {
             "pattern": {
+              "title": "pattern",
+              "description": "The regular expression that determines text that will be replaced",
               "allOf": [
                 {
                   "$ref": "#/definitions/Pattern"
-                },
-                {
-                  "title": "pattern",
-                  "description": "The regular expression that determines text that will be replaced"
                 }
               ]
             },
             "with": {
+              "title": "with",
+              "description": "The SpEL expression that evaluates to the text that will replace the previous string",
               "allOf": [
                 {
                   "$ref": "#/definitions/Expression"
-                },
-                {
-                  "title": "with",
-                  "description": "The SpEL expression that evaluates to the text that will replace the previous string"
                 }
               ]
             }
@@ -1294,13 +1209,11 @@
                 "minLength": 1
               },
               "with": {
+                "title": "with",
+                "description": "The SpEL expression that evaluates to the text that will replace the previous string",
                 "allOf": [
                   {
                     "$ref": "#/definitions/Expression"
-                  },
-                  {
-                    "title": "with",
-                    "description": "The SpEL expression that evaluates to the text that will replace the previous string"
                   }
                 ]
               }
@@ -1311,18 +1224,16 @@
       }
     },
     "ReplaceText-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "ReplaceText"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/ReplaceText-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "ReplaceText"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1330,13 +1241,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1351,42 +1260,36 @@
           "description": "The transform name"
         },
         "regex": {
+          "title": "regex",
+          "description": "The regular expression used to match each input files path",
           "allOf": [
             {
               "$ref": "#/definitions/Pattern"
-            },
-            {
-              "title": "regex",
-              "description": "The regular expression used to match each input files path"
             }
           ]
         },
         "rewriteTo": {
+          "title": "rewriteTo",
+          "description": "The SpEL expression of the location that the file will be rewritten to",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "rewriteTo",
-              "description": "The SpEL expression of the location that the file will be rewritten to"
             }
           ]
         }
       }
     },
     "RewritePath-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "RewritePath"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/RewritePath-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "RewritePath"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1394,13 +1297,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1410,31 +1311,27 @@
           "description": "The transform name"
         },
         "strategy": {
+          "title": "strategy",
+          "description": "How conflict is handled when an operation produces multiple files at the same path",
           "allOf": [
             {
               "$ref": "#/definitions/ConflictResolution"
-            },
-            {
-              "title": "strategy",
-              "description": "How conflict is handled when an operation produces multiple files at the same path"
             }
           ]
         }
       }
     },
     "UniquePath-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "UniquePath"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/UniquePath-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "UniquePath"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1442,13 +1339,11 @@
       "type": "object",
       "properties": {
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1465,18 +1360,16 @@
       }
     },
     "UseEncoding-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "UseEncoding"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/UseEncoding-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "UseEncoding"
-            }
-          },
-          "required": ["type"]
         }
       ]
     },
@@ -1488,24 +1381,20 @@
           "description": "A list of variable names that are allowed to be passed to YTT",
           "type": "array",
           "items": {
+            "title": "allowList",
             "allOf": [
               {
                 "$ref": "#/definitions/Pattern"
-              },
-              {
-                "title": "allowList"
               }
             ]
           }
         },
         "condition": {
+          "title": "condition",
+          "description": "The SpEL expression that determines if this Transform should execute",
           "allOf": [
             {
               "$ref": "#/definitions/Expression"
-            },
-            {
-              "title": "condition",
-              "description": "The SpEL expression that determines if this Transform should execute"
             }
           ]
         },
@@ -1514,12 +1403,10 @@
           "description": "A list of variable names that are denied from being passed to YTT",
           "type": "array",
           "items": {
+            "title": "denyList",
             "allOf": [
               {
                 "$ref": "#/definitions/Pattern"
-              },
-              {
-                "title": "denyList"
               }
             ]
           }
@@ -1529,12 +1416,10 @@
           "description": "A list of SpEL expressions whose results are additional command line arguments",
           "type": "array",
           "items": {
+            "title": "extraArgs",
             "allOf": [
               {
                 "$ref": "#/definitions/Expression"
-              },
-              {
-                "title": "extraArgs"
               }
             ]
           }
@@ -1547,18 +1432,16 @@
       }
     },
     "YTT-2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "YTT"
+        }
+      },
+      "required": [ "type" ],
       "allOf": [
         {
           "$ref": "#/definitions/YTT-1"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "YTT"
-            }
-          },
-          "required": ["type"]
         }
       ]
     }
@@ -1604,13 +1487,11 @@
                       "pattern": "^$|^[a-z][a-z0-9A-Z]*$"
                     },
                     "dependsOn": {
+                      "title": "dependsOn",
+                      "description": "The dependency that controls this options visibility",
                       "allOf": [
                         {
                           "$ref": "#/definitions/DependsOn"
-                        },
-                        {
-                          "title": "dependsOn",
-                          "description": "The dependency that controls this options visibility"
                         }
                       ]
                     },
@@ -1665,12 +1546,10 @@
           "description": "The list of options passed to the UI to create input text boxes",
           "type": "array",
           "items": {
+            "title": "options",
             "allOf": [
               {
                 "$ref": "#/definitions/AcceleratorOption"
-              },
-              {
-                "title": "options"
               }
             ]
           }
@@ -1704,12 +1583,10 @@
                 "minItems": 1,
                 "type": "array",
                 "items": {
+                  "title": "struct",
                   "allOf": [
                     {
                       "$ref": "#/definitions/AcceleratorOption"
-                    },
-                    {
-                      "title": "struct"
                     }
                   ]
                 }
@@ -1725,13 +1602,10 @@
     "engine": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Loop-2"
-        },
-        {
           "$ref": "#/definitions/Chain-2"
         },
         {
-          "$ref": "#/definitions/Provenance-2"
+          "$ref": "#/definitions/Combo-2"
         },
         {
           "$ref": "#/definitions/Exclude-2"
@@ -1740,13 +1614,13 @@
           "$ref": "#/definitions/Include-2"
         },
         {
-          "$ref": "#/definitions/Combo-2"
-        },
-        {
-          "$ref": "#/definitions/ReplaceText-2"
-        },
-        {
           "$ref": "#/definitions/InvokeFragment-2"
+        },
+        {
+          "$ref": "#/definitions/Let-2"
+        },
+        {
+          "$ref": "#/definitions/Loop-2"
         },
         {
           "$ref": "#/definitions/Merge-2"
@@ -1755,22 +1629,22 @@
           "$ref": "#/definitions/OpenRewriteRecipe-2"
         },
         {
+          "$ref": "#/definitions/Provenance-2"
+        },
+        {
+          "$ref": "#/definitions/ReplaceText-2"
+        },
+        {
           "$ref": "#/definitions/RewritePath-2"
         },
         {
           "$ref": "#/definitions/UniquePath-2"
         },
         {
-          "$ref": "#/definitions/YTT-2"
-        },
-        {
-          "$ref": "#/definitions/Let-2"
-        },
-        {
           "$ref": "#/definitions/UseEncoding-2"
         },
         {
-          "$ref": "#/definitions/InvokeFragment-2"
+          "$ref": "#/definitions/YTT-2"
         }
       ]
     }


### PR DESCRIPTION
### Description

This PR addresses the following linting issues in the `accelerator.json` schema:

- Removed unnecessary `allOf` wrappers for keywords other than `$ref` to improve performance.
- Eliminated duplicate subschemas in `anyOf` to avoid redundant validations.
- Replaced `type` alongside `enum` to adhere to JSON Schema best practices.

These changes were made to ensure compliance with JSON Schema standards and to resolve the reported linting errors. The schema was updated using the `jsonschema lint --fix` command

### Screenshots

Before and after:

<img width="1459" height="951" alt="Screenshot from 2025-08-30 23-12-29" src="https://github.com/user-attachments/assets/4cb3f00f-a28c-4e23-987e-898ec4492c57" />



### Note

I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. We have recently added many rules `prefixing unknown keywords with x-` which will be introduced in the newer JSON Schema drafts
If beneficial to the project, I suggest integrating the linter with it to write the best schemas and catch any errors and follow best practices. Example of an integration - https://github.com/krakend/krakend-schema/blob/main/.github/workflows/validate-json-schema.yml#L10
