### PR TITLE
cibuildwheel: update to 3.3.0

### DIFF
--- a/src/schemas/json/partial-cibuildwheel.json
+++ b/src/schemas/json/partial-cibuildwheel.json
@@ -538,6 +538,37 @@
       ],
       "title": "CIBW_TEST_ENVIRONMENT"
     },
+    "test-runtime": {
+      "description": "Additional configuration for the test runner",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^$"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "pattern": "args:"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["args"],
+          "properties": {
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ],
+      "title": "CIBW_TEST_RUNTIME"
+    },
     "overrides": {
       "type": "array",
       "description": "An overrides array",
@@ -604,6 +635,9 @@
                 "$ref": "#/$defs/inherit"
               },
               "test-environment": {
+                "$ref": "#/$defs/inherit"
+              },
+              "test-runtime": {
                 "$ref": "#/$defs/inherit"
               }
             }
@@ -715,6 +749,9 @@
           },
           "test-environment": {
             "$ref": "#/properties/test-environment"
+          },
+          "test-runtime": {
+            "$ref": "#/properties/test-runtime"
           }
         }
       }
@@ -843,6 +880,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     },
@@ -903,6 +943,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     },
@@ -976,6 +1019,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     },
@@ -1036,6 +1082,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     },
@@ -1096,6 +1145,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     },
@@ -1156,6 +1208,9 @@
         },
         "test-environment": {
           "$ref": "#/properties/test-environment"
+        },
+        "test-runtime": {
+          "$ref": "#/properties/test-runtime"
         }
       }
     }


### PR DESCRIPTION
Rerendering (with `uv run bin/generate_schema.py --schemastore`) from the latest release of cibuildwheel.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
