### PR TITLE
Add Git Town schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8793,9 +8793,7 @@
     {
       "name": "git-town.toml",
       "description": "Git Town configuration file",
-      "fileMatch": [
-        "git-town.toml"
-      ],
+      "fileMatch": ["git-town.toml"],
       "url": "https://raw.githubusercontent.com/git-town/git-town/refs/heads/main/docs/git-town.schema.json"
     },
     {


### PR DESCRIPTION
This PR adds a reference to the version mapping schema of https://github.com/git-town/git-town.

The config file can exist only as TOML.