### PR TITLE
(feature) Adding ast-grep to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -347,6 +347,27 @@
       "url": "https://www.schemastore.org/asconfig-schema.json"
     },
     {
+      "name": "ast-grep sgconfig.yml",
+      "description": "ast-grep project config",
+      "fileMatch": ["sgconfig.yml", "sgconfig.yaml"],
+      "url": "https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/project.json"
+    },
+    {
+      "name": "ast-grep rules",
+      "description": "ast-grep rule config",
+      "fileMatch": [
+        "**/.astgrep/rules/**/*.yaml",
+        "**/.astgrep/rules/**/*.yml",
+        "**/.ast-grep/rules/**/*.yaml",
+        "**/.ast-grep/rules/**/*.yml",
+        "**/ast-grep/rules/**/*.yaml",
+        "**/ast-grep/rules/**/*.yml",
+        "**/astgrep/rules/**/*.yaml",
+        "**/astgrep/rules/**/*.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json"
+    },
+    {
       "name": "AsyncAPI",
       "description": "AsyncAPI documentation files",
       "fileMatch": ["*asyncapi*.json", "*asyncapi*.yml", "*asyncapi*.yaml"],


### PR DESCRIPTION
This adds [ast-grep](https://ast-grep.github.io/) to catalog.json this provides patterns for project YAML and rule YAML files.