### PR TITLE
Fix minItems for commitlint rules

### DIFF
--- a/src/schemas/json/commitlintrc.json
+++ b/src/schemas/json/commitlintrc.json
@@ -22,7 +22,7 @@
               "description": "Value: the value for this rule"
             }
           ],
-          "minItems": 2,
+          "minItems": 1,
           "maxItems": 3,
           "additionalItems": false
         }


### PR DESCRIPTION
This appears to have been changed upstream some time ago:

https://github.com/conventional-changelog/commitlint/blob/b751b2999756c650b4b6131f99caa2c939d0a34b/%40commitlint/config-validator/src/commitlint.schema.json#L25

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
