### PR TITLE
pyproject: support for PEP 794

### DIFF
--- a/src/negative_test/pyproject/pep794-nonident.toml
+++ b/src/negative_test/pyproject/pep794-nonident.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "hi"
+version = "0.1.0"
+import-names = ["3three"]

--- a/src/negative_test/pyproject/pep794-nonprivate.toml
+++ b/src/negative_test/pyproject/pep794-nonprivate.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "hi"
+version = "0.1.0"
+import-names = ["three; other"]

--- a/src/negative_test/pyproject/pep794-space.toml
+++ b/src/negative_test/pyproject/pep794-space.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "hi"
+version = "0.1.0"
+import-names = ["three other"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -7,6 +7,13 @@
   "x-tombi-string-formats": ["email", "uri"],
   "additionalProperties": false,
   "definitions": {
+    "importNames": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][A-Za-z_0-9]*(?:\\.[A-Za-z_][A-Za-z_0-9]*)*(?:\\s*;\\s*private)?$"
+      }
+    },
     "projectAuthor": {
       "type": "object",
       "additionalProperties": false,
@@ -540,6 +547,30 @@
             }
           ]
         },
+        "import-names": {
+          "$ref": "#/definitions/importNames",
+          "description": "An array of strings specifying the import names that the project exclusively provides when installed.",
+          "markdownDescription": "An array of strings specifying the import names that the project exclusively provides when installed.",
+          "x-intellij-html-description": "An array of strings specifying the import names that the project exclusively provides when installed.",
+          "x-taplo": {
+            "links": {
+              "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#import-names"
+            }
+          },
+          "examples": [["my_package", "_internal ; private"]]
+        },
+        "import-namespaces": {
+          "$ref": "#/definitions/importNames",
+          "description": "An array of strings specifying the import names that the project provides when installed, but not exclusively.",
+          "markdownDescription": "An array of strings specifying the import names that the project provides when installed, but not exclusively.",
+          "x-intellij-html-description": "An array of strings specifying the import names that the project provides when installed, but not exclusively.",
+          "x-taplo": {
+            "links": {
+              "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#import-namespaces"
+            }
+          },
+          "examples": [["my_package", "_internal ; private"]]
+        },
         "dynamic": {
           "type": "array",
           "items": {
@@ -560,7 +591,9 @@
               "gui-scripts",
               "entry-points",
               "dependencies",
-              "optional-dependencies"
+              "optional-dependencies",
+              "import-names",
+              "import-namespaces"
             ]
           },
           "uniqueItems": true,
@@ -811,6 +844,32 @@
                 "type": "array",
                 "contains": {
                   "const": "optional-dependencies"
+                }
+              }
+            }
+          }
+        },
+        "import-names": {
+          "not": {
+            "required": ["dynamic"],
+            "properties": {
+              "dynamic": {
+                "type": "array",
+                "contains": {
+                  "const": "import-names"
+                }
+              }
+            }
+          }
+        },
+        "import-namespaces": {
+          "not": {
+            "required": ["dynamic"],
+            "properties": {
+              "dynamic": {
+                "type": "array",
+                "contains": {
+                  "const": "import-namespaces"
                 }
               }
             }

--- a/src/test/pyproject/pep794.toml
+++ b/src/test/pyproject/pep794.toml
@@ -1,0 +1,6 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "hi"
+version = "0.1.0"
+import-names = ["example", "something ; private", "_other;private"]
+import-namespaces = ["other", "more; private"]


### PR DESCRIPTION
Adding support for PEP 794.

See also https://github.com/pypa/packaging/pull/948, https://github.com/pypa/pyproject-metadata/pull/260, https://github.com/abravalheri/validate-pyproject/pull/271.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
