### PR TITLE
Add PromptKit configuration schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4785,6 +4785,42 @@
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/master/support/schemas/generators_yaml_schema.json"
     },
     {
+      "name": "PromptKit Arena Configuration",
+      "description": "Configuration file for PromptKit Arena test orchestration",
+      "fileMatch": ["arena.yaml", "*.arena.yaml", "**/arena.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/arena.json"
+    },
+    {
+      "name": "PromptKit Persona",
+      "description": "User persona for PromptKit self-play testing",
+      "fileMatch": ["**/personas/*.yaml", "*.persona.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/persona.json"
+    },
+    {
+      "name": "PromptKit Prompt Configuration",
+      "description": "Prompt template configuration for PromptKit",
+      "fileMatch": ["**/prompts/*.yaml", "*.prompt.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/promptconfig.json"
+    },
+    {
+      "name": "PromptKit Provider",
+      "description": "LLM provider configuration for PromptKit",
+      "fileMatch": ["**/providers/*.yaml", "*.provider.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/provider.json"
+    },
+    {
+      "name": "PromptKit Scenario",
+      "description": "Test scenario definition for PromptKit Arena",
+      "fileMatch": ["**/scenarios/*.yaml", "*.scenario.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/scenario.json"
+    },
+    {
+      "name": "PromptKit Tool",
+      "description": "Tool definition for PromptKit LLM interactions",
+      "fileMatch": ["**/tools/*.yaml", "*.tool.yaml"],
+      "url": "https://promptkit.altairalabs.ai/schemas/latest/tool.json"
+    },
+    {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
       "fileMatch": ["project.json"],


### PR DESCRIPTION
## Description

This PR adds JSON Schema definitions for [PromptKit](https://github.com/AltairaLabs/PromptKit), an open-source framework for testing and deploying LLM-based applications.

## Schemas Included

This PR adds 6 configuration schemas:

1. **Arena Configuration** - Test orchestration and scenario management
2. **Scenario** - Individual test case definitions
3. **Provider** - LLM provider configurations (OpenAI, Anthropic, Google, etc.)
4. **Prompt Configuration** - Prompt template definitions
5. **Tool** - Function/tool definitions for LLM interactions
6. **Persona** - User persona for self-play testing

## File Patterns

The schemas use typed file extensions to distinguish configuration types:

- `arena.yaml`, `*.arena.yaml` → Arena configurations
- `*.scenario.yaml`, `**/scenarios/*.yaml` → Scenarios
- `*.provider.yaml`, `**/providers/*.yaml` → Providers
- `*.prompt.yaml`, `**/prompts/*.yaml` → Prompts
- `*.tool.yaml`, `**/tools/*.yaml` → Tools
- `*.persona.yaml`, `**/personas/*.yaml` → Personas

## Schema URLs

All schemas use the `/schemas/latest/` endpoint which contains a `$ref` to the current version (`v1alpha1`):

```json
{
  "$ref": "https://promptkit.altairalabs.ai/schemas/v1alpha1/arena.json"
}
```

This approach allows us to update schemas without requiring users to change their `$schema` references.

## Validation

✅ All schemas are hosted and accessible at https://promptkit.altairalabs.ai/schemas/
✅ Schemas follow JSON Schema Draft 2020-12
✅ CORS headers are enabled for browser access
✅ All schemas have been tested with ajv-cli and VS Code YAML extension
✅ Example configurations validate successfully

## Testing Evidence

Live schema endpoints:
- https://promptkit.altairalabs.ai/schemas/latest/arena.json
- https://promptkit.altairalabs.ai/schemas/latest/scenario.json
- https://promptkit.altairalabs.ai/schemas/latest/provider.json
- https://promptkit.altairalabs.ai/schemas/latest/promptconfig.json
- https://promptkit.altairalabs.ai/schemas/latest/tool.json
- https://promptkit.altairalabs.ai/schemas/latest/persona.json

Example usage in a config file:
```yaml
$schema: https://promptkit.altairalabs.ai/schemas/latest/arena.json
apiVersion: promptkit.altairalabs.ai/v1alpha1
kind: Arena
metadata:
  name: my-test-arena
spec:
  prompt_configs:
    - id: assistant
      file: prompts/assistant.yaml
  providers:
    - file: providers/openai.provider.yaml
  scenarios:
    - file: scenarios/test.scenario.yaml
```

## Repository Info

- Repository: https://github.com/AltairaLabs/PromptKit
- Documentation: https://promptkit.altairalabs.ai/
- License: Apache 2.0
- Maintainer: @chaholl (AltairaLabs)

## Checklist

- [x] Schemas are publicly accessible via HTTPS
- [x] Schemas follow JSON Schema specification
- [x] File match patterns are specific and non-conflicting
- [x] Schemas have been tested in VS Code
- [x] CORS is enabled for schema URLs
- [x] Documentation links are provided