### PR TITLE
fix(schema): releax variable naming pattern for taskipy

### DIFF
--- a/src/schemas/json/partial-taskipy.json
+++ b/src/schemas/json/partial-taskipy.json
@@ -22,7 +22,7 @@
       "description": "variables used in your tasks",
       "type": "object",
       "patternProperties": {
-        "^[0-9a-zA-Z_\\-]+$": {
+        "^[0-9a-zA-Z_-]+$": {
           "title": "variable",
           "description": "variable in your tasks",
           "oneOf": [


### PR DESCRIPTION
The variable naming pattern for defining variables in tasks for taskify was unnecessarily strict, allowing only flatcase and camelCase variable naming.

This commit relaxes the pattern to also allow snake_case and kebab-case variables.
