### PR TITLE
bugfix: Moved "additionalProperties" key in pylock.json

### DIFF
--- a/src/schemas/json/pylock.json
+++ b/src/schemas/json/pylock.json
@@ -1,7 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/pylock.json",
-  "additionalProperties": false,
   "definitions": {
     "tool": {
       "type": "object",
@@ -165,6 +164,7 @@
       }
     },
     "1.0": {
+      "additionalProperties": false,
       "required": ["lock-version", "created-by", "packages"],
       "properties": {
         "lock-version": {


### PR DESCRIPTION
Fixes #5050 

Previous version of pylock.json schema has `"additionalProperties": false` specified at the root level and the expected properties defined in a subschema selected by `oneOf`, which results in any input being marked as invalid.

Moved the `"additionalProperties": false` inside the subschema definition, so that it can work as intended.
