### PR TITLE
feat: add helm-registry to Dependabot configuration

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1077,6 +1077,7 @@
                 "git",
                 "hex-organization",
                 "hex-repository",
+                "helm-registry",
                 "maven-repository",
                 "npm-registry",
                 "nuget-feed",


### PR DESCRIPTION
Dependabot now supports Helm registry as part of private registries.

[[goproxy-server](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#goproxy-server)](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#helm-registry)
