### PR TITLE
Add missing mypy options: strict_equality_for_none and fixed_format_cache

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -401,6 +401,13 @@
       "default": false,
       "type": "boolean"
     },
+    "strict_equality_for_none": {
+      "description": "Include `None` in strict equality checks. Requires `strict_equality` to be activated.",
+      "markdownDescription": "Include `None` in strict equality checks. Requires `strict_equality` to be activated.\n\nhttps://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_equality_for_none",
+      "x-intellij-html-description": "Include <code>None</code> in strict equality checks. Requires <code>strict_equality</code> to be activated.",
+      "default": false,
+      "type": "boolean"
+    },
     "strict": {
       "description": "Enable all optional error checking flags. You can see the list of flags enabled by strict mode in the full `mypy --help` output. The exact list of flags enabled by `strict` may change over time.",
       "x-intellij-html-description": "Enable all optional error checking flags. You can see the list of flags enabled by strict mode in the full <code>mypy --help</code> output. The exact list of flags enabled by <code>strict</code> may change over time.",
@@ -488,6 +495,13 @@
     },
     "skip_cache_mtime_checks": {
       "description": "Skip cache internal consistency checks based on mtime.",
+      "default": false,
+      "type": "boolean"
+    },
+    "fixed_format_cache": {
+      "description": "Use a new experimental cache format for faster incremental builds. Makes incremental builds up to twice as fast. This is experimental and currently only supported when using a compiled version of mypy.",
+      "markdownDescription": "Use a new experimental cache format for faster incremental builds. Makes incremental builds up to twice as fast. This is experimental and currently only supported when using a compiled version of mypy.\n\nhttps://mypy.readthedocs.io/en/stable/config_file.html#confval-fixed_format_cache",
+      "x-intellij-html-description": "Use a new experimental cache format for faster incremental builds. Makes incremental builds up to twice as fast. This is experimental and currently only supported when using a compiled version of mypy.",
       "default": false,
       "type": "boolean"
     },
@@ -763,6 +777,9 @@
           "strict_equality": {
             "$ref": "#/properties/strict_equality"
           },
+          "strict_equality_for_none": {
+            "$ref": "#/properties/strict_equality_for_none"
+          },
           "strict_bytes": {
             "$ref": "#/properties/strict_bytes"
           },
@@ -816,6 +833,9 @@
           },
           "skip_cache_mtime_checks": {
             "$ref": "#/properties/skip_cache_mtime_checks"
+          },
+          "fixed_format_cache": {
+            "$ref": "#/properties/fixed_format_cache"
           },
           "plugins": {
             "$ref": "#/properties/plugins"

--- a/src/test/pyproject/mypy-01.toml
+++ b/src/test/pyproject/mypy-01.toml
@@ -9,6 +9,8 @@ exclude = [
   '^file1\.py$',  # TOML literal string (single-quotes, no escaping necessary)
   "^file2\\.py$", # TOML basic string (double-quotes, backslash and other characters need escaping)
 ]
+strict_equality_for_none = true
+fixed_format_cache = true
 
 # mypy per-module options:
 


### PR DESCRIPTION
## Summary

This PR adds two missing mypy configuration options that were introduced in mypy 1.18.1:

- `strict_equality_for_none`: Include `None` in strict equality checks. Requires `strict_equality` to be activated.
- `fixed_format_cache`: Use new experimental cache format for faster incremental builds.

## Context

These options are currently missing from the schema, causing validation errors when using [validate-pyproject-schema-store](https://github.com/henryiii/validate-pyproject-schema-store):

```
[ERROR] tool.mypy must not contain {'fixed_format_cache', 'strict_equality_for_none'} properties
```

## Changes

1. **Updated `src/schemas/json/partial-mypy.json`:**
   - Added `strict_equality_for_none` property with full documentation
   - Added `fixed_format_cache` property with full documentation
   - Added both properties to the overrides section for per-module configuration support

2. **Updated `src/test/pyproject/mypy-01.toml`:**
   - Added test examples for both new options to ensure they validate correctly

## Documentation

Both options include:
- Standard `description` field
- `markdownDescription` with link to official mypy documentation
- `x-intellij-html-description` for IntelliJ IDE support
- Proper default values (`false`)

## Testing

- ✅ Schema validation passed: `node ./cli.js check --schema-name=partial-mypy.json`
- ✅ Prettier formatting applied
- ✅ Pre-commit hooks passed

## References

- Fixes #4987 and #5015
- Related issue: https://github.com/henryiii/validate-pyproject-schema-store/issues/106
- Mypy documentation:
  - https://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_equality_for_none
  - https://mypy.readthedocs.io/en/stable/config_file.html#confval-fixed_format_cache