### PR TITLE
Add schema for EUDR-X

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8568,7 +8568,7 @@
       "url": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/heads/main/json/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/tags/v1.0.0/json/schema.json",
-        "2.0.0": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/tags/v2.0.0/json/schema.json",
+        "2.0.0": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/tags/v2.0.0/json/schema.json"
       }
     }
   ]


### PR DESCRIPTION
This PR adds the schema for [EUDR-X](https://github.com/initiative-online-print/eudr-iop-standard-exchange-format) files following the [file naming convention](https://github.com/initiative-online-print/eudr-iop-standard-exchange-format?tab=readme-ov-file#file-naming-convention) that EUDR-X files end with `eudr-x.json`