### PR TITLE
Fix claude-code-settings outputStyle capitalization

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -297,9 +297,9 @@
     },
     "outputStyle": {
       "type": "string",
-      "description": "The output style to use. Can be 'default', 'explanatory', 'learning', or a custom style name.",
+      "description": "The output style to use (case-sensitive). Can be 'default', 'Explanatory', 'Learning', or a custom style name.",
       "minLength": 1,
-      "examples": ["default", "explanatory", "learning"]
+      "examples": ["default", "Explanatory", "Learning"]
     },
     "forceLoginOrgUUID": {
       "type": "string",

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -36,6 +36,7 @@
     ]
   },
   "includeCoAuthoredBy": true,
+  "outputStyle": "Explanatory",
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
     "allow": [


### PR DESCRIPTION
## Summary
Update the `outputStyle` property in the Claude Code settings schema to use the correct capitalized values that match the actual implementation.

## Changes
- Updated `outputStyle` examples from lowercase `"explanatory"`, `"learning"` to proper case `"Explanatory"`, `"Learning"`
- Added `"(case-sensitive)"` note to the description to clarify the requirement
- Added `outputStyle` to the `modern-complete-config.json` test file demonstrating correct usage

## Context
The built-in output styles in Claude Code use capitalized names (`Explanatory` and `Learning`). The schema previously showed lowercase examples which would not work correctly with the actual implementation.

## Test plan
- ✅ Updated test file: `src/test/claude-code-settings/modern-complete-config.json`
- The test file will be validated automatically by Ajv in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)