### PR TITLE
Add missing `negative_test` matches to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,9 @@
 # Managed by Ansible DevTools Team members:
 src/schemas/json/ansible-* @ssbarnea @webknjaz
 src/test/ansible-* @ssbarnea @webknjaz
+src/negative_test/ansible-* @ssbarnea @webknjaz
 src/test/yamllint/ansible-* @ssbarnea @webknjaz
+src/negative_test/yamllint/ansible-* @ssbarnea @webknjaz
 
 # Zuul CI Schemas:
 src/schemas/json/zuul.json @ssbarnea
@@ -35,6 +37,7 @@ src/negative_test/venvplus-* @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj
 # Managed by CTFer.io team:
 src/schemas/json/ctfd.json @pandatix @NicoFgrx
 src/test/ctfd/* @pandatix @NicoFgrx
+src/negative_test/ctfd/* @pandatix @NicoFgrx
 
 # Managed by tombi-toml team:
 src/schemas/json/cargo.json @ya7010
@@ -49,15 +52,19 @@ src/negative_test/contextive-glossary/ @chrissimon-au
 # pnpm Schemas:
 src/schemas/json/pnpm-workspace.json @danielbayley @btea
 src/test/pnpm-workspace/ @danielbayley @btea
+src/negative_test/pnpm-workspace/ @danielbayley @btea
 
 # Managed by Power Pages Team:
 src/schemas/json/powerpages.config.json @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
 src/test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
+src/negative_test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
 
 # Managed by Anthropic Team:
 src/schemas/json/claude-code-settings.json @domdomegg @bogini
 src/test/claude-code-settings/ @domdomegg @bogini
+src/negative_test/claude-code-settings/ @domdomegg @bogini
 
 # Managed by Convex Team:
 src/schemas/json/convex.json @ianmacartney @thomasballinger @Nicolapps
 src/test/convex/ @ianmacartney @thomasballinger @Nicolapps
+src/negative_test/convex/ @ianmacartney @thomasballinger @Nicolapps


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

In PRs like #5006, our "code-owner-self-merge" bot didn't delegate reviews like it should have because the PR "unexpectedly" included negative tests. This fixes all sections but one to include `negative_test` matches for every `test` directory match.