### PR TITLE
Update bunfig schema to support default test timeout

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -176,6 +176,14 @@
           "description": "Set path where coverage reports will be saved. Please notice, that it works only for persistent `coverageReporter` like `lcov`\nhttps://bun.sh/docs/runtime/bunfig#test-coveragedir",
           "type": "string",
           "default": "coverage"
+        },
+        "timeout": {
+          "$comment": "https://bun.com/docs/test/configuration#default-timeout",
+          "description": "Set the default timeout in milliseconds for all tests. This can be overridden by individual tests. Default `5000`\nhttps://bun.com/docs/test/configuration#default-timeout",
+          "type": "integer",
+          "minimum": 0,
+          "default": 5000,
+          "examples": [5000]
         }
       }
     },

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -77,3 +77,4 @@ coverageThreshold = 0.9
 preload = ["./setup.ts"]
 root = "./__tests__"
 smol = true
+timeout = 10000


### PR DESCRIPTION
Bun's test runner supports setting a [default timeout](https://bun.com/docs/test/configuration#default-timeout) value via `bunfig.toml`. Some of their documentation for this config file are spread across different pages, so I assume that's why it wasn't added here before.