### PR TITLE
Expand codecov fileMatch to cover allowed subdirs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1553,10 +1553,10 @@
       "name": "Codecov configuration files",
       "description": "codecov.yml files",
       "fileMatch": [
-        ".github/.codecov.yml",
-        ".github/codecov.yml",
-        "dev/.codecov.yml",
-        "dev/codecov.yml",
+        "**/.github/.codecov.yml",
+        "**/.github/codecov.yml",
+        "**/dev/.codecov.yml",
+        "**/dev/codecov.yml",
         ".codecov.yml",
         "codecov.yml"
       ],


### PR DESCRIPTION
The Codecov documentation explicitly notes support for `.github/` and `dev/` as directories containing the Codecov config:
https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-file-codecovyml

Thanks to @vivodi, who pointed this out downstream in `check-jsonschema`!
