### PR TITLE
Add Gemini CLI settings schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2629,6 +2629,16 @@
       "url": "https://www.schemastore.org/gcp-blueprint-metadata.json"
     },
     {
+      "name": "Gemini CLI settings",
+      "description": "Configuration for Gemini CLI settings files",
+      "fileMatch": [
+        "**/.gemini/settings.json",
+        "**/gemini-cli/settings.json",
+        "**/GeminiCli/settings.json"
+      ],
+      "url": "https://raw.githubusercontent.com/google-gemini/gemini-cli/refs/heads/main/schemas/settings.schema.json"
+    },
+    {
       "name": "Global Privacy Control",
       "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control",
       "fileMatch": ["**/.well-known/gpc.json"],


### PR DESCRIPTION
## Summary
- add Gemini CLI settings schema entry referencing the upstream Gemini CLI settings definition

## Testing
- node ./cli.js check