### PR TITLE
feat(powerpages): add includeSource and sourceExcludePatterns

### DIFF
--- a/src/schemas/json/powerpages.config.json
+++ b/src/schemas/json/powerpages.config.json
@@ -22,6 +22,17 @@
       "items": {
         "type": "string"
       }
+    },
+    "includeSource": {
+      "type": "boolean",
+      "description": "Whether to include source code when uploading files to Power Pages. Defaults to `false` if not specified."
+    },
+    "sourceExcludePatterns": {
+      "type": "array",
+      "description": "List of glob patterns (strings) identifying source file patterns to be excluded when uploading the site to Power Pages. This is only applicable if `includeSource` is set to `true`.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "type": "object"

--- a/src/test/powerpages.config/powerpages.config.json
+++ b/src/test/powerpages.config/powerpages.config.json
@@ -2,6 +2,6 @@
   "bundleFilePatterns": ["**/*.js", "**/*.css"],
   "compiledPath": "C:\\path\\to\\compiled\\folder",
   "defaultLandingPage": "foo.html",
-  "siteName": "Website Name",
-  "includeSource": true
+  "includeSource": true,
+  "siteName": "Website Name"
 }

--- a/src/test/powerpages.config/powerpages.config.json
+++ b/src/test/powerpages.config/powerpages.config.json
@@ -2,5 +2,6 @@
   "bundleFilePatterns": ["**/*.js", "**/*.css"],
   "compiledPath": "C:\\path\\to\\compiled\\folder",
   "defaultLandingPage": "foo.html",
-  "siteName": "Website Name"
+  "siteName": "Website Name",
+  "includeSource": true
 }


### PR DESCRIPTION
- ✨ Added `includeSource` property to control source code inclusion.
- 🗑️ Introduced `sourceExcludePatterns` for excluding specific source files when uploading.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
