### PR TITLE
add Argo CD schemas to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -340,7 +340,7 @@
     {
       "name": "Argo CD",
       "description": "Argo CD base resources",
-      "url": "https://raw.githubusercontent.com/argoproj/argo-schema-generator/refs/heads/main/schema/argo_cd_kustomize_schema.json"
+      "url": "https://raw.githubusercontent.com/argoproj/argo-schema-generator/main/schema/argo_cd_kustomize_schema.json"
     },
     {
       "name": "Argo Events",


### PR DESCRIPTION
Adds Argo CD resources to the catalog.

Notes:

- I selected the generated schema that _does not include_ workflows or events. I'm not sure if this project wants all-in-one so I left them separate.
- There did not seem to be any node tests, but I ran the pre-commit hooks.

Closes #5168 