### PR TITLE
Add schema for IXpect config.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3220,6 +3220,15 @@
       "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
     },
     {
+      "name": "ixpect.conf.yaml",
+      "description": "IXpect configuration file",
+      "fileMatch": ["ixpect.conf.yaml"],
+      "url": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json",
+      "versions": {
+        "0.1": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json"
+      }
+    },
+    {
       "name": "Jasmine",
       "description": "jasmine JSON config file",
       "fileMatch": ["jasmine.json"],


### PR DESCRIPTION
IXpect is a tool for continuously monitoring IX peering LANs.

See also: https://ixpect.net

IXpect uses a YAML configuration file and provides a versioned schema for it.
