### PR TITLE
Update ruff's JSON schema

### DIFF
--- a/src/schemas/json/ruff.json
+++ b/src/schemas/json/ruff.json
@@ -1860,7 +1860,7 @@
           ]
         },
         "future-annotations": {
-          "description": "Whether to allow rules to add `from __future__ import annotations` in cases where this would simplify a fix or enable a new diagnostic.\n\nFor example, `TC001`, `TC002`, and `TC003` can move more imports into `TYPE_CHECKING` blocks if `__future__` annotations are enabled.\n\nThis setting is currently in [preview](https://docs.astral.sh/ruff/preview/) and requires preview mode to be enabled to have any effect.",
+          "description": "Whether to allow rules to add `from __future__ import annotations` in cases where this would simplify a fix or enable a new diagnostic.\n\nFor example, `TC001`, `TC002`, and `TC003` can move more imports into `TYPE_CHECKING` blocks if `__future__` annotations are enabled.",
           "type": ["boolean", "null"]
         },
         "ignore": {
@@ -2454,6 +2454,7 @@
         "ASYNC23",
         "ASYNC230",
         "ASYNC25",
+        "ASYNC250",
         "ASYNC251",
         "B",
         "B0",
@@ -2989,9 +2990,6 @@
         "PD1",
         "PD10",
         "PD101",
-        "PD9",
-        "PD90",
-        "PD901",
         "PERF",
         "PERF1",
         "PERF10",
@@ -3741,7 +3739,6 @@
         "UP035",
         "UP036",
         "UP037",
-        "UP038",
         "UP039",
         "UP04",
         "UP040",


### PR DESCRIPTION
This updates ruff's JSON schema to [a1fdd66f10a045a574efb20e422868b21decda40](https://github.com/astral-sh/ruff/commit/a1fdd66f10a045a574efb20e422868b21decda40)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
