### PR TITLE
Fix default schema versions for aio connector metadata schemas

### DIFF
--- a/src/schemas/json/aio-connector-metadata-8.0-preview.json
+++ b/src/schemas/json/aio-connector-metadata-8.0-preview.json
@@ -137,7 +137,7 @@
     "$schema": {
       "type": "string",
       "description": "The address of the AIO connector metadata schema that this connector metadata file adheres to.",
-      "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-7.0-preview.json"
+      "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-8.0-preview.json"
     },
     "name": {
       "type": "string",

--- a/src/schemas/json/aio-connector-metadata-9.0-preview.json
+++ b/src/schemas/json/aio-connector-metadata-9.0-preview.json
@@ -137,7 +137,7 @@
     "$schema": {
       "type": "string",
       "description": "The address of the AIO connector metadata schema that this connector metadata file adheres to.",
-      "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-7.0-preview.json"
+      "default": "https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/aio-connector-metadata-9.0-preview.json"
     },
     "name": {
       "type": "string",


### PR DESCRIPTION
Have version 8/9's default schema be version 8/9, not version 7