### PR TITLE
Added tag trigger to bamboo yaml spec; allowed trigger description

### DIFF
--- a/src/schemas/json/bamboo-spec.json
+++ b/src/schemas/json/bamboo-spec.json
@@ -511,6 +511,10 @@
                     "period": {
                       "type": "integer"
                     },
+                    "description": {
+                      "type": "string",
+                      "description": "Trigger description."
+                    },
                     "conditions": {
                       "type": "array",
                       "items": {
@@ -573,6 +577,46 @@
               ]
             }
           }
+        },
+        "tag": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tag": {
+              "type": "object",
+              "description": "UNDOCUMENTED. Bamboo detects new tags in repository and builds for all these tags",
+              "properties": {
+                "filter": {
+                  "type": "string",
+                  "description": "Use a regular expression to only build for tag that match specific names."
+                },
+                "tagInBranch": {
+                  "type": "boolean",
+                  "description": "Only run build if the branch contains the matched tag. The build will be triggered only if the tag revision is in the vcs branch."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Trigger description."
+                },
+                "conditions": {
+                  "type": "array",
+                  "description": "Only run Build if other Plans are currently passing.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "green-plan": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "Plan Keys"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "items": {
@@ -585,6 +629,9 @@
           },
           {
             "$ref": "#/definitions/triggers/definitions/remote"
+          },
+          {
+            "$ref": "#/definitions/triggers/definitions/tag"
           },
           {
             "type": "string"

--- a/src/test/bamboo-spec/bamboo-spec-tag.yml
+++ b/src/test/bamboo-spec/bamboo-spec-tag.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../schemas/json/bamboo-spec.json
+version: 2
+
+triggers:
+  - tag:
+      filter: v?[0-9]+\.[0-9]|\.[0-9].*
+      description: Build on version number
+      tagInBranch: false
+      conditions:
+        - green-plan:
+            - PROJ-PLAN1
+            - PROJ-PLAN2


### PR DESCRIPTION
Though not documented in https://docs.atlassian.com/bamboo-specs-docs/10.0.2/specs.html?yaml#triggers, when exporting a bamboo plan to yaml triggers are supported (and recognized upon import). This PR adds the supported but undocumented tag to the json schema, as well as adds `description` for `polling`; see the screenshots below:

<img width="1055" height="852" alt="image" src="https://github.com/user-attachments/assets/f04ece39-b90c-46f0-abb6-c0d0324af3fe" />

<img width="424" height="239" alt="image" src="https://github.com/user-attachments/assets/a68e3924-f0a1-487a-a6cc-25926460cb75" />
