### PR TITLE
feat: add rumdl schema for Markdown linter configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5162,6 +5162,12 @@
       "url": "https://raw.githubusercontent.com/simonwhitaker/runny/main/schema/runny.schema.json"
     },
     {
+      "name": "rumdl",
+      "description": "Configuration file for rumdl, a fast Markdown linter and formatter",
+      "fileMatch": [".rumdl.toml", "rumdl.toml"],
+      "url": "https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json"
+    },
+    {
       "name": "rustfmt",
       "description": "rustfmt, a tool to format Rust code",
       "fileMatch": ["rustfmt.toml"],


### PR DESCRIPTION
Adds JSON schema for rumdl configuration files.

rumdl is a fast Markdown linter and formatter written in Rust. This PR adds the schema catalog entry for rumdl configuration files (`.rumdl.toml` and `rumdl.toml`).

**Changes:**
- Added catalog entry in `src/api/json/catalog.json`
- Schema is hosted externally at: https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json

**Related Links:**
- Project repository: https://github.com/rvben/rumdl
- Schema file: https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json