### PR TITLE
feat: add minimumReleaseAge and minimumReleaseAgeExcludes to bunfig.json

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -365,6 +365,20 @@
               "examples": ["@acme/bun-security-scanner"]
             }
           }
+        },
+        "minimumReleaseAge": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-minimumreleaseage",
+          "description": "Configure a minimum age (in seconds) for npm package versions. Package versions published more recently than this threshold will be filtered out during installation. Default is null (disabled)\nhttps://bun.com/docs/runtime/bunfig#install-minimumreleaseage",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [259200]
+        },
+        "minimumReleaseAgeExcludes": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-minimumreleaseage",
+          "description": "Packages that bypass the minimumReleaseAge requirement and can install immediately.\nhttps://bun.com/docs/runtime/bunfig#install-minimumreleaseage",
+          "type": "array",
+          "items": { "type": "string" },
+          "examples": [["@types/bun", "typescript"]]
         }
       }
     },


### PR DESCRIPTION
This adds `minimumReleaseAge` and `minimumReleaseAgeExcludes`. 
See https://bun.com/docs/runtime/bunfig#install-minimumreleaseage