### PR TITLE
Python pytest: add 'legacy' alias for xunit1 to junit_family parameter

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -112,7 +112,7 @@
         },
         "junit_family": {
           "type": "string",
-          "enum": ["xunit1", "xunit2"],
+          "enum": ["legacy", "xunit1", "xunit2"],
           "description": "Sets format of generated JUnit XML files.",
           "default": "xunit2"
         },


### PR DESCRIPTION
For `junit_family`, `legacy` is a documented alias of `xunit1`.
CodeCov's docs tell you to use this alias.

Docs showing alias: https://docs.pytest.org/en/stable/reference/reference.html#confval-junit_family
CodeCov docs using the `legacy` value: https://docs.codecov.com/docs/test-analytics#2-output-a-junit-xml-file