### PR TITLE
Add k8s EndpointSlice support to prometheus.json

### DIFF
--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -698,7 +698,14 @@
           "role": {
             "description": "The Kubernetes role of entities that should be discovered. One of endpoints, service, pod, node, or ingress.",
             "type": "string",
-            "enum": ["endpointslice", "endpoints", "service", "pod", "node", "ingress"]
+            "enum": [
+              "endpointslice",
+              "endpoints",
+              "service",
+              "pod",
+              "node",
+              "ingress"
+            ]
           },
           "kubeconfig_file": {
             "$ref": "#/definitions/filepath"


### PR DESCRIPTION
Adds the missing enum entry for k8s EndpointSlice support in prometheus.json.
https://prometheus.io/docs/prometheus/3.5/configuration/configuration/#endpointslice