### PR TITLE
Make machine check image optional

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -204,13 +204,7 @@
                 "pattern": "^\\d+s$"
               }
             },
-            "required": [
-              "command",
-              "entrypoint",
-              "image",
-              "kill_signal",
-              "kill_timeout"
-            ]
+            "required": ["command", "entrypoint", "kill_signal", "kill_timeout"]
           }
         },
         "tcp_checks": {


### PR DESCRIPTION
## Summary
- remove `image` from the machine check required fields so the schema matches current behavior\n\n## Testing
- npm run prettier\n\nFly.io docs confirm `image` defaults to the process group image and is optional: https://fly.io/docs/reference/configuration/#services-machine_checks