### PR TITLE
Fix broken `tool.uv.default-groups` schema

### DIFF
--- a/src/schemas/json/uv.json
+++ b/src/schemas/json/uv.json
@@ -733,21 +733,14 @@
         {
           "description": "All groups are defaulted",
           "type": "string",
-          "const": "All"
+          "const": "all"
         },
         {
           "description": "A list of groups",
-          "type": "object",
-          "properties": {
-            "List": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/GroupName"
-              }
-            }
-          },
-          "additionalProperties": false,
-          "required": ["List"]
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupName"
+          }
         }
       ]
     },


### PR DESCRIPTION
The uv schema (found for `uv.toml` and `pyproject.toml`) had a broken layout for the `tool.uv.default-groups` key, compared to the configuration format required by the uv executable at runtime.