### PR TITLE
feat: add Airbyte's file formats: `metadata.yaml` and `manifest.yaml`

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7709,7 +7709,6 @@
       "name": "Airbyte Declarative Connectors Specification (manifest.yaml)",
       "description": "Airbyte Specification for custom connectors",
       "fileMatch": [
-        "manifest.yaml",
         "source-*-manifest.yaml",
         "destination-*-manifest.yaml",
         "**/source-*/manifest.yaml",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR adds two Airbyte yaml file formats to the SchemaStore.org JSON Schema registry:

- `metadata.yaml` - Airbyte's standard format for describing connector metadata.
- `manifest.yaml` - Airbyte's standard format for describing defining source connector interfaces directly in YAML.

