### PR TITLE
Remove Knip TypeScript and JavaScript extensions

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2549,12 +2549,7 @@
     {
       "name": "Knip",
       "description": "Knip configuration files",
-      "fileMatch": [
-        "knip.json",
-        ".knip.json",
-        "knip.jsonc",
-        ".knip.jsonc",
-      ],
+      "fileMatch": ["knip.json", ".knip.json", "knip.jsonc", ".knip.jsonc"],
       "url": "https://unpkg.com/knip@5/schema.json"
     },
     {


### PR DESCRIPTION
TypeScript and JavaScript files can’t be validated with JSON schema.