### PR TITLE
uv: "all" in dependency group parsing not properly recognized

### DIFF
--- a/src/schemas/json/uv.json
+++ b/src/schemas/json/uv.json
@@ -733,7 +733,7 @@
         {
           "description": "All groups are defaulted",
           "type": "string",
-          "const": "All"
+          "const": "all"
         },
         {
           "description": "A list of groups",


### PR DESCRIPTION
Attempt to fix #5098 

According to the docs ([Default groups](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups)) ,"all" should be a valid argument to include all groups. Optionally, one can list all group names individually.

"all" is not recognized as valid input. However, the capital version "All" is, which in turn is not a valid argument and will fail config parsing.