### PR TITLE
Fix `Inherits` in cargo.json

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -265,8 +265,13 @@
     "Inherits": {
       "title": "Inherits",
       "description": "In addition to the built-in profiles, additional custom profiles can be defined.",
-      "type": "string",
-      "enum": ["dev", "test", "bench", "release"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["dev", "test", "bench", "release"]
+        },
+        { "type": "string" }
+      ],
       "x-taplo": {
         "links": {
           "key": "https://doc.rust-lang.org/cargo/reference/profiles.html#custom-profiles"


### PR DESCRIPTION
<img width="605" height="458" alt="image" src="https://github.com/user-attachments/assets/9fd2c407-46fd-493a-a1d0-5f4565417b25" />

This PR fixes false validation error of `Inherits`.
As the `description` field says, a value can be a custom profile. So the `enum` should be removed.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
