### PR TITLE
fix(schema): resolve linting issues in expo-37.0.0.json schema

### DIFF
--- a/src/schemas/json/expo-37.0.0.json
+++ b/src/schemas/json/expo-37.0.0.json
@@ -25,7 +25,7 @@
         },
         "privacy": {
           "description": "Either `public` or `unlisted`. If not provided, defaults to `unlisted`. In the future `private` will be supported. `unlisted` hides the experience from search results.",
-          "enum": [ "public", "unlisted" ]
+          "enum": ["public", "unlisted"]
         },
         "sdkVersion": {
           "description": "The Expo sdkVersion to run the project on. This should line up with the version specified in your package.json.",
@@ -38,11 +38,11 @@
         },
         "platforms": {
           "description": "Platforms that your project explicitly supports. If not specified, it defaults to `[\"ios\", \"android\"]`.",
-          "x-example": [ "ios", "android", "web" ],
+          "x-example": ["ios", "android", "web"],
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "enum": [ "android", "ios", "web" ]
+            "enum": ["android", "ios", "web"]
           }
         },
         "githubUrl": {
@@ -53,12 +53,12 @@
         },
         "orientation": {
           "description": "Lock your app to a specific orientation with `portrait` or `landscape`. Defaults to no lock.",
-          "enum": [ "default", "portrait", "landscape" ]
+          "enum": ["default", "portrait", "landscape"]
         },
         "userInterfaceStyle": {
           "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
           "x-fallback": "light",
-          "enum": [ "light", "dark", "automatic" ]
+          "enum": ["light", "dark", "automatic"]
         },
         "backgroundColor": {
           "description": "The background color for your app, behind any of your React views.",
@@ -114,7 +114,7 @@
             },
             "androidMode": {
               "description": "Show each push notification individually (`default`) or collapse into one (`collapse`).",
-              "enum": [ "default", "collapse" ]
+              "enum": ["default", "collapse"]
             },
             "androidCollapsedTitle": {
               "description": "If `androidMode` is set to `collapse`, this title is used for the collapsed notification message. eg: `'#{unread_notifications} new interactions'`.",
@@ -138,7 +138,7 @@
             },
             "exponentIconColor": {
               "description": "If no icon is provided, we will show the Expo logo. You can choose between `white` and `blue`.",
-              "enum": [ "white", "blue" ]
+              "enum": ["white", "blue"]
             },
             "exponentIconGrayscale": {
               "description": "Similar to `exponentIconColor` but instead indicate if it should be grayscale (`1`) or not (`0`).",
@@ -197,7 +197,7 @@
           "properties": {
             "barStyle": {
               "description": "Configures the status bar icons to have a light or dark color.",
-              "enum": [ "light-content", "dark-content" ]
+              "enum": ["light-content", "dark-content"]
             },
             "backgroundColor": {
               "description": "Specifies the background color of the status bar.",
@@ -215,11 +215,11 @@
           "properties": {
             "visible": {
               "description": "Determines how and when the navigation bar is shown.",
-              "enum": [ "leanback", "immersive", "sticky-immersive" ]
+              "enum": ["leanback", "immersive", "sticky-immersive"]
             },
             "barStyle": {
               "description": "Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer.",
-              "enum": [ "light-content", "dark-content" ]
+              "enum": ["light-content", "dark-content"]
             },
             "backgroundColor": {
               "description": "Specifies the background color of the navigation bar.",
@@ -274,7 +274,7 @@
             },
             "checkAutomatically": {
               "description": "By default, Expo will check for updates every time the app is loaded. Set this to `'ON_ERROR_RECOVERY'` to disable automatic checking unless recovering from an error.",
-              "enum": [ "ON_ERROR_RECOVERY", "ON_LOAD" ]
+              "enum": ["ON_ERROR_RECOVERY", "ON_LOAD"]
             },
             "fallbackToCacheTimeout": {
               "description": "How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 30000 (30 sec).",
@@ -425,7 +425,7 @@
             "userInterfaceStyle": {
               "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
               "x-fallback": "light",
-              "enum": [ "light", "dark", "automatic" ]
+              "enum": ["light", "dark", "automatic"]
             },
             "infoPlist": {
               "description": "Dictionary of arbitrary configuration to add to your standalone app's native Info.plist. Applied prior to all other Expo-specific configuration. No other validation is performed, so use this at your own risk of rejection from the App Store.",
@@ -472,7 +472,7 @@
                 },
                 "resizeMode": {
                   "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
-                  "enum": [ "cover", "contain" ]
+                  "enum": ["cover", "contain"]
                 },
                 "image": {
                   "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
@@ -541,7 +541,7 @@
             "userInterfaceStyle": {
               "description": "Configuration to force the app to always use the light or dark user-interface appearance, such as \"dark mode\", or make it automatically adapt to the system preferences. If not provided, defaults to `light`.",
               "x-fallback": "light",
-              "enum": [ "light", "dark", "automatic" ]
+              "enum": ["light", "dark", "automatic"]
             },
             "icon": {
               "description": "Local path or remote url to an image to use for your app's icon on Android. If specified, this overrides the top-level `icon` key. We recommend that you use a 1024x1024 png file (transparency is recommended for the Google Play Store). This icon will appear on the home screen and within the Expo app.",
@@ -682,7 +682,7 @@
                 },
                 "resizeMode": {
                   "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.",
-                  "enum": [ "cover", "contain", "native" ]
+                  "enum": ["cover", "contain", "native"]
                 },
                 "mdpi": {
                   "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
@@ -741,7 +741,7 @@
                     "scheme": "https",
                     "host": "*.expo.io"
                   },
-                  "category": [ "BROWSABLE", "DEFAULT" ]
+                  "category": ["BROWSABLE", "DEFAULT"]
                 }
               ],
               "type": "array",
@@ -756,7 +756,7 @@
                     "type": "string"
                   },
                   "data": {
-                    "type": [ "array", "object" ],
+                    "type": ["array", "object"],
                     "items": {
                       "type": "object",
                       "properties": {
@@ -810,11 +810,11 @@
                     "additionalProperties": false
                   },
                   "category": {
-                    "type": [ "array", "string" ]
+                    "type": ["array", "string"]
                   }
                 },
                 "additionalProperties": false,
-                "required": [ "action" ]
+                "required": ["action"]
               }
             }
           },
@@ -857,7 +857,7 @@
               "description": "Defines the color of the Android tool bar, and may be reflected in the app's preview in task switchers.",
               "x-PWA": "theme_color",
               "x-metatag": "theme-color",
-              "x-fallback": [ "expo.primaryColor", "#4630EB" ],
+              "x-fallback": ["expo.primaryColor", "#4630EB"],
               "type": "string",
               "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$",
               "x-meta": {
@@ -868,20 +868,20 @@
               "description": "Provides a general description of what the pinned website does.",
               "x-metatag": "description",
               "x-PWA": "description",
-              "x-fallback": [ "expo.description", "'A Neat Expo App'" ],
+              "x-fallback": ["expo.description", "'A Neat Expo App'"],
               "type": "string"
             },
             "dir": {
               "description": "Specifies the primary text direction for the name, short_name, and description members. Together with the lang member, it helps the correct display of right-to-left languages.",
               "x-fallback": "auto",
               "x-PWA": "dir",
-              "enum": [ "auto", "ltr", "rtl" ]
+              "enum": ["auto", "ltr", "rtl"]
             },
             "display": {
               "description": "Defines the developers' preferred display mode for the website.",
               "x-fallback": "standalone",
               "x-PWA": "display",
-              "enum": [ "fullscreen", "standalone", "minimal-ui", "browser" ]
+              "enum": ["fullscreen", "standalone", "minimal-ui", "browser"]
             },
             "startUrl": {
               "description": "The URL that loads when a user launches the application (e.g. when added to home screen), typically the index. Note that this has to be a relative URL, relative to the manifest URL.",
@@ -904,7 +904,7 @@
             "backgroundColor": {
               "description": "Defines the expected \"background color\" for the website. This value repeats what is already available in the site's CSS, but can be used by browsers to draw the background color of a shortcut when the manifest is available before the stylesheet has loaded. This creates a smooth transition between launching the web application and loading the site's content.",
               "x-PWA": "background_color",
-              "x-fallback": [ "expo.splash.backgroundColor", "#ffffff" ],
+              "x-fallback": ["expo.splash.backgroundColor", "#ffffff"],
               "type": "string",
               "pattern": "^(?:#|(&#x23;))[0-9a-fA-F]{6}$",
               "x-meta": {
@@ -915,7 +915,7 @@
               "description": "If content is set to default, the status bar appears normal. If set to black, the status bar has a black background. If set to black-translucent, the status bar is black and translucent. If set to default or black, the web content is displayed below the status bar. If set to black-translucent, the web content is displayed on the entire screen, partially obscured by the status bar.",
               "x-fallback": "default",
               "x-metatag": "apple-mobile-web-app-status-bar-style",
-              "enum": [ "default", "black", "black-translucent" ]
+              "enum": ["default", "black", "black-translucent"]
             },
             "preferRelatedApplications": {
               "description": "Hints for the user agent to indicate to the user that the specified native applications (defined in expo.ios and expo.android) are recommended over the website.",
@@ -928,7 +928,7 @@
               "x-meta": {
                 "deprecated": true
               },
-              "enum": [ "default", "nextjs" ]
+              "enum": ["default", "nextjs"]
             },
             "build": {
               "description": "Basic customization options for dangerously configuring the default webpack config. Please use `expo customize:web` to modify the versioned Webpack config directly instead.",
@@ -1002,9 +1002,9 @@
                     },
                     "barStyle": {
                       "description": "If content is set to \"default\", the status bar appears normal. If set to \"black\", the status bar has a black background. If set to \"black-translucent\", the status bar is black and translucent. If set to \"default\" or \"black\", the web content is displayed below the status bar. If set to \"black-translucent\", the web content is displayed on the entire screen, partially obscured by the status bar.",
-                      "x-fallback": [ "expo.web.barStyle", "default" ],
+                      "x-fallback": ["expo.web.barStyle", "default"],
                       "x-metatag": "apple-mobile-web-app-status-bar-style",
-                      "enum": [ "default", "black", "black-translucent" ]
+                      "enum": ["default", "black", "black-translucent"]
                     }
                   }
                 },
@@ -1052,7 +1052,7 @@
                 },
                 "resizeMode": {
                   "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
-                  "enum": [ "cover", "contain" ]
+                  "enum": ["cover", "contain"]
                 },
                 "image": {
                   "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
@@ -1121,7 +1121,7 @@
             },
             "resizeMode": {
               "description": "Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.",
-              "enum": [ "cover", "contain" ]
+              "enum": ["cover", "contain"]
             },
             "image": {
               "description": "Local path or remote url to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.",
@@ -1150,10 +1150,10 @@
         }
       },
       "additionalProperties": false,
