### PR TITLE
Add rust edition 2024 for rust project schema

### DIFF
--- a/src/schemas/json/rust-project.json
+++ b/src/schemas/json/rust-project.json
@@ -18,7 +18,7 @@
           "description": "Edition of the crate.",
           "title": "Edition",
           "type": "string",
-          "enum": ["2015", "2018", "2021"]
+          "enum": ["2015", "2018", "2021", "2024"]
         },
         "deps": {
           "description": "Crate dependencies.",


### PR DESCRIPTION
Adding the newest rust edition, [edition 2024](https://doc.rust-lang.org/edition-guide/rust-2024/index.html) for rust-project.json. The new edition was already added in cargo.json with #3675 and rustfmt.json with #4162.

Documentation for `rust-project.json` also [mentions the edition 2024](https://rust-analyzer.github.io/book/non_cargo_based_projects.html).