### PR TITLE
Add Robust Station Image schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8553,6 +8553,12 @@
       "description": "Zarf Packages contain a comprehensive description of system software and all of it's components for declaratively deploying in a disconnected environment",
       "fileMatch": ["**/zarf.yaml", "**/zarf.yml"],
       "url": "https://www.schemastore.org/zarf.json"
+    },
+    {
+      "name": "Robust Station Image",
+      "description": "JSON Schema for SS14 RSI validation.",
+      "fileMatch": ["**/*.rsi/meta.json"],
+      "url": "https://raw.githubusercontent.com/space-wizards/RobustToolbox/refs/heads/master/Schemas/rsi.json"
     }
   ]
 }


### PR DESCRIPTION
Adds in the [RSI](https://docs.spacestation14.com/en/specifications/robust-station-image.html#json) format used by games built using [Robust Toolbox](https://github.com/space-wizards/RobustToolbox) (primarily Space Station 14).

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
