### PR TITLE
Update descriptions in tsconfig and jsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1095,16 +1095,16 @@
               "markdownDescription": "Enable importing .json files.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
-              "description": "Use the package.json `exports` field when resolving package imports.",
+              "description": "Use the package.json 'exports' field when resolving package imports.",
               "type": ["boolean", "null"],
               "default": false,
-              "markdownDescription": "Use the package.json `exports` field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
+              "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
-              "description": "Use the package.json `imports` field when resolving imports.",
+              "description": "Use the package.json 'imports' field when resolving imports.",
               "type": ["boolean", "null"],
               "default": false,
-              "markdownDescription": "Use the package.json `imports` field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
+              "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1104,16 +1104,16 @@
               "markdownDescription": "Enable importing .json files.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
-              "description": "Use the package.json `exports` field when resolving package imports.",
+              "description": "Use the package.json 'exports' field when resolving package imports.",
               "type": ["boolean", "null"],
               "default": false,
-              "markdownDescription": "Use the package.json `exports` field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
+              "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
-              "description": "Use the package.json `imports` field when resolving imports.",
+              "description": "Use the package.json 'imports' field when resolving imports.",
               "type": ["boolean", "null"],
               "default": false,
-              "markdownDescription": "Use the package.json `imports` field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
+              "markdownDescription": "Use the package.json 'imports' field when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonImports"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",


### PR DESCRIPTION
Update the descriptions (and `markdownDescription`) in `tsconfig.json` and `jsconfig.json`.

I wrote [a script](https://gist.github.com/bluwy/f776bc97c78cbbddada9390e6172fb30) to automate this based on latest TypeScript (v5.9.3) and manually reviewed for correctness. Change summary:

- Uses descriptions from TypeScript's [diagnostic messages](https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json), which results in:
  - Up-to-date behaviour descriptions.
  - More consistent period/full-stop usage.
- Automation script:
  - Normalizes backticks usage
  - Adds missing typescript docs links

---


### Notes

- I found this while comparing between TypeScript-Website's [own schema](https://github.com/microsoft/TypeScript-Website/blob/fdbf8d2a61a1bf2fffcccfe44566fc01dbdfbce5/packages/tsconfig-reference/scripts/schema/result/schema.json).
- I didn't update the descriptions in the top-level `files`, `include` etc as it doesn't seem to be documented in TypeScript's diagnostics directly. But it could be possible to normalize the backticks and documentation links. I'll leave those as a separate PR next time though so it's easier to review.