### PR TITLE
claude-code-settings: add permissions.ask support and tests

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-permission-rule.json
+++ b/src/negative_test/claude-code-settings/invalid-permission-rule.json
@@ -5,6 +5,12 @@
       "Bash without parentheses",
       "Read[wrong-brackets]",
       "WebFetch(invalid:syntax"
+    ],
+    "ask": [
+      "AnotherInvalidTool",
+      "Write missing parentheses",
+      "LS[wrong-brackets]",
+      "Edit(invalid:syntax"
     ]
   }
 }

--- a/src/negative_test/claude-code-settings/wrong-property-types.json
+++ b/src/negative_test/claude-code-settings/wrong-property-types.json
@@ -4,6 +4,7 @@
   "includeCoAuthoredBy": "yes",
   "permissions": {
     "additionalDirectories": "should be array",
-    "allow": "should be array"
+    "allow": "should be array",
+    "ask": "should be array"
   }
 }

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -100,6 +100,12 @@
           "items": { "$ref": "#/$defs/permissionRule" },
           "uniqueItems": true
         },
+        "ask": {
+          "type": "array",
+          "description": "List of ask tool permission rules",
+          "items": { "$ref": "#/$defs/permissionRule" },
+          "uniqueItems": true
+        },
         "deny": {
           "type": "array",
           "description": "List of denied tool permission rules",

--- a/src/test/claude-code-settings/complete-config.json
+++ b/src/test/claude-code-settings/complete-config.json
@@ -15,6 +15,7 @@
       "Bash(git log:*)",
       "WebFetch(domain:anthropic.com)"
     ],
+    "ask": ["Write(/tmp/**)", "WebFetch(domain:trusted.example.com)"],
     "deny": [
       "Bash(rm:*)",
       "Bash(curl:*)",

--- a/src/test/claude-code-settings/edge-cases.json
+++ b/src/test/claude-code-settings/edge-cases.json
@@ -4,6 +4,7 @@
   "env": {},
   "permissions": {
     "allow": [],
+    "ask": [],
     "deny": []
   }
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -55,6 +55,7 @@
       "Write",
       "mcp__*"
     ],
+    "ask": ["TodoRead", "NotebookRead", "Bash(pip:*)", "Write(~/.cache/**)"],
     "defaultMode": "plan",
     "deny": [
       "Bash(sudo:*)",

--- a/src/test/claude-code-settings/permissions-advanced.json
+++ b/src/test/claude-code-settings/permissions-advanced.json
@@ -19,6 +19,7 @@
       "mcp__ide__getDiagnostics",
       "mcp__ide__executeCode"
     ],
+    "ask": ["Write(~/projects/**)", "TodoRead", "NotebookRead", "Bash(make:*)"],
     "defaultMode": "acceptEdits",
     "deny": ["Bash(rm:*)", "Write(/etc/**)", "WebFetch(domain:malicious.com)"],
     "disableBypassPermissionsMode": "disable"

--- a/src/test/claude-code-settings/permissions-basic.json
+++ b/src/test/claude-code-settings/permissions-basic.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": ["Read(~/.bashrc)", "Bash(pwd:*)"],
+    "ask": ["Write(/tmp/**)"],
     "deny": ["Bash(sudo:*)"]
   }
 }

--- a/src/test/claude-code-settings/permissions-mcp.json
+++ b/src/test/claude-code-settings/permissions-mcp.json
@@ -5,6 +5,7 @@
       "mcp__filesystem(read:/home/user)",
       "mcp__git(status:*)"
     ],
+    "ask": ["mcp__filesystem(write:/home/user)"],
     "deny": []
   }
 }


### PR DESCRIPTION
- Schema: add 'ask' array under 'permissions' (same schema as 'allow'/'deny')
- Positive tests: include 'ask' anywhere 'allow' or 'deny' appear
- Negative tests: cover invalid 'ask' rules and wrong types
- Formatting: run Prettier