### PR TITLE
Add support for railpack.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4998,6 +4998,12 @@
       "url": "https://railway.com/railway.schema.json"
     },
     {
+      "name": "Railpack",
+      "description": "Configuration file for Railpack deployment tool",
+      "fileMatch": ["railpack.json"],
+      "url": "https://schema.railpack.com"
+    },
+    {
       "name": "Rattler-build",
       "description": "Rattler-build recipe",
       "fileMatch": ["recipe.yaml", "recipe.yml"],


### PR DESCRIPTION
- Register Railpack schema in catalog with railpack.json file pattern
- Point to external schema hosted at https://schema.railpack.com

Railpack is a deployment tool that uses railpack.json for build and deploy configuration. The schema is maintained by Railpack at https://schema.railpack.com Reference: https://railpack.com/config/file/