### PR TITLE
Update Hazelcast schema for release 5.6.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3055,7 +3055,7 @@
         "hz-*.yaml",
         "hz-*.json"
       ],
-      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.5.json"
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.6.json"
     },
     {
       "name": "Home Assistant Integration Manifest",


### PR DESCRIPTION
Hazelcast 5.6.0 has been released which includes new schema