### PR TITLE
fix(schema): Update links to UI5 CLI related schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6018,7 +6018,7 @@
     },
     {
       "name": "ui5.yaml",
-      "description": "UI5 Tooling Configuration File (ui5.yaml)",
+      "description": "UI5 CLI Configuration File (ui5.yaml)",
       "fileMatch": [
         "ui5.yaml",
         "*-ui5.yaml",
@@ -6027,11 +6027,11 @@
         "ui5-dist.yaml",
         "ui5-local.yaml"
       ],
-      "url": "https://sap.github.io/ui5-tooling/schema/ui5.yaml.json"
+      "url": "https://ui5.github.io/cli/schema/ui5.yaml.json"
     },
     {
       "name": "ui5-workspace.yaml",
-      "description": "UI5 Tooling Workspace Configuration File (ui5-workspace.yaml)",
+      "description": "UI5 CLI Workspace Configuration File (ui5-workspace.yaml)",
       "fileMatch": [
         "ui5-workspace.yaml",
         "*-ui5-workspace.yaml",
@@ -6040,7 +6040,7 @@
         "ui5-workspace-dist.yaml",
         "ui5-workspace-local.yaml"
       ],
-      "url": "https://sap.github.io/ui5-tooling/schema/ui5-workspace.yaml.json"
+      "url": "https://ui5.github.io/cli/schema/ui5-workspace.yaml.json"
     },
     {
       "name": "UTAM Page Object",


### PR DESCRIPTION
UI5 Tooling is renamed to UI5 CLI and transferred to the new UI5 GitHub Organization. Therefore also the schema links are updated.