### PR TITLE
feat: add src/schema-validation.jsonc CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 # the repo, unless a later match takes precedence.
 * @madskristensen @hyperupcall
 
+src/schema-validation.jsonc @ssbarnea @webknjaz @CircleCI-Public/developer-experience @meeech @gordonsyme @skoch13 @andrey-skl @zmaks @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj @VCecileKefelian @pandatix @NicoFgrx @ya7010 @chrissimon-au @danielbayley @btea @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi @domdomegg @bogini @ianmacartney @thomasballinger @Nicolapps
+
 # Managed by Ansible DevTools Team members:
 src/schemas/json/ansible-* @ssbarnea @webknjaz
 src/test/ansible-* @ssbarnea @webknjaz


### PR DESCRIPTION
`schema-validation.jsonc` may require simultaneous modifications when enforcing strict schema validation(See https://github.com/SchemaStore/schemastore/pull/5141).

This prevents code owners for specific domains from merging code they should otherwise be able to approve.

Therefore, I would like to update the target files for code owners.