### PR TITLE
Remove learnMode property from claude-code-settings schema

### DIFF
--- a/src/negative_test/claude-code-settings/wrong-property-types.json
+++ b/src/negative_test/claude-code-settings/wrong-property-types.json
@@ -2,7 +2,6 @@
   "cleanupPeriodDays": "thirty",
   "enableAllProjectMcpServers": 1,
   "includeCoAuthoredBy": "yes",
-  "learnMode": "true",
   "permissions": {
     "additionalDirectories": "should be array",
     "allow": "should be array"

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -191,10 +191,6 @@
         }
       }
     },
-    "learnMode": {
-      "type": "boolean",
-      "description": "Request the model focuses more on educating and co-creating with the user, rather than just completing tasks"
-    },
     "forceLoginMethod": {
       "type": "string",
       "description": "Force a specific login method, and skip the login method selection screen",

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -36,7 +36,6 @@
     ]
   },
   "includeCoAuthoredBy": true,
-  "learnMode": true,
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
     "allow": [


### PR DESCRIPTION
This PR removes the `learnMode` property from the claude-code-settings JSON schema. `learnMode` is not a real setting per https://docs.anthropic.com/en/docs/claude-code/settings, I think this became output styles.

## Changes Made:
- ✅ Removed `learnMode` property definition from main schema file (`src/schemas/json/claude-code-settings.json`)
- ✅ Removed `learnMode` usage from test configuration file (`src/test/claude-code-settings/modern-complete-config.json`)
- ✅ Removed `learnMode` from negative test file (`src/negative_test/claude-code-settings/wrong-property-types.json`)

## Validation:
- ✅ All schema validation checks pass (`node ./cli.js check --schema-name=claude-code-settings.json`)
- ✅ All files properly formatted with Prettier
- ✅ No remaining references to `learnMode` in the codebase

The removal is clean and complete, with all related test files updated accordingly.