### PR TITLE
Add `wp-env` schema for WordPress local development configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "wp-env",
+      "description": "WordPress local development environment configuration file schema.",
+      "fileMatch": [".wp-env.json", ".wp-env.override.json"],
+      "url": "https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/trunk/schemas/json/wp-env.json"
+    },
+    {
       "name": "Upsun config",
       "description": "Upsun configuration file",
       "fileMatch": ["**/.upsun/*.yml", "**/.upsun/*.yaml"],

--- a/src/schemas/json/wp-env.json
+++ b/src/schemas/json/wp-env.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/schema-catalog",
+  "schemas": [
+    {
+      "name": "wp-env",
+      "description": "WordPress local development environment configuration file schema.",
+      "fileMatch": [
+        ".wp-env.json",
+        ".wp-env.override.json"
+      ],
+      "url": "https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/trunk/schemas/json/wp-env.json"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
