### PR TITLE
feat: update pytest.

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -2,8 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/partial-pytest.json",
   "description": "JSON schema for pytest configuration options under `[tool.pytest]` in `pyproject.toml`.",
-  "type": "object",
-  "x-tombi-table-keys-order": "schema",
   "oneOf": [
     {
       "$ref": "#/definitions/LegacyConfig"
@@ -697,7 +695,6 @@
     },
     "Config": {
       "description": "Direct key configuration with proper TOML types (pytest >=9)\nhttps://docs.pytest.org/en/stable/reference/reference.html#configuration-options",
-      "type": "object",
       "allOf": [
         {
           "$ref": "#/definitions/ConfigOptionsPytest"
@@ -706,13 +703,11 @@
           "$ref": "#/definitions/ConfigOptionsAsyncio"
         }
       ],
-      "properties": {
-        "ini_options": {
-          "not": {}
-        }
-      },
-      "additionalProperties": true,
-      "x-tombi-table-keys-order": "schema"
+      "not": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["ini_options"]
+      }
     },
     "ConfigOptionsPytest": {
       "type": "object",
@@ -1077,8 +1072,8 @@
       "x-tombi-table-keys-order": "schema"
     },
     "ConfigOptionsAsyncio": {
-      "description": "Configuration options for pytest-asyncio.\nhttps://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html",
       "type": "object",
+      "description": "Configuration options for pytest-asyncio.\nhttps://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html",
       "properties": {
         "asyncio_default_fixture_loop_scope": {
           "$ref": "#/definitions/AsyncioScope",

--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -705,6 +705,9 @@
       ],
       "not": {
         "type": "object",
+        "properties": {
+          "ini_options": {}
+        },
         "additionalProperties": true,
         "required": ["ini_options"]
       }


### PR DESCRIPTION
Adjusted the schema so Tombi can read it from [v0.6.54](https://github.com/tombi-toml/tombi/releases/tag/v0.6.54).

Since the significant schema change in pytest, the completion function for pytest has become unavailable. We will adjust the schema so that completion candidates become available.

Related: https://github.com/tombi-toml/tombi/issues/1238

