### PR TITLE
Add configuration for PNPM package.yaml

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4500,6 +4500,12 @@
       "url": "https://www.schemastore.org/package.json"
     },
     {
+      "name": "package.yaml",
+      "description": "PNPM configuration file",
+      "fileMatch": ["package.yaml"],
+      "url": "https://www.schemastore.org/package.json"
+    },
+    {
       "name": "package.manifest",
       "description": "Umbraco package configuration file",
       "fileMatch": ["package.manifest"],


### PR DESCRIPTION
PNPM lets you use package.yaml instead of package.json. 

It uses the same schema as package.json, so you can set it manually in vscode with this in settings.json - 

"yaml.schemas": {
  "https://json.schemastore.org/package.json": "package.yaml"  
}

So adding this config for package.yaml should allow it to apply automatically, at least when using RedHat's YAML extension.

From your docs - 

> The catalog.json file is generally used by IDEs and language servers to determine which schemas apply to what files. Specifically:
> VSCode ignores this file
> RedHat's YAML language server uses this file

