### PR TITLE
Fix url from venvironment schema (should point to the new 4.2 version)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6273,7 +6273,7 @@
         "venvironment.json",
         "*.venvironment.json"
       ],
-      "url": "https://www.schemastore.org/venvironment-schema-v4.1.0.json",
+      "url": "https://www.schemastore.org/venvironment-schema-v4.2.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/venvironment-schema-v1.0.0.json",
         "1.1.0": "https://www.schemastore.org/venvironment-schema-v1.1.0.json",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
