### PR TITLE
update descriptions in `popxf-1.0.json` schema

### DIFF
--- a/src/schemas/json/popxf-1.0.json
+++ b/src/schemas/json/popxf-1.0.json
@@ -107,7 +107,7 @@
       "properties": {
         "observable_names": {
           "type": "array",
-          "description": "Array of $M$ names identifying each observable. Must be an array of unique, non-empty strings, with at least one entry.",
+          "description": "Array of $M$ names identifying each observable $O_m$. Must be an array of unique, non-empty strings, with at least one entry.",
           "minItems": 1,
           "items": {
             "type": "string",
@@ -128,7 +128,7 @@
             "minLength": 1
           },
           "uniqueItems": true,
-          "description": "Array of model parameters (e.g., Wilson coefficient names) used in the polynomial expansion. Must be an array of unique, non-empty strings, with at least one entry.",
+          "description": "Array of $S$ names identifying each model parameter $C_s$ (e.g., Wilson coefficient names). Must be an array of unique, non-empty strings, with at least one entry. In general, this includes $S_\\mathbb{R}$ real-valued and $S_\\mathbb{C}$ complex-valued parameters with $S = S_\\mathbb{R} + S_\\mathbb{C}$. The real-valued parameters and the real and imaginary parts of the complex-valued parameters are used as the $R=S_\\mathbb{R} + 2\\ S_\\mathbb{C}$ independent variables of all polynomial terms and can be grouped together in a real-valued parameter vector $\\vec{C}$ of length $R$.",
           "examples": [
             {
               "parameters": ["C1", "C2", "C3"]
@@ -197,7 +197,7 @@
             "minLength": 1
           },
           "uniqueItems": true,
-          "description": "*This field is required to express observables as functions of polynomials. It requires the simultaneous presence of `metadata.observable_expressions` and `data.polynomial_central`.*\n\nArray of names identifying the individual polynomials that enter the observable predictions through the functions defined in `metadata.observable_expressions`. Must contain unique, non-empty strings.",
+          "description": "*This field is required to express observables as functions of polynomials. It requires the simultaneous presence of `metadata.observable_expressions` and `data.polynomial_central`.*\n\nArray of $K$ names identifying the individual polynomials $P_k$ that enter the observable predictions through the functions defined in `metadata.observable_expressions` (see below). Must contain unique, non-empty strings.",
           "examples": [
             {
               "polynomial_names": ["polynomial 1", "polynomial 2"]
@@ -224,7 +224,7 @@
               "expression": {
                 "type": "string",
                 "minLength": 1,
-                "description": "A Python-compatible mathematical expression using the dummy variable names defined in `variables`, e.g. `\"num/den\"`. Standard mathematical functions like `sqrt` or `cos` that are implemented in packages like `numpy` may be used."
+                "description": "A Python-compatible mathematical expression using the variable names defined in `variables`, e.g. `\"num/den\"`. Standard mathematical functions like `sqrt` or `cos` that are implemented in packages like `numpy` may be used."
               }
             },
             "required": ["variables", "expression"],
@@ -258,7 +258,7 @@
               "items": { "type": "number" }
             }
           ],
-          "description": "The renormalisation scale in GeV at which the parameter vector $\\vec{C}$, the polynomial coefficients $\\vec p_k$, and the observable coefficients $\\vec o_m$ are defined. The parameter vector $\\vec{C}$ that enters a given polynomial $P_k$ or observable $O_m$ has to be given at the same scale at which the polynomial coefficients $\\vec{p}_k$ or observable coefficients $\\vec{o}_m$ are defined, such that the polynomial or observable itself is scale-independent up to higher-order corrections in perturbation theory.\n\nThis field can take one of two forms:\n\n- **single number**: A common scale $\\mu$ at which all polynomial coefficients $\\vec p_k$ or observable coefficients $\\vec o_m$ are defined.\n\n  - If the observables $O_m$ are expressed in terms of polynomials $P_k$, the polynomials are functions of the parameters evolved to the common scale $\\mu$:\n\n    $$P_k = a_{k} + \\vec{C}(\\mu) \\cdot \\vec{b}_{k}(\\mu) + \\dots\\ $$\n\n  - If the observables $O_m$ are themselves polynomials, they are themselves functions of the parameters evolved to the common scale $\\mu$:\n\n    $$O_m = a_m + \\vec{C}(\\mu) \\cdot \\vec{b}_m(\\mu) + \\dots\\ $$\n\n- **array of numbers**: An array defining separate scales $\\mu_k$ of polynomial coefficients $\\vec p_k$  if `metadata.polynomial_names` is present, or separate scales $\\mu_m$ of observable coefficients $\\vec o_m$ if `metadata.polynomial_names` is absent.\n\n  - If `metadata.polynomial_names` is present, the observables $O_m$ are expressed in terms of polynomials $P_k$ and each polynomial is a function of the parameters evolved to its corresponding scale $\\mu_k$:\n\n    $$P_k = a_{k} + \\vec{C}(\\mu_k) \\cdot \\vec{b}_{k}(\\mu_k) + \\dots\\ $$\n\n    The length and order of the array defining the scales $\\mu_k$ must match those of the field `metadata.polynomial_names`. To avoid ambiguities, the following restrictions apply to this case:\n\n    - `data.observable_central` must be absent;\n    - `data.observable_uncertainties` must be absent or only define uncertainties for the parameter-independent terms (i.e. only the SM uncertainties in EFT applications).\n  - If `metadata.polynomial_names` is absent, the observables $O_m$ are themselves polynomials and each observable is a function of the parameters evolved to its corresponding scale $\\mu_m$:\n\n    $$O_m = a_m + \\vec{C}(\\mu_m) \\cdot \\vec{b}_m(\\mu_m) + \\dots\\ $$\n\n    The length and order of the array defining the scales $\\mu_m$ must match those of the field `metadata.observable_names`.",
+          "description": "The renormalisation scale in GeV at which the parameter vector $\\vec{C}$, the polynomial coefficients ${\\vec{p}_k \\supset \\vec{b}_k, \\vec{c}_k, ...}$, and the observable coefficients ${\\vec{o}_m \\supset \\vec{b}_m, \\vec{c}_m, ...}$ and their uncertainties $\\vec{\\sigma}_m$ are defined. The parameter vector $\\vec{C}$ that enters a given polynomial $P_k$ or observable $O_m$ has to be given at the same scale at which the polynomial coefficients $\\vec{p}_k$ or observable coefficients $\\vec{o}_m$ are defined, such that the polynomial or observable itself is scale-independent up to higher-order corrections in perturbation theory.\n\nThis field can take one of two forms:\n\n- **single number**: A common scale $\\mu$ at which all polynomial coefficients $\\vec p_k$ or observable coefficients $\\vec o_m$ are defined.\n\n  - If the observables $O_m$ are expressed in terms of polynomials $P_k$, the polynomials are functions of the parameters evolved to the common scale $\\mu$:\n\n    $$P_k = a_{k} + \\vec{C}(\\mu) \\cdot \\vec{b}_{k}(\\mu) + \\dots\\ $$\n\n  - If the observables $O_m$ are themselves polynomials, they are themselves functions of the parameters evolved to the common scale $\\mu$:\n\n    $$O_m = a_m + \\vec{C}(\\mu) \\cdot \\vec{b}_m(\\mu) + \\dots\\ $$\n\n- **array of numbers**: An array defining separate scales $\\mu_k$ of polynomial coefficients $\\vec p_k$  if `metadata.polynomial_names` is present, or separate scales $\\mu_m$ of observable coefficients $\\vec o_m$ if `metadata.polynomial_names` is absent.\n\n  - If `metadata.polynomial_names` is present, the observables $O_m$ are expressed in terms of polynomials $P_k$ and each polynomial is a function of the parameters evolved to its corresponding scale $\\mu_k$:\n\n    $$P_k = a_{k} + \\vec{C}(\\mu_k) \\cdot \\vec{b}_{k}(\\mu_k) + \\dots\\ $$\n\n    The length and order of the array defining the scales $\\mu_k$ must match those of the field `metadata.polynomial_names`. To avoid ambiguities, the following restrictions apply to this case:\n\n    - `data.observable_central` must be absent;\n    - `data.observable_uncertainties` must be absent or only define uncertainties for the parameter-independent terms (i.e. only the SM uncertainties in EFT applications).\n  - If `metadata.polynomial_names` is absent, the observables $O_m$ are themselves polynomials and each observable is a function of the parameters evolved to its corresponding scale $\\mu_m$:\n\n    $$O_m = a_m + \\vec{C}(\\mu_m) \\cdot \\vec{b}_m(\\mu_m) + \\dots\\ $$\n\n    The length and order of the array defining the scales $\\mu_m$ must match those of the field `metadata.observable_names`.",
           "examples": [
             {
               "scale": 91.1876
@@ -519,29 +519,8 @@
     "data": {
       "type": "object",
       "title": "`data` Field",
-      "description": "The `data` field contains the numerical representation of the observable predictions. This information is provided in terms of central values and uncertainties of polynomial coefficients, which are associated either directly with observables or with named polynomials on which the observables depend.\n\nEach polynomial coefficient is labelled by a *monomial key*, written as a stringified tuple of model parameters (e.g., Wilson coefficients) defined in the `metadata` field `parameters`. For example, the key `\"('C1', 'C2')\":` corresponds to the monomial $C_1 C_2$. While the model parameters can be complex numbers, the polynomial coefficients are defined for the real and imaginary parts of the model parameters (see below) and are therefore strictly real. The format and conventions for monomial keys are as follows:\n\n- Each key is a string representation of a Python-style tuple: a comma-separated array of strings enclosed in parentheses.\n- The length of the tuple is determined by the polynomial degree $k$, as defined by the `metadata` field `polynomial_degree` (default value: $k=2$, i.e. quadratic polynomial, if `polynomial_degree` is omitted). The tuple length equals $k$, unless a real/imaginary tag is included (see below), in which case the length is $k+1$.\n- The first $k$ entries in the tuple are model parameter names, as defined in the `metadata` field `parameters`. These names must be sorted alphabetically to ensure unique monomial keys (assuming the same sorting rules as Python's `sort()` method which sorts alphabetically according to ASCII or UNICODE-value, where upper case comes before lower case, and shorter strings take precedence). Empty strings `''` are used to represent constant terms (equivalent to $1$) and to pad monomials of lower degree. For example, for a quadratic polynomial in real parameters (see below for how complex parameters are handled):\n  - A constant $1$ is written as `\"('','')\"`,\n  - A linear term $C_1$ is written as `\"('', 'C1')\"`,\n  - A quadratic term $C_1 C_2$ is written as `\"('C1', 'C2')\"`.\n- To handle complex parameters, the tuple may optionally include a real/imaginary tag as its final element. This tag consists of `R` (real) and `I` (imaginary) characters, and its length must match the polynomial degree $k$. It indicates whether each parameter refers to its real or imaginary part. For example:\n  - `\"('', 'C1', 'RI')\"` corresponds to $\\mathrm{Im}(C_1)$;\n  - `\"('C1', 'C2', 'IR')\"` corresponds to $\\mathrm{Im}(C_1)\\mathrm{Re}(C_2)$.\n- If the real/imaginary tag is omitted, the parameters are assumed to be real. For example:\n  - `\"('', 'C1')\"` corresponds to $\\mathrm{Re}(C_1)$;\n  - `\"('C1', 'C2')\"` corresponds to $\\mathrm{Re}(C_1)\\mathrm{Re}(C_2)$.\n\nThese conventions ensure a canonical and unambiguous representation of polynomial terms while offering flexibility in the naming of model parameters. Missing monomials are implicitly treated as having zero coefficients.\n\n The `data` field is a `JSON` object with the following subfields:",
+      "description": "The `data` field contains the numerical representation of all polynomial terms, which define the polynomials $P_k$ and observables $O_m$. This information is provided in terms of central values of polynomial coefficients $\\vec{p}_k$ and observable coefficients $\\vec{o}_m$, and uncertainties of observable coefficients $\\vec{\\sigma}_m$.\n\nEach component of $\\vec{o}_m$, $\\vec{p}_k$, and $\\vec{\\sigma}_m$ is labelled by a *monomial key*, written as a stringified tuple of model parameters (e.g., Wilson coefficients) defined in `metadata.parameters`. For example, the key `\"('C1', 'C2')\"` corresponds to the monomial $C_1 C_2$. While the model parameters can be complex numbers, the monomials are defined for the real and imaginary parts of the model parameters (see below) and are therefore strictly real. The format and conventions for monomial keys are as follows:\n\n- Each key is a string representation of a Python-style tuple: a comma-separated array of strings enclosed in parentheses.\n- The length of the tuple is determined by the polynomial degree $d$, as defined by the `metadata` field `polynomial_degree` (default value: $d=2$, i.e. quadratic polynomial, if `polynomial_degree` is omitted). The tuple length equals $d$, unless a real/imaginary tag is included (see below), in which case the length is $d+1$.\n- The first $d$ entries in the tuple are model parameter names, as defined in the `metadata` field `parameters`. These names must be sorted alphabetically to ensure unique monomial keys (assuming the same sorting rules as Python's `sort()` method which sorts alphabetically according to ASCII or UNICODE-value, where all upper-case letters come before all lower-case letters, and shorter strings take precedence). Empty strings `''` are used to represent constant terms (equivalent to $1$) and to pad monomials of lower degree. For example, for a quadratic polynomial in real parameters (see below for how complex parameters are handled):\n  - A constant $1$ is written as `\"('','')\"`,\n  - A linear term $C_1$ is written as `\"('', 'C1')\"`,\n  - A quadratic term $C_1 C_2$ is written as `\"('C1', 'C2')\"`.\n- To handle complex parameters, the tuple may optionally include a real/imaginary tag as its final element. This tag consists of `R` (real) and `I` (imaginary) characters, and its length must match the polynomial degree $d$. It indicates whether each parameter refers to its real or imaginary part. For example:\n  - `\"('', 'C1', 'RI')\"` corresponds to $\\mathrm{Im}(C_1)$;\n  - `\"('C1', 'C2', 'IR')\"` corresponds to $\\mathrm{Im}(C_1)\\mathrm{Re}(C_2)$.\n- If the real/imaginary tag is omitted, the parameters are assumed to be real. For example:\n  - `\"('', 'C1')\"` corresponds to $\\mathrm{Re}(C_1)$;\n  - `\"('C1', 'C2')\"` corresponds to $\\mathrm{Re}(C_1)\\mathrm{Re}(C_2)$.\n\nThese conventions ensure a canonical and unambiguous representation of polynomial terms while offering flexibility in the naming of model parameters. Missing monomials are implicitly treated as having zero coefficients.\n\n The `data` field is a `JSON` object with the following subfields:",
       "properties": {
-        "observable_central": {
-          "type": "object",
-          "minProperties": 1,
-          "additionalProperties": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "type": "number" }
-          },
-          "description": "An object representing the central values of the polynomial coefficients for the expanded observables, $\\vec{o}_m$. Each key must be a monomial key as defined above. The values must be an array of $M$ numbers whose order matches `metadata.observable_names`.",
-          "examples": [
-            {
-              "description": "Specifying three observable predictions, $O_{m}$, given in terms of the three real parameters $C_1$, $C_2$, and $C_3$ as\n\n$$\n\\begin{aligned}\n    O_1 &= 1.0 + 1.2 \\ C_1 + 1.4 \\ C_1C_2+ 1.6 \\ C_1C_3\\ , \\\\\n    O_2 &= 1.1 + 1.3 \\ C_1 + 1.5 \\ C_1C_2+ 1.7 \\ C_1C_3\\ , \\\\\n    O_3 &= 2.3 + 0.3\\ C_1 + 0.7 \\ C_1C_2 + 0.5 \\ C_1C_3\\ .\n\\end{aligned}\n$$",
-              "observable_central": {
-                "('','')": [1.0, 1.1, 2.3],
-                "('', 'C1')": [1.2, 1.3, 0.3],
-                "('C1', 'C2')": [1.4, 1.5, 0.7],
-                "('C1', 'C3')": [1.6, 1.7, 0.5]
-              }
-            }
-          ]
-        },
         "polynomial_central": {
           "type": "object",
           "minProperties": 1,
@@ -550,12 +529,12 @@
             "minItems": 1,
             "items": { "type": "number" }
           },
-          "description": "*This field is required to express observables as functions of polynomials. It requires the simultaneous presence of `metadata.polynomial_names` and `metadata.observable_expressions`.*\n\nAn object representing the central values of the polynomial coefficients for each named polynomial, $\\vec{p}_k$. Each key must be a monomial key as defined above. The values must be an array of $K$ numbers whose order matches `metadata.polynomial_names`.",
+          "description": "*This field is required to express observables as functions of polynomials. It requires the simultaneous presence of `metadata.polynomial_names` and `metadata.observable_expressions`.*\n\nAn object representing the central values of the polynomial coefficients $\\vec{p}_k$ for each named polynomial $P_k$. Each key must be a monomial key as defined above. Each value must be an array of $K$ numbers whose order matches `metadata.polynomial_names`.",
           "examples": [
             {
               "description": "Specifying two polynomials, $P_k$, given in terms of two complex parameters $C_1$ and $C_2$ as\n\n$$\n\\begin{aligned}\n    P_1 &= 1.0 + 1.2 \\ \\mathrm{Im}(C_1) + 0.8 \\ \\mathrm{Re}(C_1) \\mathrm{Re}(C_2) + 0.5 \\ \\mathrm{Re}(C_1) \\mathrm{Im}(C_2)+ 0.2 \\ \\mathrm{Im}(C_1) \\mathrm{Im}(C_2)\\ , \\\\\n    P_2 &= 1.1 + 1.3 \\ \\mathrm{Im}(C_1)  + 0.85 \\ \\mathrm{Re}(C_1) \\mathrm{Re}(C_2) + 0.55 \\ \\mathrm{Re}(C_1) \\mathrm{Im}(C_2)+ 0.25 \\ \\mathrm{Im}(C_1) \\mathrm{Im}(C_2)\\ .\n\\end{aligned}\n$$",
               "polynomial_central": {
-                "('','')": [1.0, 1.1],
+                "('', '', 'RR')": [1.0, 1.1],
                 "('', 'C1', 'RI')": [1.2, 1.3],
                 "('C1', 'C2', 'RR')": [0.8, 0.85],
                 "('C1', 'C2', 'RI')": [0.5, 0.55],
@@ -564,10 +543,31 @@
             }
           ]
         },
+        "observable_central": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "number" }
+          },
+          "description": "An object representing the central values of the observable coefficients $\\vec{o}_m$ for each observable<span>&nbsp;</span>$O_m$. In case the observables are not themselves polynomials, the observable coefficients correspond to the polynomial approximation of the observables obtained from a Taylor expansion of the observable expressions defined in `metadata.observable_expressions`. Each key must be a monomial key as defined above. Each value must be an array of $M$ numbers whose order matches `metadata.observable_names`.",
+          "examples": [
+            {
+              "description": "Specifying three observable predictions, $O_{m}$, given in terms of the three real parameters $C_1$, $C_2$, and $C_3$ as\n\n$$\n\\begin{aligned}\n    O_1 &= 1.0 + 1.2 \\ C_1 + 1.4 \\ C_1C_2+ 1.6 \\ C_1C_3\\ , \\\\\n    O_2 &= 1.1 + 1.3 \\ C_1 + 1.5 \\ C_1C_2+ 1.7 \\ C_1C_3\\ , \\\\\n    O_3 &= 2.3 + 0.3\\ C_1 + 0.7 \\ C_1C_2 + 0.5 \\ C_1C_3\\ .\n\\end{aligned}\n$$",
+              "observable_central": {
+                "('', '')": [1.0, 1.1, 2.3],
+                "('', 'C1')": [1.2, 1.3, 0.3],
+                "('C1', 'C2')": [1.4, 1.5, 0.7],
+                "('C1', 'C3')": [1.6, 1.7, 0.5]
+              }
+            }
+          ]
+        },
         "observable_uncertainties": {
           "type": "object",
           "minProperties": 1,
-          "description": "An object representing the uncertainties on the polynomial coefficients for the expanded observables. The fields specify the nature of quoted uncertainty. In many cases there may only be a single top-level field, `\"total\"`, but multiple fields can be used to specify a breakdown into several sources of uncertainty (e.g., statistical, scale, PDF, ...). To avoid mistakes, the names of the top-level fields must not have the format of a monomial key (i.e., stringified tuples as defined above). The values of the top-level fields can either be an object or an array of floats. Objects must have the same structure as `observable_central`, arrays must have length $M$. If instead of an object, an array of floats is specified, it is assumed to correspond to the parameter independent uncertainty only (e.g. the uncertainty on the SM prediction). This would be equivalent to specifying an object with the single key, `\"('', '')\"`, matching the number of empty strings in the tuple to `metadata.polynomial_degree`.",
+          "description": "An object representing the uncertainties on the observable coefficients $\\vec{\\sigma}_m$ for each observable<span>&nbsp;</span>$O_m$. In case the observables are not themselves polynomials, the observable coefficients correspond to the polynomial approximation of the observables obtained from a Taylor expansion of the observable expressions defined in `metadata.observable_expressions`. The fields specify the nature of quoted uncertainty. In many cases there may only be a single top-level field, `\"total\"`, but multiple fields can be used to specify a breakdown into several sources of uncertainty (e.g., statistical, scale, PDF, ...). To avoid mistakes, the names of the top-level fields must not have the format of a monomial key (i.e., stringified tuples as defined above). The value of each top-level field can either be an object or an array of floats. Objects must have the same structure as `observable_central`, arrays must have length $M$. If instead of an object, an array of floats is specified, it is assumed to correspond to the parameter independent uncertainty only (e.g. the uncertainty on the SM prediction). This would be equivalent to specifying an object containing a single element with the monomial key of the constant term (e.g.&nbsp;`\"('','')\"` for a quadratic polynomial).",
           "additionalProperties": {
             "oneOf": [
               {
@@ -590,7 +590,7 @@
             {
               "observable_uncertainties": {
                 "total": {
-                  "('','')": [0.05, 0.06, 0.01],
+                  "('', '')": [0.05, 0.06, 0.01],
                   "('', 'C1')": [0.1, 0.12, 0.01],
                   "('C1', 'C2')": [0.02, 0.03, 0.02],
                   "('C1', 'C3')": [0.05, 0.06, 0.01]
@@ -607,15 +607,15 @@
               "description": "Specifying an uncertainty breakdown:",
               "observable_uncertainties": {
                 "MC_stats": {
-                  "('','')": [0.002, 0.0012, 0.001],
+                  "('', '')": [0.002, 0.0012, 0.001],
                   "('', 'C1')": [0.001, 0.0015, 0.0001]
                 },
                 "scale": {
-                  "('','')": [0.04, 0.05, 0.06],
+                  "('', '')": [0.04, 0.05, 0.06],
                   "('', 'C1')": [0.1, 0.12, 0.01]
                 },
                 "PDF": {
-                  "('','')": [0.03, 0.04, 0.05],
+                  "('', '')": [0.03, 0.04, 0.05],
                   "('', 'C1')": [0.02, 0.08, 0.01]
                 }
               }


### PR DESCRIPTION
This PR updates the documentation of the `POPxf` data format in the `description` fields of of the `popxf-1.0.json` schema.