### PR TITLE
fix: update QType AI DSL schema URL to point to bazaarvoice

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4988,7 +4988,7 @@
       "name": "QType AI DSL",
       "description": "A DSL for rapid prototyping of AI applications",
       "fileMatch": ["qtype.config.yaml", "*.qtype.yaml"],
-      "url": "https://raw.githubusercontent.com/lou-k/qtype/refs/heads/main/schema/qtype.schema.json"
+      "url": "https://raw.githubusercontent.com/bazaarvoice/qtype/refs/heads/main/schema/qtype.schema.json"
     },
     {
       "name": "Railway",


### PR DESCRIPTION
Bazaarvoice is now sponsoring this project and all future schemas will be published under their github