### PR TITLE
Add the schema of bacon configuration files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5,10 +5,7 @@
     {
       "name": "Bacon config",
       "description": "Bacon configuration file",
-      "fileMatch": [
-        "bacon.toml",
-        "**/bacon/prefs.toml"
-      ],
+      "fileMatch": ["bacon.toml", "**/bacon/prefs.toml"],
       "url": "https://dystroy.org/bacon/.bacon.schema.json"
     },
     {


### PR DESCRIPTION
Bacon tool is at https://dystroy.org/bacon/

The same site hosts the schema file, which is updated at every release

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
