### PR TITLE
feat(starcraft): use modern URLs for starcraft projects

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1130,7 +1130,7 @@
     },
     {
       "name": "Charmcraft",
-      "description": "Charmcraft project. Documentation: https://canonical-charmcraft.readthedocs-hosted.com",
+      "description": "Charmcraft project. Documentation: https://documentation.ubuntu.com/charmcraft/stable/",
       "fileMatch": ["charmcraft.yaml"],
       "url": "https://raw.githubusercontent.com/canonical/charmcraft/main/schema/charmcraft.json"
     },
@@ -5145,9 +5145,9 @@
       }
     },
     {
-      "name": "rockcraft",
-      "description": "rockcraft project. Documentation: https://canonical-rockcraft.readthedocs-hosted.com",
-      "fileMatch": ["rockcraft.yaml", "rockcraft.yml"],
+      "name": "Rockcraft",
+      "description": "Rockcraft project. Documentation: https://documentation.ubuntu.com/rockcraft/stable/",
+      "fileMatch": ["rockcraft.yaml"],
       "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
     },
     {
@@ -5480,10 +5480,10 @@
       "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/4.x.x/skyuxconfig-schema.json"
     },
     {
-      "name": "snapcraft",
-      "description": "snapcraft project. Documentation: https://snapcraft.io",
+      "name": "Snapcraft",
+      "description": "Snapcraft project. Documentation: https://documentation.ubuntu.com/snapcraft/stable/",
       "fileMatch": [".snapcraft.yaml", "snapcraft.yaml"],
-      "url": "https://raw.githubusercontent.com/snapcore/snapcraft/master/schema/snapcraft.json"
+      "url": "https://raw.githubusercontent.com/canonical/snapcraft/main/schema/snapcraft.json"
     },
     {
       "name": "snowflake-config",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Hello, this adds a bunch of small adjustments to the "Starcraft" family of products from Canonical. Notably, I reformatted some language and updated the URLs to their most modern counterparts. Thanks.