### PR TITLE
Improve helmfile schema validation and add new fields

### DIFF
--- a/src/schemas/json/helmfile.json
+++ b/src/schemas/json/helmfile.json
@@ -374,7 +374,7 @@
         }
       },
       "required": ["name"],
-      "oneOf": [
+      "anyOf": [
         {
           "required": ["chart"]
         },

--- a/src/schemas/json/helmfile.json
+++ b/src/schemas/json/helmfile.json
@@ -371,6 +371,60 @@
           "type": "boolean",
           "description": "If set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout.",
           "default": false
+        },
+        "needs": {
+          "type": "array",
+          "description": "Define dependencies between releases. This release will only be installed after all releases in the needs list are installed.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependencies": {
+          "type": "array",
+          "description": "Add chart dependencies without forking. Can be local paths or OCI charts.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "chart": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "alias": {
+                "type": "string"
+              }
+            },
+            "required": ["chart"]
+          }
+        },
+        "strategicMergePatches": {
+          "type": "array",
+          "description": "Apply strategic merge patches to Kubernetes resources using Kustomize.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transformers": {
+          "type": "array",
+          "description": "Apply Kustomize transformers to add labels, annotations, etc.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "jsonPatches": {
+          "type": "array",
+          "description": "Apply JSON patches to Kubernetes resources.",
+          "items": {
+            "type": "object"
+          }
+        },
+        "adopt": {
+          "type": "array",
+          "description": "Adopt existing resources into Helm management.",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": ["name"],


### PR DESCRIPTION
## Summary
  - Fix `oneOf` to `anyOf` to allow `chart` and `inherit` to be used simultaneously without validation warnings
  - Add support for new helmfile fields: `needs`, `dependencies`, `strategicMergePatches`, `transformers`, `jsonPatches`, and `adopt`

<img width="610" height="258" alt="image" src="https://github.com/user-attachments/assets/53159c5e-6541-4dae-8a66-57c09b559b96" />
