### PR TITLE
add `webapp` web manifest platform

### DIFF
--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -54,7 +54,7 @@
       "properties": {
         "platform": {
           "description": "The platform it is associated to.",
-          "enum": ["chrome_web_store", "play", "itunes", "windows"]
+          "enum": ["chrome_web_store", "play", "itunes", "webapp", "windows"]
         },
         "url": {
           "description": "The URL where the application can be found.",


### PR DESCRIPTION
This adds the `webapp` web manifest platform, as described here

- MDN > Navigator: getInstalledRelatedApps() method > [platform](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getInstalledRelatedApps#platform)
- web.dev > Learn PWA > Detection > [Related applications](https://web.dev/learn/pwa/detection#related_applications)