### PR TITLE
feat: support `x-tombi-string-formats`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,15 +316,19 @@ Used by: `tamasfe/taplo`.
 
 **`x-tombi-toml-version`**
 
-Used by: `tombi-toml/tombi`.
+Used by: `tombi-toml/tombi`. See [this](https://tombi-toml.github.io/tombi/docs/json-schema#x-tombi-toml-version) for details.
 
 **`x-tombi-array-values-order`**
 
-Used by: `tombi-toml/tombi`.
+Used by: `tombi-toml/tombi`. See [this](https://tombi-toml.github.io/tombi/docs/json-schema#x-tombi-array-values-order) for details.
 
 **`x-tombi-table-keys-order`**
 
-Used by: `tombi-toml/tombi`.
+Used by: `tombi-toml/tombi`. See [this](https://tombi-toml.github.io/tombi/docs/json-schema#x-tombi-table-keys-order) for details.
+
+**`x-tombi-string-formats`**
+
+Used by: `tombi-toml/tombi`. See [this](https://tombi-toml.github.io/tombi/docs/json-schema#x-tombi-string-formats) for details.
 
 **`x-intellij-language-injection`**
 

--- a/cli.js
+++ b/cli.js
@@ -505,6 +505,7 @@ async function ajvFactory(
     'x-tombi-toml-version',
     'x-tombi-array-values-order',
     'x-tombi-table-keys-order',
+    'x-tombi-string-formats',
     'x-intellij-language-injection',
     'x-intellij-html-description',
     'x-intellij-enum-metadata',


### PR DESCRIPTION
Tombi supports `x-tombi-string-formats`.

See: https://tombi-toml.github.io/tombi/docs/json-schema/#x-tombi-string-formats