### PR TITLE
Adding configurationProfile property to host.json

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1512,7 +1512,7 @@
         },
         "configurationProfile": {
           "description": "Configuration profile to use for the Function App. Settings defined by the configuration profile will be implicitly applied to the Function App.",
-          "type": "string"          
+          "type": "string"
         }
       },
       "required": ["version"],

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -7,6 +7,7 @@
     "dynamicConcurrencyEnabled": true,
     "snapshotPersistenceEnabled": true
   },
+  "configurationProfile": "sample-profile",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
@@ -204,6 +205,5 @@
   "telemetryMode": "OpenTelemetry",
   "version": "2.0",
   "watchDirectories": ["Shared", "Test"],
-  "watchFiles": ["myFile.txt"],
-  "configurationProfile": "sample-profile"
+  "watchFiles": ["myFile.txt"]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
This PR adds a new host.json property named `configurationProfile` to support a recently introduced Azure Functions feature (https://github.com/Azure/azure-functions-host/issues/11320)