### PR TITLE
Add CODEOWNERS for Convex

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,3 +57,7 @@ src/test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyag
 # Managed by Anthropic Team:
 src/schemas/json/claude-code-settings.json @domdomegg @bogini
 src/test/claude-code-settings/ @domdomegg @bogini
+
+# Managed by Convex Team:
+src/schemas/json/convex.json @ianmacartney @thomasballinger @Nicolapps
+src/test/convex/ @ianmacartney @thomasballinger @Nicolapps


### PR DESCRIPTION
I work at Convex (you can verify this through my GitHub profile or https://www.convex.dev/about-us). Adding myself and @ianmacartney + @thomasballinger for `convex.json` schemas.