### PR TITLE
Fix intersecting Cargo.toml inherits types

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -265,7 +265,7 @@
     "Inherits": {
       "title": "Inherits",
       "description": "In addition to the built-in profiles, additional custom profiles can be defined.",
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "enum": ["dev", "test", "bench", "release"]


### PR DESCRIPTION
Certain validators, such as taplo, complain when `oneOf` entries overlap. Since a plain `string` already covers all the enum entries, we can just remove the latter.