### PR TITLE
Add `compilerOptions.moduleSuffixes` to tsconfig and jsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -413,6 +413,15 @@
               ],
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
+            "moduleSuffixes": {
+              "description": "List of file name suffixes to search when resolving a module.",
+              "type": ["array", "null"],
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of file name suffixes to search when resolving a module.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleSuffixes"
+            },
             "newLine": {
               "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -416,6 +416,15 @@
               ],
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
+            "moduleSuffixes": {
+              "description": "List of file name suffixes to search when resolving a module.",
+              "type": ["array", "null"],
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of file name suffixes to search when resolving a module.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleSuffixes"
+            },
             "newLine": {
               "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],


### PR DESCRIPTION
Looks like it is missing as it's documented in https://www.typescriptlang.org/tsconfig/#moduleSuffixes

And also in the typescript website's schema: https://github.com/microsoft/TypeScript-Website/blob/c2b25d220465dac34dd2da41a2a44cb30c6f42e4/packages/tsconfig-reference/scripts/schema/result/schema.json#L395

Additionally, here's a github search of public projects using this field: https://github.com/search?q=%2F%5B%5E%5C%2F%5D+%22moduleSuffixes%22%3A%2F+language%3AJSON&type=code