-      "required": [ "name", "slug" ]
+      "required": ["name", "slug"]
     }
   },
-  "required": [ "expo" ],
+  "required": ["expo"],
   "title": "JSON schema for Expo SDK 37 app manifest",
   "type": "object"
 }


### PR DESCRIPTION
### Description

This PR addresses the following linting issues in the `expo-37.0.0.json` schema:

- Replaced `type` alongside `enum` to adhere to JSON Schema best practices.
- Prefixed unknown keywords with `x-` to ensure compatibility with future versions of JSON Schema.
- Removed redundant `additionalProperties` and `properties` declarations that added no further constraints.
- Simplified `type` declarations that used arrays with a single type.

These changes were made to ensure compliance with JSON Schema standards and to resolve the reported linting errors. The schema was updated using the `jsonschema lint --fix` command

### Screenshots

Before and after:

<img width="1459" height="979" alt="image" src="https://github.com/user-attachments/assets/7729e384-3209-4835-ac28-6d51146188b4" />

### Note

I, along with [Juan](https://www.jviotti.com/)  (JSON Schema TSC member) are defining linting rules for JSON Schema as a Part of a [GSoC (Google Summer of code) project](https://github.com/json-schema-org/community/issues/856) here - https://github.com/Karan-Palan/JSON-Schema-Linting, and implementing their auto-fixes here - https://github.com/sourcemeta/jsonschema/blob/main/docs/lint.markdown. We have recently added many rules `prefixing unknown keywords with x-` which will be introduced in the newer JSON Schema drafts
If beneficial to the project, I suggest integrating the linter with it to write the best schemas and catch any errors and follow best practices. Example of an integration - https://github.com/krakend/krakend-schema/blob/main/.github/workflows/validate-json-schema.yml#L10
