### PR TITLE
kustomizations: update replacements fields 

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -656,33 +656,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "PatchTargetOptional": {
-      "properties": {
-        "group": {
-          "type": "string"
-        },
-        "kind": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "namespace": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
-        },
-        "labelSelector": {
-          "type": "string"
-        },
-        "annotationSelector": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
     "PatchesOptions": {
       "properties": {
         "allowNameChange": {
@@ -705,7 +678,7 @@
           "type": "string"
         },
         "target": {
-          "$ref": "#/definitions/PatchTargetOptional",
+          "$ref": "#/definitions/Selector",
           "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
         }
       },
@@ -721,7 +694,7 @@
           "type": "string"
         },
         "target": {
-          "$ref": "#/definitions/PatchTargetOptional",
+          "$ref": "#/definitions/Selector",
           "description": "Refers to a Kubernetes object that the patch will be applied to. It must refer to a Kubernetes resource under the purview of this kustomization"
         }
       },
@@ -825,59 +798,14 @@
       "type": "object",
       "properties": {
         "select": {
-          "type": "object",
-          "description": "Include objects that match this",
-          "properties": {
-            "group": {
-              "type": "string",
-              "description": "The group of the referent"
-            },
-            "version": {
-              "type": "string",
-              "description": "The version of the referent"
-            },
-            "kind": {
-              "type": "string",
-              "description": "The kind of the referent"
-            },
-            "name": {
-              "type": "string",
-              "description": "The name of the referent"
-            },
-            "namespace": {
-              "type": "string",
-              "description": "The namespace of the referent"
-            }
-          }
+          "$ref": "#/definitions/Selector",
+          "description": "Include objects that match this"
         },
         "reject": {
           "type": "array",
           "description": "Exclude objects that match this",
           "items": {
-            "type": "object",
-            "description": "Exclude objects that match this",
-            "properties": {
-              "group": {
-                "type": "string",
-                "description": "The group of the referent"
-              },
-              "version": {
-                "type": "string",
-                "description": "The version of the referent"
-              },
-              "kind": {
-                "type": "string",
-                "description": "The kind of the referent"
-              },
-              "name": {
-                "type": "string",
-                "description": "The name of the referent"
-              },
-              "namespace": {
-                "type": "string",
-                "description": "The namespace of the referent"
-              }
-            }
+            "$ref": "#/definitions/Selector"
           }
         },
         "fieldPaths": {
@@ -962,6 +890,41 @@
         },
         "type": {
           "description": "Type of the secret, optional",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Selector": {
+      "description": "Selector specifies a set of resources.\nAny resource that matches intersection of all conditions is included in this set.",
+      "properties": {
+        "group": {
+          "description": "The group of the referent",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of the referent",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the referent",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace of the referent",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the referent",
+          "type": "string"
+        },
+        "annotationSelector": {
+          "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
+          "type": "string"
+        },
+        "labelSelector": {
+          "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api",
           "type": "string"
         }
       },

--- a/src/test/kustomization/replacements.json
+++ b/src/test/kustomization/replacements.json
@@ -17,12 +17,14 @@
           ],
           "reject": [
             {
+              "annotationSelector": "config.kubernetes.io/local-config=true",
               "kind": "Job",
               "name": "bye"
             }
           ],
           "select": {
             "kind": "Job",
+            "labelSelector": "environment=production,tier in (frontend, backend)",
             "name": "hello"
           }
         }


### PR DESCRIPTION
Added some missing fields on Replacements:

- It allow for a scalar source value as an alternative to the source field.
  See https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/#sourcevalue
- The selector format for both target.select and target.reject was missing `annotationSelector` and `labelSelector`.
  Since this format is the same as for patches.target, which already had a definition, I renamed the definition and reused it here.

Refactoring: Extract ReplacementsSource and ReplacementsTarget into definitions to avoid duplication and make the ReplacementsInline-definition easier to read.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
