### PR TITLE
chore: relax pytest ini schema

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -60,14 +60,28 @@
           "default": ".pytest_cache"
         },
         "collect_imported_tests": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Settings this to false will make pytest collect classes/functions from test files _only_ if they are defined in that file (as opposed to imported there).",
           "default": "true"
         },
         "consider_namespace_packages": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Controls if pytest should attempt to identify namespace packages when collecting Python modules.",
           "default": "false"
         },
@@ -84,8 +98,15 @@
           "default": "progress"
         },
         "disable_test_id_escaping_and_forfeit_all_rights_to_community_support": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "pytest by default escapes any non-ascii characters used in unicode strings for the parametrization because it has several downsides. If however you would like to use unicode strings in parametrization and see them in the terminal as is (non-escaped), use this option in your configuration file",
           "default": "false"
         },
@@ -115,20 +136,42 @@
           "default": "skip"
         },
         "enable_assertion_pass_hook": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Enables the pytest_assertion_pass hook. Make sure to delete any previously generated .pyc cache files.",
           "default": "false"
         },
         "faulthandler_exit_on_timeout": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Exit the pytest process after the per-test timeout is reached by passing exit=True to the faulthandler.dump_traceback_later() function. This is particularly useful to avoid wasting CI resources for test suites that are prone to putting the main Python interpreter into a deadlock state.",
           "default": "false"
         },
         "faulthandler_timeout": {
-          "type": "string",
-          "pattern": "^[0-9]+$",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            }
+          ],
           "description": "Dumps the tracebacks of all threads if a test takes longer than X seconds to run (including fixture setup and teardown). Implemented using the faulthandler.dump_traceback_later() function, so all caveats there apply."
         },
         "filterwarnings": {
@@ -159,8 +202,15 @@
           "default": "xunit2"
         },
         "junit_log_passing_tests": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If junit_logging is enabled, configures if the captured output should be written to the JUnit XML file for passing tests.",
           "default": "true"
         },
@@ -184,12 +234,23 @@
             {
               "type": "string",
               "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
             }
           ]
         },
         "log_cli": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Enable log display during test run (also known as \"live logging\").",
           "default": "false"
         },
@@ -352,32 +413,67 @@
           "x-tombi-array-values-order": "ascending"
         },
         "strict": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If set to true, enable 'strict mode', which enables a number of other strict options.",
           "default": "false"
         },
         "strict_config": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If set to true, any warnings encountered while parsing the pytest section of the configuration file will raise errors.",
           "default": "false"
         },
         "strict_markers": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If set to true, markers not registered in the markers section of the configuration file will raise errors.",
           "default": "false"
         },
         "strict_parametrization_ids": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If set to true, pytest emits an error if it detects non-unique parameter set IDs. If not set (the default), pytest automatically handles this by adding 0, 1, … to duplicate IDs, making them unique.",
           "default": "false"
         },
         "strict_xfail": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "If set to true, tests marked with @pytest.mark.xfail that actually succeed will by default fail the test suite.",
           "default": "false"
         },
@@ -397,8 +493,16 @@
           "x-tombi-array-values-order": "ascending"
         },
         "tmp_path_retention_count": {
-          "type": "string",
-          "pattern": "^[0-9]+$",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            }
+          ],
           "description": "How many sessions should we keep the tmp_path directories, according to tmp_path_retention_policy.",
           "default": "3"
         },
@@ -409,14 +513,30 @@
           "default": "all"
         },
         "truncation_limit_chars": {
-          "type": "string",
-          "pattern": "^[0-9]+$",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            }
+          ],
           "description": "Controls maximum number of characters to truncate assertion message contents. Setting value to 0 disables the character limit for truncation.",
           "default": "640"
         },
         "truncation_limit_lines": {
-          "type": "string",
-          "pattern": "^[0-9]+$",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
+            }
+          ],
           "description": "Controls maximum number of linesto truncate assertion message contents. Setting value to 0 disables the lines limit for truncation.",
           "default": "8"
         },
@@ -442,6 +562,10 @@
               "pattern": "^[0-9]+$"
             },
             {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
               "type": "string",
               "enum": ["auto"]
             }
@@ -453,6 +577,10 @@
             {
               "type": "string",
               "pattern": "^[0-9]+$"
+            },
+            {
+              "type": "integer",
+              "minimum": 0
             },
             {
               "type": "string",
@@ -468,6 +596,10 @@
               "pattern": "^[0-9]+$"
             },
             {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
               "type": "string",
               "enum": ["auto"]
             }
@@ -475,8 +607,15 @@
           "description": "Set a verbosity level specifically for test case execution related output, overriding the application wide level."
         },
         "xfail_strict": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "DEPRECATED. Alias for strict_xfail. If true, test suite will fail if a test marked with `@pytest.mark.xfail` unexpectedly passes.",
           "deprecated": true,
           "default": "false"
@@ -503,8 +642,15 @@
           "default": "function"
         },
         "asyncio_debug": {
-          "type": "string",
-          "enum": ["true", "false"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "boolean"
+            }
+          ],
           "description": "Enables asyncio debug mode for the default event loop used by asynchronous tests and fixtures.",
           "default": "false"
         },


### PR DESCRIPTION
The Pytest docs make it clear that only strings and arrays of strings are supported, and anything else is converted into a string.

This relaxes some common types which should be safe to implicitly convert to a string.

See discussion in #5121