### PR TITLE
Drone add type vm support

### DIFF
--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -332,7 +332,8 @@
             "ssh",
             "exec",
             "digitalocean",
-            "macstadium"
+            "macstadium",
+            "vm"
           ]
         },
         "platform": {
@@ -608,6 +609,53 @@
         "depends_on": {}
       }
     },
+    "pipeline_vm": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "vm"
+        },
+        "environment": {
+          "$ref": "#/definitions/environment"
+        },
+        "pool": {
+          "object": {
+            "use": "string"
+          }
+        },
+        "steps": {
+          "items": {
+            "$ref": "#/definitions/step_docker"
+          }
+        },
+        "volumes": {
+          "$ref": "#/definitions/volumes"
+        },
+        "services": {
+          "$ref": "#/definitions/services"
+        },
+        "image_pull_secrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "node": {
+          "$ref": "#/definitions/node"
+        },
+        "concurrency": {
+          "$ref": "#/definitions/concurrency"
+        },
+        "kind": {},
+        "name": {},
+        "platform": {},
+        "workspace": {},
+        "clone": {},
+        "trigger": {},
+        "depends_on": {}
+      }
+    },
     "step": {
       "type": "object",
       "required": ["name"],
@@ -848,6 +896,9 @@
             },
             {
               "$ref": "#/definitions/pipeline_macstadium"
+            },
+            {
+              "$ref": "#/definitions/pipeline_vm"
             }
           ]
         }

--- a/src/schemas/json/drone.json
+++ b/src/schemas/json/drone.json
@@ -620,8 +620,11 @@
           "$ref": "#/definitions/environment"
         },
         "pool": {
-          "object": {
-            "use": "string"
+          "type": "object",
+          "properties": {
+            "use": {
+              "$ref": "#/definitions/nonEmptyString"
+            }
           }
         },
         "steps": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Reference:
- https://docs.drone.io/pipeline/aws/overview/
- https://github.com/drone/docs/blob/master/content/pipeline/aws/syntax/images.md

`steps` is fully compatible with docker type, but adds `pool`