### PR TITLE
add hulak config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3087,6 +3087,12 @@
       "url": "https://hyperfoil.io/schema.json"
     },
     {
+      "name": "Hulak Configuration",
+      "description": "Hulak API client configuration file",
+      "fileMatch": ["**/*.hk.yaml", "**/*.hk.yml", "**/*.hk.json"],
+      "url": "https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json"
+    },
+    {
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
       "fileMatch": ["zapp.yaml", "zapp.yml", "zapp.json"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
Add Hulak API client configuration schema to SchemaStore

- Adds a new, externally hosted schema to `src/api/json/catalog.json` for Hulak configuration files as mentioned in https://github.com/SchemaStore/schemastore/issues/4645
