### PR TITLE
Add tag_pattern and version to git dependency for pubspec

### DIFF
--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -115,10 +115,17 @@
                     "ref": {
                       "type": "string",
                       "description": "The branch, tag, or anything else Git allows to identify a commit."
+                    },
+                    "tag_pattern": {
+                      "type": "string",
+                      "description": "Pattern for matching git tags with version placeholders"
                     }
                   }
                 }
               ]
+            },
+            "version": {
+              "$ref": "#/definitions/versionConstraint"
             }
           },
           "required": ["git"],


### PR DESCRIPTION
This adds 2 new properties, tag_pattern and version for git dependency in pubspec.yaml as new features were added in Dart 3.9