### PR TITLE
Apollo Router: schema 2.8.2 & 2.9.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6940,9 +6940,11 @@
       "name": "Apollo Router",
       "description": "Apollo Router: The runtime for graph-based API orchestration",
       "fileMatch": ["apollo-router-*.json"],
-      "url": "https://www.schemastore.org/apollo-router-2.8.1.json",
+      "url": "https://www.schemastore.org/apollo-router-2.9.0.json",
       "versions": {
-        "2.8.1": "https://www.schemastore.org/apollo-router-2.8.1.json"
+        "2.8.1": "https://www.schemastore.org/apollo-router-2.8.1.json",
+        "2.8.2": "https://www.schemastore.org/apollo-router-2.8.2.json",
+        "2.9.0": "https://www.schemastore.org/apollo-router-2.9.0.json"
       }
     },
     {

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -690,6 +690,14 @@
       "externalSchema": ["base.json"],
       "unknownFormat": ["uint", "uint32", "uint64"]
     },
+    "apollo-router-2.8.2.json": {
+      "externalSchema": ["base.json"],
+      "unknownFormat": ["uint", "uint32", "uint64"]
+    },
+    "apollo-router-2.9.0.json": {
+      "externalSchema": ["base.json"],
+      "unknownFormat": ["uint", "uint32", "uint64"]
+    },
     "app-config.json": {
       "externalSchema": ["base.json"]
     },

--- a/src/schemas/json/apollo-router-2.8.2.json
+++ b/src/schemas/json/apollo-router-2.8.2.json
@@ -1,0 +1,11154 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/apollo-router-2.8.2.json",
+  "title": "Configuration",
+  "description": "The configuration for the router.\n\nCan be created through `serde::Deserialize` from various formats,\nor inline in Rust code with `serde_json::json!` and `serde_json::from_value`.",
+  "type": "object",
+  "properties": {
+    "health_check": {
+      "$ref": "#/definitions/HealthCheckConfig"
+    },
+    "sandbox": {
+      "description": "Sandbox configuration",
+      "default": {
+        "enabled": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Sandbox"
+        }
+      ]
+    },
+    "homepage": {
+      "description": "Homepage configuration",
+      "default": {
+        "enabled": true,
+        "graph_ref": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Homepage"
+        }
+      ]
+    },
+    "server": {
+      "description": "Configuration for the server",
+      "default": {
+        "http": {
+          "header_read_timeout": {
+            "secs": 10,
+            "nanos": 0
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Server"
+        }
+      ]
+    },
+    "supergraph": {
+      "description": "Configuration for the supergraph",
+      "default": {
+        "listen": "127.0.0.1:4000",
+        "connection_shutdown_timeout": {
+          "secs": 60,
+          "nanos": 0
+        },
+        "path": "/",
+        "introspection": false,
+        "generate_query_fragments": true,
+        "defer_support": true,
+        "query_planning": {
+          "cache": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "warmed_up_queries": null,
+          "experimental_plans_limit": null,
+          "experimental_paths_limit": null,
+          "experimental_reuse_query_plans": false,
+          "experimental_cooperative_cancellation": {
+            "enabled": true,
+            "mode": "measure",
+            "timeout": null
+          }
+        },
+        "early_cancel": false,
+        "enable_result_coercion_errors": false,
+        "experimental_log_on_broken_pipe": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Supergraph"
+        }
+      ]
+    },
+    "cors": {
+      "description": "Cross origin request headers.",
+      "default": {
+        "allow_any_origin": false,
+        "allow_credentials": false,
+        "allow_headers": [],
+        "expose_headers": null,
+        "methods": ["GET", "POST", "OPTIONS"],
+        "max_age": null,
+        "policies": [
+          {
+            "allow_credentials": null,
+            "allow_headers": [],
+            "expose_headers": [],
+            "match_origins": [],
+            "max_age": null,
+            "methods": ["GET", "POST", "OPTIONS"],
+            "origins": ["https://studio.apollographql.com"]
+          }
+        ]
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Cors"
+        }
+      ]
+    },
+    "tls": {
+      "default": {
+        "supergraph": null,
+        "subgraph": {
+          "all": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "subgraphs": {}
+        },
+        "connector": {
+          "sources": {},
+          "all": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tls"
+        }
+      ]
+    },
+    "apq": {
+      "description": "Configures automatic persisted queries",
+      "default": {
+        "enabled": true,
+        "router": {
+          "cache": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          }
+        },
+        "subgraph": {
+          "all": {
+            "enabled": false
+          },
+          "subgraphs": {}
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Apq"
+        }
+      ]
+    },
+    "persisted_queries": {
+      "description": "Configures managed persisted queries",
+      "default": {
+        "enabled": false,
+        "log_unknown": false,
+        "safelist": {
+          "enabled": false,
+          "require_id": false
+        },
+        "experimental_prewarm_query_plan_cache": {
+          "on_startup": false,
+          "on_reload": true
+        },
+        "local_manifests": null,
+        "hot_reload": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PersistedQueries"
+        }
+      ]
+    },
+    "limits": {
+      "$ref": "#/definitions/LimitsConfig"
+    },
+    "experimental_chaos": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.\nYou probably don’t want this in production!",
+      "default": {
+        "force_schema_reload": null,
+        "force_config_reload": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Config"
+        }
+      ]
+    },
+    "plugins": {
+      "description": "Plugin configuration",
+      "default": null,
+      "allOf": [
+        {
+          "$ref": "#/definitions/Plugins"
+        }
+      ]
+    },
+    "authentication": {
+      "$ref": "#/definitions/AuthenticationConfig"
+    },
+    "authorization": {
+      "$ref": "#/definitions/AuthorizationConfig"
+    },
+    "connectors": {
+      "$ref": "#/definitions/ConnectorsConfig"
+    },
+    "coprocessor": {
+      "$ref": "#/definitions/CoprocessorConfig"
+    },
+    "csrf": {
+      "$ref": "#/definitions/CSRFConfig"
+    },
+    "demand_control": {
+      "$ref": "#/definitions/DemandControlConfig"
+    },
+    "enhanced_client_awareness": {
+      "$ref": "#/definitions/Config4"
+    },
+    "experimental_diagnostics": {
+      "$ref": "#/definitions/Config5"
+    },
+    "fleet_detector": {
+      "$ref": "#/definitions/Conf"
+    },
+    "forbid_mutations": {
+      "$ref": "#/definitions/ForbidMutationsConfig"
+    },
+    "headers": {
+      "$ref": "#/definitions/HeadersConfig"
+    },
+    "include_subgraph_errors": {
+      "$ref": "#/definitions/IncludeSubgraphErrorsConfig"
+    },
+    "license_enforcement": {
+      "$ref": "#/definitions/LicenseEnforcementConfig"
+    },
+    "override_subgraph_url": {
+      "$ref": "#/definitions/Conf2"
+    },
+    "preview_entity_cache": {
+      "$ref": "#/definitions/Config6"
+    },
+    "preview_file_uploads": {
+      "$ref": "#/definitions/FileUploadsConfig"
+    },
+    "progressive_override": {
+      "$ref": "#/definitions/Config9"
+    },
+    "rhai": {
+      "$ref": "#/definitions/RhaiConfig"
+    },
+    "subscription": {
+      "$ref": "#/definitions/SubscriptionConfig"
+    },
+    "telemetry": {
+      "$ref": "#/definitions/TelemetryConfig"
+    },
+    "traffic_shaping": {
+      "$ref": "#/definitions/TrafficShapingConfig"
+    },
+    "batching": {
+      "description": "Batching configuration.",
+      "default": {
+        "enabled": false,
+        "mode": "batch_http_link",
+        "subgraph": null,
+        "maximum_size": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Batching"
+        }
+      ]
+    },
+    "experimental_type_conditioned_fetching": {
+      "description": "Type conditioned fetching configuration.",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "patternProperties": {
+    "^experimental_mock_subgraphs$": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphConfig"
+      }
+    },
+    "^preview_response_cache$": {
+      "$ref": "#/definitions/Config7"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "HealthCheckConfig": {
+      "description": "Configuration options pertaining to the health component.",
+      "type": "object",
+      "properties": {
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:8088",
+          "default": "127.0.0.1:8088",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "enabled": {
+          "description": "Set to false to disable the health check",
+          "type": "boolean",
+          "default": true
+        },
+        "path": {
+          "description": "Optionally set a custom healthcheck path\nDefaults to /health",
+          "type": "string",
+          "default": "/health"
+        },
+        "readiness": {
+          "description": "Optionally specify readiness configuration",
+          "default": {
+            "interval": {
+              "sampling": "5s",
+              "unready": null
+            },
+            "allowed": 100
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReadinessConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ListenAddr": {
+      "description": "Listening address.",
+      "anyOf": [
+        {
+          "description": "Socket address.",
+          "type": "string"
+        },
+        {
+          "description": "Unix socket.",
+          "type": "string"
+        }
+      ]
+    },
+    "ReadinessConfig": {
+      "description": "Configuration options pertaining to the readiness health sub-component.",
+      "type": "object",
+      "properties": {
+        "interval": {
+          "description": "The readiness interval configuration",
+          "default": {
+            "sampling": "5s",
+            "unready": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReadinessIntervalConfig"
+            }
+          ]
+        },
+        "allowed": {
+          "description": "How many rejections are allowed in an interval (default: 100)\nIf this number is exceeded, the router will start to report unready.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReadinessIntervalConfig": {
+      "description": "Configuration options pertaining to the readiness health interval sub-component.",
+      "type": "object",
+      "properties": {
+        "sampling": {
+          "description": "The sampling interval (default: 5s)",
+          "type": ["string", "null"],
+          "default": "0s"
+        },
+        "unready": {
+          "description": "The unready interval (default: 2 * sampling interval)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Sandbox": {
+      "description": "Configuration options pertaining to the sandbox page.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to enable sandbox",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "Homepage": {
+      "description": "Configuration options pertaining to the home page.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to false to disable the homepage",
+          "type": "boolean",
+          "default": true
+        },
+        "graph_ref": {
+          "description": "Graph reference\nThis will allow you to redirect from the Apollo Router landing page back to Apollo Studio Explorer",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "description": "The server http configuration",
+          "default": {
+            "header_read_timeout": {
+              "secs": 10,
+              "nanos": 0
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ServerHttpConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ServerHttpConfig": {
+      "description": "Configuration for HTTP",
+      "type": "object",
+      "properties": {
+        "header_read_timeout": {
+          "description": "Header read timeout in human-readable format; defaults to 10s",
+          "type": "string",
+          "default": {
+            "secs": 10,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Supergraph": {
+      "description": "Configuration options pertaining to the supergraph server component.",
+      "type": "object",
+      "properties": {
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:4000",
+          "default": "127.0.0.1:4000",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "connection_shutdown_timeout": {
+          "description": "The timeout for shutting down connections during a router shutdown or a schema reload.",
+          "type": "string",
+          "default": {
+            "secs": 60,
+            "nanos": 0
+          }
+        },
+        "path": {
+          "description": "The HTTP path on which GraphQL requests will be served.\ndefault: \"/\"",
+          "type": "string",
+          "default": "/"
+        },
+        "introspection": {
+          "description": "Enable introspection\nDefault: false",
+          "type": "boolean",
+          "default": false
+        },
+        "generate_query_fragments": {
+          "description": "Enable QP generation of fragments for subgraph requests\nDefault: true",
+          "type": "boolean",
+          "default": true
+        },
+        "defer_support": {
+          "description": "Set to false to disable defer support",
+          "type": "boolean",
+          "default": true
+        },
+        "query_planning": {
+          "description": "Query planning options",
+          "default": {
+            "cache": {
+              "in_memory": {
+                "limit": 512
+              },
+              "redis": null
+            },
+            "warmed_up_queries": null,
+            "experimental_plans_limit": null,
+            "experimental_paths_limit": null,
+            "experimental_reuse_query_plans": false,
+            "experimental_cooperative_cancellation": {
+              "enabled": true,
+              "mode": "measure",
+              "timeout": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/QueryPlanning"
+            }
+          ]
+        },
+        "early_cancel": {
+          "description": "abort request handling when the client drops the connection.\nDefault: false.\nWhen set to true, some parts of the request pipeline like telemetry will not work properly,\nbut request handling will stop immediately when the client connection is closed.",
+          "type": "boolean",
+          "default": false
+        },
+        "enable_result_coercion_errors": {
+          "description": "Enable errors generated during response reformatting and result coercion to be returned in\nresponses.\nDefault: false\nAll subgraph responses are checked and corrected to ensure alignment with the schema and\nquery. When enabled, misaligned values will generate errors which are included in errors\narray in the response.",
+          "type": "boolean",
+          "default": false
+        },
+        "experimental_log_on_broken_pipe": {
+          "description": "Log a message if the client closes the connection before the response is sent.\nDefault: false.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "QueryPlanning": {
+      "description": "Query planning cache configuration",
+      "type": "object",
+      "properties": {
+        "cache": {
+          "description": "Cache configuration",
+          "default": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/QueryPlanCache"
+            }
+          ]
+        },
+        "warmed_up_queries": {
+          "description": "Warms up the cache on reloads by running the query plan over\na list of the most used queries (from the in memory cache)\nConfigures the number of queries warmed up. Defaults to 1/3 of\nthe in memory cache",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_plans_limit": {
+          "description": "Sets a limit to the number of generated query plans.\nThe planning process generates many different query plans as it\nexplores the graph, and the list can grow large. By using this\nlimit, we prevent that growth and still get a valid query plan,\nbut it may not be the optimal one.\n\nThe default limit is set to 10000, but it may change in the future",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_paths_limit": {
+          "description": "Before creating query plans, for each path of fields in the query we compute all the\npossible options to traverse that path via the subgraphs. Multiple options can arise because\nfields in the path can be provided by multiple subgraphs, and abstract types (i.e. unions\nand interfaces) returned by fields sometimes require the query planner to traverse through\neach constituent object type. The number of options generated in this computation can grow\nlarge if the schema or query are sufficiently complex, and that will increase the time spent\nplanning.\n\nThis config allows specifying a per-path limit to the number of options considered. If any\npath's options exceeds this limit, query planning will abort and the operation will fail.\n\nThe default value is None, which specifies no limit.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_reuse_query_plans": {
+          "description": "If cache warm up is configured, this will allow the router to keep a query plan created with\nthe old schema, if it determines that the schema update does not affect the corresponding query",
+          "type": "boolean",
+          "default": false
+        },
+        "experimental_cooperative_cancellation": {
+          "description": "Configures cooperative cancellation of query planning\n\nSee [`CooperativeCancellation`] for more details.",
+          "default": {
+            "enabled": true,
+            "mode": "measure",
+            "timeout": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/CooperativeCancellation"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "QueryPlanCache": {
+      "description": "Cache configuration",
+      "type": "object",
+      "properties": {
+        "in_memory": {
+          "description": "Configures the in memory cache (always active)",
+          "default": {
+            "limit": 512
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/InMemoryCache"
+            }
+          ]
+        },
+        "redis": {
+          "description": "Configures and activates the Redis cache",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/QueryPlanRedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "InMemoryCache": {
+      "description": "In memory cache configuration",
+      "type": "object",
+      "properties": {
+        "limit": {
+          "description": "Number of entries in the Least Recently Used cache",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["limit"]
+    },
+    "QueryPlanRedisCache": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "timeout": {
+          "description": "Redis request timeout (default: 500ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "ttl": {
+          "description": "TTL for entries",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 2592000,
+            "nanos": 0
+          }
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "reset_ttl": {
+          "description": "When a TTL is set on a key, reset it when reading the data from that key",
+          "type": "boolean",
+          "default": true
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "TlsClient": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "certificate_authorities": {
+          "description": "list of certificate authorities in PEM format",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "client_authentication": {
+          "description": "client certificate authentication",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClientAuth"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "TlsClientAuth": {
+      "description": "TLS client authentication",
+      "type": "object",
+      "properties": {
+        "certificate_chain": {
+          "description": "list of certificates in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "key": {
+          "description": "key in PEM format",
+          "type": "string",
+          "writeOnly": true
+        }
+      },
+      "additionalProperties": false,
+      "required": ["certificate_chain", "key"]
+    },
+    "CooperativeCancellation": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "When true, cooperative cancellation is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "When enabled, this sets whether the router will cancel query planning or\nmerely emit a metric when it would have happened.",
+          "default": "measure",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for query planning.",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Mode": {
+      "type": "string",
+      "enum": ["measure", "enforce"]
+    },
+    "Cors": {
+      "description": "Cross origin request configuration.",
+      "type": "object",
+      "properties": {
+        "allow_any_origin": {
+          "description": "Set to true to allow any origin. Defaults to false. This is the only way to allow Origin: null.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow_credentials": {
+          "description": "Set to true to add the `Access-Control-Allow-Credentials` header.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow_headers": {
+          "description": "The headers to allow.\n\nIf this value is not set, the router will mirror client's `Access-Control-Request-Headers`.\n\nNote that if you set headers here,\nyou also want to have a look at your `CSRF` plugins configuration,\nand make sure you either:\n- accept `x-apollo-operation-name` AND / OR `apollo-require-preflight`\n- defined `csrf` required headers in your yml configuration, as shown in the\n  `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "expose_headers": {
+          "description": "Which response headers should be made available to scripts running in the browser,\nin response to a cross-origin request.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "methods": {
+          "description": "Allowed request methods. See module documentation for default behavior.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["GET", "POST", "OPTIONS"]
+        },
+        "max_age": {
+          "description": "The `Access-Control-Max-Age` header value in time units",
+          "type": "string",
+          "default": null
+        },
+        "policies": {
+          "description": "The origin(s) to allow requests from. The router matches request origins against policies\nin order, first by exact match, then by regex. See module documentation for default behavior.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/Policy"
+          },
+          "default": [
+            {
+              "allow_credentials": null,
+              "allow_headers": [],
+              "expose_headers": [],
+              "match_origins": [],
+              "max_age": null,
+              "methods": ["GET", "POST", "OPTIONS"],
+              "origins": ["https://studio.apollographql.com"]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Policy": {
+      "description": "Configuration for a specific set of origins",
+      "type": "object",
+      "properties": {
+        "allow_credentials": {
+          "description": "Set to true to add the `Access-Control-Allow-Credentials` header for these origins",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "allow_headers": {
+          "description": "The headers to allow for these origins",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "expose_headers": {
+          "description": "Which response headers should be made available to scripts running in the browser",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "match_origins": {
+          "description": "Regex patterns to match origins against.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "max_age": {
+          "description": "The `Access-Control-Max-Age` header value in time units",
+          "type": "string",
+          "default": null
+        },
+        "methods": {
+          "description": "Allowed request methods for these origins.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "origins": {
+          "description": "The origins to allow requests from.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["https://studio.apollographql.com"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Tls": {
+      "description": "TLS related configuration options.",
+      "type": "object",
+      "properties": {
+        "supergraph": {
+          "description": "TLS server configuration\n\nThis will affect the GraphQL endpoint and any other endpoint targeting the same listen address.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsSupergraph"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraph": {
+          "description": "Outgoing TLS configuration to subgraphs.",
+          "default": {
+            "all": {
+              "certificate_authorities": null,
+              "client_authentication": null
+            },
+            "subgraphs": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphTlsClientConfiguration"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Outgoing TLS configuration to Apollo Connectors.",
+          "default": {
+            "sources": {},
+            "all": {
+              "certificate_authorities": null,
+              "client_authentication": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TlsSupergraph": {
+      "description": "Configuration options pertaining to the supergraph server component.",
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "server certificate in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "key": {
+          "description": "server key in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "certificate_chain": {
+          "description": "list of certificate authorities in PEM format",
+          "type": "string",
+          "writeOnly": true
+        }
+      },
+      "additionalProperties": false,
+      "required": ["certificate", "key", "certificate_chain"]
+    },
+    "SubgraphTlsClientConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/TlsClient"
+          },
+          "default": {}
+        }
+      }
+    },
+    "ConnectorConfiguration": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/TlsClient"
+          },
+          "default": {}
+        },
+        "all": {
+          "description": "Options applying to all sources",
+          "default": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            }
+          ]
+        }
+      }
+    },
+    "Apq": {
+      "description": "Automatic Persisted Queries (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Automatic Persisted Queries (enabled by default)",
+          "type": "boolean",
+          "default": true
+        },
+        "router": {
+          "default": {
+            "cache": {
+              "in_memory": {
+                "limit": 512
+              },
+              "redis": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Router"
+            }
+          ]
+        },
+        "subgraph": {
+          "default": {
+            "all": {
+              "enabled": false
+            },
+            "subgraphs": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphApqConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Router": {
+      "description": "Router level (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "cache": {
+          "default": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Cache"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Cache": {
+      "description": "Cache configuration",
+      "type": "object",
+      "properties": {
+        "in_memory": {
+          "description": "Configures the in memory cache (always active)",
+          "default": {
+            "limit": 512
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/InMemoryCache"
+            }
+          ]
+        },
+        "redis": {
+          "description": "Configures and activates the Redis cache",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RedisCache": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "timeout": {
+          "description": "Redis request timeout (default: 500ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "ttl": {
+          "description": "TTL for entries",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "reset_ttl": {
+          "description": "When a TTL is set on a key, reset it when reading the data from that key",
+          "type": "boolean",
+          "default": true
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        },
+        "metrics_interval": {
+          "description": "Interval for collecting Redis metrics (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "SubgraphSubgraphApqConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "enabled": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphApq"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphApq"
+          },
+          "default": {}
+        }
+      }
+    },
+    "SubgraphApq": {
+      "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueries": {
+      "description": "Persisted Queries (PQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Persisted Queries (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "log_unknown": {
+          "description": "Enabling this field configures the router to log any freeform GraphQL request that is not in the persisted query list",
+          "type": "boolean",
+          "default": false
+        },
+        "safelist": {
+          "description": "Restricts execution of operations that are not found in the Persisted Query List",
+          "default": {
+            "enabled": false,
+            "require_id": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PersistedQueriesSafelist"
+            }
+          ]
+        },
+        "experimental_prewarm_query_plan_cache": {
+          "description": "Experimental feature to prewarm the query plan cache with persisted queries",
+          "default": {
+            "on_startup": false,
+            "on_reload": true
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PersistedQueriesPrewarmQueryPlanCache"
+            }
+          ]
+        },
+        "local_manifests": {
+          "description": "Enables using a local copy of the persisted query manifest to safelist operations",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "hot_reload": {
+          "description": "Enables hot reloading of the local persisted query manifests",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueriesSafelist": {
+      "description": "Persisted Queries (PQ) Safelisting configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enables using the persisted query list as a safelist (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "require_id": {
+          "description": "Enabling this field configures the router to reject any request that does not include the persisted query ID",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueriesPrewarmQueryPlanCache": {
+      "description": "Persisted Queries (PQ) query plan cache prewarm configuration",
+      "type": "object",
+      "properties": {
+        "on_startup": {
+          "description": "Enabling this field uses the persisted query list to pre-warm the query planner cache on startup (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "on_reload": {
+          "description": "Enabling this field uses the persisted query list to pre-warm the query planner cache on schema and config changes (enabled by default)",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "LimitsConfig": {
+      "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
+      "type": "object",
+      "properties": {
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets,˛\nincluding fields in fragments and inline fragments. The following\nexample has a depth of 3.\n\n```graphql\nquery getProduct {\n  book { # 1\n    ...bookDetails\n  }\n}\n\nfragment bookDetails on Book {\n  details { # 2\n    ... on ProductDetailsBook {\n      country # 3\n    }\n  }\n}\n```",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias,\nbut only within the same selection set.\nFor example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql\nquery {\n    name { first }\n    name { last }\n}\n```\n\nThis may change in a future version of Apollo Router to do\n[full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set,\nincluding fragments and inline fragments.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode),\nrequests that exceed a `max_*` limit are *not* rejected.\nInstead they are executed normally, and a warning is logged.",
+          "type": "boolean",
+          "default": false
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow.\ndefault: 500",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 500
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 15000
+        },
+        "http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network,\nto protect against running out of memory. Default: 2000000 (2 MB)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2000000
+        },
+        "http1_max_request_headers": {
+          "description": "Limit the maximum number of headers of incoming HTTP1 requests. Default is 100.\n\nIf router receives more headers than the buffer size, it responds to the client with\n\"431 Request Header Fields Too Large\".",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "http1_max_request_buf_size": {
+          "description": "Limit the maximum buffer size for the HTTP1 connection.\n\nDefault is ~400kib.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "introspection_max_depth": {
+          "description": "Limit the depth of nested list fields in introspection queries\nto protect avoid generating huge responses. Returns a GraphQL\nerror with `{ message: \"Maximum introspection depth exceeded\" }`\nwhen nested fields exceed the limit.\nDefault: true",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "Config": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.\nYou probably don't want this in production!\n\n## How Chaos Reloading Works\n\nThe chaos system automatically captures and replays the last known schema and configuration\nevents to force hot reloads even when the underlying content hasn't actually changed. This\nis particularly useful for memory leak detection during hot reload scenarios.\nIf configured, it will activate upon the first config event that is encountered.\n\n### Schema Reloading (`force_schema_reload`)\nWhen enabled, the router will periodically replay the last schema event with a timestamp\ncomment injected into the SDL (e.g., `# Chaos reload timestamp: 1234567890`). This ensures\nthe schema is seen as \"different\" and triggers a full hot reload, even though the functional\nschema content is identical.\n\n### Configuration Reloading (`force_config_reload`)\nWhen enabled, the router will periodically replay the last configuration event. The\nconfiguration is cloned and re-emitted, which triggers the router's configuration change\ndetection and reload logic.\n\n### Example Usage\n```yaml\nexperimental_chaos:\n  force_schema_reload: \"30s\"    # Trigger schema reload every 30 seconds\n  force_config_reload: \"2m\"     # Trigger config reload every 2 minutes\n```",
+      "type": "object",
+      "properties": {
+        "force_schema_reload": {
+          "description": "Force a hot reload of the schema at regular intervals by injecting a timestamp comment\ninto the SDL. This ensures schema reloads occur even when the functional schema content\nhasn't changed, which is useful for testing memory leaks during schema hot reloads.\n\nThe system automatically captures the last schema event and replays it with a timestamp\ncomment added to make it appear \"different\" to the reload detection logic.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "force_config_reload": {
+          "description": "Force a hot reload of the configuration at regular intervals by replaying the last\nconfiguration event. This triggers the router's configuration change detection even\nwhen the configuration content hasn't actually changed.\n\nThe system automatically captures the last configuration event and replays it to\nforce configuration reload processing.",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Plugins": {
+      "type": "object",
+      "properties": {
+        "experimental.broken": {
+          "$ref": "#/definitions/Config2"
+        },
+        "experimental.expose_query_plan": {
+          "$ref": "#/definitions/ExposeQueryPlanConfig"
+        },
+        "experimental.record": {
+          "$ref": "#/definitions/RecordConfig"
+        },
+        "experimental.restricted": {
+          "$ref": "#/definitions/Config3"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {}
+    },
+    "Config2": {
+      "description": "This is a broken plugin for testing purposes only.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the broken plugin.",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "ExposeQueryPlanConfig": {
+      "description": "Expose query plan",
+      "type": "boolean"
+    },
+    "RecordConfig": {
+      "description": "Request recording configuration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "The recording plugin is disabled by default.",
+          "type": "boolean"
+        },
+        "storage_path": {
+          "description": "The path to the directory where recordings will be stored. Defaults to\nthe current working directory.",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "Config3": {
+      "description": "Restricted plugin (for testing purposes only)",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the restricted plugin (for testing purposes only)",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "AuthenticationConfig": {
+      "description": "Authentication",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Router configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationRouterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationSubgraphConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationConnectorConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthenticationRouterConfig": {
+      "type": "object",
+      "properties": {
+        "jwt": {
+          "description": "The JWT configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JWTConf"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["jwt"]
+    },
+    "JWTConf": {
+      "type": "object",
+      "properties": {
+        "jwks": {
+          "description": "List of JWKS used to verify tokens",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JwksConf"
+          }
+        },
+        "header_name": {
+          "description": "HTTP header expected to contain JWT",
+          "type": "string",
+          "default": "authorization"
+        },
+        "header_value_prefix": {
+          "description": "Header value prefix",
+          "type": "string",
+          "default": "Bearer"
+        },
+        "ignore_other_prefixes": {
+          "description": "Whether to ignore any mismatched prefixes",
+          "type": "boolean",
+          "default": false
+        },
+        "sources": {
+          "description": "Alternative sources to extract the JWT",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Source"
+          }
+        },
+        "on_error": {
+          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `Error`. When set to `Continue`, requests that fail JWT authentication will\ncontinue to be processed by the router, but without the JWT claims in the context. When set\nto `Error`, requests that fail JWT authentication will be rejected with a HTTP 403 error.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OnError"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["jwks"]
+    },
+    "JwksConf": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Retrieve the JWK Set",
+          "type": "string"
+        },
+        "poll_interval": {
+          "description": "Polling interval for each JWKS endpoint in human-readable format; defaults to 60s",
+          "type": "string",
+          "default": {
+            "secs": 60,
+            "nanos": 0
+          }
+        },
+        "issuers": {
+          "description": "Expected issuers for tokens verified by that JWKS\n\nIf not specified, the issuer will not be checked.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "audiences": {
+          "description": "Expected audiences for tokens verified by that JWKS\n\nIf not specified, the audience will not be checked.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "algorithms": {
+          "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "headers": {
+          "description": "List of headers to add to the JWKS request",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Header"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url"]
+    },
+    "Header": {
+      "description": "Insert a header",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the header",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the header",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "value"]
+    },
+    "Source": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "HTTP header expected to contain JWT",
+              "type": "string",
+              "default": "authorization"
+            },
+            "value_prefix": {
+              "description": "Header value prefix",
+              "type": "string",
+              "default": "Bearer"
+            },
+            "type": {
+              "type": "string",
+              "const": "header"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the cookie containing the JWT",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "cookie"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "name"]
+        }
+      ]
+    },
+    "OnError": {
+      "type": "string",
+      "enum": ["Continue", "Error"]
+    },
+    "AuthenticationSubgraphConfig": {
+      "description": "Configure subgraph authentication",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Configuration that will apply to all subgraphs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraphs": {
+          "description": "Create a configuration that will apply only to a specific subgraph.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AuthConfig"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthConfig": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "aws_sig_v4": {
+              "$ref": "#/definitions/AWSSigV4Config"
+            }
+          },
+          "required": ["aws_sig_v4"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AWSSigV4Config": {
+      "description": "Configure AWS sigv4 auth.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "hardcoded": {
+              "$ref": "#/definitions/AWSSigV4HardcodedConfig"
+            }
+          },
+          "required": ["hardcoded"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default_chain": {
+              "$ref": "#/definitions/DefaultChainConfig"
+            }
+          },
+          "required": ["default_chain"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AWSSigV4HardcodedConfig": {
+      "description": "Hardcoded Config using access_key and secret.\nPrefer using DefaultChain instead.",
+      "type": "object",
+      "properties": {
+        "access_key_id": {
+          "description": "The ID for this access key.",
+          "type": "string"
+        },
+        "secret_access_key": {
+          "description": "The secret key used to sign requests.",
+          "type": "string"
+        },
+        "region": {
+          "description": "The AWS region this chain applies to.",
+          "type": "string"
+        },
+        "service_name": {
+          "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+          "type": "string"
+        },
+        "assume_role": {
+          "description": "Specify assumed role configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssumeRoleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "access_key_id",
+        "secret_access_key",
+        "region",
+        "service_name"
+      ]
+    },
+    "AssumeRoleProvider": {
+      "description": "Specify assumed role configuration.",
+      "type": "object",
+      "properties": {
+        "role_arn": {
+          "description": "Amazon Resource Name (ARN)\nfor the role assumed when making requests",
+          "type": "string"
+        },
+        "session_name": {
+          "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+          "type": "string"
+        },
+        "external_id": {
+          "description": "Unique identifier that might be required when you assume a role in another account.",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["role_arn", "session_name"]
+    },
+    "DefaultChainConfig": {
+      "description": "Configuration of the DefaultChainProvider",
+      "type": "object",
+      "properties": {
+        "region": {
+          "description": "The AWS region this chain applies to.",
+          "type": "string"
+        },
+        "profile_name": {
+          "description": "The profile name used by this provider",
+          "type": ["string", "null"]
+        },
+        "service_name": {
+          "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+          "type": "string"
+        },
+        "assume_role": {
+          "description": "Specify assumed role configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssumeRoleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["region", "service_name"]
+    },
+    "AuthenticationConnectorConfig": {
+      "description": "Configure connector authentication",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Create a configuration that will apply only to a specific source.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AuthConfig"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationConfig": {
+      "description": "Authorization plugin",
+      "type": "object",
+      "properties": {
+        "require_authentication": {
+          "description": "Reject unauthenticated requests",
+          "type": "boolean",
+          "default": false
+        },
+        "directives": {
+          "description": "`@authenticated`, `@requiresScopes` and `@policy` directives",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AuthorizationDirectivesConfig"
+            }
+          ]
+        }
+      }
+    },
+    "AuthorizationDirectivesConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "enables the `@authenticated` and `@requiresScopes` directives",
+          "type": "boolean",
+          "default": true
+        },
+        "dry_run": {
+          "description": "generates the authorization error messages without modying the query",
+          "type": "boolean",
+          "default": false
+        },
+        "reject_unauthorized": {
+          "description": "refuse a query entirely if any part would be filtered",
+          "type": "boolean",
+          "default": false
+        },
+        "errors": {
+          "description": "authorization errors behaviour",
+          "default": {
+            "log": true,
+            "response": "errors"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AuthorizationErrorConfig"
+            }
+          ]
+        }
+      }
+    },
+    "AuthorizationErrorConfig": {
+      "type": "object",
+      "properties": {
+        "log": {
+          "description": "log authorization errors",
+          "type": "boolean",
+          "default": true
+        },
+        "response": {
+          "description": "location of authorization errors in the GraphQL response",
+          "default": "errors",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorLocation"
+            }
+          ]
+        }
+      }
+    },
+    "ErrorLocation": {
+      "oneOf": [
+        {
+          "description": "store authorization errors in the response errors",
+          "type": "string",
+          "const": "errors"
+        },
+        {
+          "description": "store authorization errors in the response extensions",
+          "type": "string",
+          "const": "extensions"
+        },
+        {
+          "description": "do not add the authorization errors to the GraphQL response",
+          "type": "string",
+          "const": "disabled"
+        }
+      ]
+    },
+    "ConnectorsConfig": {
+      "description": "Configuration for Apollo Connectors.\n\nhttps://www.apollographql.com/docs/graphos/routing/configuration/yaml#connectors",
+      "type": "object",
+      "properties": {
+        "subgraphs": {
+          "description": "A map of subgraph name to connectors config for that subgraph",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphConnectorConfiguration"
+          },
+          "deprecated": true,
+          "default": {}
+        },
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to source configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceConfiguration"
+          },
+          "default": {}
+        },
+        "debug_extensions": {
+          "description": "Enables connector debugging information on response extensions if the feature is enabled",
+          "type": "boolean",
+          "default": false
+        },
+        "max_requests_per_operation_per_source": {
+          "description": "The maximum number of requests for a connector source",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "expose_sources_in_context": {
+          "description": "When enabled, adds an entry to the context for use in coprocessors\n\n```json\n{\n  \"context\": {\n    \"entries\": {\n      \"apollo_connectors::sources_in_query_plan\": [\n        { \"subgraph_name\": \"subgraph\", \"source_name\": \"source\" }\n      ]\n    }\n  }\n}\n```",
+          "type": "boolean",
+          "default": false
+        },
+        "preview_connect_v0_2": {
+          "description": "Enables Connect spec v0.2 during the preview.",
+          "type": ["boolean", "null"],
+          "deprecated": true,
+          "default": null
+        },
+        "preview_connect_v0_3": {
+          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "type": ["boolean", "null"],
+          "deprecated": true,
+          "default": null
+        },
+        "preview_connect_v0_4": {
+          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "type": ["boolean", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphConnectorConfiguration": {
+      "description": "Configuration for a connector subgraph",
+      "type": "object",
+      "properties": {
+        "$config": {
+          "description": "Other values that can be used by connectors via `{$config.<key>}`",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "sources": {
+          "description": "A map of `@source(name:)` to configuration for that source",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceConfiguration"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourceConfiguration": {
+      "description": "Configuration for a `@source` directive",
+      "type": "object",
+      "properties": {
+        "$config": {
+          "description": "Other values that can be used by connectors via `{$config.<key>}`",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "override_url": {
+          "description": "Override the `@source(http: {baseURL:})`",
+          "type": ["string", "null"],
+          "format": "uri",
+          "default": null
+        },
+        "max_requests_per_operation": {
+          "description": "The maximum number of requests for this source",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "CoprocessorConfig": {
+      "description": "Configures the externalization plugin",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "The url you'd like to offload processing to (can be overridden per-stage)",
+          "type": "string"
+        },
+        "client": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Client"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "The timeout for external requests",
+          "type": "string",
+          "default": {
+            "secs": 1,
+            "nanos": 0
+          }
+        },
+        "response_validation": {
+          "description": "Response validation defaults to true",
+          "type": "boolean",
+          "default": true
+        },
+        "router": {
+          "description": "The router stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterStage"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "The supergraph stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphStage"
+            }
+          ]
+        },
+        "execution": {
+          "description": "The execution stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExecutionStage"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "The subgraph stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphStages"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url"]
+    },
+    "Client": {
+      "description": "HTTP client configuration for coprocessors.",
+      "type": "object",
+      "properties": {
+        "experimental_http2": {
+          "description": "Use HTTP/2 to communicate with the coprocessor.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "Specify a DNS resolution strategy to use when resolving the coprocessor URL.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Http2Config": {
+      "oneOf": [
+        {
+          "description": "Enable HTTP2 for subgraphs",
+          "type": "string",
+          "const": "enable"
+        },
+        {
+          "description": "Disable HTTP2 for subgraphs",
+          "type": "string",
+          "const": "disable"
+        },
+        {
+          "description": "Only HTTP2 is active",
+          "type": "string",
+          "const": "http2only"
+        }
+      ]
+    },
+    "DnsResolutionStrategy": {
+      "oneOf": [
+        {
+          "description": "Only query for `A` (IPv4) records",
+          "type": "string",
+          "const": "ipv4_only"
+        },
+        {
+          "description": "Only query for `AAAA` (IPv6) records",
+          "type": "string",
+          "const": "ipv6_only"
+        },
+        {
+          "description": "Query for both `A` (IPv4) and `AAAA` (IPv6) records in parallel",
+          "type": "string",
+          "const": "ipv4_and_ipv6"
+        },
+        {
+          "description": "Query for `AAAA` (IPv6) records first; if that fails, query for `A` (IPv4) records",
+          "type": "string",
+          "const": "ipv6_then_ipv4"
+        },
+        {
+          "description": "Default: Query for `A` (IPv4) records first; if that fails, query for `AAAA` (IPv6) records",
+          "type": "string",
+          "const": "ipv4_then_ipv6"
+        }
+      ]
+    },
+    "RouterStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "description": "The response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterResponseConf"
+            }
+          ]
+        }
+      }
+    },
+    "RouterRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "path": {
+          "description": "Send the path",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionRouterSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/RouterSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionRouterSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionRouterSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "RouterSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "AttributeValue": {
+      "anyOf": [
+        {
+          "description": "bool values",
+          "type": "boolean"
+        },
+        {
+          "description": "i64 values",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "f64 values",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "description": "String values",
+          "type": "string"
+        },
+        {
+          "description": "Array of homogeneous values",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeArray"
+            }
+          ]
+        }
+      ]
+    },
+    "AttributeArray": {
+      "anyOf": [
+        {
+          "description": "Array of bools",
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        {
+          "description": "Array of integers",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "description": "Array of floats",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        {
+          "description": "Array of strings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "RouterSelector": {
+      "anyOf": [
+        {
+          "description": "A value from baggage.",
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "description": "A value from an environment variable.",
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Critical error if it happens",
+          "type": "object",
+          "properties": {
+            "error": {
+              "$ref": "#/definitions/ErrorRepr"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "description": "Boolean set to true if the response body contains graphql error",
+          "type": "object",
+          "properties": {
+            "on_graphql_error": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["on_graphql_error"]
+        },
+        {
+          "description": "The operation name from the query.",
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "description": "A header from the request",
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "description": "A value from context.",
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "description": "The request method.",
+          "type": "object",
+          "properties": {
+            "request_method": {
+              "description": "The request method enabled or not",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_method"]
+        },
+        {
+          "description": "The body of the response",
+          "type": "object",
+          "properties": {
+            "response_body": {
+              "description": "The response body enabled or not",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_body"]
+        },
+        {
+          "description": "The body response errors",
+          "type": "object",
+          "properties": {
+            "response_errors": {
+              "description": "The router response body json path of the chunks.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_errors"]
+        },
+        {
+          "description": "A header from the response",
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        },
+        {
+          "description": "A value from context.",
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "description": "A status from the response",
+          "type": "object",
+          "properties": {
+            "response_status": {
+              "description": "The http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_status"]
+        },
+        {
+          "description": "Router overhead duration (time not spent in subgraph requests)",
+          "type": "object",
+          "properties": {
+            "router_overhead": {
+              "description": "Extract router overhead duration in seconds",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["router_overhead"]
+        },
+        {
+          "description": "Number of active subgraph requests at the time of overhead calculation",
+          "type": "object",
+          "properties": {
+            "active_subgraph_requests": {
+              "description": "The mode for extracting active subgraph request information",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ActiveSubgraphRequests"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["active_subgraph_requests"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "description": "Apollo Studio operation id",
+          "type": "object",
+          "properties": {
+            "studio_operation_id": {
+              "description": "Apollo Studio operation id",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["studio_operation_id"]
+        },
+        {
+          "description": "The trace ID of the request.",
+          "type": "object",
+          "properties": {
+            "trace_id": {
+              "description": "The format of the trace ID.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/TraceIdFormat"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["trace_id"]
+        }
+      ]
+    },
+    "ErrorRepr": {
+      "oneOf": [
+        {
+          "description": "The error reason",
+          "type": "string",
+          "const": "reason"
+        }
+      ]
+    },
+    "OperationName": {
+      "oneOf": [
+        {
+          "description": "The raw operation name.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "A hash of the operation name.",
+          "type": "string",
+          "const": "hash"
+        }
+      ]
+    },
+    "ResponseStatus": {
+      "oneOf": [
+        {
+          "description": "The http status code.",
+          "type": "string",
+          "const": "code"
+        },
+        {
+          "description": "The http status reason.",
+          "type": "string",
+          "const": "reason"
+        }
+      ]
+    },
+    "ActiveSubgraphRequests": {
+      "oneOf": [
+        {
+          "description": "The number of active subgraph requests as a count.",
+          "type": "string",
+          "const": "count"
+        },
+        {
+          "description": "Whether there are any active subgraph requests as a boolean.",
+          "type": "string",
+          "const": "bool"
+        }
+      ]
+    },
+    "TraceIdFormat": {
+      "oneOf": [
+        {
+          "description": "Format the Trace ID as a hexadecimal number\n\n(e.g. Trace ID 16 -> 00000000000000000000000000000010)",
+          "type": "string",
+          "const": "hexadecimal"
+        },
+        {
+          "description": "Format the Trace ID as a hexadecimal number\n\n(e.g. Trace ID 16 -> 00000000000000000000000000000010)",
+          "type": "string",
+          "const": "open_telemetry"
+        },
+        {
+          "description": "Format the Trace ID as a decimal number\n\n(e.g. Trace ID 16 -> 16)",
+          "type": "string",
+          "const": "decimal"
+        },
+        {
+          "description": "Datadog",
+          "type": "string",
+          "const": "datadog"
+        },
+        {
+          "description": "UUID format with dashes\n(eg. 67e55044-10b1-426f-9247-bb680e5fe0c8)",
+          "type": "string",
+          "const": "uuid"
+        }
+      ]
+    },
+    "ContextConf": {
+      "description": "Configures the context",
+      "anyOf": [
+        {
+          "description": "Deprecated configuration using a boolean",
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/NewContextConf"
+        }
+      ]
+    },
+    "NewContextConf": {
+      "description": "Configures the context",
+      "oneOf": [
+        {
+          "description": "Send all context keys to coprocessor",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send all context keys using deprecated names (from router 1.x) to coprocessor",
+          "type": "string",
+          "const": "deprecated"
+        },
+        {
+          "description": "Only send the list of context keys to coprocessor",
+          "type": "object",
+          "properties": {
+            "selective": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["selective"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RouterResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SupergraphStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "$ref": "#/definitions/SupergraphResponseConf"
+        }
+      }
+    },
+    "SupergraphRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionSupergraphSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSupergraphSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSupergraphSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "SupergraphSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "SupergraphSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operation_kind": {
+              "description": "The operation kind from the query (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "description": "The graphql query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Query"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "query_variable": {
+              "description": "The name of a graphql query variable.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        },
+        {
+          "description": "A status from the response",
+          "type": "object",
+          "properties": {
+            "response_status": {
+              "description": "The http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_data": {
+              "description": "The supergraph response body json path of the chunks.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_errors": {
+              "description": "The supergraph response body json path of the chunks.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_errors"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "on_graphql_error": {
+              "description": "Boolean set to true if the response body contains graphql error",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["on_graphql_error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "description": "Cost attributes",
+          "type": "object",
+          "properties": {
+            "cost": {
+              "description": "The cost value to select, one of: estimated, actual, delta.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CostValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["cost"]
+        },
+        {
+          "description": "Boolean returning true if it's the primary response and not events like subscription events or deferred responses",
+          "type": "object",
+          "properties": {
+            "is_primary_response": {
+              "description": "Boolean returning true if it's the primary response and not events like subscription events or deferred responses",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["is_primary_response"]
+        }
+      ]
+    },
+    "OperationKind": {
+      "oneOf": [
+        {
+          "description": "The raw operation kind.",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "Query": {
+      "oneOf": [
+        {
+          "description": "The raw query kind.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "The query aliases.",
+          "type": "string",
+          "const": "aliases"
+        },
+        {
+          "description": "The query depth.",
+          "type": "string",
+          "const": "depth"
+        },
+        {
+          "description": "The query height.",
+          "type": "string",
+          "const": "height"
+        },
+        {
+          "description": "The query root fields.",
+          "type": "string",
+          "const": "root_fields"
+        }
+      ]
+    },
+    "CostValue": {
+      "oneOf": [
+        {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "estimated"
+        },
+        {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "actual"
+        },
+        {
+          "description": "The delta between the estimated and actual cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "delta"
+        },
+        {
+          "description": "The result of the cost calculation. This is the error code returned by the cost calculation.",
+          "type": "string",
+          "const": "result"
+        }
+      ]
+    },
+    "SupergraphResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExecutionStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExecutionRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "$ref": "#/definitions/ExecutionResponseConf"
+        }
+      }
+    },
+    "ExecutionRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "query_plan": {
+          "description": "Send the query plan",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExecutionResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphStages": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/SubgraphStage"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphStage": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/SubgraphRequestConf"
+        },
+        "response": {
+          "$ref": "#/definitions/SubgraphResponseConf"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphRequestConf": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "uri": {
+          "description": "Send the subgraph URI",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method URI",
+          "type": "boolean",
+          "default": false
+        },
+        "service_name": {
+          "description": "Send the service name",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_request_id": {
+          "description": "Send the subgraph request id",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionSubgraphSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/SubgraphSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSubgraphSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSubgraphSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "SubgraphSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "SubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_operation_name": {
+              "description": "The operation name from the subgraph query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_operation_kind": {
+              "description": "The kind of the subgraph operation (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_name": {
+              "description": "The subgraph name",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_query": {
+              "description": "The graphql query to the subgraph.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SubgraphQuery"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_query_variable": {
+              "description": "The name of a subgraph query variable.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_data": {
+              "description": "The subgraph response body json path.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_errors": {
+              "description": "The subgraph response body json path.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_errors"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_request_header": {
+              "description": "The name of a subgraph request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_header": {
+              "description": "The name of a subgraph response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_status": {
+              "description": "The subgraph http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_resend_count": {
+              "description": "The subgraph http resend count",
+              "type": "boolean"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_resend_count"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_name": {
+              "description": "The supergraph query operation name.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_kind": {
+              "description": "The supergraph query operation kind (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_query": {
+              "description": "The supergraph query to the subgraph.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Query"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_query_variable": {
+              "description": "The supergraph query variable name.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_request_header": {
+              "description": "The supergraph request header name.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_on_graphql_error": {
+              "description": "Boolean set to true if the response body contains graphql error",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_on_graphql_error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "cache": {
+              "description": "Select if you want to get cache hit or cache miss",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheKind"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["cache"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_cache": {
+              "description": "Select if you want to get response cache hit or response cache miss",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheKind"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_cache"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_cache_status": {
+              "description": "Select if you want to know if it's a cache hit (all data coming from cache), miss (all data coming from subgraph) or partial_hit (not all entities are coming from cache for example)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheStatus"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data status. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_cache_status"]
+        }
+      ]
+    },
+    "SubgraphQuery": {
+      "oneOf": [
+        {
+          "description": "The raw query kind.",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "CacheKind": {
+      "type": "string",
+      "enum": ["hit", "miss"]
+    },
+    "EntityType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/All"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "All": {
+      "type": "string",
+      "enum": ["all"]
+    },
+    "CacheStatus": {
+      "type": "string",
+      "enum": ["hit", "miss", "partial_hit", "status"]
+    },
+    "SubgraphResponseConf": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "service_name": {
+          "description": "Send the service name",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the http status",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_request_id": {
+          "description": "Send the subgraph request id",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "CSRFConfig": {
+      "description": "CSRF protection configuration.\n\nSee <https://owasp.org/www-community/attacks/csrf> for an explanation on CSRF attacks.",
+      "type": "object",
+      "properties": {
+        "unsafe_disabled": {
+          "description": "The CSRF plugin is enabled by default.\n\nSetting `unsafe_disabled: true` *disables* CSRF protection.",
+          "type": "boolean",
+          "default": false
+        },
+        "required_headers": {
+          "description": "Override the headers to check for by setting\ncustom_headers\nNote that if you set required_headers here,\nyou may also want to have a look at your `CORS` configuration,\nand make sure you either:\n- did not set any `allow_headers` list (so it defaults to `mirror_request`)\n- added your required headers to the allow_headers list, as shown in the\n  `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["x-apollo-operation-name", "apollo-require-preflight"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DemandControlConfig": {
+      "description": "Demand control configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable demand control",
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "The mode that the demand control plugin should operate in.\n- Measure: The plugin will measure the cost of incoming requests but not reject them.\n- Enforce: The plugin will enforce the cost of incoming requests and reject them if the algorithm indicates that they should be rejected.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode2"
+            }
+          ]
+        },
+        "strategy": {
+          "description": "The strategy used to reject requests.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StrategyConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled", "mode", "strategy"]
+    },
+    "Mode2": {
+      "type": "string",
+      "enum": ["measure", "enforce"]
+    },
+    "StrategyConfig": {
+      "description": "Algorithm for calculating the cost of an incoming query.",
+      "oneOf": [
+        {
+          "description": "A simple, statically-defined cost mapping for operations and types.\n\nOperation costs:\n- Mutation: 10\n- Query: 0\n- Subscription 0\n\nType costs:\n- Object: 1\n- Interface: 1\n- Union: 1\n- Scalar: 0\n- Enum: 0",
+          "type": "object",
+          "properties": {
+            "static_estimated": {
+              "type": "object",
+              "properties": {
+                "list_size": {
+                  "description": "The assumed length of lists returned by the operation.",
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0
+                },
+                "max": {
+                  "description": "The maximum cost of a query",
+                  "type": "number",
+                  "format": "double"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["list_size", "max"]
+            }
+          },
+          "required": ["static_estimated"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Config4": {
+      "description": "The enhanced client-awareness plugin has no configuration.",
+      "type": "object"
+    },
+    "Config5": {
+      "description": "Configuration for the diagnostics plugin\n\n**Platform Requirements**: This plugin is supported on all platforms.\nHeap dump functionality is only available on Linux platforms due to\njemalloc requirements. Other diagnostic features work across platforms.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the diagnostics plugin",
+          "type": "boolean",
+          "default": false
+        },
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:8089\nDo not expose this endpoint to the internet as it exposes sensitive information.",
+          "default": "127.0.0.1:8089",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "output_directory": {
+          "description": "Directory path for memory dump files\nDefaults to \"/tmp/router-diagnostics\" on Unix, or temp directory on other platforms\n\nThis directory will be created automatically if it doesn't exist.\nNote: Memory dumps are only generated on Linux platforms.",
+          "type": "string",
+          "default": "/tmp/router-diagnostics"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphConfig": {
+      "description": "Configuration for one subgraph for the `mock_subgraphs` plugin",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "HTTP headers for the subgraph response",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "query": {
+          "description": "Data for `query` operations (excluding the special `_entities` field)\n\nIn maps nested in this one (but not at the top level), the `__cacheTags` key is special.\nInstead of representing a field that can be selected, when its parent field is selected\nits value is expected to be an array which is appended\nto the `response.extensions[\"apolloCacheTags\"]` array.",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "mutation": {
+          "description": "Data for `mutation` operations",
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "default": null
+        },
+        "entities": {
+          "description": "Entities that can be queried through Federation’s special `_entities` field\n\nIn maps directly in the top-level `Vec` (but not in other maps nested deeper),\nthe `__cacheTags` key is special.\nInstead of representing a field that can be selected, when its parent entity is selected\nits contents are added to the `response.extensions[\"apolloEntityCacheTags\"]` array.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "default": []
+        }
+      }
+    },
+    "Conf": {
+      "description": "The fleet detector plugin has no configuration.",
+      "type": "object"
+    },
+    "ForbidMutationsConfig": {
+      "description": "Forbid mutations configuration",
+      "type": "boolean"
+    },
+    "HeadersConfig": {
+      "description": "Configuration for header propagation",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Rules to apply to all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HeadersLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Rules to specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/HeadersLocation"
+          }
+        },
+        "connector": {
+          "description": "Rules for connectors",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorHeadersConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HeadersLocation": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Propagate/Insert/Remove headers from request",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["request"]
+    },
+    "Operation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "insert": {
+              "$ref": "#/definitions/Insert"
+            }
+          },
+          "required": ["insert"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "remove": {
+              "$ref": "#/definitions/Remove"
+            }
+          },
+          "required": ["remove"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "propagate": {
+              "$ref": "#/definitions/Propagate"
+            }
+          },
+          "required": ["propagate"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Insert": {
+      "description": "Insert header",
+      "anyOf": [
+        {
+          "description": "Insert static header",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertStatic"
+            }
+          ]
+        },
+        {
+          "description": "Insert header with a value coming from context key (works only for a string in the context)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertFromContext"
+            }
+          ]
+        },
+        {
+          "description": "Insert header with a value coming from body",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertFromBody"
+            }
+          ]
+        }
+      ]
+    },
+    "InsertStatic": {
+      "description": "Insert static header",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the header",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the header",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "value"]
+    },
+    "InsertFromContext": {
+      "description": "Insert header with a value coming from context key",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Specify header name",
+          "type": "string"
+        },
+        "from_context": {
+          "description": "Specify context key to fetch value",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "from_context"]
+    },
+    "InsertFromBody": {
+      "description": "Insert header with a value coming from body",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The target header name",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path in the request body",
+          "type": "string"
+        },
+        "default": {
+          "description": "The default if the path in the body did not resolve to an element",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "path"]
+    },
+    "Remove": {
+      "description": "Remove header",
+      "oneOf": [
+        {
+          "description": "Remove a header given a header name",
+          "type": "object",
+          "properties": {
+            "named": {
+              "description": "Remove a header given a header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "required": ["named"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Remove a header given a regex matching header name",
+          "type": "object",
+          "properties": {
+            "matching": {
+              "description": "Remove a header given a regex matching against the header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "required": ["matching"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Propagate": {
+      "description": "Propagate header",
+      "anyOf": [
+        {
+          "description": "Propagate header given a header name",
+          "type": "object",
+          "properties": {
+            "named": {
+              "description": "The source header name",
+              "type": "string"
+            },
+            "rename": {
+              "description": "An optional target header name",
+              "type": ["string", "null"]
+            },
+            "default": {
+              "description": "Default value for the header.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["named"]
+        },
+        {
+          "description": "Propagate header given a regex to match header name",
+          "type": "object",
+          "properties": {
+            "matching": {
+              "description": "The regex on header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "additionalProperties": false,
+          "required": ["matching"]
+        }
+      ]
+    },
+    "ConnectorHeadersConfiguration": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/HeadersLocation"
+          }
+        },
+        "all": {
+          "description": "Options applying to all sources across all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HeadersLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IncludeSubgraphErrorsConfig": {
+      "description": "Configuration for exposing errors that originate from subgraphs",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Global configuration for error redaction. Applies to all subgraphs.",
+          "default": false,
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorMode"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Overrides global configuration on a per-subgraph basis",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphConfig2"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorMode": {
+      "anyOf": [
+        {
+          "description": "When `true`, Propagate the original error as is. Otherwise, redact it.",
+          "type": "boolean"
+        },
+        {
+          "description": "Allow specific extension keys with required redact_message",
+          "type": "object",
+          "properties": {
+            "allow_extensions_keys": {
+              "description": "Allow specific extension keys",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "redact error messages for all subgraphs",
+              "type": "boolean"
+            }
+          },
+          "required": ["allow_extensions_keys", "redact_message"]
+        },
+        {
+          "description": "Deny specific extension keys with required redact_message",
+          "type": "object",
+          "properties": {
+            "deny_extensions_keys": {
+              "description": "Deny specific extension keys",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "redact error messages for all subgraphs",
+              "type": "boolean"
+            }
+          },
+          "required": ["deny_extensions_keys", "redact_message"]
+        }
+      ]
+    },
+    "SubgraphConfig2": {
+      "anyOf": [
+        {
+          "description": "Enable or disable error redaction for a subgraph",
+          "type": "boolean"
+        },
+        {
+          "description": "Allow specific error extension keys for a subgraph",
+          "type": "object",
+          "properties": {
+            "allow_extensions_keys": {
+              "description": "Allow specific extension keys for a subgraph. Will extending global allow list or override a global deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "required": ["allow_extensions_keys"]
+        },
+        {
+          "description": "Deny specific error extension keys for a subgraph",
+          "type": "object",
+          "properties": {
+            "deny_extensions_keys": {
+              "description": "Allow specific extension keys for a subgraph. Will extending global deny list or override a global allow list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "required": ["deny_extensions_keys"]
+        },
+        {
+          "description": "Override global configuration, but don't allow or deny any new keys explicitly",
+          "type": "object",
+          "properties": {
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          }
+        }
+      ]
+    },
+    "LicenseEnforcementConfig": {
+      "description": "The license enforcement plugin has no configuration.",
+      "type": "object"
+    },
+    "Conf2": {
+      "description": "Subgraph URL mappings",
+      "anyOf": [
+        {
+          "description": "Subgraph URL mappings",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "Config6": {
+      "description": "Configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable or disable the entity caching feature",
+          "type": "boolean",
+          "default": false
+        },
+        "expose_keys_in_context": {
+          "description": "Expose cache keys in context",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph": {
+          "description": "Configure invalidation per subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphConfiguration"
+            }
+          ]
+        },
+        "invalidation": {
+          "description": "Global invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InvalidationEndpointConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Entity caching evaluation metrics",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metrics"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["subgraph"]
+    },
+    "SubgraphSubgraphConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "redis": null,
+            "ttl": null,
+            "enabled": true,
+            "private_id": null,
+            "invalidation": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Subgraph"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Subgraph"
+          },
+          "default": {}
+        }
+      }
+    },
+    "Subgraph": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "redis": {
+          "description": "Redis configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ttl": {
+          "description": "expiration for all keys for this subgraph, unless overridden by the `Cache-Control` header in subgraph responses",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "enabled": {
+          "description": "activates caching for this subgraph, overrides the global configuration",
+          "type": ["boolean", "null"],
+          "default": true
+        },
+        "private_id": {
+          "description": "Context key used to separate cache sections per user",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "invalidation": {
+          "description": "Invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphInvalidationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Ttl": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "string"
+    },
+    "SubgraphInvalidationConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the invalidation",
+          "type": "boolean",
+          "default": false
+        },
+        "shared_key": {
+          "description": "Shared key needed to request the invalidation endpoint",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
+    },
+    "InvalidationEndpointConfig": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Specify on which path you want to listen for invalidation endpoint.",
+          "type": "string"
+        },
+        "listen": {
+          "description": "Listen address on which the invalidation endpoint must listen.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "scan_count": {
+          "description": "Number of keys to return at once from a redis SCAN command",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1000
+        },
+        "concurrent_requests": {
+          "description": "Number of concurrent invalidation requests",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 10
+        }
+      },
+      "additionalProperties": false,
+      "required": ["path", "listen"]
+    },
+    "Metrics": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "enables metrics evaluating the benefits of entity caching",
+          "type": "boolean",
+          "default": false
+        },
+        "ttl": {
+          "description": "Metrics counter TTL",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "separate_per_type": {
+          "description": "Adds the entity type name to attributes. This can greatly increase the cardinality",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "FileUploadsConfig": {
+      "description": "Configuration for File Uploads plugin",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether the file upload plugin should be enabled (default: false)",
+          "type": "boolean"
+        },
+        "protocols": {
+          "description": "Supported protocol configurations for file uploads",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FileUploadProtocols"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled", "protocols"]
+    },
+    "FileUploadProtocols": {
+      "description": "Configuration for the various protocols supported by the file upload plugin",
+      "type": "object",
+      "properties": {
+        "multipart": {
+          "description": "Configuration for multipart requests.\n\nThis protocol conforms to [jaydenseric's multipart spec](https://github.com/jaydenseric/graphql-multipart-request-spec)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequest"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["multipart"]
+    },
+    "MultipartRequest": {
+      "description": "Configuration for a multipart request for file uploads.\n\nThis protocol conforms to [jaydenseric's multipart spec](https://github.com/jaydenseric/graphql-multipart-request-spec)",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether to enable the multipart protocol for file uploads (default: true)",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "The supported mode for the request (default: [MultipartRequestMode::Stream])",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequestMode"
+            }
+          ]
+        },
+        "limits": {
+          "description": "Resource limits for multipart requests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequestLimits"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MultipartRequestMode": {
+      "description": "Supported mode for a multipart request",
+      "oneOf": [
+        {
+          "description": "The multipart request will not be loaded into memory and instead will\nbe streamed directly to the subgraph in the order received. This has some\nlimitations, mainly that the query _must_ be able to be streamed directly\nto the subgraph without buffering.\n\nIn practice, this means that certain queries will fail due to ordering of the\nfiles.",
+          "type": "string",
+          "const": "stream"
+        }
+      ]
+    },
+    "MultipartRequestLimits": {
+      "description": "Request limits for a multipart request",
+      "type": "object",
+      "properties": {
+        "max_files": {
+          "description": "The maximum amount of files allowed for a single query (default: 4)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        },
+        "max_file_size": {
+          "description": "The maximum size of each file, in bytes (default: 5MB)",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["max_files", "max_file_size"]
+    },
+    "Config7": {
+      "description": "Configuration for response caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable or disable the response caching feature",
+          "type": "boolean",
+          "default": false
+        },
+        "debug": {
+          "description": "Enable debug mode for the debugger",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph": {
+          "description": "Configure invalidation per subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphConfiguration2"
+            }
+          ]
+        },
+        "invalidation": {
+          "description": "Global invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InvalidationEndpointConfig2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "private_queries_buffer_size": {
+          "description": "Buffer size for known private queries (default: 2048)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 2048
+        }
+      },
+      "additionalProperties": false,
+      "required": ["subgraph"]
+    },
+    "SubgraphSubgraphConfiguration2": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "redis": null,
+            "ttl": null,
+            "enabled": true,
+            "private_id": null,
+            "invalidation": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Subgraph2"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Subgraph2"
+          },
+          "default": {}
+        }
+      }
+    },
+    "Subgraph2": {
+      "description": "Per subgraph configuration for response caching",
+      "type": "object",
+      "properties": {
+        "redis": {
+          "description": "Redis configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Config8"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ttl": {
+          "description": "expiration for all keys for this subgraph, unless overridden by the `Cache-Control` header in subgraph responses",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "enabled": {
+          "description": "activates caching for this subgraph, overrides the global configuration",
+          "type": ["boolean", "null"],
+          "default": true
+        },
+        "private_id": {
+          "description": "Context key used to separate cache sections per user",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "invalidation": {
+          "description": "Invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphInvalidationConfig2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Config8": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "fetch_timeout": {
+          "description": "Timeout for Redis fetch commands (default: 150ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "insert_timeout": {
+          "description": "Timeout for Redis insert commands (default: 500ms)\n\nInserts are processed asynchronously, so this will not affect response duration.",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "invalidate_timeout": {
+          "description": "Timeout for Redis invalidation commands (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "maintenance_timeout": {
+          "description": "Timeout for Redis maintenance commands (default: 500ms)\n\nMaintenance tasks are processed asynchronously, so this will not affect response duration.",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "ttl": {
+          "description": "TTL for entries",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool (default: 5)",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 5
+        },
+        "metrics_interval": {
+          "description": "Interval for collecting Redis metrics (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "Ttl2": {
+      "description": "Per subgraph configuration for response caching",
+      "type": "string"
+    },
+    "SubgraphInvalidationConfig2": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the invalidation",
+          "type": "boolean",
+          "default": false
+        },
+        "shared_key": {
+          "description": "Shared key needed to request the invalidation endpoint",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
+    },
+    "InvalidationEndpointConfig2": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Specify on which path you want to listen for invalidation endpoint.",
+          "type": "string"
+        },
+        "listen": {
+          "description": "Listen address on which the invalidation endpoint must listen.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["path", "listen"]
+    },
+    "Config9": {
+      "description": "Configuration for the progressive override plugin",
+      "type": "object"
+    },
+    "RhaiConfig": {
+      "description": "Configuration for the Rhai Plugin",
+      "type": "object",
+      "properties": {
+        "scripts": {
+          "description": "The directory where Rhai scripts can be found",
+          "type": ["string", "null"]
+        },
+        "main": {
+          "description": "The main entry point for Rhai script evaluation",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubscriptionConfig": {
+      "description": "Subscriptions configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable subscription",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "Select a subscription mode (callback or passthrough)",
+          "default": {
+            "callback": null,
+            "passthrough": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubscriptionModeConfig"
+            }
+          ]
+        },
+        "deduplication": {
+          "description": "Configure subgraph subscription deduplication",
+          "default": {
+            "enabled": true,
+            "ignored_headers": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeduplicationConfig"
+            }
+          ]
+        },
+        "max_opened_subscriptions": {
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "queue_capacity": {
+          "description": "It represent the capacity of the in memory queue to know how many events we can keep in a buffer",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubscriptionModeConfig": {
+      "type": "object",
+      "properties": {
+        "callback": {
+          "description": "Enable callback mode for subgraph(s)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CallbackMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "passthrough": {
+          "description": "Enable passthrough mode for subgraph(s)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphPassthroughMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CallbackMode": {
+      "description": "Using a callback url",
+      "type": "object",
+      "properties": {
+        "public_url": {
+          "description": "URL used to access this router instance, including the path configured on the Router",
+          "type": "string"
+        },
+        "heartbeat_interval": {
+          "description": "Heartbeat interval for callback mode (default: 5secs)",
+          "default": "enabled",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HeartbeatInterval"
+            }
+          ]
+        },
+        "listen": {
+          "description": "Listen address on which the callback must listen (default: 127.0.0.1:4000)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "writeOnly": true
+        },
+        "path": {
+          "description": "Specify on which path you want to listen for callbacks (default: /callback)",
+          "type": ["string", "null"],
+          "writeOnly": true
+        },
+        "subgraphs": {
+          "description": "Specify on which subgraph we enable the callback mode for subscription\nIf empty it applies to all subgraphs (passthrough mode takes precedence)",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "required": ["public_url"]
+    },
+    "HeartbeatInterval": {
+      "anyOf": [
+        {
+          "description": "disable heartbeat",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Disabled"
+            }
+          ]
+        },
+        {
+          "description": "enable with default interval of 5s",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Enabled"
+            }
+          ]
+        },
+        {
+          "description": "enable with custom interval, e.g. '100ms', '10s' or '1m'",
+          "type": "string"
+        }
+      ]
+    },
+    "Disabled": {
+      "type": "string",
+      "enum": ["disabled"]
+    },
+    "Enabled": {
+      "type": "string",
+      "enum": ["enabled"]
+    },
+    "SubgraphPassthroughMode": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Configuration for all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WebSocketConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraphs": {
+          "description": "Configuration for specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WebSocketConfiguration"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "WebSocketConfiguration": {
+      "description": "WebSocket configuration for a specific subgraph",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Path on which WebSockets are listening",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "protocol": {
+          "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+          "default": "graphql_ws",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WebSocketProtocol"
+            }
+          ]
+        },
+        "heartbeat_interval": {
+          "description": "Heartbeat interval for graphql-ws protocol (default: disabled)",
+          "default": "disabled",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HeartbeatInterval"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "WebSocketProtocol": {
+      "oneOf": [
+        {
+          "description": "The modern graphql-ws protocol. The subprotocol name is \"graphql-transport-ws\".\n\nSpec URL: https://github.com/enisdenjo/graphql-ws/blob/0c0eb499c3a0278c6d9cc799064f22c5d24d2f60/PROTOCOL.md",
+          "type": "string",
+          "const": "graphql_ws"
+        },
+        {
+          "description": "The legacy subscriptions-transport-ws protocol. Confusingly, the subprotocol name is\n\"graphql-ws\".\n\nhttps://github.com/apollographql/subscriptions-transport-ws/blob/36f3f6f780acc1a458b768db13fd39c65e5e6518/PROTOCOL.md",
+          "type": "string",
+          "const": "graphql_transport_ws"
+        }
+      ]
+    },
+    "DeduplicationConfig": {
+      "description": "Subscription deduplication configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable subgraph subscription deduplication. When enabled, multiple identical requests to the same subgraph will share one WebSocket connection in passthrough mode.\n(default: true)",
+          "type": "boolean",
+          "default": true
+        },
+        "ignored_headers": {
+          "description": "List of headers to ignore for deduplication. Even if these headers are different, the subscription request is considered identical.\nFor example, if you forward the \"User-Agent\" header, but the subgraph doesn't depend on the value of that header,\nadding it to this list will let the router dedupe subgraph subscriptions even if the header value is different.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "TelemetryConfig": {
+      "description": "Telemetry configuration",
+      "type": "object",
+      "properties": {
+        "apollo": {
+          "description": "Apollo reporting configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloTelemetryConfig"
+            }
+          ]
+        },
+        "exporters": {
+          "description": "Instrumentation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Exporters"
+            }
+          ]
+        },
+        "instrumentation": {
+          "description": "Instrumentation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Instrumentation"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ApolloTelemetryConfig": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+          "type": "string",
+          "default": "https://usage-reporting.api.apollographql.com/api/ingress/traces"
+        },
+        "experimental_otlp_endpoint": {
+          "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+          "type": "string",
+          "default": "https://usage-reporting.api.apollographql.com/"
+        },
+        "client_name_header": {
+          "description": "The name of the header to extract from requests when populating 'client name' for traces and metrics in Apollo Studio.",
+          "type": ["string", "null"],
+          "default": "apollographql-client-name"
+        },
+        "client_version_header": {
+          "description": "The name of the header to extract from requests when populating 'client version' for traces and metrics in Apollo Studio.",
+          "type": ["string", "null"],
+          "default": "apollographql-client-version"
+        },
+        "buffer_size": {
+          "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 10000
+        },
+        "field_level_instrumentation_sampler": {
+          "description": "Field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "otlp_tracing_sampler": {
+          "description": "Percentage of traces to send via the OTel protocol when sending to Apollo Studio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "experimental_otlp_tracing_protocol": {
+          "description": "OTLP protocol used for OTel traces.\nNote this only applies if OTel traces are enabled and is only intended for use in tests.",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "experimental_otlp_metrics_protocol": {
+          "description": "OTLP protocol used for OTel metrics.\nNote this is only intended for use in tests.",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "send_headers": {
+          "description": "To configure which request header names and values are included in trace data that's sent to Apollo Studio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardHeaders"
+            }
+          ]
+        },
+        "send_variable_values": {
+          "description": "To configure which GraphQL variable values are included in trace data that's sent to Apollo Studio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardValues"
+            }
+          ]
+        },
+        "tracing": {
+          "description": "Configuration for tracing.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TracingConfiguration"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Configuration for metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetricsConfiguration"
+            }
+          ]
+        },
+        "errors": {
+          "description": "Configure the way errors are transmitted to Apollo Studio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorsConfiguration"
+            }
+          ]
+        },
+        "signature_normalization_algorithm": {
+          "description": "Set the signature normalization algorithm to use when sending Apollo usage reports.",
+          "default": "enhanced",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloSignatureNormalizationAlgorithm"
+            }
+          ]
+        },
+        "metrics_reference_mode": {
+          "description": "Set the Apollo usage report reference reporting mode to use.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloMetricsReferenceMode"
+            }
+          ]
+        },
+        "experimental_local_field_metrics": {
+          "description": "Enable field metrics that are generated without FTV1 to be sent to Apollo Studio.",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_metrics": {
+          "description": "Enable sending additional subgraph metrics to Apollo Studio via OTLP",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "SamplerOption": {
+      "anyOf": [
+        {
+          "description": "Sample a given fraction. Fractions >= 1 will always sample.",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "$ref": "#/definitions/Sampler"
+        }
+      ]
+    },
+    "Sampler": {
+      "oneOf": [
+        {
+          "description": "Always sample",
+          "type": "string",
+          "const": "always_on"
+        },
+        {
+          "description": "Never sample",
+          "type": "string",
+          "const": "always_off"
+        }
+      ]
+    },
+    "Protocol": {
+      "type": "string",
+      "enum": ["grpc", "http"]
+    },
+    "ForwardHeaders": {
+      "description": "Forward headers",
+      "oneOf": [
+        {
+          "description": "Don't send any headers",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Send all headers",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send only the headers specified",
+          "type": "object",
+          "properties": {
+            "only": {
+              "description": "Send only the headers specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["only"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Send all headers except those specified",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Send all headers except those specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["except"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ForwardValues": {
+      "description": "Forward GraphQL variables",
+      "oneOf": [
+        {
+          "description": "Dont send any variables",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Send all variables",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send only the variables specified",
+          "type": "object",
+          "properties": {
+            "only": {
+              "description": "Send only the variables specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["only"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Send all variables except those specified",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Send all variables except those specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["except"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TracingConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Configuration for tracing batch processor.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "BatchProcessorConfig": {
+      "description": "Batch processor configuration",
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_queue_size": {
+          "description": "The maximum queue size to buffer spans for delayed processing. If the\nqueue gets full it drops the spans. The default value is 2048.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2048
+        },
+        "max_export_batch_size": {
+          "description": "The maximum number of spans to process in a single batch. If there are\nmore than one batch worth of spans then it processes multiple batches\nof spans one batch after the other without any delay. The default value\nis 512.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 512
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        },
+        "max_concurrent_exports": {
+          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed\nby an exporter. A value of 1 will cause exports to be performed\nsynchronously on the BatchSpanProcessor task.\nThe default is 1.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 1
+        }
+      }
+    },
+    "MetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "otlp": {
+          "description": "Configuration for exporting metrics via OTLP.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OtlpMetricsConfiguration"
+            }
+          ]
+        },
+        "usage_reports": {
+          "description": "Configuration for exporting metrics via Apollo usage reports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UsageReportsMetricsConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OtlpMetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Batch processor config for OTLP metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OtlpMetricsBatchProcessorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OtlpMetricsBatchProcessorConfiguration": {
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        }
+      }
+    },
+    "UsageReportsMetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Batch processor config for Apollo usage report metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloUsageReportsBatchProcessorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ApolloUsageReportsBatchProcessorConfiguration": {
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_queue_size": {
+          "description": "The maximum queue size to buffer spans for delayed processing. If the\nqueue gets full it drops the reports. The default value is 2048.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2048
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        }
+      }
+    },
+    "ErrorsConfiguration": {
+      "type": "object",
+      "properties": {
+        "subgraph": {
+          "description": "Handling of errors coming from subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphErrorConfig"
+            }
+          ]
+        },
+        "preview_extended_error_metrics": {
+          "description": "Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedErrorMetricsMode"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphErrorConfig": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Handling of errors coming from all subgraphs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorConfiguration"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Handling of errors coming from specified subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ErrorConfiguration"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorConfiguration": {
+      "type": "object",
+      "properties": {
+        "send": {
+          "description": "Send subgraph errors to Apollo Studio",
+          "type": "boolean",
+          "default": true
+        },
+        "redact": {
+          "description": "Redact subgraph errors to Apollo Studio",
+          "type": "boolean",
+          "default": true
+        },
+        "redaction_policy": {
+          "description": "Allows additional dimension `extensions.code` to be sent with errors\neven when `redact` is set to `true`.  Has no effect when `redact` is false.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorRedactionPolicy"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorRedactionPolicy": {
+      "description": "Allow some error fields to be send to Apollo Studio even when `redact` is true.",
+      "oneOf": [
+        {
+          "description": "Applies redaction to all error details.",
+          "type": "string",
+          "const": "strict"
+        },
+        {
+          "description": "Modifies the `redact` setting by excluding the `extensions.code` field in errors from redaction.",
+          "type": "string",
+          "const": "extended"
+        }
+      ]
+    },
+    "ExtendedErrorMetricsMode": {
+      "description": "Extended Open Telemetry error metrics mode",
+      "oneOf": [
+        {
+          "description": "Do not send extended OTLP error metrics",
+          "type": "string",
+          "const": "disabled"
+        },
+        {
+          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`].\nIf enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
+          "type": "string",
+          "const": "enabled"
+        }
+      ]
+    },
+    "ApolloSignatureNormalizationAlgorithm": {
+      "description": "Apollo usage report signature normalization algorithm",
+      "oneOf": [
+        {
+          "description": "Use the algorithm that matches the JavaScript-based implementation.",
+          "type": "string",
+          "const": "legacy"
+        },
+        {
+          "description": "Use a new algorithm that includes input object forms, normalized aliases and variable names, and removes some\nedge cases from the JS implementation that affected normalization.",
+          "type": "string",
+          "const": "enhanced"
+        }
+      ]
+    },
+    "ApolloMetricsReferenceMode": {
+      "description": "Apollo usage report reference generation modes.",
+      "oneOf": [
+        {
+          "description": "Use the extended mode to report input object fields and enum value references as well as object fields.",
+          "type": "string",
+          "const": "extended"
+        },
+        {
+          "description": "Use the standard mode that only reports referenced object fields.",
+          "type": "string",
+          "const": "standard"
+        }
+      ]
+    },
+    "Exporters": {
+      "description": "Exporter configuration",
+      "type": "object",
+      "properties": {
+        "logging": {
+          "description": "Logging configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Logging"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Metrics configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metrics2"
+            }
+          ]
+        },
+        "tracing": {
+          "description": "Tracing configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Tracing"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Logging": {
+      "description": "Logging configuration.",
+      "type": "object",
+      "properties": {
+        "common": {
+          "description": "Common configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LoggingCommon"
+            }
+          ]
+        },
+        "stdout": {
+          "description": "Settings for logging to stdout.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StdOut"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LoggingCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "Set a service.name resource in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "Set a service.namespace attribute in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "StdOut": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to log to stdout.",
+          "type": "boolean",
+          "default": true
+        },
+        "format": {
+          "description": "The format to log to stdout.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/logging_format"
+            }
+          ]
+        },
+        "tty_format": {
+          "description": "The format to log to stdout when you're running on an interactive terminal. When configured it will automatically use this `tty_format`` instead of the original `format` when an interactive terminal is detected",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/logging_format"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rate_limit": {
+          "description": "Log rate limiting. The limit is set per type of log message",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RateLimit"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "logging_format": {
+      "oneOf": [
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+          "type": "object",
+          "properties": {
+            "json": {
+              "type": "object",
+              "properties": {
+                "display_timestamp": {
+                  "description": "Include the timestamp with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_target": {
+                  "description": "Include the target with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_level": {
+                  "description": "Include the level with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_thread_id": {
+                  "description": "Include the thread_id with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_thread_name": {
+                  "description": "Include the thread_name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_filename": {
+                  "description": "Include the filename with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_line_number": {
+                  "description": "Include the line number with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_current_span": {
+                  "description": "Include the current span in this log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_span_list": {
+                  "description": "Include all of the containing span information with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_resource": {
+                  "description": "Include the resource with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_trace_id": {
+                  "description": "Include the trace id (if any) with the log event. (default: true)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DisplayTraceIdFormat"
+                    }
+                  ]
+                },
+                "display_span_id": {
+                  "description": "Include the span id (if any) with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "span_attributes": {
+                  "description": "List of span attributes to attach to the json log object",
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": []
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["json"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+          "type": "string",
+          "enum": ["json"]
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "object",
+              "properties": {
+                "ansi_escape_codes": {
+                  "description": "Process ansi escapes (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_timestamp": {
+                  "description": "Include the timestamp with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_target": {
+                  "description": "Include the target with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_level": {
+                  "description": "Include the level with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_thread_id": {
+                  "description": "Include the thread_id with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_thread_name": {
+                  "description": "Include the thread_name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_filename": {
+                  "description": "Include the filename with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_line_number": {
+                  "description": "Include the line number with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_service_namespace": {
+                  "description": "Include the service namespace with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_service_name": {
+                  "description": "Include the service name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_resource": {
+                  "description": "Include the resource with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_current_span": {
+                  "description": "Include the current span in this log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_span_list": {
+                  "description": "Include all of the containing span information with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_trace_id": {
+                  "description": "Include the trace id (if any) with the log event. (default: false)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DisplayTraceIdFormat"
+                    }
+                  ]
+                },
+                "display_span_id": {
+                  "description": "Include the span id (if any) with the log event. (default: false)",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["text"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+          "type": "string",
+          "enum": ["text"]
+        }
+      ]
+    },
+    "DisplayTraceIdFormat": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TraceIdFormat"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "RateLimit": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to limit the rate of log messages",
+          "type": "boolean",
+          "default": false
+        },
+        "capacity": {
+          "description": "Number of log lines allowed in interval per message",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        },
+        "interval": {
+          "description": "Interval for rate limiting",
+          "type": "string",
+          "default": {
+            "secs": 1,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Metrics2": {
+      "description": "Metrics configuration",
+      "type": "object",
+      "properties": {
+        "common": {
+          "description": "Common metrics configuration across all exporters",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetricsCommon"
+            }
+          ]
+        },
+        "otlp": {
+          "description": "Open Telemetry native exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OTLPConfig"
+            }
+          ]
+        },
+        "prometheus": {
+          "description": "Prometheus exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PrometheusMetricsConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricsCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "Set a service.name resource in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "Set a service.namespace attribute in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        },
+        "buckets": {
+          "description": "Custom buckets for all histograms",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "default": [
+            0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 5.0, 10.0
+          ]
+        },
+        "views": {
+          "description": "Views applied on metrics",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricView"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricView": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The instrument name you're targeting",
+          "type": "string"
+        },
+        "rename": {
+          "description": "Rename the metric to this name\n\nThis allows you to customize metric names for both OTLP and Prometheus exporters.\nNote: Prometheus will apply additional transformations (dots to underscores, unit suffixes).\nApollo metrics are not affected by this rename - they will retain original names.",
+          "type": ["string", "null"]
+        },
+        "description": {
+          "description": "New description to set to the instrument",
+          "type": ["string", "null"]
+        },
+        "unit": {
+          "description": "New unit to set to the instrument",
+          "type": ["string", "null"]
+        },
+        "aggregation": {
+          "description": "New aggregation settings to set",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricAggregation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowed_attribute_keys": {
+          "description": "An allow-list of attribute keys that will be preserved for the instrument.\n\nAny attribute recorded for the instrument with a key not in this set will be\ndropped. If the set is empty, all attributes will be dropped, if `None` all\nattributes will be kept.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name"]
+    },
+    "MetricAggregation": {
+      "oneOf": [
+        {
+          "description": "An aggregation that summarizes a set of measurements as an histogram with\nexplicitly defined buckets.",
+          "type": "object",
+          "properties": {
+            "histogram": {
+              "type": "object",
+              "properties": {
+                "buckets": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["buckets"]
+            }
+          },
+          "required": ["histogram"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Simply drop the metrics matching this view",
+          "type": "string",
+          "const": "drop"
+        }
+      ]
+    },
+    "OTLPConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable otlp",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send data to",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "protocol": {
+          "description": "The protocol to use when sending data",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "grpc": {
+          "description": "gRPC configuration settings",
+          "default": {
+            "domain_name": null,
+            "ca": null,
+            "cert": null,
+            "key": null,
+            "metadata": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GrpcExporter"
+            }
+          ]
+        },
+        "http": {
+          "description": "HTTP configuration settings",
+          "default": {
+            "headers": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpExporter"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "Batch processor settings",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        },
+        "temporality": {
+          "description": "Temporality for export (default: `Cumulative`).\nNote that when exporting to Datadog agent use `Delta`.",
+          "default": "cumulative",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Temporality"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "GrpcExporter": {
+      "type": "object",
+      "properties": {
+        "domain_name": {
+          "description": "The optional domain name for tls config.\nNote that domain name is will be defaulted to match the endpoint is not explicitly set.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "ca": {
+          "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "cert": {
+          "description": "The optional cert for tls config",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "key": {
+          "description": "The optional private key file for TLS configuration.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "metadata": {
+          "description": "gRPC metadata",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpExporter": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Headers to send on report requests",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "Temporality": {
+      "oneOf": [
+        {
+          "description": "Export cumulative metrics.",
+          "type": "string",
+          "const": "cumulative"
+        },
+        {
+          "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+          "type": "string",
+          "const": "delta"
+        }
+      ]
+    },
+    "PrometheusMetricsConfig": {
+      "description": "Prometheus configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to enable",
+          "type": "boolean",
+          "default": false
+        },
+        "resource_selector": {
+          "description": "resource_selector is used to select which resource to export with every metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResourceSelectorConfig"
+            }
+          ]
+        },
+        "listen": {
+          "description": "The listen address",
+          "default": "127.0.0.1:9090",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "path": {
+          "description": "The path where prometheus will be exposed",
+          "type": "string",
+          "default": "/metrics"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResourceSelectorConfig": {
+      "oneOf": [
+        {
+          "description": "Export all resource attributes with every metrics.",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Do not export any resource attributes with every metrics.",
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "Tracing": {
+      "description": "Tracing configuration",
+      "type": "object",
+      "properties": {
+        "experimental_response_trace_id": {
+          "description": "A way to expose trace id in response headers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExposeTraceId"
+            }
+          ]
+        },
+        "propagation": {
+          "description": "Propagation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Propagation"
+            }
+          ]
+        },
+        "common": {
+          "description": "Common configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TracingCommon"
+            }
+          ]
+        },
+        "otlp": {
+          "description": "OpenTelemetry native exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OTLPConfig"
+            }
+          ]
+        },
+        "zipkin": {
+          "description": "Zipkin exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZipkinConfig"
+            }
+          ]
+        },
+        "datadog": {
+          "description": "Datadog exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DatadogConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExposeTraceId": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Expose the trace_id in response headers",
+          "type": "boolean",
+          "default": false
+        },
+        "header_name": {
+          "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+          "type": ["string", "null"]
+        },
+        "format": {
+          "description": "Format of the trace ID in response headers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TraceIdFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Propagation": {
+      "description": "Configure propagation of traces. In general you won't have to do this as these are automatically configured\nalong with any exporter you configure.",
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RequestPropagation"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "Propagate baggage https://www.w3.org/TR/baggage/",
+          "type": "boolean",
+          "default": false
+        },
+        "trace_context": {
+          "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
+          "type": "boolean",
+          "default": false
+        },
+        "jaeger": {
+          "description": "Propagate Jaeger",
+          "type": "boolean",
+          "default": false
+        },
+        "datadog": {
+          "description": "Propagate Datadog",
+          "type": "boolean",
+          "default": false
+        },
+        "zipkin": {
+          "description": "Propagate Zipkin",
+          "type": "boolean",
+          "default": false
+        },
+        "aws_xray": {
+          "description": "Propagate AWS X-Ray",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "RequestPropagation": {
+      "type": "object",
+      "properties": {
+        "header_name": {
+          "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+          "type": "string"
+        },
+        "format": {
+          "description": "The trace ID format that will be used when propagating to subgraph services.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TraceIdFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["header_name"]
+    },
+    "TracingCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "The trace service name",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "The trace service namespace",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "sampler": {
+          "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "preview_datadog_agent_sampling": {
+          "description": "Use datadog agent sampling. This means that all spans will be sent to the Datadog agent\nand the `sampling.priority` attribute will be used to control if the span will then be sent to Datadog",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "parent_based_sampler": {
+          "description": "Whether to use parent based sampling",
+          "type": "boolean",
+          "default": true
+        },
+        "max_events_per_span": {
+          "description": "The maximum events per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_span": {
+          "description": "The maximum attributes per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_links_per_span": {
+          "description": "The maximum links per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_event": {
+          "description": "The maximum attributes per event before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_link": {
+          "description": "The maximum attributes per link before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "ZipkinConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable zipkin",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UriEndpoint"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "Batch processor configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "UriEndpoint": {
+      "type": "string"
+    },
+    "DatadogConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable datadog",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UriEndpoint"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "batch processor configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        },
+        "enable_span_mapping": {
+          "description": "Enable datadog span mapping for span name and resource name.",
+          "type": "boolean",
+          "default": true
+        },
+        "fixed_span_names": {
+          "description": "Fixes the span names, this means that the APM view will show the original span names in the operation dropdown.",
+          "type": "boolean",
+          "default": true
+        },
+        "resource_mapping": {
+          "description": "Custom mapping to be used as the resource field in spans, defaults to:\nrouter -> http.route\nsupergraph -> graphql.operation.name\nquery_planning -> graphql.operation.name\nsubgraph -> subgraph.name\nsubgraph_request -> subgraph.name\nhttp_request -> http.route",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "span_metrics": {
+          "description": "Which spans will be eligible for span stats to be collected for viewing in the APM view.\nDefaults to true for `request`, `router`, `query_parsing`, `supergraph`, `execution`, `query_planning`, `subgraph`, `subgraph_request`, `connect`, `connect_request` and `http_request`.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {
+            "execution": true,
+            "request": true,
+            "parse_query": true,
+            "connect_request": true,
+            "router": true,
+            "http_request": true,
+            "connect": true,
+            "supergraph": true,
+            "subgraph_request": true,
+            "subgraph": true,
+            "query_planning": true
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "Instrumentation": {
+      "description": "Instrumentation configuration",
+      "type": "object",
+      "properties": {
+        "events": {
+          "description": "Event configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Events"
+            }
+          ]
+        },
+        "spans": {
+          "description": "Span configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Spans"
+            }
+          ]
+        },
+        "instruments": {
+          "description": "Instrument configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentsConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Events": {
+      "description": "Events are",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Router service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterEventsConfigWithEvent"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Subgraph service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphEventsConfigWithEvent"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Supergraph service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphEventsConfigWithEvent"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorEventsConfigWithEvent"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the router request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the router response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the router error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event"
+      }
+    },
+    "Event": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "EventLevelConfig": {
+      "description": "Log level configuration for events. Use \"off\" to not log the event, or a level name to log the\nevent at that level and above.",
+      "type": "string",
+      "enum": ["info", "warn", "error", "off"]
+    },
+    "EventOn": {
+      "description": "When to trigger the event.",
+      "oneOf": [
+        {
+          "description": "Log the event on request",
+          "type": "string",
+          "const": "request"
+        },
+        {
+          "description": "Log the event on response",
+          "type": "string",
+          "const": "response"
+        },
+        {
+          "description": "Log the event on every chunks in the response",
+          "type": "string",
+          "const": "event_response"
+        },
+        {
+          "description": "Log the event on error",
+          "type": "string",
+          "const": "error"
+        }
+      ]
+    },
+    "ExtendedRouterAttributesWithRouterSelector": {
+      "description": "Common attributes for http server and client.\nSee https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
+      "type": "object",
+      "properties": {
+        "dd.trace_id": {
+          "description": "The datadog trace ID.\nThis can be output in logs and used to correlate traces in Datadog.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trace_id": {
+          "description": "The OpenTelemetry trace ID.\nThis can be output in logs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "All key values from trace baggage.",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "error.type": {
+          "description": "Describes a class of error the operation ended with.\nExamples:\n\n* timeout\n* name_resolution_error\n* 500\n\nRequirement level: Conditionally Required: If request has ended with an error.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.body.size": {
+          "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.method": {
+          "description": "HTTP request method.\nExamples:\n\n* GET\n* POST\n* HEAD\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.body.size": {
+          "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.status_code": {
+          "description": "HTTP response status code.\nExamples:\n\n* 200\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.name": {
+          "description": "OSI application layer or non-OSI equivalent.\nExamples:\n\n* http\n* spdy\n\nRequirement level: Recommended: if not default (http).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.version": {
+          "description": "Version of the protocol specified in network.protocol.name.\nExamples:\n\n* 1.0\n* 1.1\n* 2\n* 3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.transport": {
+          "description": "OSI transport layer.\nExamples:\n\n* tcp\n* udp\n\nRequirement level: Conditionally Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.type": {
+          "description": "OSI network layer or non-OSI equivalent.\nExamples:\n\n* ipv4\n* ipv6\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.route": {
+          "description": "The matched route (path template in the format used by the respective server framework).\nExamples:\n\n* /graphql\n\nRequirement level: Conditionally Required: If and only if it’s available",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.address": {
+          "description": "Local socket address. Useful in case of a multi-IP host.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.port": {
+          "description": "Local socket port. Useful in case of a multi-port host.\nExamples:\n\n* 65123\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.address": {
+          "description": "Peer address of the network connection - IP address or Unix domain socket name.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.port": {
+          "description": "Peer port number of the network connection.\nExamples:\n\n* 65123\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.address": {
+          "description": "Name of the local HTTP server that received the request.\nExamples:\n\n* example.com\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.port": {
+          "description": "Port of the local HTTP server that received the request.\nExamples:\n\n* 80\n* 8080\n* 443\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.path": {
+          "description": "The URI path component\nExamples:\n\n* /search\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.query": {
+          "description": "The URI query component\nExamples:\n\n* q=OpenTelemetry\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.scheme": {
+          "description": "The URI scheme component identifying the used protocol.\nExamples:\n\n* http\n* https\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user_agent.original": {
+          "description": "Value of the HTTP User-Agent header sent by the client.\nExamples:\n\n* CERN-LineMode/2.15\n* libwww/2.17b3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/RouterSelector"
+      }
+    },
+    "StandardAttribute": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "alias": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["alias"]
+        }
+      ]
+    },
+    "StandardEventConfigRouterSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedSupergraphEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the supergraph request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the supergraph response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the supergraph error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event2"
+      }
+    },
+    "Event2": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedSupergraphAttributesWithSupergraphSelector": {
+      "description": "Attributes for Cost",
+      "type": "object",
+      "properties": {
+        "graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.estimated": {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.result": {
+          "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SupergraphSelector"
+      }
+    },
+    "StandardEventConfigSupergraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedSubgraphEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the subgraph request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the subgraph response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the subgraph error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event3"
+      }
+    },
+    "Event3": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedSubgraphAttributesWithSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph\nExamples:\n\n* products\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.resend_count": {
+          "description": "The number of times the request has been resent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphSelector"
+      }
+    },
+    "StandardEventConfigSubgraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedConnectorEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the connector HTTP request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the connector HTTP response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the connector HTTP error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event4"
+      }
+    },
+    "Event4": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedConnectorAttributesWithConnectorSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph containing the connector\nExamples:\n\n* posts\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.source.name": {
+          "description": "The name of the source for this connector, if defined\nExamples:\n\n* posts_api\n\nRequirement level: Conditionally Required: If the connector has a source defined",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.http.method": {
+          "description": "The HTTP method for the connector\nExamples:\n\n* GET\n* POST\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.url.template": {
+          "description": "The connector URL template, relative to the source base URL if one is defined\nExamples:\n\n* /users/{$this.id!}/post\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConnectorSelector"
+      }
+    },
+    "ConnectorSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_name": {
+              "description": "The subgraph name",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_source": {
+              "description": "The connector source.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ConnectorSource"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_source"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_request_header": {
+              "description": "The name of a connector HTTP request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_response_header": {
+              "description": "The name of a connector HTTP response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_response_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_response_status": {
+              "description": "The connector HTTP response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_method": {
+              "description": "The connector HTTP method.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_method"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_url_template": {
+              "description": "The connector URL template.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_url_template"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_request_mapping_problems": {
+              "description": "Request mapping problems, if any",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/MappingProblems"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_request_mapping_problems"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_response_mapping_problems": {
+              "description": "Response mapping problems, if any",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/MappingProblems"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_response_mapping_problems"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_name": {
+              "description": "The supergraph query operation name.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_kind": {
+              "description": "The supergraph query operation kind (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_on_response_error": {
+              "description": "Boolean set to true if the response's `is_successful` condition is false. If this is not\nset, returns true when the response contains a non-200 status code",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_on_response_error"]
+        }
+      ]
+    },
+    "ConnectorSource": {
+      "oneOf": [
+        {
+          "description": "The name of the connector source.",
+          "type": "string",
+          "const": "name"
+        }
+      ]
+    },
+    "MappingProblems": {
+      "oneOf": [
+        {
+          "description": "String representation of all problems",
+          "type": "string",
+          "const": "problems"
+        },
+        {
+          "description": "The count of mapping problems",
+          "type": "string",
+          "const": "count"
+        },
+        {
+          "description": "Whether there are any mapping problems",
+          "type": "string",
+          "const": "boolean"
+        }
+      ]
+    },
+    "ConditionConnectorSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/ConnectorSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionConnectorSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionConnectorSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "ConnectorSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "StandardEventConfigConnectorSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "Spans": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be defaulted in future to `spec_compliant`, eventually removed in future.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SpanMode"
+            }
+          ]
+        },
+        "default_attribute_requirement_level": {
+          "description": "The attributes to include by default in spans based on their level as specified in the otel semantic conventions and Apollo documentation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DefaultAttributeRequirementLevel"
+            }
+          ]
+        },
+        "router": {
+          "description": "Configuration of router spans.\nLog events inherit attributes from the containing span, so attributes configured here will be included on log events for a request.\nRouter spans contain http request and response information and therefore contain http specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterSpans"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Configuration of supergraph spans.\nSupergraph spans contain information about the graphql request and response and therefore contain graphql specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphSpans"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Attributes to include on the subgraph span.\nSubgraph spans contain information about the subgraph request and response and therefore contain subgraph specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSpans"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Attributes to include on the connector span.\nConnector spans contain information about the connector request and response and therefore contain connector specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorSpans"
+            }
+          ]
+        },
+        "http_client": {
+          "description": "Attributes to include on the HTTP client span.\nHTTP client spans contain information about HTTP requests made to subgraphs, including any changes made by Rhai scripts.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpClientSpans"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpanMode": {
+      "description": "Span mode to create new or deprecated spans",
+      "oneOf": [
+        {
+          "description": "Keep the request span as root span and deprecated attributes. This option will eventually removed.",
+          "type": "string",
+          "const": "deprecated"
+        },
+        {
+          "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be the default in future.",
+          "type": "string",
+          "const": "spec_compliant"
+        }
+      ]
+    },
+    "DefaultAttributeRequirementLevel": {
+      "oneOf": [
+        {
+          "description": "No default attributes set on spans, you have to set it one by one in the configuration to enable some attributes",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Attributes that are marked as required in otel semantic conventions and apollo documentation will be included (default)",
+          "type": "string",
+          "const": "required"
+        },
+        {
+          "description": "Attributes that are marked as required or recommended in otel semantic conventions and apollo documentation will be included",
+          "type": "string",
+          "const": "recommended"
+        }
+      ]
+    },
+    "RouterSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the router span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithConditionalRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterAttributesWithConditionalRouterSelector": {
+      "description": "Common attributes for http server and client.\nSee https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
+      "type": "object",
+      "properties": {
+        "dd.trace_id": {
+          "description": "The datadog trace ID.\nThis can be output in logs and used to correlate traces in Datadog.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trace_id": {
+          "description": "The OpenTelemetry trace ID.\nThis can be output in logs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "All key values from trace baggage.",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "error.type": {
+          "description": "Describes a class of error the operation ended with.\nExamples:\n\n* timeout\n* name_resolution_error\n* 500\n\nRequirement level: Conditionally Required: If request has ended with an error.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.body.size": {
+          "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.method": {
+          "description": "HTTP request method.\nExamples:\n\n* GET\n* POST\n* HEAD\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.body.size": {
+          "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.status_code": {
+          "description": "HTTP response status code.\nExamples:\n\n* 200\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.name": {
+          "description": "OSI application layer or non-OSI equivalent.\nExamples:\n\n* http\n* spdy\n\nRequirement level: Recommended: if not default (http).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.version": {
+          "description": "Version of the protocol specified in network.protocol.name.\nExamples:\n\n* 1.0\n* 1.1\n* 2\n* 3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.transport": {
+          "description": "OSI transport layer.\nExamples:\n\n* tcp\n* udp\n\nRequirement level: Conditionally Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.type": {
+          "description": "OSI network layer or non-OSI equivalent.\nExamples:\n\n* ipv4\n* ipv6\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.route": {
+          "description": "The matched route (path template in the format used by the respective server framework).\nExamples:\n\n* /graphql\n\nRequirement level: Conditionally Required: If and only if it’s available",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.address": {
+          "description": "Local socket address. Useful in case of a multi-IP host.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.port": {
+          "description": "Local socket port. Useful in case of a multi-port host.\nExamples:\n\n* 65123\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.address": {
+          "description": "Peer address of the network connection - IP address or Unix domain socket name.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.port": {
+          "description": "Peer port number of the network connection.\nExamples:\n\n* 65123\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.address": {
+          "description": "Name of the local HTTP server that received the request.\nExamples:\n\n* example.com\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.port": {
+          "description": "Port of the local HTTP server that received the request.\nExamples:\n\n* 80\n* 8080\n* 443\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.path": {
+          "description": "The URI path component\nExamples:\n\n* /search\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.query": {
+          "description": "The URI query component\nExamples:\n\n* q=OpenTelemetry\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.scheme": {
+          "description": "The URI scheme component identifying the used protocol.\nExamples:\n\n* http\n* https\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user_agent.original": {
+          "description": "Value of the HTTP User-Agent header sent by the client.\nExamples:\n\n* CERN-LineMode/2.15\n* libwww/2.17b3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalRouterSelector"
+      }
+    },
+    "ConditionalRouterSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RouterSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          }
+        }
+      ]
+    },
+    "SupergraphSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the supergraph span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithConditionalSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedSupergraphAttributesWithConditionalSupergraphSelector": {
+      "description": "Attributes for Cost",
+      "type": "object",
+      "properties": {
+        "graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.estimated": {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.result": {
+          "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalSupergraphSelector"
+      }
+    },
+    "ConditionalSupergraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SupergraphSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          }
+        }
+      ]
+    },
+    "SubgraphSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the subgraph span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithConditionalSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedSubgraphAttributesWithConditionalSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph\nExamples:\n\n* products\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.resend_count": {
+          "description": "The number of times the request has been resent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalSubgraphSelector"
+      }
+    },
+    "ConditionalSubgraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SubgraphSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          }
+        }
+      ]
+    },
+    "ConnectorSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the connector span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConditionalConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedConnectorAttributesWithConditionalConnectorSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph containing the connector\nExamples:\n\n* posts\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.source.name": {
+          "description": "The name of the source for this connector, if defined\nExamples:\n\n* posts_api\n\nRequirement level: Conditionally Required: If the connector has a source defined",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.http.method": {
+          "description": "The HTTP method for the connector\nExamples:\n\n* GET\n* POST\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.url.template": {
+          "description": "The connector URL template, relative to the source base URL if one is defined\nExamples:\n\n* /users/{$this.id!}/post\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalConnectorSelector"
+      }
+    },
+    "ConditionalConnectorSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConnectorSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          }
+        }
+      ]
+    },
+    "HttpClientSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the HTTP client span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedHttpClientAttributesWithConditionalHttpClientSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedHttpClientAttributesWithConditionalHttpClientSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalHttpClientSelector"
+      }
+    },
+    "ConditionalHttpClientSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HttpClientSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionHttpClientSelector"
+            }
+          }
+        }
+      ]
+    },
+    "HttpClientSelector": {
+      "anyOf": [
+        {
+          "description": "A header from the HTTP request",
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "description": "A header from the HTTP response",
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        }
+      ]
+    },
+    "ConditionHttpClientSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/HttpClientSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionHttpClientSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionHttpClientSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionHttpClientSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "HttpClientSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpClientSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "InstrumentsConfig": {
+      "type": "object",
+      "properties": {
+        "default_requirement_level": {
+          "description": "The attributes and instruments to include by default in instruments based on their level as specified in the otel semantic conventions and Apollo documentation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DefaultAttributeRequirementLevel"
+            }
+          ]
+        },
+        "router": {
+          "description": "Router service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Supergraph service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector service instruments.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "graphql": {
+          "description": "GraphQL response field instruments.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedGraphQLInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "cache": {
+          "description": "Cache instruments",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedCacheInstrumentsConfigWithInstrument"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.server.request.duration": {
+          "description": "Histogram of server request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "http.server.active_requests": {
+          "description": "Counter of active requests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentActiveRequestsAttributes"
+            }
+          ]
+        },
+        "http.server.request.body.size": {
+          "description": "Histogram of server request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "http.server.response.body.size": {
+          "description": "Histogram of server response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "apollo.router.overhead": {
+          "description": "Histogram of router overhead (time not spent in subgraph requests)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterOverheadAttributesWithRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument"
+      }
+    },
+    "Instrument": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "InstrumentType": {
+      "oneOf": [
+        {
+          "description": "A monotonic counter https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums",
+          "type": "string",
+          "const": "counter"
+        },
+        {
+          "description": "A histogram https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram",
+          "type": "string",
+          "const": "histogram"
+        }
+      ]
+    },
+    "RouterValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/RouterSelector"
+        }
+      ]
+    },
+    "Standard": {
+      "type": "string",
+      "enum": ["duration", "unit"]
+    },
+    "StandardInstrumentExtendedRouterAttributesWithRouterSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "StandardInstrumentActiveRequestsAttributes": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ActiveRequestsAttributes"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ActiveRequestsAttributes": {
+      "type": "object",
+      "properties": {
+        "http.request.method": {
+          "description": "The HTTP request method",
+          "type": "boolean",
+          "default": false
+        },
+        "server.address": {
+          "description": "The server address",
+          "type": "boolean",
+          "default": false
+        },
+        "server.port": {
+          "description": "The server port",
+          "type": "boolean",
+          "default": false
+        },
+        "url.scheme": {
+          "description": "The URL scheme",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "StandardInstrumentExtendedRouterOverheadAttributesWithRouterSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedRouterOverheadAttributesWithRouterSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedRouterOverheadAttributesWithRouterSelector": {
+      "description": "Empty attributes struct for router overhead - no standard attributes, only custom selectors",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/RouterSelector"
+      }
+    },
+    "ExtendedSupergraphInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "cost.estimated": {
+          "description": "A histogram of the estimated cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "A histogram of the actual cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "A histogram of the delta between the estimated and actual cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument2"
+      }
+    },
+    "Instrument2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "SupergraphValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/Event5"
+        },
+        {
+          "$ref": "#/definitions/SupergraphSelector"
+        }
+      ]
+    },
+    "Event5": {
+      "oneOf": [
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "string",
+          "const": "event_duration"
+        },
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "string",
+          "const": "event_unit"
+        },
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "object",
+          "properties": {
+            "event_custom": {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          },
+          "required": ["event_custom"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedSubgraphInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.client.request.duration": {
+          "description": "Histogram of client request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "http.client.request.body.size": {
+          "description": "Histogram of client request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "http.client.response.body.size": {
+          "description": "Histogram of client response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument3"
+      }
+    },
+    "Instrument3": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "SubgraphValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/SubgraphSelector"
+        }
+      ]
+    },
+    "StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedConnectorInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.client.request.duration": {
+          "description": "Histogram of client request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "http.client.request.body.size": {
+          "description": "Histogram of client request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "http.client.response.body.size": {
+          "description": "Histogram of client response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument4"
+      }
+    },
+    "Instrument4": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "ConnectorValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/ConnectorSelector"
+        }
+      ]
+    },
+    "StandardInstrumentExtendedConnectorAttributesWithConnectorSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedGraphQLInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "list.length": {
+          "description": "A histogram of the length of a selected field in the GraphQL response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        },
+        "field.execution": {
+          "description": "A counter of the number of times a field is used.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument5"
+      }
+    },
+    "Instrument5": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphQLValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionGraphQLSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "GraphQLValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StandardUnit"
+        },
+        {
+          "$ref": "#/definitions/GraphQLSelector"
+        }
+      ]
+    },
+    "StandardUnit": {
+      "type": "string",
+      "enum": ["unit"]
+    },
+    "GraphQLSelector": {
+      "anyOf": [
+        {
+          "description": "If the field is a list, the length of the list",
+          "type": "object",
+          "properties": {
+            "list_length": {
+              "$ref": "#/definitions/ListLength"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["list_length"]
+        },
+        {
+          "description": "The GraphQL field name",
+          "type": "object",
+          "properties": {
+            "field_name": {
+              "$ref": "#/definitions/FieldName"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["field_name"]
+        },
+        {
+          "description": "The GraphQL field type",
+          "type": "object",
+          "properties": {
+            "field_type": {
+              "$ref": "#/definitions/FieldType"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["field_type"]
+        },
+        {
+          "description": "The GraphQL type name",
+          "type": "object",
+          "properties": {
+            "type_name": {
+              "$ref": "#/definitions/TypeName"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        }
+      ]
+    },
+    "ListLength": {
+      "oneOf": [
+        {
+          "description": "The length of the list",
+          "type": "string",
+          "const": "value"
+        }
+      ]
+    },
+    "FieldName": {
+      "oneOf": [
+        {
+          "description": "The GraphQL field name",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "FieldType": {
+      "oneOf": [
+        {
+          "description": "The GraphQL field name",
+          "type": "string",
+          "const": "name"
+        },
+        {
+          "description": "The GraphQL field type\n- `bool`\n- `number`\n- `scalar`\n- `object`\n- `list`",
+          "type": "string",
+          "const": "type"
+        }
+      ]
+    },
+    "TypeName": {
+      "oneOf": [
+        {
+          "description": "The GraphQL type name",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "ExtendedGraphQLAttributesWithGraphQLSelector": {
+      "type": "object",
+      "properties": {
+        "graphql.field.name": {
+          "description": "The GraphQL field name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.field.type": {
+          "description": "The GraphQL field type",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.list.length": {
+          "description": "If the field is a list, the length of the list",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The GraphQL operation name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.type.name": {
+          "description": "The GraphQL type name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/GraphQLSelector"
+      }
+    },
+    "ConditionGraphQLSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/GraphQLSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionGraphQLSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionGraphQLSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionGraphQLSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "GraphQLSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphQLSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedCacheInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "apollo.router.operations.entity.cache": {
+          "description": "A counter of times we have a cache hit or cache miss (deprecated)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "apollo.router.operations.response.cache": {
+          "description": "A counter of times we have a cache hit or cache miss",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument6"
+      }
+    },
+    "Instrument6": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "ExtendedCacheAttributesWithSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "graphql.type.name": {
+          "description": "Entity type",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphSelector"
+      }
+    },
+    "StandardInstrumentExtendedCacheAttributesWithSubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedCacheAttributesWithSubgraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "TrafficShapingConfig": {
+      "description": "Configuration for the traffic shaping plugin",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Applied at the router level",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RouterShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "all": {
+          "description": "Applied on all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Applied on specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphShaping"
+          }
+        },
+        "connector": {
+          "description": "Applied on specific subgraphs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorsShapingConfig"
+            }
+          ]
+        },
+        "deduplicate_variables": {
+          "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
+          "type": ["boolean", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RouterShaping": {
+      "type": "object",
+      "properties": {
+        "concurrency_limit": {
+          "description": "The global concurrency limit",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for incoming requests",
+          "type": "string",
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RateLimitConf": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "description": "Number of requests allowed",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1
+        },
+        "interval": {
+          "description": "Per interval",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["capacity", "interval"]
+    },
+    "SubgraphShaping": {
+      "description": "Traffic shaping options",
+      "type": "object",
+      "properties": {
+        "deduplicate_query": {
+          "description": "Enable query deduplication",
+          "type": ["boolean", "null"]
+        },
+        "compression": {
+          "description": "Enable compression for subgraphs (available compressions are deflate, br, gzip)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Compression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for incoming requests",
+          "type": "string",
+          "default": null
+        },
+        "experimental_http2": {
+          "description": "Enable HTTP2 for subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "DNS resolution strategy for subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Compression": {
+      "oneOf": [
+        {
+          "description": "gzip",
+          "type": "string",
+          "const": "gzip"
+        },
+        {
+          "description": "deflate",
+          "type": "string",
+          "const": "deflate"
+        },
+        {
+          "description": "brotli",
+          "type": "string",
+          "const": "br"
+        },
+        {
+          "description": "identity",
+          "type": "string",
+          "const": "identity"
+        }
+      ]
+    },
+    "ConnectorsShapingConfig": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Applied on all connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConnectorShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "Applied on specific connector sources",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConnectorShaping"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConnectorShaping": {
+      "type": "object",
+      "properties": {
+        "compression": {
+          "description": "Enable compression for connectors (available compressions are deflate, br, gzip)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Compression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for connectors requests",
+          "type": "string",
+          "default": null
+        },
+        "experimental_http2": {
+          "description": "Enable HTTP2 for connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "DNS resolution strategy for connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Batching": {
+      "description": "Configuration for Batching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Batching (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "mode": {
+          "description": "Batching mode",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchingMode"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph options for batching",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphCommonBatchingConfigConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maximum_size": {
+          "description": "Maximum size for a batch",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false,
+      "required": ["mode"]
+    },
+    "BatchingMode": {
+      "oneOf": [
+        {
+          "description": "batch_http_link",
+          "type": "string",
+          "const": "batch_http_link"
+        }
+      ]
+    },
+    "SubgraphCommonBatchingConfigConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "enabled": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommonBatchingConfig"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CommonBatchingConfig"
+          },
+          "default": {}
+        }
+      }
+    },
+    "CommonBatchingConfig": {
+      "description": "Common options for configuring subgraph batching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether this batching config should be enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    }
+  }
+}

--- a/src/schemas/json/apollo-router-2.9.0.json
+++ b/src/schemas/json/apollo-router-2.9.0.json
@@ -1,0 +1,11218 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/apollo-router-2.9.0.json",
+  "title": "Configuration",
+  "description": "The configuration for the router.\n\nCan be created through `serde::Deserialize` from various formats,\nor inline in Rust code with `serde_json::json!` and `serde_json::from_value`.",
+  "type": "object",
+  "properties": {
+    "health_check": {
+      "$ref": "#/definitions/HealthCheckConfig"
+    },
+    "sandbox": {
+      "description": "Sandbox configuration",
+      "default": {
+        "enabled": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Sandbox"
+        }
+      ]
+    },
+    "homepage": {
+      "description": "Homepage configuration",
+      "default": {
+        "enabled": true,
+        "graph_ref": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Homepage"
+        }
+      ]
+    },
+    "server": {
+      "description": "Configuration for the server",
+      "default": {
+        "http": {
+          "header_read_timeout": {
+            "secs": 10,
+            "nanos": 0
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Server"
+        }
+      ]
+    },
+    "supergraph": {
+      "description": "Configuration for the supergraph",
+      "default": {
+        "listen": "127.0.0.1:4000",
+        "connection_shutdown_timeout": {
+          "secs": 60,
+          "nanos": 0
+        },
+        "path": "/",
+        "introspection": false,
+        "generate_query_fragments": true,
+        "defer_support": true,
+        "query_planning": {
+          "cache": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "warmed_up_queries": null,
+          "experimental_plans_limit": null,
+          "experimental_paths_limit": null,
+          "experimental_reuse_query_plans": false,
+          "experimental_cooperative_cancellation": {
+            "enabled": true,
+            "mode": "measure",
+            "timeout": null
+          }
+        },
+        "early_cancel": false,
+        "enable_result_coercion_errors": false,
+        "experimental_log_on_broken_pipe": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Supergraph"
+        }
+      ]
+    },
+    "cors": {
+      "description": "Cross origin request headers.",
+      "default": {
+        "allow_any_origin": false,
+        "allow_credentials": false,
+        "allow_headers": [],
+        "expose_headers": null,
+        "methods": ["GET", "POST", "OPTIONS"],
+        "max_age": null,
+        "policies": [
+          {
+            "allow_credentials": null,
+            "allow_headers": [],
+            "expose_headers": [],
+            "match_origins": [],
+            "max_age": null,
+            "methods": ["GET", "POST", "OPTIONS"],
+            "origins": ["https://studio.apollographql.com"],
+            "private_network_access": null
+          }
+        ]
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Cors"
+        }
+      ]
+    },
+    "tls": {
+      "default": {
+        "supergraph": null,
+        "subgraph": {
+          "all": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "subgraphs": {}
+        },
+        "connector": {
+          "sources": {},
+          "all": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tls"
+        }
+      ]
+    },
+    "apq": {
+      "description": "Configures automatic persisted queries",
+      "default": {
+        "enabled": true,
+        "router": {
+          "cache": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          }
+        },
+        "subgraph": {
+          "all": {
+            "enabled": false
+          },
+          "subgraphs": {}
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Apq"
+        }
+      ]
+    },
+    "persisted_queries": {
+      "description": "Configures managed persisted queries",
+      "default": {
+        "enabled": false,
+        "log_unknown": false,
+        "safelist": {
+          "enabled": false,
+          "require_id": false
+        },
+        "experimental_prewarm_query_plan_cache": {
+          "on_startup": false,
+          "on_reload": true
+        },
+        "local_manifests": null,
+        "hot_reload": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PersistedQueries"
+        }
+      ]
+    },
+    "limits": {
+      "$ref": "#/definitions/LimitsConfig"
+    },
+    "experimental_chaos": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.\nYou probably don’t want this in production!",
+      "default": {
+        "force_schema_reload": null,
+        "force_config_reload": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Config"
+        }
+      ]
+    },
+    "plugins": {
+      "description": "Plugin configuration",
+      "default": null,
+      "allOf": [
+        {
+          "$ref": "#/definitions/Plugins"
+        }
+      ]
+    },
+    "authentication": {
+      "$ref": "#/definitions/AuthenticationConfig"
+    },
+    "authorization": {
+      "$ref": "#/definitions/AuthorizationConfig"
+    },
+    "connectors": {
+      "$ref": "#/definitions/ConnectorsConfig"
+    },
+    "coprocessor": {
+      "$ref": "#/definitions/CoprocessorConfig"
+    },
+    "csrf": {
+      "$ref": "#/definitions/CSRFConfig"
+    },
+    "demand_control": {
+      "$ref": "#/definitions/DemandControlConfig"
+    },
+    "enhanced_client_awareness": {
+      "$ref": "#/definitions/Config4"
+    },
+    "experimental_diagnostics": {
+      "$ref": "#/definitions/Config5"
+    },
+    "fleet_detector": {
+      "$ref": "#/definitions/Conf"
+    },
+    "forbid_mutations": {
+      "$ref": "#/definitions/ForbidMutationsConfig"
+    },
+    "headers": {
+      "$ref": "#/definitions/HeadersConfig"
+    },
+    "include_subgraph_errors": {
+      "$ref": "#/definitions/IncludeSubgraphErrorsConfig"
+    },
+    "license_enforcement": {
+      "$ref": "#/definitions/LicenseEnforcementConfig"
+    },
+    "override_subgraph_url": {
+      "$ref": "#/definitions/Conf2"
+    },
+    "preview_entity_cache": {
+      "$ref": "#/definitions/Config6"
+    },
+    "preview_file_uploads": {
+      "$ref": "#/definitions/FileUploadsConfig"
+    },
+    "progressive_override": {
+      "$ref": "#/definitions/Config9"
+    },
+    "rhai": {
+      "$ref": "#/definitions/RhaiConfig"
+    },
+    "subscription": {
+      "$ref": "#/definitions/SubscriptionConfig"
+    },
+    "telemetry": {
+      "$ref": "#/definitions/TelemetryConfig"
+    },
+    "traffic_shaping": {
+      "$ref": "#/definitions/TrafficShapingConfig"
+    },
+    "batching": {
+      "description": "Batching configuration.",
+      "default": {
+        "enabled": false,
+        "mode": "batch_http_link",
+        "subgraph": null,
+        "maximum_size": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Batching"
+        }
+      ]
+    },
+    "experimental_type_conditioned_fetching": {
+      "description": "Type conditioned fetching configuration.",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "patternProperties": {
+    "^experimental_mock_subgraphs$": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphConfig"
+      }
+    },
+    "^preview_response_cache$": {
+      "$ref": "#/definitions/Config7"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "HealthCheckConfig": {
+      "description": "Configuration options pertaining to the health component.",
+      "type": "object",
+      "properties": {
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:8088",
+          "default": "127.0.0.1:8088",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "enabled": {
+          "description": "Set to false to disable the health check",
+          "type": "boolean",
+          "default": true
+        },
+        "path": {
+          "description": "Optionally set a custom healthcheck path\nDefaults to /health",
+          "type": "string",
+          "default": "/health"
+        },
+        "readiness": {
+          "description": "Optionally specify readiness configuration",
+          "default": {
+            "interval": {
+              "sampling": "5s",
+              "unready": null
+            },
+            "allowed": 100
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReadinessConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ListenAddr": {
+      "description": "Listening address.",
+      "anyOf": [
+        {
+          "description": "Socket address.",
+          "type": "string"
+        },
+        {
+          "description": "Unix socket.",
+          "type": "string"
+        }
+      ]
+    },
+    "ReadinessConfig": {
+      "description": "Configuration options pertaining to the readiness health sub-component.",
+      "type": "object",
+      "properties": {
+        "interval": {
+          "description": "The readiness interval configuration",
+          "default": {
+            "sampling": "5s",
+            "unready": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReadinessIntervalConfig"
+            }
+          ]
+        },
+        "allowed": {
+          "description": "How many rejections are allowed in an interval (default: 100)\nIf this number is exceeded, the router will start to report unready.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReadinessIntervalConfig": {
+      "description": "Configuration options pertaining to the readiness health interval sub-component.",
+      "type": "object",
+      "properties": {
+        "sampling": {
+          "description": "The sampling interval (default: 5s)",
+          "type": ["string", "null"],
+          "default": "0s"
+        },
+        "unready": {
+          "description": "The unready interval (default: 2 * sampling interval)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Sandbox": {
+      "description": "Configuration options pertaining to the sandbox page.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to enable sandbox",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "Homepage": {
+      "description": "Configuration options pertaining to the home page.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to false to disable the homepage",
+          "type": "boolean",
+          "default": true
+        },
+        "graph_ref": {
+          "description": "Graph reference\nThis will allow you to redirect from the Apollo Router landing page back to Apollo Studio Explorer",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Server": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "description": "The server http configuration",
+          "default": {
+            "header_read_timeout": {
+              "secs": 10,
+              "nanos": 0
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ServerHttpConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ServerHttpConfig": {
+      "description": "Configuration for HTTP",
+      "type": "object",
+      "properties": {
+        "header_read_timeout": {
+          "description": "Header read timeout in human-readable format; defaults to 10s",
+          "type": "string",
+          "default": {
+            "secs": 10,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Supergraph": {
+      "description": "Configuration options pertaining to the supergraph server component.",
+      "type": "object",
+      "properties": {
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:4000",
+          "default": "127.0.0.1:4000",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "connection_shutdown_timeout": {
+          "description": "The timeout for shutting down connections during a router shutdown or a schema reload.",
+          "type": "string",
+          "default": {
+            "secs": 60,
+            "nanos": 0
+          }
+        },
+        "path": {
+          "description": "The HTTP path on which GraphQL requests will be served.\ndefault: \"/\"",
+          "type": "string",
+          "default": "/"
+        },
+        "introspection": {
+          "description": "Enable introspection\nDefault: false",
+          "type": "boolean",
+          "default": false
+        },
+        "generate_query_fragments": {
+          "description": "Enable QP generation of fragments for subgraph requests\nDefault: true",
+          "type": "boolean",
+          "default": true
+        },
+        "defer_support": {
+          "description": "Set to false to disable defer support",
+          "type": "boolean",
+          "default": true
+        },
+        "query_planning": {
+          "description": "Query planning options",
+          "default": {
+            "cache": {
+              "in_memory": {
+                "limit": 512
+              },
+              "redis": null
+            },
+            "warmed_up_queries": null,
+            "experimental_plans_limit": null,
+            "experimental_paths_limit": null,
+            "experimental_reuse_query_plans": false,
+            "experimental_cooperative_cancellation": {
+              "enabled": true,
+              "mode": "measure",
+              "timeout": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/QueryPlanning"
+            }
+          ]
+        },
+        "early_cancel": {
+          "description": "abort request handling when the client drops the connection.\nDefault: false.\nWhen set to true, some parts of the request pipeline like telemetry will not work properly,\nbut request handling will stop immediately when the client connection is closed.",
+          "type": "boolean",
+          "default": false
+        },
+        "enable_result_coercion_errors": {
+          "description": "Enable errors generated during response reformatting and result coercion to be returned in\nresponses.\nDefault: false\nAll subgraph responses are checked and corrected to ensure alignment with the schema and\nquery. When enabled, misaligned values will generate errors which are included in errors\narray in the response.",
+          "type": "boolean",
+          "default": false
+        },
+        "experimental_log_on_broken_pipe": {
+          "description": "Log a message if the client closes the connection before the response is sent.\nDefault: false.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "QueryPlanning": {
+      "description": "Query planning cache configuration",
+      "type": "object",
+      "properties": {
+        "cache": {
+          "description": "Cache configuration",
+          "default": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/QueryPlanCache"
+            }
+          ]
+        },
+        "warmed_up_queries": {
+          "description": "Warms up the cache on reloads by running the query plan over\na list of the most used queries (from the in memory cache)\nConfigures the number of queries warmed up. Defaults to 1/3 of\nthe in memory cache",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_plans_limit": {
+          "description": "Sets a limit to the number of generated query plans.\nThe planning process generates many different query plans as it\nexplores the graph, and the list can grow large. By using this\nlimit, we prevent that growth and still get a valid query plan,\nbut it may not be the optimal one.\n\nThe default limit is set to 10000, but it may change in the future",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_paths_limit": {
+          "description": "Before creating query plans, for each path of fields in the query we compute all the\npossible options to traverse that path via the subgraphs. Multiple options can arise because\nfields in the path can be provided by multiple subgraphs, and abstract types (i.e. unions\nand interfaces) returned by fields sometimes require the query planner to traverse through\neach constituent object type. The number of options generated in this computation can grow\nlarge if the schema or query are sufficiently complex, and that will increase the time spent\nplanning.\n\nThis config allows specifying a per-path limit to the number of options considered. If any\npath's options exceeds this limit, query planning will abort and the operation will fail.\n\nThe default value is None, which specifies no limit.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "experimental_reuse_query_plans": {
+          "description": "If cache warm up is configured, this will allow the router to keep a query plan created with\nthe old schema, if it determines that the schema update does not affect the corresponding query",
+          "type": "boolean",
+          "default": false
+        },
+        "experimental_cooperative_cancellation": {
+          "description": "Configures cooperative cancellation of query planning\n\nSee [`CooperativeCancellation`] for more details.",
+          "default": {
+            "enabled": true,
+            "mode": "measure",
+            "timeout": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/CooperativeCancellation"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "QueryPlanCache": {
+      "description": "Cache configuration",
+      "type": "object",
+      "properties": {
+        "in_memory": {
+          "description": "Configures the in memory cache (always active)",
+          "default": {
+            "limit": 512
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/InMemoryCache"
+            }
+          ]
+        },
+        "redis": {
+          "description": "Configures and activates the Redis cache",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/QueryPlanRedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "InMemoryCache": {
+      "description": "In memory cache configuration",
+      "type": "object",
+      "properties": {
+        "limit": {
+          "description": "Number of entries in the Least Recently Used cache",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["limit"]
+    },
+    "QueryPlanRedisCache": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "timeout": {
+          "description": "Redis request timeout (default: 500ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "ttl": {
+          "description": "TTL for entries",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 2592000,
+            "nanos": 0
+          }
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "reset_ttl": {
+          "description": "When a TTL is set on a key, reset it when reading the data from that key",
+          "type": "boolean",
+          "default": true
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "TlsClient": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "certificate_authorities": {
+          "description": "list of certificate authorities in PEM format",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "client_authentication": {
+          "description": "client certificate authentication",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClientAuth"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "TlsClientAuth": {
+      "description": "TLS client authentication",
+      "type": "object",
+      "properties": {
+        "certificate_chain": {
+          "description": "list of certificates in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "key": {
+          "description": "key in PEM format",
+          "type": "string",
+          "writeOnly": true
+        }
+      },
+      "additionalProperties": false,
+      "required": ["certificate_chain", "key"]
+    },
+    "CooperativeCancellation": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "When true, cooperative cancellation is enabled.",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "When enabled, this sets whether the router will cancel query planning or\nmerely emit a metric when it would have happened.",
+          "default": "measure",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for query planning.",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Mode": {
+      "type": "string",
+      "enum": ["measure", "enforce"]
+    },
+    "Cors": {
+      "description": "Cross origin request configuration.",
+      "type": "object",
+      "properties": {
+        "allow_any_origin": {
+          "description": "Set to true to allow any origin. Defaults to false. This is the only way to allow Origin: null.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow_credentials": {
+          "description": "Set to true to add the `Access-Control-Allow-Credentials` header.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow_headers": {
+          "description": "The headers to allow.\n\nIf this value is not set, the router will mirror client's `Access-Control-Request-Headers`.\n\nNote that if you set headers here,\nyou also want to have a look at your `CSRF` plugins configuration,\nand make sure you either:\n- accept `x-apollo-operation-name` AND / OR `apollo-require-preflight`\n- defined `csrf` required headers in your yml configuration, as shown in the\n  `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "expose_headers": {
+          "description": "Which response headers should be made available to scripts running in the browser,\nin response to a cross-origin request.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "methods": {
+          "description": "Allowed request methods. See module documentation for default behavior.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["GET", "POST", "OPTIONS"]
+        },
+        "max_age": {
+          "description": "The `Access-Control-Max-Age` header value in time units",
+          "type": "string",
+          "default": null
+        },
+        "policies": {
+          "description": "The origin(s) to allow requests from. The router matches request origins against policies\nin order, first by exact match, then by regex. See module documentation for default behavior.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/definitions/Policy"
+          },
+          "default": [
+            {
+              "allow_credentials": null,
+              "allow_headers": [],
+              "expose_headers": [],
+              "match_origins": [],
+              "max_age": null,
+              "methods": ["GET", "POST", "OPTIONS"],
+              "origins": ["https://studio.apollographql.com"],
+              "private_network_access": null
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Policy": {
+      "description": "Configuration for a specific set of origins",
+      "type": "object",
+      "properties": {
+        "allow_credentials": {
+          "description": "Set to true to add the `Access-Control-Allow-Credentials` header for these origins",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "allow_headers": {
+          "description": "The headers to allow for these origins",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "expose_headers": {
+          "description": "Which response headers should be made available to scripts running in the browser",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "match_origins": {
+          "description": "Regex patterns to match origins against.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "max_age": {
+          "description": "The `Access-Control-Max-Age` header value in time units",
+          "type": "string",
+          "default": null
+        },
+        "methods": {
+          "description": "Allowed request methods for these origins.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "origins": {
+          "description": "The origins to allow requests from.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["https://studio.apollographql.com"]
+        },
+        "private_network_access": {
+          "description": "When `Some`, the `Access-Control-Allow-Private-Network` header will be added as well as the\nrespective headers contained within the policy.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PrivateNetworkAccessPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "PrivateNetworkAccessPolicy": {
+      "type": "object",
+      "properties": {
+        "access_id": {
+          "description": "When specified, the `Private-Network-Access-ID` header will be added with the given ID.\nThe ID must be a 48-bit value presented as 6 hexadecimal bytes separated by colons, e.g.\n`01:23:45:67:89:0A`.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "access_name": {
+          "description": "When `Some`, the `Private-Network-Access-Name` header will be added with the given name.\nThe name can be at most 248 UTF-8 code units and match a RegEx equivalent to the ECMAScript\nRegEx `/^[a-z0-9_-.]+$/.`",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Tls": {
+      "description": "TLS related configuration options.",
+      "type": "object",
+      "properties": {
+        "supergraph": {
+          "description": "TLS server configuration\n\nThis will affect the GraphQL endpoint and any other endpoint targeting the same listen address.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsSupergraph"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraph": {
+          "description": "Outgoing TLS configuration to subgraphs.",
+          "default": {
+            "all": {
+              "certificate_authorities": null,
+              "client_authentication": null
+            },
+            "subgraphs": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphTlsClientConfiguration"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Outgoing TLS configuration to Apollo Connectors.",
+          "default": {
+            "sources": {},
+            "all": {
+              "certificate_authorities": null,
+              "client_authentication": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TlsSupergraph": {
+      "description": "Configuration options pertaining to the supergraph server component.",
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "server certificate in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "key": {
+          "description": "server key in PEM format",
+          "type": "string",
+          "writeOnly": true
+        },
+        "certificate_chain": {
+          "description": "list of certificate authorities in PEM format",
+          "type": "string",
+          "writeOnly": true
+        }
+      },
+      "additionalProperties": false,
+      "required": ["certificate", "key", "certificate_chain"]
+    },
+    "SubgraphTlsClientConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/TlsClient"
+          },
+          "default": {}
+        }
+      }
+    },
+    "ConnectorConfiguration": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/TlsClient"
+          },
+          "default": {}
+        },
+        "all": {
+          "description": "Options applying to all sources",
+          "default": {
+            "certificate_authorities": null,
+            "client_authentication": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            }
+          ]
+        }
+      }
+    },
+    "Apq": {
+      "description": "Automatic Persisted Queries (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Automatic Persisted Queries (enabled by default)",
+          "type": "boolean",
+          "default": true
+        },
+        "router": {
+          "default": {
+            "cache": {
+              "in_memory": {
+                "limit": 512
+              },
+              "redis": null
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Router"
+            }
+          ]
+        },
+        "subgraph": {
+          "default": {
+            "all": {
+              "enabled": false
+            },
+            "subgraphs": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphApqConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Router": {
+      "description": "Router level (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "cache": {
+          "default": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Cache"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Cache": {
+      "description": "Cache configuration",
+      "type": "object",
+      "properties": {
+        "in_memory": {
+          "description": "Configures the in memory cache (always active)",
+          "default": {
+            "limit": 512
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/InMemoryCache"
+            }
+          ]
+        },
+        "redis": {
+          "description": "Configures and activates the Redis cache",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RedisCache": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "timeout": {
+          "description": "Redis request timeout (default: 500ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "ttl": {
+          "description": "TTL for entries",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "reset_ttl": {
+          "description": "When a TTL is set on a key, reset it when reading the data from that key",
+          "type": "boolean",
+          "default": true
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        },
+        "metrics_interval": {
+          "description": "Interval for collecting Redis metrics (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "SubgraphSubgraphApqConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "enabled": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphApq"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphApq"
+          },
+          "default": {}
+        }
+      }
+    },
+    "SubgraphApq": {
+      "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueries": {
+      "description": "Persisted Queries (PQ) configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Persisted Queries (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "log_unknown": {
+          "description": "Enabling this field configures the router to log any freeform GraphQL request that is not in the persisted query list",
+          "type": "boolean",
+          "default": false
+        },
+        "safelist": {
+          "description": "Restricts execution of operations that are not found in the Persisted Query List",
+          "default": {
+            "enabled": false,
+            "require_id": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PersistedQueriesSafelist"
+            }
+          ]
+        },
+        "experimental_prewarm_query_plan_cache": {
+          "description": "Experimental feature to prewarm the query plan cache with persisted queries",
+          "default": {
+            "on_startup": false,
+            "on_reload": true
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/PersistedQueriesPrewarmQueryPlanCache"
+            }
+          ]
+        },
+        "local_manifests": {
+          "description": "Enables using a local copy of the persisted query manifest to safelist operations",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "hot_reload": {
+          "description": "Enables hot reloading of the local persisted query manifests",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueriesSafelist": {
+      "description": "Persisted Queries (PQ) Safelisting configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enables using the persisted query list as a safelist (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "require_id": {
+          "description": "Enabling this field configures the router to reject any request that does not include the persisted query ID",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "PersistedQueriesPrewarmQueryPlanCache": {
+      "description": "Persisted Queries (PQ) query plan cache prewarm configuration",
+      "type": "object",
+      "properties": {
+        "on_startup": {
+          "description": "Enabling this field uses the persisted query list to pre-warm the query planner cache on startup (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "on_reload": {
+          "description": "Enabling this field uses the persisted query list to pre-warm the query planner cache on schema and config changes (enabled by default)",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "LimitsConfig": {
+      "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
+      "type": "object",
+      "properties": {
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets,˛\nincluding fields in fragments and inline fragments. The following\nexample has a depth of 3.\n\n```graphql\nquery getProduct {\n  book { # 1\n    ...bookDetails\n  }\n}\n\nfragment bookDetails on Book {\n  details { # 2\n    ... on ProductDetailsBook {\n      country # 3\n    }\n  }\n}\n```",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias,\nbut only within the same selection set.\nFor example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql\nquery {\n    name { first }\n    name { last }\n}\n```\n\nThis may change in a future version of Apollo Router to do\n[full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set,\nincluding fragments and inline fragments.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum\nare rejected with a HTTP 400 Bad Request response and GraphQL error with\n`\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "default": null
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode),\nrequests that exceed a `max_*` limit are *not* rejected.\nInstead they are executed normally, and a warning is logged.",
+          "type": "boolean",
+          "default": false
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow.\ndefault: 500",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 500
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 15000
+        },
+        "http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network,\nto protect against running out of memory. Default: 2000000 (2 MB)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2000000
+        },
+        "http1_max_request_headers": {
+          "description": "Limit the maximum number of headers of incoming HTTP1 requests. Default is 100.\n\nIf router receives more headers than the buffer size, it responds to the client with\n\"431 Request Header Fields Too Large\".",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "http1_max_request_buf_size": {
+          "description": "Limit the maximum buffer size for the HTTP1 connection.\n\nDefault is ~400kib.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "http2_max_headers_list_bytes": {
+          "description": "For HTTP2, limit the header list to a threshold of bytes. Default is 16kb.\n\nIf router receives more headers than allowed size of the header list, it responds to the client with\n\"431 Request Header Fields Too Large\".",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "introspection_max_depth": {
+          "description": "Limit the depth of nested list fields in introspection queries\nto protect avoid generating huge responses. Returns a GraphQL\nerror with `{ message: \"Maximum introspection depth exceeded\" }`\nwhen nested fields exceed the limit.\nDefault: true",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "Config": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.\nYou probably don't want this in production!\n\n## How Chaos Reloading Works\n\nThe chaos system automatically captures and replays the last known schema and configuration\nevents to force hot reloads even when the underlying content hasn't actually changed. This\nis particularly useful for memory leak detection during hot reload scenarios.\nIf configured, it will activate upon the first config event that is encountered.\n\n### Schema Reloading (`force_schema_reload`)\nWhen enabled, the router will periodically replay the last schema event with a timestamp\ncomment injected into the SDL (e.g., `# Chaos reload timestamp: 1234567890`). This ensures\nthe schema is seen as \"different\" and triggers a full hot reload, even though the functional\nschema content is identical.\n\n### Configuration Reloading (`force_config_reload`)\nWhen enabled, the router will periodically replay the last configuration event. The\nconfiguration is cloned and re-emitted, which triggers the router's configuration change\ndetection and reload logic.\n\n### Example Usage\n```yaml\nexperimental_chaos:\n  force_schema_reload: \"30s\"    # Trigger schema reload every 30 seconds\n  force_config_reload: \"2m\"     # Trigger config reload every 2 minutes\n```",
+      "type": "object",
+      "properties": {
+        "force_schema_reload": {
+          "description": "Force a hot reload of the schema at regular intervals by injecting a timestamp comment\ninto the SDL. This ensures schema reloads occur even when the functional schema content\nhasn't changed, which is useful for testing memory leaks during schema hot reloads.\n\nThe system automatically captures the last schema event and replays it with a timestamp\ncomment added to make it appear \"different\" to the reload detection logic.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "force_config_reload": {
+          "description": "Force a hot reload of the configuration at regular intervals by replaying the last\nconfiguration event. This triggers the router's configuration change detection even\nwhen the configuration content hasn't actually changed.\n\nThe system automatically captures the last configuration event and replays it to\nforce configuration reload processing.",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Plugins": {
+      "type": "object",
+      "properties": {
+        "experimental.broken": {
+          "$ref": "#/definitions/Config2"
+        },
+        "experimental.expose_query_plan": {
+          "$ref": "#/definitions/ExposeQueryPlanConfig"
+        },
+        "experimental.record": {
+          "$ref": "#/definitions/RecordConfig"
+        },
+        "experimental.restricted": {
+          "$ref": "#/definitions/Config3"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {}
+    },
+    "Config2": {
+      "description": "This is a broken plugin for testing purposes only.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the broken plugin.",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "ExposeQueryPlanConfig": {
+      "description": "Expose query plan",
+      "type": "boolean"
+    },
+    "RecordConfig": {
+      "description": "Request recording configuration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "The recording plugin is disabled by default.",
+          "type": "boolean"
+        },
+        "storage_path": {
+          "description": "The path to the directory where recordings will be stored. Defaults to\nthe current working directory.",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "Config3": {
+      "description": "Restricted plugin (for testing purposes only)",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the restricted plugin (for testing purposes only)",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "AuthenticationConfig": {
+      "description": "Authentication",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Router configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationRouterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationSubgraphConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthenticationConnectorConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthenticationRouterConfig": {
+      "type": "object",
+      "properties": {
+        "jwt": {
+          "description": "The JWT configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JWTConf"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["jwt"]
+    },
+    "JWTConf": {
+      "type": "object",
+      "properties": {
+        "jwks": {
+          "description": "List of JWKS used to verify tokens",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JwksConf"
+          }
+        },
+        "header_name": {
+          "description": "HTTP header expected to contain JWT",
+          "type": "string",
+          "default": "authorization"
+        },
+        "header_value_prefix": {
+          "description": "Header value prefix",
+          "type": "string",
+          "default": "Bearer"
+        },
+        "ignore_other_prefixes": {
+          "description": "Whether to ignore any mismatched prefixes",
+          "type": "boolean",
+          "default": false
+        },
+        "sources": {
+          "description": "Alternative sources to extract the JWT",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Source"
+          }
+        },
+        "on_error": {
+          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `Error`. When set to `Continue`, requests that fail JWT authentication will\ncontinue to be processed by the router, but without the JWT claims in the context. When set\nto `Error`, requests that fail JWT authentication will be rejected with a HTTP 403 error.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OnError"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["jwks"]
+    },
+    "JwksConf": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Retrieve the JWK Set",
+          "type": "string"
+        },
+        "poll_interval": {
+          "description": "Polling interval for each JWKS endpoint in human-readable format; defaults to 60s",
+          "type": "string",
+          "default": {
+            "secs": 60,
+            "nanos": 0
+          }
+        },
+        "issuers": {
+          "description": "Expected issuers for tokens verified by that JWKS\n\nIf not specified, the issuer will not be checked.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "audiences": {
+          "description": "Expected audiences for tokens verified by that JWKS\n\nIf not specified, the audience will not be checked.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "algorithms": {
+          "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "headers": {
+          "description": "List of headers to add to the JWKS request",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Header"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url"]
+    },
+    "Header": {
+      "description": "Insert a header",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the header",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the header",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "value"]
+    },
+    "Source": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "HTTP header expected to contain JWT",
+              "type": "string",
+              "default": "authorization"
+            },
+            "value_prefix": {
+              "description": "Header value prefix",
+              "type": "string",
+              "default": "Bearer"
+            },
+            "type": {
+              "type": "string",
+              "const": "header"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the cookie containing the JWT",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "cookie"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type", "name"]
+        }
+      ]
+    },
+    "OnError": {
+      "type": "string",
+      "enum": ["Continue", "Error"]
+    },
+    "AuthenticationSubgraphConfig": {
+      "description": "Configure subgraph authentication",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Configuration that will apply to all subgraphs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AuthConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraphs": {
+          "description": "Create a configuration that will apply only to a specific subgraph.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AuthConfig"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthConfig": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "aws_sig_v4": {
+              "$ref": "#/definitions/AWSSigV4Config"
+            }
+          },
+          "required": ["aws_sig_v4"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AWSSigV4Config": {
+      "description": "Configure AWS sigv4 auth.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "hardcoded": {
+              "$ref": "#/definitions/AWSSigV4HardcodedConfig"
+            }
+          },
+          "required": ["hardcoded"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default_chain": {
+              "$ref": "#/definitions/DefaultChainConfig"
+            }
+          },
+          "required": ["default_chain"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AWSSigV4HardcodedConfig": {
+      "description": "Hardcoded Config using access_key and secret.\nPrefer using DefaultChain instead.",
+      "type": "object",
+      "properties": {
+        "access_key_id": {
+          "description": "The ID for this access key.",
+          "type": "string"
+        },
+        "secret_access_key": {
+          "description": "The secret key used to sign requests.",
+          "type": "string"
+        },
+        "region": {
+          "description": "The AWS region this chain applies to.",
+          "type": "string"
+        },
+        "service_name": {
+          "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+          "type": "string"
+        },
+        "assume_role": {
+          "description": "Specify assumed role configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssumeRoleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "access_key_id",
+        "secret_access_key",
+        "region",
+        "service_name"
+      ]
+    },
+    "AssumeRoleProvider": {
+      "description": "Specify assumed role configuration.",
+      "type": "object",
+      "properties": {
+        "role_arn": {
+          "description": "Amazon Resource Name (ARN)\nfor the role assumed when making requests",
+          "type": "string"
+        },
+        "session_name": {
+          "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+          "type": "string"
+        },
+        "external_id": {
+          "description": "Unique identifier that might be required when you assume a role in another account.",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["role_arn", "session_name"]
+    },
+    "DefaultChainConfig": {
+      "description": "Configuration of the DefaultChainProvider",
+      "type": "object",
+      "properties": {
+        "region": {
+          "description": "The AWS region this chain applies to.",
+          "type": "string"
+        },
+        "profile_name": {
+          "description": "The profile name used by this provider",
+          "type": ["string", "null"]
+        },
+        "service_name": {
+          "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+          "type": "string"
+        },
+        "assume_role": {
+          "description": "Specify assumed role configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AssumeRoleProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["region", "service_name"]
+    },
+    "AuthenticationConnectorConfig": {
+      "description": "Configure connector authentication",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Create a configuration that will apply only to a specific source.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AuthConfig"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "AuthorizationConfig": {
+      "description": "Authorization plugin",
+      "type": "object",
+      "properties": {
+        "require_authentication": {
+          "description": "Reject unauthenticated requests",
+          "type": "boolean",
+          "default": false
+        },
+        "directives": {
+          "description": "`@authenticated`, `@requiresScopes` and `@policy` directives",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AuthorizationDirectivesConfig"
+            }
+          ]
+        }
+      }
+    },
+    "AuthorizationDirectivesConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "enables the `@authenticated` and `@requiresScopes` directives",
+          "type": "boolean",
+          "default": true
+        },
+        "dry_run": {
+          "description": "generates the authorization error messages without modying the query",
+          "type": "boolean",
+          "default": false
+        },
+        "reject_unauthorized": {
+          "description": "refuse a query entirely if any part would be filtered",
+          "type": "boolean",
+          "default": false
+        },
+        "errors": {
+          "description": "authorization errors behaviour",
+          "default": {
+            "log": true,
+            "response": "errors"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AuthorizationErrorConfig"
+            }
+          ]
+        }
+      }
+    },
+    "AuthorizationErrorConfig": {
+      "type": "object",
+      "properties": {
+        "log": {
+          "description": "log authorization errors",
+          "type": "boolean",
+          "default": true
+        },
+        "response": {
+          "description": "location of authorization errors in the GraphQL response",
+          "default": "errors",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorLocation"
+            }
+          ]
+        }
+      }
+    },
+    "ErrorLocation": {
+      "oneOf": [
+        {
+          "description": "store authorization errors in the response errors",
+          "type": "string",
+          "const": "errors"
+        },
+        {
+          "description": "store authorization errors in the response extensions",
+          "type": "string",
+          "const": "extensions"
+        },
+        {
+          "description": "do not add the authorization errors to the GraphQL response",
+          "type": "string",
+          "const": "disabled"
+        }
+      ]
+    },
+    "ConnectorsConfig": {
+      "description": "Configuration for Apollo Connectors.\n\nhttps://www.apollographql.com/docs/graphos/routing/configuration/yaml#connectors",
+      "type": "object",
+      "properties": {
+        "subgraphs": {
+          "description": "A map of subgraph name to connectors config for that subgraph",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphConnectorConfiguration"
+          },
+          "deprecated": true,
+          "default": {}
+        },
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to source configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceConfiguration"
+          },
+          "default": {}
+        },
+        "debug_extensions": {
+          "description": "Enables connector debugging information on response extensions if the feature is enabled",
+          "type": "boolean",
+          "default": false
+        },
+        "max_requests_per_operation_per_source": {
+          "description": "The maximum number of requests for a connector source",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "expose_sources_in_context": {
+          "description": "When enabled, adds an entry to the context for use in coprocessors\n\n```json\n{\n  \"context\": {\n    \"entries\": {\n      \"apollo_connectors::sources_in_query_plan\": [\n        { \"subgraph_name\": \"subgraph\", \"source_name\": \"source\" }\n      ]\n    }\n  }\n}\n```",
+          "type": "boolean",
+          "default": false
+        },
+        "preview_connect_v0_2": {
+          "description": "Enables Connect spec v0.2 during the preview.",
+          "type": ["boolean", "null"],
+          "deprecated": true,
+          "default": null
+        },
+        "preview_connect_v0_3": {
+          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "type": ["boolean", "null"],
+          "deprecated": true,
+          "default": null
+        },
+        "preview_connect_v0_4": {
+          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "type": ["boolean", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphConnectorConfiguration": {
+      "description": "Configuration for a connector subgraph",
+      "type": "object",
+      "properties": {
+        "$config": {
+          "description": "Other values that can be used by connectors via `{$config.<key>}`",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "sources": {
+          "description": "A map of `@source(name:)` to configuration for that source",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SourceConfiguration"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourceConfiguration": {
+      "description": "Configuration for a `@source` directive",
+      "type": "object",
+      "properties": {
+        "$config": {
+          "description": "Other values that can be used by connectors via `{$config.<key>}`",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "override_url": {
+          "description": "Override the `@source(http: {baseURL:})`",
+          "type": ["string", "null"],
+          "format": "uri",
+          "default": null
+        },
+        "max_requests_per_operation": {
+          "description": "The maximum number of requests for this source",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "CoprocessorConfig": {
+      "description": "Configures the externalization plugin",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "The url you'd like to offload processing to (can be overridden per-stage)",
+          "type": "string"
+        },
+        "client": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Client"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "The timeout for external requests",
+          "type": "string",
+          "default": {
+            "secs": 1,
+            "nanos": 0
+          }
+        },
+        "response_validation": {
+          "description": "Response validation defaults to true",
+          "type": "boolean",
+          "default": true
+        },
+        "router": {
+          "description": "The router stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterStage"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "The supergraph stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphStage"
+            }
+          ]
+        },
+        "execution": {
+          "description": "The execution stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExecutionStage"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "The subgraph stage request/response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphStages"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url"]
+    },
+    "Client": {
+      "description": "HTTP client configuration for coprocessors.",
+      "type": "object",
+      "properties": {
+        "experimental_http2": {
+          "description": "Use HTTP/2 to communicate with the coprocessor.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "Specify a DNS resolution strategy to use when resolving the coprocessor URL.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Http2Config": {
+      "oneOf": [
+        {
+          "description": "Enable HTTP2 for subgraphs",
+          "type": "string",
+          "const": "enable"
+        },
+        {
+          "description": "Disable HTTP2 for subgraphs",
+          "type": "string",
+          "const": "disable"
+        },
+        {
+          "description": "Only HTTP2 is active",
+          "type": "string",
+          "const": "http2only"
+        }
+      ]
+    },
+    "DnsResolutionStrategy": {
+      "oneOf": [
+        {
+          "description": "Only query for `A` (IPv4) records",
+          "type": "string",
+          "const": "ipv4_only"
+        },
+        {
+          "description": "Only query for `AAAA` (IPv6) records",
+          "type": "string",
+          "const": "ipv6_only"
+        },
+        {
+          "description": "Query for both `A` (IPv4) and `AAAA` (IPv6) records in parallel",
+          "type": "string",
+          "const": "ipv4_and_ipv6"
+        },
+        {
+          "description": "Query for `AAAA` (IPv6) records first; if that fails, query for `A` (IPv4) records",
+          "type": "string",
+          "const": "ipv6_then_ipv4"
+        },
+        {
+          "description": "Default: Query for `A` (IPv4) records first; if that fails, query for `AAAA` (IPv6) records",
+          "type": "string",
+          "const": "ipv4_then_ipv6"
+        }
+      ]
+    },
+    "RouterStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "description": "The response configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterResponseConf"
+            }
+          ]
+        }
+      }
+    },
+    "RouterRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "path": {
+          "description": "Send the path",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionRouterSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/RouterSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/RouterSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionRouterSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionRouterSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "RouterSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "AttributeValue": {
+      "anyOf": [
+        {
+          "description": "bool values",
+          "type": "boolean"
+        },
+        {
+          "description": "i64 values",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "f64 values",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "description": "String values",
+          "type": "string"
+        },
+        {
+          "description": "Array of homogeneous values",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeArray"
+            }
+          ]
+        }
+      ]
+    },
+    "AttributeArray": {
+      "anyOf": [
+        {
+          "description": "Array of bools",
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        {
+          "description": "Array of integers",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "description": "Array of floats",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        {
+          "description": "Array of strings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "RouterSelector": {
+      "anyOf": [
+        {
+          "description": "A value from baggage.",
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "description": "A value from an environment variable.",
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Critical error if it happens",
+          "type": "object",
+          "properties": {
+            "error": {
+              "$ref": "#/definitions/ErrorRepr"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "description": "Boolean set to true if the response body contains graphql error",
+          "type": "object",
+          "properties": {
+            "on_graphql_error": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["on_graphql_error"]
+        },
+        {
+          "description": "The operation name from the query.",
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "description": "A header from the request",
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "description": "A value from context.",
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "description": "The request method.",
+          "type": "object",
+          "properties": {
+            "request_method": {
+              "description": "The request method enabled or not",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_method"]
+        },
+        {
+          "description": "The body of the response",
+          "type": "object",
+          "properties": {
+            "response_body": {
+              "description": "The response body enabled or not",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_body"]
+        },
+        {
+          "description": "The body response errors",
+          "type": "object",
+          "properties": {
+            "response_errors": {
+              "description": "The router response body json path of the chunks.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_errors"]
+        },
+        {
+          "description": "A header from the response",
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        },
+        {
+          "description": "A value from context.",
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "description": "A status from the response",
+          "type": "object",
+          "properties": {
+            "response_status": {
+              "description": "The http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_status"]
+        },
+        {
+          "description": "Router overhead duration (time not spent in subgraph requests)",
+          "type": "object",
+          "properties": {
+            "router_overhead": {
+              "description": "Extract router overhead duration in seconds",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["router_overhead"]
+        },
+        {
+          "description": "Number of active subgraph requests at the time of overhead calculation",
+          "type": "object",
+          "properties": {
+            "active_subgraph_requests": {
+              "description": "The mode for extracting active subgraph request information",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ActiveSubgraphRequests"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["active_subgraph_requests"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "description": "Apollo Studio operation id",
+          "type": "object",
+          "properties": {
+            "studio_operation_id": {
+              "description": "Apollo Studio operation id",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["studio_operation_id"]
+        },
+        {
+          "description": "The trace ID of the request.",
+          "type": "object",
+          "properties": {
+            "trace_id": {
+              "description": "The format of the trace ID.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/TraceIdFormat"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["trace_id"]
+        }
+      ]
+    },
+    "ErrorRepr": {
+      "oneOf": [
+        {
+          "description": "The error reason",
+          "type": "string",
+          "const": "reason"
+        }
+      ]
+    },
+    "OperationName": {
+      "oneOf": [
+        {
+          "description": "The raw operation name.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "A hash of the operation name.",
+          "type": "string",
+          "const": "hash"
+        }
+      ]
+    },
+    "ResponseStatus": {
+      "oneOf": [
+        {
+          "description": "The http status code.",
+          "type": "string",
+          "const": "code"
+        },
+        {
+          "description": "The http status reason.",
+          "type": "string",
+          "const": "reason"
+        }
+      ]
+    },
+    "ActiveSubgraphRequests": {
+      "oneOf": [
+        {
+          "description": "The number of active subgraph requests as a count.",
+          "type": "string",
+          "const": "count"
+        },
+        {
+          "description": "Whether there are any active subgraph requests as a boolean.",
+          "type": "string",
+          "const": "bool"
+        }
+      ]
+    },
+    "TraceIdFormat": {
+      "oneOf": [
+        {
+          "description": "Format the Trace ID as a hexadecimal number\n\n(e.g. Trace ID 16 -> 00000000000000000000000000000010)",
+          "type": "string",
+          "const": "hexadecimal"
+        },
+        {
+          "description": "Format the Trace ID as a hexadecimal number\n\n(e.g. Trace ID 16 -> 00000000000000000000000000000010)",
+          "type": "string",
+          "const": "open_telemetry"
+        },
+        {
+          "description": "Format the Trace ID as a decimal number\n\n(e.g. Trace ID 16 -> 16)",
+          "type": "string",
+          "const": "decimal"
+        },
+        {
+          "description": "Datadog",
+          "type": "string",
+          "const": "datadog"
+        },
+        {
+          "description": "UUID format with dashes\n(eg. 67e55044-10b1-426f-9247-bb680e5fe0c8)",
+          "type": "string",
+          "const": "uuid"
+        }
+      ]
+    },
+    "ContextConf": {
+      "description": "Configures the context",
+      "anyOf": [
+        {
+          "description": "Deprecated configuration using a boolean",
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/NewContextConf"
+        }
+      ]
+    },
+    "NewContextConf": {
+      "description": "Configures the context",
+      "oneOf": [
+        {
+          "description": "Send all context keys to coprocessor",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send all context keys using deprecated names (from router 1.x) to coprocessor",
+          "type": "string",
+          "const": "deprecated"
+        },
+        {
+          "description": "Only send the list of context keys to coprocessor",
+          "type": "object",
+          "properties": {
+            "selective": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["selective"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RouterResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SupergraphStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "$ref": "#/definitions/SupergraphResponseConf"
+        }
+      }
+    },
+    "SupergraphRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionSupergraphSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SupergraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSupergraphSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSupergraphSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "SupergraphSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "SupergraphSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operation_kind": {
+              "description": "The operation kind from the query (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "description": "The graphql query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Query"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "query_variable": {
+              "description": "The name of a graphql query variable.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        },
+        {
+          "description": "A status from the response",
+          "type": "object",
+          "properties": {
+            "response_status": {
+              "description": "The http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_data": {
+              "description": "The supergraph response body json path of the chunks.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_errors": {
+              "description": "The supergraph response body json path of the chunks.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_errors"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "on_graphql_error": {
+              "description": "Boolean set to true if the response body contains graphql error",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["on_graphql_error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "description": "Cost attributes",
+          "type": "object",
+          "properties": {
+            "cost": {
+              "description": "The cost value to select, one of: estimated, actual, delta.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CostValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["cost"]
+        },
+        {
+          "description": "Boolean returning true if it's the primary response and not events like subscription events or deferred responses",
+          "type": "object",
+          "properties": {
+            "is_primary_response": {
+              "description": "Boolean returning true if it's the primary response and not events like subscription events or deferred responses",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["is_primary_response"]
+        }
+      ]
+    },
+    "OperationKind": {
+      "oneOf": [
+        {
+          "description": "The raw operation kind.",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "Query": {
+      "oneOf": [
+        {
+          "description": "The raw query kind.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "The query aliases.",
+          "type": "string",
+          "const": "aliases"
+        },
+        {
+          "description": "The query depth.",
+          "type": "string",
+          "const": "depth"
+        },
+        {
+          "description": "The query height.",
+          "type": "string",
+          "const": "height"
+        },
+        {
+          "description": "The query root fields.",
+          "type": "string",
+          "const": "root_fields"
+        }
+      ]
+    },
+    "CostValue": {
+      "oneOf": [
+        {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "estimated"
+        },
+        {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "actual"
+        },
+        {
+          "description": "The delta between the estimated and actual cost of the operation using the currently configured cost model",
+          "type": "string",
+          "const": "delta"
+        },
+        {
+          "description": "The result of the cost calculation. This is the error code returned by the cost calculation.",
+          "type": "string",
+          "const": "result"
+        }
+      ]
+    },
+    "SupergraphResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExecutionStage": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "The request configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExecutionRequestConf"
+            }
+          ]
+        },
+        "response": {
+          "$ref": "#/definitions/ExecutionResponseConf"
+        }
+      }
+    },
+    "ExecutionRequestConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method",
+          "type": "boolean",
+          "default": false
+        },
+        "query_plan": {
+          "description": "Send the query plan",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExecutionResponseConf": {
+      "description": "What information is passed to a router request/response stage",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "sdl": {
+          "description": "Send the SDL",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the HTTP status",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphStages": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/SubgraphStage"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphStage": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "request": {
+          "$ref": "#/definitions/SubgraphRequestConf"
+        },
+        "response": {
+          "$ref": "#/definitions/SubgraphResponseConf"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphRequestConf": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "uri": {
+          "description": "Send the subgraph URI",
+          "type": "boolean",
+          "default": false
+        },
+        "method": {
+          "description": "Send the method URI",
+          "type": "boolean",
+          "default": false
+        },
+        "service_name": {
+          "description": "Send the service name",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_request_id": {
+          "description": "Send the subgraph request id",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConditionSubgraphSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SubgraphSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/SubgraphSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSubgraphSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionSubgraphSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "SubgraphSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "SubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_operation_name": {
+              "description": "The operation name from the subgraph query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_operation_kind": {
+              "description": "The kind of the subgraph operation (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_name": {
+              "description": "The subgraph name",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_query": {
+              "description": "The graphql query to the subgraph.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SubgraphQuery"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_query_variable": {
+              "description": "The name of a subgraph query variable.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_data": {
+              "description": "The subgraph response body json path.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_errors": {
+              "description": "The subgraph response body json path.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_errors"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_request_header": {
+              "description": "The name of a subgraph request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_header": {
+              "description": "The name of a subgraph response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_response_status": {
+              "description": "The subgraph http response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_resend_count": {
+              "description": "The subgraph http resend count",
+              "type": "boolean"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_resend_count"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_name": {
+              "description": "The supergraph query operation name.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_kind": {
+              "description": "The supergraph query operation kind (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_query": {
+              "description": "The supergraph query to the subgraph.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Query"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_query"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_query_variable": {
+              "description": "The supergraph query variable name.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_query_variable"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_request_header": {
+              "description": "The supergraph request header name.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_context": {
+              "description": "The response context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_on_graphql_error": {
+              "description": "Boolean set to true if the response body contains graphql error",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_on_graphql_error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "baggage": {
+              "description": "The name of the baggage item.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["baggage"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "env": {
+              "description": "The name of the environment variable",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["env"]
+        },
+        {
+          "description": "Deprecated, should not be used anymore, use static field instead",
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "cache": {
+              "description": "Select if you want to get cache hit or cache miss",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheKind"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["cache"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_cache": {
+              "description": "Select if you want to get response cache hit or response cache miss",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheKind"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_cache"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_cache_status": {
+              "description": "Select if you want to know if it's a cache hit (all data coming from cache), miss (all data coming from subgraph) or partial_hit (not all entities are coming from cache for example)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheStatus"
+                }
+              ]
+            },
+            "entity_type": {
+              "description": "Specify the entity type on which you want the cache data status. (default: all)",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/EntityType"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_cache_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "response_cache_control": {
+              "description": "Select data you want from the computed cache control from response caching",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CacheControlSelector"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_cache_control"]
+        }
+      ]
+    },
+    "SubgraphQuery": {
+      "oneOf": [
+        {
+          "description": "The raw query kind.",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "CacheKind": {
+      "type": "string",
+      "enum": ["hit", "miss"]
+    },
+    "EntityType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/All"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "All": {
+      "type": "string",
+      "enum": ["all"]
+    },
+    "CacheStatus": {
+      "type": "string",
+      "enum": ["hit", "miss", "partial_hit", "status"]
+    },
+    "CacheControlSelector": {
+      "oneOf": [
+        {
+          "description": "Returns the scope, either `public` or `private`",
+          "type": "string",
+          "const": "scope"
+        },
+        {
+          "description": "Boolean to know the value of no-store",
+          "type": "string",
+          "const": "no_store"
+        },
+        {
+          "description": "Value of s-maxage or max-age in cache-control",
+          "type": "string",
+          "const": "max_age"
+        }
+      ]
+    },
+    "SubgraphResponseConf": {
+      "description": "What information is passed to a subgraph request/response stage",
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "Condition to trigger this stage",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        },
+        "headers": {
+          "description": "Send the headers",
+          "type": "boolean",
+          "default": false
+        },
+        "context": {
+          "description": "Send the context",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContextConf"
+            }
+          ]
+        },
+        "body": {
+          "description": "Send the body",
+          "type": "boolean",
+          "default": false
+        },
+        "service_name": {
+          "description": "Send the service name",
+          "type": "boolean",
+          "default": false
+        },
+        "status_code": {
+          "description": "Send the http status",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_request_id": {
+          "description": "Send the subgraph request id",
+          "type": "boolean",
+          "default": false
+        },
+        "url": {
+          "description": "The coprocessor URL for this stage (overrides the global URL if specified)",
+          "type": ["string", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "CSRFConfig": {
+      "description": "CSRF protection configuration.\n\nSee <https://owasp.org/www-community/attacks/csrf> for an explanation on CSRF attacks.",
+      "type": "object",
+      "properties": {
+        "unsafe_disabled": {
+          "description": "The CSRF plugin is enabled by default.\n\nSetting `unsafe_disabled: true` *disables* CSRF protection.",
+          "type": "boolean",
+          "default": false
+        },
+        "required_headers": {
+          "description": "Override the headers to check for by setting\ncustom_headers\nNote that if you set required_headers here,\nyou may also want to have a look at your `CORS` configuration,\nand make sure you either:\n- did not set any `allow_headers` list (so it defaults to `mirror_request`)\n- added your required headers to the allow_headers list, as shown in the\n  `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["x-apollo-operation-name", "apollo-require-preflight"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DemandControlConfig": {
+      "description": "Demand control configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable demand control",
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "The mode that the demand control plugin should operate in.\n- Measure: The plugin will measure the cost of incoming requests but not reject them.\n- Enforce: The plugin will enforce the cost of incoming requests and reject them if the algorithm indicates that they should be rejected.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Mode2"
+            }
+          ]
+        },
+        "strategy": {
+          "description": "The strategy used to reject requests.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StrategyConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled", "mode", "strategy"]
+    },
+    "Mode2": {
+      "type": "string",
+      "enum": ["measure", "enforce"]
+    },
+    "StrategyConfig": {
+      "description": "Algorithm for calculating the cost of an incoming query.",
+      "oneOf": [
+        {
+          "description": "A simple, statically-defined cost mapping for operations and types.\n\nOperation costs:\n- Mutation: 10\n- Query: 0\n- Subscription 0\n\nType costs:\n- Object: 1\n- Interface: 1\n- Union: 1\n- Scalar: 0\n- Enum: 0",
+          "type": "object",
+          "properties": {
+            "static_estimated": {
+              "type": "object",
+              "properties": {
+                "list_size": {
+                  "description": "The assumed length of lists returned by the operation.",
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0
+                },
+                "max": {
+                  "description": "The maximum cost of a query",
+                  "type": "number",
+                  "format": "double"
+                }
+              },
+              "additionalProperties": false,
+              "required": ["list_size", "max"]
+            }
+          },
+          "required": ["static_estimated"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Config4": {
+      "description": "The enhanced client-awareness plugin has no configuration.",
+      "type": "object"
+    },
+    "Config5": {
+      "description": "Configuration for the diagnostics plugin\n\n**Platform Requirements**: This plugin is supported on all platforms.\nHeap dump functionality is only available on Linux platforms due to\njemalloc requirements. Other diagnostic features work across platforms.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the diagnostics plugin",
+          "type": "boolean",
+          "default": false
+        },
+        "listen": {
+          "description": "The socket address and port to listen on\nDefaults to 127.0.0.1:8089\nDo not expose this endpoint to the internet as it exposes sensitive information.",
+          "default": "127.0.0.1:8089",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "output_directory": {
+          "description": "Directory path for memory dump files\nDefaults to \"/tmp/router-diagnostics\" on Unix, or temp directory on other platforms\n\nThis directory will be created automatically if it doesn't exist.\nNote: Memory dumps are only generated on Linux platforms.",
+          "type": "string",
+          "default": "/tmp/router-diagnostics"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphConfig": {
+      "description": "Configuration for one subgraph for the `mock_subgraphs` plugin",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "HTTP headers for the subgraph response",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "query": {
+          "description": "Data for `query` operations (excluding the special `_entities` field)\n\nIn maps nested in this one (but not at the top level), the `__cacheTags` key is special.\nInstead of representing a field that can be selected, when its parent field is selected\nits value is expected to be an array which is appended\nto the `response.extensions[\"apolloCacheTags\"]` array.",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        },
+        "mutation": {
+          "description": "Data for `mutation` operations",
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "default": null
+        },
+        "entities": {
+          "description": "Entities that can be queried through Federation’s special `_entities` field\n\nIn maps directly in the top-level `Vec` (but not in other maps nested deeper),\nthe `__cacheTags` key is special.\nInstead of representing a field that can be selected, when its parent entity is selected\nits contents are added to the `response.extensions[\"apolloEntityCacheTags\"]` array.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "default": []
+        }
+      }
+    },
+    "Conf": {
+      "description": "The fleet detector plugin has no configuration.",
+      "type": "object"
+    },
+    "ForbidMutationsConfig": {
+      "description": "Forbid mutations configuration",
+      "type": "boolean"
+    },
+    "HeadersConfig": {
+      "description": "Configuration for header propagation",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Rules to apply to all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HeadersLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Rules to specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/HeadersLocation"
+          }
+        },
+        "connector": {
+          "description": "Rules for connectors",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorHeadersConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HeadersLocation": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Propagate/Insert/Remove headers from request",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["request"]
+    },
+    "Operation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "insert": {
+              "$ref": "#/definitions/Insert"
+            }
+          },
+          "required": ["insert"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "remove": {
+              "$ref": "#/definitions/Remove"
+            }
+          },
+          "required": ["remove"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "propagate": {
+              "$ref": "#/definitions/Propagate"
+            }
+          },
+          "required": ["propagate"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Insert": {
+      "description": "Insert header",
+      "anyOf": [
+        {
+          "description": "Insert static header",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertStatic"
+            }
+          ]
+        },
+        {
+          "description": "Insert header with a value coming from context key (works only for a string in the context)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertFromContext"
+            }
+          ]
+        },
+        {
+          "description": "Insert header with a value coming from body",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InsertFromBody"
+            }
+          ]
+        }
+      ]
+    },
+    "InsertStatic": {
+      "description": "Insert static header",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the header",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the header",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "value"]
+    },
+    "InsertFromContext": {
+      "description": "Insert header with a value coming from context key",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Specify header name",
+          "type": "string"
+        },
+        "from_context": {
+          "description": "Specify context key to fetch value",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "from_context"]
+    },
+    "InsertFromBody": {
+      "description": "Insert header with a value coming from body",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The target header name",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path in the request body",
+          "type": "string"
+        },
+        "default": {
+          "description": "The default if the path in the body did not resolve to an element",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name", "path"]
+    },
+    "Remove": {
+      "description": "Remove header",
+      "oneOf": [
+        {
+          "description": "Remove a header given a header name",
+          "type": "object",
+          "properties": {
+            "named": {
+              "description": "Remove a header given a header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "required": ["named"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Remove a header given a regex matching header name",
+          "type": "object",
+          "properties": {
+            "matching": {
+              "description": "Remove a header given a regex matching against the header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "required": ["matching"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Propagate": {
+      "description": "Propagate header",
+      "anyOf": [
+        {
+          "description": "Propagate header given a header name",
+          "type": "object",
+          "properties": {
+            "named": {
+              "description": "The source header name",
+              "type": "string"
+            },
+            "rename": {
+              "description": "An optional target header name",
+              "type": ["string", "null"]
+            },
+            "default": {
+              "description": "Default value for the header.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["named"]
+        },
+        {
+          "description": "Propagate header given a regex to match header name",
+          "type": "object",
+          "properties": {
+            "matching": {
+              "description": "The regex on header name",
+              "type": "string",
+              "default": null
+            }
+          },
+          "additionalProperties": false,
+          "required": ["matching"]
+        }
+      ]
+    },
+    "ConnectorHeadersConfiguration": {
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "Map of subgraph_name.connector_source_name to configuration",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/HeadersLocation"
+          }
+        },
+        "all": {
+          "description": "Options applying to all sources across all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HeadersLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IncludeSubgraphErrorsConfig": {
+      "description": "Configuration for exposing errors that originate from subgraphs",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Global configuration for error redaction. Applies to all subgraphs.",
+          "default": false,
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorMode"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Overrides global configuration on a per-subgraph basis",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphConfig2"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorMode": {
+      "anyOf": [
+        {
+          "description": "When `true`, Propagate the original error as is. Otherwise, redact it.",
+          "type": "boolean"
+        },
+        {
+          "description": "Allow specific extension keys with required redact_message",
+          "type": "object",
+          "properties": {
+            "allow_extensions_keys": {
+              "description": "Allow specific extension keys",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "redact error messages for all subgraphs",
+              "type": "boolean"
+            }
+          },
+          "required": ["allow_extensions_keys", "redact_message"]
+        },
+        {
+          "description": "Deny specific extension keys with required redact_message",
+          "type": "object",
+          "properties": {
+            "deny_extensions_keys": {
+              "description": "Deny specific extension keys",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "redact error messages for all subgraphs",
+              "type": "boolean"
+            }
+          },
+          "required": ["deny_extensions_keys", "redact_message"]
+        }
+      ]
+    },
+    "SubgraphConfig2": {
+      "anyOf": [
+        {
+          "description": "Enable or disable error redaction for a subgraph",
+          "type": "boolean"
+        },
+        {
+          "description": "Allow specific error extension keys for a subgraph",
+          "type": "object",
+          "properties": {
+            "allow_extensions_keys": {
+              "description": "Allow specific extension keys for a subgraph. Will extending global allow list or override a global deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "required": ["allow_extensions_keys"]
+        },
+        {
+          "description": "Deny specific error extension keys for a subgraph",
+          "type": "object",
+          "properties": {
+            "deny_extensions_keys": {
+              "description": "Allow specific extension keys for a subgraph. Will extending global deny list or override a global allow list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "required": ["deny_extensions_keys"]
+        },
+        {
+          "description": "Override global configuration, but don't allow or deny any new keys explicitly",
+          "type": "object",
+          "properties": {
+            "redact_message": {
+              "description": "Redact error messages for a subgraph",
+              "type": ["boolean", "null"]
+            },
+            "exclude_global_keys": {
+              "description": "Exclude specific extension keys from global allow/deny list",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          }
+        }
+      ]
+    },
+    "LicenseEnforcementConfig": {
+      "description": "The license enforcement plugin has no configuration.",
+      "type": "object"
+    },
+    "Conf2": {
+      "description": "Subgraph URL mappings",
+      "anyOf": [
+        {
+          "description": "Subgraph URL mappings",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "Config6": {
+      "description": "Configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable or disable the entity caching feature",
+          "type": "boolean",
+          "default": false
+        },
+        "expose_keys_in_context": {
+          "description": "Expose cache keys in context",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph": {
+          "description": "Configure invalidation per subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphConfiguration"
+            }
+          ]
+        },
+        "invalidation": {
+          "description": "Global invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InvalidationEndpointConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Entity caching evaluation metrics",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metrics"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["subgraph"]
+    },
+    "SubgraphSubgraphConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "redis": null,
+            "ttl": null,
+            "enabled": true,
+            "private_id": null,
+            "invalidation": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Subgraph"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Subgraph"
+          },
+          "default": {}
+        }
+      }
+    },
+    "Subgraph": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "redis": {
+          "description": "Redis configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RedisCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ttl": {
+          "description": "expiration for all keys for this subgraph, unless overridden by the `Cache-Control` header in subgraph responses",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "enabled": {
+          "description": "activates caching for this subgraph, overrides the global configuration",
+          "type": ["boolean", "null"],
+          "default": true
+        },
+        "private_id": {
+          "description": "Context key used to separate cache sections per user",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "invalidation": {
+          "description": "Invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphInvalidationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Ttl": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "string"
+    },
+    "SubgraphInvalidationConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the invalidation",
+          "type": "boolean",
+          "default": false
+        },
+        "shared_key": {
+          "description": "Shared key needed to request the invalidation endpoint",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
+    },
+    "InvalidationEndpointConfig": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Specify on which path you want to listen for invalidation endpoint.",
+          "type": "string"
+        },
+        "listen": {
+          "description": "Listen address on which the invalidation endpoint must listen.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "scan_count": {
+          "description": "Number of keys to return at once from a redis SCAN command",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1000
+        },
+        "concurrent_requests": {
+          "description": "Number of concurrent invalidation requests",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 10
+        }
+      },
+      "additionalProperties": false,
+      "required": ["path", "listen"]
+    },
+    "Metrics": {
+      "description": "Per subgraph configuration for entity caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "enables metrics evaluating the benefits of entity caching",
+          "type": "boolean",
+          "default": false
+        },
+        "ttl": {
+          "description": "Metrics counter TTL",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "separate_per_type": {
+          "description": "Adds the entity type name to attributes. This can greatly increase the cardinality",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "FileUploadsConfig": {
+      "description": "Configuration for File Uploads plugin",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether the file upload plugin should be enabled (default: false)",
+          "type": "boolean"
+        },
+        "protocols": {
+          "description": "Supported protocol configurations for file uploads",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FileUploadProtocols"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled", "protocols"]
+    },
+    "FileUploadProtocols": {
+      "description": "Configuration for the various protocols supported by the file upload plugin",
+      "type": "object",
+      "properties": {
+        "multipart": {
+          "description": "Configuration for multipart requests.\n\nThis protocol conforms to [jaydenseric's multipart spec](https://github.com/jaydenseric/graphql-multipart-request-spec)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequest"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["multipart"]
+    },
+    "MultipartRequest": {
+      "description": "Configuration for a multipart request for file uploads.\n\nThis protocol conforms to [jaydenseric's multipart spec](https://github.com/jaydenseric/graphql-multipart-request-spec)",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether to enable the multipart protocol for file uploads (default: true)",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "The supported mode for the request (default: [MultipartRequestMode::Stream])",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequestMode"
+            }
+          ]
+        },
+        "limits": {
+          "description": "Resource limits for multipart requests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultipartRequestLimits"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MultipartRequestMode": {
+      "description": "Supported mode for a multipart request",
+      "oneOf": [
+        {
+          "description": "The multipart request will not be loaded into memory and instead will\nbe streamed directly to the subgraph in the order received. This has some\nlimitations, mainly that the query _must_ be able to be streamed directly\nto the subgraph without buffering.\n\nIn practice, this means that certain queries will fail due to ordering of the\nfiles.",
+          "type": "string",
+          "const": "stream"
+        }
+      ]
+    },
+    "MultipartRequestLimits": {
+      "description": "Request limits for a multipart request",
+      "type": "object",
+      "properties": {
+        "max_files": {
+          "description": "The maximum amount of files allowed for a single query (default: 4)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        },
+        "max_file_size": {
+          "description": "The maximum size of each file, in bytes (default: 5MB)",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["max_files", "max_file_size"]
+    },
+    "Config7": {
+      "description": "Configuration for response caching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable or disable the response caching feature",
+          "type": "boolean",
+          "default": false
+        },
+        "debug": {
+          "description": "Enable debug mode for the debugger",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph": {
+          "description": "Configure invalidation per subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSubgraphConfiguration2"
+            }
+          ]
+        },
+        "invalidation": {
+          "description": "Global invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InvalidationEndpointConfig2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "private_queries_buffer_size": {
+          "description": "Buffer size for known private queries (default: 2048)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 2048
+        }
+      },
+      "additionalProperties": false,
+      "required": ["subgraph"]
+    },
+    "SubgraphSubgraphConfiguration2": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "redis": null,
+            "ttl": null,
+            "enabled": true,
+            "private_id": null,
+            "invalidation": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Subgraph2"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Subgraph2"
+          },
+          "default": {}
+        }
+      }
+    },
+    "Subgraph2": {
+      "description": "Per subgraph configuration for response caching",
+      "type": "object",
+      "properties": {
+        "redis": {
+          "description": "Redis configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Config8"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ttl": {
+          "description": "expiration for all keys for this subgraph, unless overridden by the `Cache-Control` header in subgraph responses",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Ttl2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "enabled": {
+          "description": "activates caching for this subgraph, overrides the global configuration",
+          "type": ["boolean", "null"],
+          "default": true
+        },
+        "private_id": {
+          "description": "Context key used to separate cache sections per user",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "invalidation": {
+          "description": "Invalidation configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphInvalidationConfig2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "Config8": {
+      "description": "Redis cache configuration",
+      "type": "object",
+      "properties": {
+        "urls": {
+          "description": "List of URLs to the Redis cluster",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "username": {
+          "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
+          "type": ["string", "null"]
+        },
+        "password": {
+          "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
+          "type": ["string", "null"]
+        },
+        "fetch_timeout": {
+          "description": "Timeout for Redis fetch commands (default: 150ms)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "insert_timeout": {
+          "description": "Timeout for Redis insert commands (default: 500ms)\n\nInserts are processed asynchronously, so this will not affect response duration.",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "invalidate_timeout": {
+          "description": "Timeout for Redis invalidation commands (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "maintenance_timeout": {
+          "description": "Timeout for Redis maintenance commands (default: 500ms)\n\nMaintenance tasks are processed asynchronously, so this will not affect response duration.",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        },
+        "namespace": {
+          "description": "namespace used to prefix Redis keys",
+          "type": ["string", "null"]
+        },
+        "tls": {
+          "description": "TLS client configuration",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TlsClient"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "required_to_start": {
+          "description": "Prevents the router from starting if it cannot connect to Redis",
+          "type": "boolean",
+          "default": false
+        },
+        "pool_size": {
+          "description": "The size of the Redis connection pool (default: 5)",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 5
+        },
+        "metrics_interval": {
+          "description": "Interval for collecting Redis metrics (default: 1s)",
+          "type": ["string", "null"],
+          "default": {
+            "secs": 0,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["urls"]
+    },
+    "Ttl2": {
+      "description": "Per subgraph configuration for response caching",
+      "type": "string"
+    },
+    "SubgraphInvalidationConfig2": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable the invalidation",
+          "type": "boolean",
+          "default": false
+        },
+        "shared_key": {
+          "description": "Shared key needed to request the invalidation endpoint",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
+    },
+    "InvalidationEndpointConfig2": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Specify on which path you want to listen for invalidation endpoint.",
+          "type": "string"
+        },
+        "listen": {
+          "description": "Listen address on which the invalidation endpoint must listen.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["path", "listen"]
+    },
+    "Config9": {
+      "description": "Configuration for the progressive override plugin",
+      "type": "object"
+    },
+    "RhaiConfig": {
+      "description": "Configuration for the Rhai Plugin",
+      "type": "object",
+      "properties": {
+        "scripts": {
+          "description": "The directory where Rhai scripts can be found",
+          "type": ["string", "null"]
+        },
+        "main": {
+          "description": "The main entry point for Rhai script evaluation",
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubscriptionConfig": {
+      "description": "Subscriptions configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable subscription",
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "description": "Select a subscription mode (callback or passthrough)",
+          "default": {
+            "callback": null,
+            "passthrough": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubscriptionModeConfig"
+            }
+          ]
+        },
+        "deduplication": {
+          "description": "Configure subgraph subscription deduplication",
+          "default": {
+            "enabled": true,
+            "ignored_headers": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeduplicationConfig"
+            }
+          ]
+        },
+        "max_opened_subscriptions": {
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        },
+        "queue_capacity": {
+          "description": "It represent the capacity of the in memory queue to know how many events we can keep in a buffer",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubscriptionModeConfig": {
+      "type": "object",
+      "properties": {
+        "callback": {
+          "description": "Enable callback mode for subgraph(s)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CallbackMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "passthrough": {
+          "description": "Enable passthrough mode for subgraph(s)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphPassthroughMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CallbackMode": {
+      "description": "Using a callback url",
+      "type": "object",
+      "properties": {
+        "public_url": {
+          "description": "URL used to access this router instance, including the path configured on the Router",
+          "type": "string"
+        },
+        "heartbeat_interval": {
+          "description": "Heartbeat interval for callback mode (default: 5secs)",
+          "default": "enabled",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HeartbeatInterval"
+            }
+          ]
+        },
+        "listen": {
+          "description": "Listen address on which the callback must listen (default: 127.0.0.1:4000)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "writeOnly": true
+        },
+        "path": {
+          "description": "Specify on which path you want to listen for callbacks (default: /callback)",
+          "type": ["string", "null"],
+          "writeOnly": true
+        },
+        "subgraphs": {
+          "description": "Specify on which subgraph we enable the callback mode for subscription\nIf empty it applies to all subgraphs (passthrough mode takes precedence)",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "required": ["public_url"]
+    },
+    "HeartbeatInterval": {
+      "anyOf": [
+        {
+          "description": "disable heartbeat",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Disabled"
+            }
+          ]
+        },
+        {
+          "description": "enable with default interval of 5s",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Enabled"
+            }
+          ]
+        },
+        {
+          "description": "enable with custom interval, e.g. '100ms', '10s' or '1m'",
+          "type": "string"
+        }
+      ]
+    },
+    "Disabled": {
+      "type": "string",
+      "enum": ["disabled"]
+    },
+    "Enabled": {
+      "type": "string",
+      "enum": ["enabled"]
+    },
+    "SubgraphPassthroughMode": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Configuration for all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/WebSocketConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "subgraphs": {
+          "description": "Configuration for specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/WebSocketConfiguration"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "WebSocketConfiguration": {
+      "description": "WebSocket configuration for a specific subgraph",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Path on which WebSockets are listening",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "protocol": {
+          "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+          "default": "graphql_ws",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WebSocketProtocol"
+            }
+          ]
+        },
+        "heartbeat_interval": {
+          "description": "Heartbeat interval for graphql-ws protocol (default: disabled)",
+          "default": "disabled",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HeartbeatInterval"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "WebSocketProtocol": {
+      "oneOf": [
+        {
+          "description": "The modern graphql-ws protocol. The subprotocol name is \"graphql-transport-ws\".\n\nSpec URL: https://github.com/enisdenjo/graphql-ws/blob/0c0eb499c3a0278c6d9cc799064f22c5d24d2f60/PROTOCOL.md",
+          "type": "string",
+          "const": "graphql_ws"
+        },
+        {
+          "description": "The legacy subscriptions-transport-ws protocol. Confusingly, the subprotocol name is\n\"graphql-ws\".\n\nhttps://github.com/apollographql/subscriptions-transport-ws/blob/36f3f6f780acc1a458b768db13fd39c65e5e6518/PROTOCOL.md",
+          "type": "string",
+          "const": "graphql_transport_ws"
+        }
+      ]
+    },
+    "DeduplicationConfig": {
+      "description": "Subscription deduplication configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable subgraph subscription deduplication. When enabled, multiple identical requests to the same subgraph will share one WebSocket connection in passthrough mode.\n(default: true)",
+          "type": "boolean",
+          "default": true
+        },
+        "ignored_headers": {
+          "description": "List of headers to ignore for deduplication. Even if these headers are different, the subscription request is considered identical.\nFor example, if you forward the \"User-Agent\" header, but the subgraph doesn't depend on the value of that header,\nadding it to this list will let the router dedupe subgraph subscriptions even if the header value is different.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "TelemetryConfig": {
+      "description": "Telemetry configuration",
+      "type": "object",
+      "properties": {
+        "apollo": {
+          "description": "Apollo reporting configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloTelemetryConfig"
+            }
+          ]
+        },
+        "exporters": {
+          "description": "Instrumentation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Exporters"
+            }
+          ]
+        },
+        "instrumentation": {
+          "description": "Instrumentation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Instrumentation"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ApolloTelemetryConfig": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+          "type": "string",
+          "default": "https://usage-reporting.api.apollographql.com/api/ingress/traces"
+        },
+        "experimental_otlp_endpoint": {
+          "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+          "type": "string",
+          "default": "https://usage-reporting.api.apollographql.com/"
+        },
+        "client_name_header": {
+          "description": "The name of the header to extract from requests when populating 'client name' for traces and metrics in Apollo Studio.",
+          "type": ["string", "null"],
+          "default": "apollographql-client-name"
+        },
+        "client_version_header": {
+          "description": "The name of the header to extract from requests when populating 'client version' for traces and metrics in Apollo Studio.",
+          "type": ["string", "null"],
+          "default": "apollographql-client-version"
+        },
+        "buffer_size": {
+          "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 10000
+        },
+        "field_level_instrumentation_sampler": {
+          "description": "Field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "otlp_tracing_sampler": {
+          "description": "Percentage of traces to send via the OTel protocol when sending to Apollo Studio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "experimental_otlp_tracing_protocol": {
+          "description": "OTLP protocol used for OTel traces.\nNote this only applies if OTel traces are enabled and is only intended for use in tests.",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "experimental_otlp_metrics_protocol": {
+          "description": "OTLP protocol used for OTel metrics.\nNote this is only intended for use in tests.",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "send_headers": {
+          "description": "To configure which request header names and values are included in trace data that's sent to Apollo Studio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardHeaders"
+            }
+          ]
+        },
+        "send_variable_values": {
+          "description": "To configure which GraphQL variable values are included in trace data that's sent to Apollo Studio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForwardValues"
+            }
+          ]
+        },
+        "tracing": {
+          "description": "Configuration for tracing.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TracingConfiguration"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Configuration for metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetricsConfiguration"
+            }
+          ]
+        },
+        "errors": {
+          "description": "Configure the way errors are transmitted to Apollo Studio",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorsConfiguration"
+            }
+          ]
+        },
+        "signature_normalization_algorithm": {
+          "description": "Set the signature normalization algorithm to use when sending Apollo usage reports.",
+          "default": "enhanced",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloSignatureNormalizationAlgorithm"
+            }
+          ]
+        },
+        "metrics_reference_mode": {
+          "description": "Set the Apollo usage report reference reporting mode to use.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloMetricsReferenceMode"
+            }
+          ]
+        },
+        "experimental_local_field_metrics": {
+          "description": "Enable field metrics that are generated without FTV1 to be sent to Apollo Studio.",
+          "type": "boolean",
+          "default": false
+        },
+        "subgraph_metrics": {
+          "description": "Enable sending additional subgraph metrics to Apollo Studio via OTLP",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "SamplerOption": {
+      "anyOf": [
+        {
+          "description": "Sample a given fraction. Fractions >= 1 will always sample.",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "$ref": "#/definitions/Sampler"
+        }
+      ]
+    },
+    "Sampler": {
+      "oneOf": [
+        {
+          "description": "Always sample",
+          "type": "string",
+          "const": "always_on"
+        },
+        {
+          "description": "Never sample",
+          "type": "string",
+          "const": "always_off"
+        }
+      ]
+    },
+    "Protocol": {
+      "type": "string",
+      "enum": ["grpc", "http"]
+    },
+    "ForwardHeaders": {
+      "description": "Forward headers",
+      "oneOf": [
+        {
+          "description": "Don't send any headers",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Send all headers",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send only the headers specified",
+          "type": "object",
+          "properties": {
+            "only": {
+              "description": "Send only the headers specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["only"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Send all headers except those specified",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Send all headers except those specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["except"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ForwardValues": {
+      "description": "Forward GraphQL variables",
+      "oneOf": [
+        {
+          "description": "Dont send any variables",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Send all variables",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Send only the variables specified",
+          "type": "object",
+          "properties": {
+            "only": {
+              "description": "Send only the variables specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["only"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Send all variables except those specified",
+          "type": "object",
+          "properties": {
+            "except": {
+              "description": "Send all variables except those specified",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": ["except"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TracingConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Configuration for tracing batch processor.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "BatchProcessorConfig": {
+      "description": "Batch processor configuration",
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_queue_size": {
+          "description": "The maximum queue size to buffer spans for delayed processing. If the\nqueue gets full it drops the spans. The default value is 2048.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2048
+        },
+        "max_export_batch_size": {
+          "description": "The maximum number of spans to process in a single batch. If there are\nmore than one batch worth of spans then it processes multiple batches\nof spans one batch after the other without any delay. The default value\nis 512.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 512
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        },
+        "max_concurrent_exports": {
+          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed\nby an exporter. A value of 1 will cause exports to be performed\nsynchronously on the BatchSpanProcessor task.\nThe default is 1.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 1
+        }
+      }
+    },
+    "MetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "otlp": {
+          "description": "Configuration for exporting metrics via OTLP.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OtlpMetricsConfiguration"
+            }
+          ]
+        },
+        "usage_reports": {
+          "description": "Configuration for exporting metrics via Apollo usage reports.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UsageReportsMetricsConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OtlpMetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Batch processor config for OTLP metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OtlpMetricsBatchProcessorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "OtlpMetricsBatchProcessorConfiguration": {
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        }
+      }
+    },
+    "UsageReportsMetricsConfiguration": {
+      "type": "object",
+      "properties": {
+        "batch_processor": {
+          "description": "Batch processor config for Apollo usage report metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApolloUsageReportsBatchProcessorConfiguration"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ApolloUsageReportsBatchProcessorConfiguration": {
+      "type": "object",
+      "properties": {
+        "scheduled_delay": {
+          "description": "The delay interval in milliseconds between two consecutive processing\nof batches. The default value is 5 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 5,
+            "nanos": 0
+          }
+        },
+        "max_queue_size": {
+          "description": "The maximum queue size to buffer spans for delayed processing. If the\nqueue gets full it drops the reports. The default value is 2048.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 2048
+        },
+        "max_export_timeout": {
+          "description": "The maximum duration to export a batch of data.\nThe default value is 30 seconds.",
+          "type": "string",
+          "default": {
+            "secs": 30,
+            "nanos": 0
+          }
+        }
+      }
+    },
+    "ErrorsConfiguration": {
+      "type": "object",
+      "properties": {
+        "subgraph": {
+          "description": "Handling of errors coming from subgraph",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphErrorConfig"
+            }
+          ]
+        },
+        "preview_extended_error_metrics": {
+          "description": "Send error metrics via OTLP with additional dimensions [`extensions.service`, `extensions.code`]",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedErrorMetricsMode"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SubgraphErrorConfig": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Handling of errors coming from all subgraphs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorConfiguration"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Handling of errors coming from specified subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ErrorConfiguration"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorConfiguration": {
+      "type": "object",
+      "properties": {
+        "send": {
+          "description": "Send subgraph errors to Apollo Studio",
+          "type": "boolean",
+          "default": true
+        },
+        "redact": {
+          "description": "Redact subgraph errors to Apollo Studio",
+          "type": "boolean",
+          "default": true
+        },
+        "redaction_policy": {
+          "description": "Allows additional dimension `extensions.code` to be sent with errors\neven when `redact` is set to `true`.  Has no effect when `redact` is false.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ErrorRedactionPolicy"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorRedactionPolicy": {
+      "description": "Allow some error fields to be send to Apollo Studio even when `redact` is true.",
+      "oneOf": [
+        {
+          "description": "Applies redaction to all error details.",
+          "type": "string",
+          "const": "strict"
+        },
+        {
+          "description": "Modifies the `redact` setting by excluding the `extensions.code` field in errors from redaction.",
+          "type": "string",
+          "const": "extended"
+        }
+      ]
+    },
+    "ExtendedErrorMetricsMode": {
+      "description": "Extended Open Telemetry error metrics mode",
+      "oneOf": [
+        {
+          "description": "Do not send extended OTLP error metrics",
+          "type": "string",
+          "const": "disabled"
+        },
+        {
+          "description": "Send extended OTLP error metrics to Apollo Studio with additional dimensions [`extensions.service`, `extensions.code`].\nIf enabled, it's also recommended to enable `redaction_policy: extended` on subgraphs to send the `extensions.code` for subgraph errors.",
+          "type": "string",
+          "const": "enabled"
+        }
+      ]
+    },
+    "ApolloSignatureNormalizationAlgorithm": {
+      "description": "Apollo usage report signature normalization algorithm",
+      "oneOf": [
+        {
+          "description": "Use the algorithm that matches the JavaScript-based implementation.",
+          "type": "string",
+          "const": "legacy"
+        },
+        {
+          "description": "Use a new algorithm that includes input object forms, normalized aliases and variable names, and removes some\nedge cases from the JS implementation that affected normalization.",
+          "type": "string",
+          "const": "enhanced"
+        }
+      ]
+    },
+    "ApolloMetricsReferenceMode": {
+      "description": "Apollo usage report reference generation modes.",
+      "oneOf": [
+        {
+          "description": "Use the extended mode to report input object fields and enum value references as well as object fields.",
+          "type": "string",
+          "const": "extended"
+        },
+        {
+          "description": "Use the standard mode that only reports referenced object fields.",
+          "type": "string",
+          "const": "standard"
+        }
+      ]
+    },
+    "Exporters": {
+      "description": "Exporter configuration",
+      "type": "object",
+      "properties": {
+        "logging": {
+          "description": "Logging configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Logging"
+            }
+          ]
+        },
+        "metrics": {
+          "description": "Metrics configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Metrics2"
+            }
+          ]
+        },
+        "tracing": {
+          "description": "Tracing configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Tracing"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Logging": {
+      "description": "Logging configuration.",
+      "type": "object",
+      "properties": {
+        "common": {
+          "description": "Common configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LoggingCommon"
+            }
+          ]
+        },
+        "stdout": {
+          "description": "Settings for logging to stdout.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StdOut"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LoggingCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "Set a service.name resource in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "Set a service.namespace attribute in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "StdOut": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to log to stdout.",
+          "type": "boolean",
+          "default": true
+        },
+        "format": {
+          "description": "The format to log to stdout.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/logging_format"
+            }
+          ]
+        },
+        "tty_format": {
+          "description": "The format to log to stdout when you're running on an interactive terminal. When configured it will automatically use this `tty_format`` instead of the original `format` when an interactive terminal is detected",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/logging_format"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rate_limit": {
+          "description": "Log rate limiting. The limit is set per type of log message",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RateLimit"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "logging_format": {
+      "oneOf": [
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+          "type": "object",
+          "properties": {
+            "json": {
+              "type": "object",
+              "properties": {
+                "display_timestamp": {
+                  "description": "Include the timestamp with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_target": {
+                  "description": "Include the target with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_level": {
+                  "description": "Include the level with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_thread_id": {
+                  "description": "Include the thread_id with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_thread_name": {
+                  "description": "Include the thread_name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_filename": {
+                  "description": "Include the filename with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_line_number": {
+                  "description": "Include the line number with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_current_span": {
+                  "description": "Include the current span in this log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_span_list": {
+                  "description": "Include all of the containing span information with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_resource": {
+                  "description": "Include the resource with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_trace_id": {
+                  "description": "Include the trace id (if any) with the log event. (default: true)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DisplayTraceIdFormat"
+                    }
+                  ]
+                },
+                "display_span_id": {
+                  "description": "Include the span id (if any) with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "span_attributes": {
+                  "description": "List of span attributes to attach to the json log object",
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": []
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["json"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+          "type": "string",
+          "enum": ["json"]
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "object",
+              "properties": {
+                "ansi_escape_codes": {
+                  "description": "Process ansi escapes (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_timestamp": {
+                  "description": "Include the timestamp with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_target": {
+                  "description": "Include the target with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_level": {
+                  "description": "Include the level with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_thread_id": {
+                  "description": "Include the thread_id with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_thread_name": {
+                  "description": "Include the thread_name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_filename": {
+                  "description": "Include the filename with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_line_number": {
+                  "description": "Include the line number with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_service_namespace": {
+                  "description": "Include the service namespace with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_service_name": {
+                  "description": "Include the service name with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_resource": {
+                  "description": "Include the resource with the log event.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "display_current_span": {
+                  "description": "Include the current span in this log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_span_list": {
+                  "description": "Include all of the containing span information with the log event. (default: true)",
+                  "type": "boolean",
+                  "default": true
+                },
+                "display_trace_id": {
+                  "description": "Include the trace id (if any) with the log event. (default: false)",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DisplayTraceIdFormat"
+                    }
+                  ]
+                },
+                "display_span_id": {
+                  "description": "Include the span id (if any) with the log event. (default: false)",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["text"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+          "type": "string",
+          "enum": ["text"]
+        }
+      ]
+    },
+    "DisplayTraceIdFormat": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TraceIdFormat"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "RateLimit": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to limit the rate of log messages",
+          "type": "boolean",
+          "default": false
+        },
+        "capacity": {
+          "description": "Number of log lines allowed in interval per message",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 1
+        },
+        "interval": {
+          "description": "Interval for rate limiting",
+          "type": "string",
+          "default": {
+            "secs": 1,
+            "nanos": 0
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Metrics2": {
+      "description": "Metrics configuration",
+      "type": "object",
+      "properties": {
+        "common": {
+          "description": "Common metrics configuration across all exporters",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetricsCommon"
+            }
+          ]
+        },
+        "otlp": {
+          "description": "Open Telemetry native exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OTLPConfig"
+            }
+          ]
+        },
+        "prometheus": {
+          "description": "Prometheus exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PrometheusMetricsConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricsCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "Set a service.name resource in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "Set a service.namespace attribute in your metrics",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        },
+        "buckets": {
+          "description": "Custom buckets for all histograms",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "default": [
+            0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 5.0, 10.0
+          ]
+        },
+        "views": {
+          "description": "Views applied on metrics",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetricView"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "MetricView": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The instrument name you're targeting",
+          "type": "string"
+        },
+        "rename": {
+          "description": "Rename the metric to this name\n\nThis allows you to customize metric names for both OTLP and Prometheus exporters.\nNote: Prometheus will apply additional transformations (dots to underscores, unit suffixes).\nApollo metrics are not affected by this rename - they will retain original names.",
+          "type": ["string", "null"]
+        },
+        "description": {
+          "description": "New description to set to the instrument",
+          "type": ["string", "null"]
+        },
+        "unit": {
+          "description": "New unit to set to the instrument",
+          "type": ["string", "null"]
+        },
+        "aggregation": {
+          "description": "New aggregation settings to set",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MetricAggregation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "allowed_attribute_keys": {
+          "description": "An allow-list of attribute keys that will be preserved for the instrument.\n\nAny attribute recorded for the instrument with a key not in this set will be\ndropped. If the set is empty, all attributes will be dropped, if `None` all\nattributes will be kept.",
+          "type": ["array", "null"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name"]
+    },
+    "MetricAggregation": {
+      "oneOf": [
+        {
+          "description": "An aggregation that summarizes a set of measurements as an histogram with\nexplicitly defined buckets.",
+          "type": "object",
+          "properties": {
+            "histogram": {
+              "type": "object",
+              "properties": {
+                "buckets": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["buckets"]
+            }
+          },
+          "required": ["histogram"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Simply drop the metrics matching this view",
+          "type": "string",
+          "const": "drop"
+        }
+      ]
+    },
+    "OTLPConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable otlp",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send data to",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "protocol": {
+          "description": "The protocol to use when sending data",
+          "default": "grpc",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Protocol"
+            }
+          ]
+        },
+        "grpc": {
+          "description": "gRPC configuration settings",
+          "default": {
+            "domain_name": null,
+            "ca": null,
+            "cert": null,
+            "key": null,
+            "metadata": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/GrpcExporter"
+            }
+          ]
+        },
+        "http": {
+          "description": "HTTP configuration settings",
+          "default": {
+            "headers": {}
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpExporter"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "Batch processor settings",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        },
+        "temporality": {
+          "description": "Temporality for export (default: `Cumulative`).\nNote that when exporting to Datadog agent use `Delta`.",
+          "default": "cumulative",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Temporality"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "GrpcExporter": {
+      "type": "object",
+      "properties": {
+        "domain_name": {
+          "description": "The optional domain name for tls config.\nNote that domain name is will be defaulted to match the endpoint is not explicitly set.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "ca": {
+          "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "cert": {
+          "description": "The optional cert for tls config",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "key": {
+          "description": "The optional private key file for TLS configuration.",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "metadata": {
+          "description": "gRPC metadata",
+          "type": "object",
+          "additionalProperties": true,
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "HttpExporter": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "Headers to send on report requests",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "Temporality": {
+      "oneOf": [
+        {
+          "description": "Export cumulative metrics.",
+          "type": "string",
+          "const": "cumulative"
+        },
+        {
+          "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+          "type": "string",
+          "const": "delta"
+        }
+      ]
+    },
+    "PrometheusMetricsConfig": {
+      "description": "Prometheus configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Set to true to enable",
+          "type": "boolean",
+          "default": false
+        },
+        "resource_selector": {
+          "description": "resource_selector is used to select which resource to export with every metrics.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ResourceSelectorConfig"
+            }
+          ]
+        },
+        "listen": {
+          "description": "The listen address",
+          "default": "127.0.0.1:9090",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ListenAddr"
+            }
+          ]
+        },
+        "path": {
+          "description": "The path where prometheus will be exposed",
+          "type": "string",
+          "default": "/metrics"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResourceSelectorConfig": {
+      "oneOf": [
+        {
+          "description": "Export all resource attributes with every metrics.",
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "description": "Do not export any resource attributes with every metrics.",
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "Tracing": {
+      "description": "Tracing configuration",
+      "type": "object",
+      "properties": {
+        "experimental_response_trace_id": {
+          "description": "A way to expose trace id in response headers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExposeTraceId"
+            }
+          ]
+        },
+        "propagation": {
+          "description": "Propagation configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Propagation"
+            }
+          ]
+        },
+        "common": {
+          "description": "Common configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TracingCommon"
+            }
+          ]
+        },
+        "otlp": {
+          "description": "OpenTelemetry native exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OTLPConfig"
+            }
+          ]
+        },
+        "zipkin": {
+          "description": "Zipkin exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ZipkinConfig"
+            }
+          ]
+        },
+        "datadog": {
+          "description": "Datadog exporter configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DatadogConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExposeTraceId": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Expose the trace_id in response headers",
+          "type": "boolean",
+          "default": false
+        },
+        "header_name": {
+          "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+          "type": ["string", "null"]
+        },
+        "format": {
+          "description": "Format of the trace ID in response headers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TraceIdFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Propagation": {
+      "description": "Configure propagation of traces. In general you won't have to do this as these are automatically configured\nalong with any exporter you configure.",
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RequestPropagation"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "Propagate baggage https://www.w3.org/TR/baggage/",
+          "type": "boolean",
+          "default": false
+        },
+        "trace_context": {
+          "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
+          "type": "boolean",
+          "default": false
+        },
+        "jaeger": {
+          "description": "Propagate Jaeger",
+          "type": "boolean",
+          "default": false
+        },
+        "datadog": {
+          "description": "Propagate Datadog",
+          "type": "boolean",
+          "default": false
+        },
+        "zipkin": {
+          "description": "Propagate Zipkin",
+          "type": "boolean",
+          "default": false
+        },
+        "aws_xray": {
+          "description": "Propagate AWS X-Ray",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "RequestPropagation": {
+      "type": "object",
+      "properties": {
+        "header_name": {
+          "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+          "type": "string"
+        },
+        "format": {
+          "description": "The trace ID format that will be used when propagating to subgraph services.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TraceIdFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["header_name"]
+    },
+    "TracingCommon": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "description": "The trace service name",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "service_namespace": {
+          "description": "The trace service namespace",
+          "type": ["string", "null"],
+          "default": null
+        },
+        "sampler": {
+          "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SamplerOption"
+            }
+          ]
+        },
+        "preview_datadog_agent_sampling": {
+          "description": "Use datadog agent sampling. This means that all spans will be sent to the Datadog agent\nand the `sampling.priority` attribute will be used to control if the span will then be sent to Datadog",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "parent_based_sampler": {
+          "description": "Whether to use parent based sampling",
+          "type": "boolean",
+          "default": true
+        },
+        "max_events_per_span": {
+          "description": "The maximum events per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_span": {
+          "description": "The maximum attributes per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_links_per_span": {
+          "description": "The maximum links per span before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_event": {
+          "description": "The maximum attributes per event before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "max_attributes_per_link": {
+          "description": "The maximum attributes per link before discarding",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 128
+        },
+        "resource": {
+          "description": "The Open Telemetry resource",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AttributeValue"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "ZipkinConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable zipkin",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UriEndpoint"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "Batch processor configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "UriEndpoint": {
+      "type": "string"
+    },
+    "DatadogConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable datadog",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The endpoint to send to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/UriEndpoint"
+            }
+          ]
+        },
+        "batch_processor": {
+          "description": "batch processor configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchProcessorConfig"
+            }
+          ]
+        },
+        "enable_span_mapping": {
+          "description": "Enable datadog span mapping for span name and resource name.",
+          "type": "boolean",
+          "default": true
+        },
+        "fixed_span_names": {
+          "description": "Fixes the span names, this means that the APM view will show the original span names in the operation dropdown.",
+          "type": "boolean",
+          "default": true
+        },
+        "resource_mapping": {
+          "description": "Custom mapping to be used as the resource field in spans, defaults to:\nrouter -> http.route\nsupergraph -> graphql.operation.name\nquery_planning -> graphql.operation.name\nsubgraph -> subgraph.name\nsubgraph_request -> subgraph.name\nhttp_request -> http.route",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "span_metrics": {
+          "description": "Which spans will be eligible for span stats to be collected for viewing in the APM view.\nDefaults to true for `request`, `router`, `query_parsing`, `supergraph`, `execution`, `query_planning`, `subgraph`, `subgraph_request`, `connect`, `connect_request` and `http_request`.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {
+            "http_request": true,
+            "request": true,
+            "supergraph": true,
+            "subgraph": true,
+            "execution": true,
+            "subgraph_request": true,
+            "connect": true,
+            "router": true,
+            "parse_query": true,
+            "query_planning": true,
+            "connect_request": true
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": ["enabled"]
+    },
+    "Instrumentation": {
+      "description": "Instrumentation configuration",
+      "type": "object",
+      "properties": {
+        "events": {
+          "description": "Event configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Events"
+            }
+          ]
+        },
+        "spans": {
+          "description": "Span configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Spans"
+            }
+          ]
+        },
+        "instruments": {
+          "description": "Instrument configuration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentsConfig"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Events": {
+      "description": "Events are",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Router service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterEventsConfigWithEvent"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Subgraph service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphEventsConfigWithEvent"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Supergraph service events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphEventsConfigWithEvent"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector events",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorEventsConfigWithEvent"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the router request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the router response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the router error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event"
+      }
+    },
+    "Event": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "EventLevelConfig": {
+      "description": "Log level configuration for events. Use \"off\" to not log the event, or a level name to log the\nevent at that level and above.",
+      "type": "string",
+      "enum": ["info", "warn", "error", "off"]
+    },
+    "EventOn": {
+      "description": "When to trigger the event.",
+      "oneOf": [
+        {
+          "description": "Log the event on request",
+          "type": "string",
+          "const": "request"
+        },
+        {
+          "description": "Log the event on response",
+          "type": "string",
+          "const": "response"
+        },
+        {
+          "description": "Log the event on every chunks in the response",
+          "type": "string",
+          "const": "event_response"
+        },
+        {
+          "description": "Log the event on error",
+          "type": "string",
+          "const": "error"
+        }
+      ]
+    },
+    "ExtendedRouterAttributesWithRouterSelector": {
+      "description": "Common attributes for http server and client.\nSee https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
+      "type": "object",
+      "properties": {
+        "dd.trace_id": {
+          "description": "The datadog trace ID.\nThis can be output in logs and used to correlate traces in Datadog.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trace_id": {
+          "description": "The OpenTelemetry trace ID.\nThis can be output in logs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "All key values from trace baggage.",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "error.type": {
+          "description": "Describes a class of error the operation ended with.\nExamples:\n\n* timeout\n* name_resolution_error\n* 500\n\nRequirement level: Conditionally Required: If request has ended with an error.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.body.size": {
+          "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.method": {
+          "description": "HTTP request method.\nExamples:\n\n* GET\n* POST\n* HEAD\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.body.size": {
+          "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.status_code": {
+          "description": "HTTP response status code.\nExamples:\n\n* 200\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.name": {
+          "description": "OSI application layer or non-OSI equivalent.\nExamples:\n\n* http\n* spdy\n\nRequirement level: Recommended: if not default (http).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.version": {
+          "description": "Version of the protocol specified in network.protocol.name.\nExamples:\n\n* 1.0\n* 1.1\n* 2\n* 3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.transport": {
+          "description": "OSI transport layer.\nExamples:\n\n* tcp\n* udp\n\nRequirement level: Conditionally Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.type": {
+          "description": "OSI network layer or non-OSI equivalent.\nExamples:\n\n* ipv4\n* ipv6\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.route": {
+          "description": "The matched route (path template in the format used by the respective server framework).\nExamples:\n\n* /graphql\n\nRequirement level: Conditionally Required: If and only if it’s available",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.address": {
+          "description": "Local socket address. Useful in case of a multi-IP host.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.port": {
+          "description": "Local socket port. Useful in case of a multi-port host.\nExamples:\n\n* 65123\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.address": {
+          "description": "Peer address of the network connection - IP address or Unix domain socket name.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.port": {
+          "description": "Peer port number of the network connection.\nExamples:\n\n* 65123\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.address": {
+          "description": "Name of the local HTTP server that received the request.\nExamples:\n\n* example.com\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.port": {
+          "description": "Port of the local HTTP server that received the request.\nExamples:\n\n* 80\n* 8080\n* 443\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.path": {
+          "description": "The URI path component\nExamples:\n\n* /search\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.query": {
+          "description": "The URI query component\nExamples:\n\n* q=OpenTelemetry\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.scheme": {
+          "description": "The URI scheme component identifying the used protocol.\nExamples:\n\n* http\n* https\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user_agent.original": {
+          "description": "Value of the HTTP User-Agent header sent by the client.\nExamples:\n\n* CERN-LineMode/2.15\n* libwww/2.17b3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/RouterSelector"
+      }
+    },
+    "StandardAttribute": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "alias": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["alias"]
+        }
+      ]
+    },
+    "StandardEventConfigRouterSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedSupergraphEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the supergraph request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the supergraph response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the supergraph error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event2"
+      }
+    },
+    "Event2": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedSupergraphAttributesWithSupergraphSelector": {
+      "description": "Attributes for Cost",
+      "type": "object",
+      "properties": {
+        "graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.estimated": {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.result": {
+          "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SupergraphSelector"
+      }
+    },
+    "StandardEventConfigSupergraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedSubgraphEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the subgraph request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the subgraph response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the subgraph error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event3"
+      }
+    },
+    "Event3": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedSubgraphAttributesWithSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph\nExamples:\n\n* products\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.resend_count": {
+          "description": "The number of times the request has been resent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphSelector"
+      }
+    },
+    "StandardEventConfigSubgraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "ExtendedConnectorEventsConfigWithEvent": {
+      "type": "object",
+      "properties": {
+        "request": {
+          "description": "Log the connector HTTP request",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        },
+        "response": {
+          "description": "Log the connector HTTP response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        },
+        "error": {
+          "description": "Log the connector HTTP error",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardEventConfigConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Event4"
+      }
+    },
+    "Event4": {
+      "description": "An event that can be logged as part of a trace.\nThe event has an implicit `type` attribute that matches the name of the event in the yaml\nand a message that can be used to provide additional information.",
+      "type": "object",
+      "properties": {
+        "level": {
+          "description": "The log level of the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventLevelConfig"
+            }
+          ]
+        },
+        "message": {
+          "description": "The event message.",
+          "type": "string"
+        },
+        "on": {
+          "description": "When to trigger the event.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EventOn"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The event attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The event conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          ]
+        }
+      },
+      "required": ["level", "message", "on"]
+    },
+    "ExtendedConnectorAttributesWithConnectorSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph containing the connector\nExamples:\n\n* posts\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.source.name": {
+          "description": "The name of the source for this connector, if defined\nExamples:\n\n* posts_api\n\nRequirement level: Conditionally Required: If the connector has a source defined",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.http.method": {
+          "description": "The HTTP method for the connector\nExamples:\n\n* GET\n* POST\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.url.template": {
+          "description": "The connector URL template, relative to the source base URL if one is defined\nExamples:\n\n* /users/{$this.id!}/post\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConnectorSelector"
+      }
+    },
+    "ConnectorSelector": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "subgraph_name": {
+              "description": "The subgraph name",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["subgraph_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_source": {
+              "description": "The connector source.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ConnectorSource"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_source"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_request_header": {
+              "description": "The name of a connector HTTP request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_request_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_response_header": {
+              "description": "The name of a connector HTTP response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_response_header"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_response_status": {
+              "description": "The connector HTTP response status code.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResponseStatus"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_response_status"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_http_method": {
+              "description": "The connector HTTP method.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_http_method"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_url_template": {
+              "description": "The connector URL template.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_url_template"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "description": "Critical error if it happens",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ErrorRepr"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["error"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_request_mapping_problems": {
+              "description": "Request mapping problems, if any",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/MappingProblems"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_request_mapping_problems"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_response_mapping_problems": {
+              "description": "Response mapping problems, if any",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/MappingProblems"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_response_mapping_problems"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "request_context": {
+              "description": "The request context key.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_context"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_name": {
+              "description": "The supergraph query operation name.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "supergraph_operation_kind": {
+              "description": "The supergraph query operation kind (query|mutation|subscription).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationKind"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["supergraph_operation_kind"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "connector_on_response_error": {
+              "description": "Boolean set to true if the response's `is_successful` condition is false. If this is not\nset, returns true when the response contains a non-200 status code",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["connector_on_response_error"]
+        }
+      ]
+    },
+    "ConnectorSource": {
+      "oneOf": [
+        {
+          "description": "The name of the connector source.",
+          "type": "string",
+          "const": "name"
+        }
+      ]
+    },
+    "MappingProblems": {
+      "oneOf": [
+        {
+          "description": "String representation of all problems",
+          "type": "string",
+          "const": "problems"
+        },
+        {
+          "description": "The count of mapping problems",
+          "type": "string",
+          "const": "count"
+        },
+        {
+          "description": "Whether there are any mapping problems",
+          "type": "string",
+          "const": "boolean"
+        }
+      ]
+    },
+    "ConditionConnectorSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConnectorSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/ConnectorSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionConnectorSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionConnectorSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "ConnectorSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "StandardEventConfigConnectorSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EventLevelConfig"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "level": {
+              "$ref": "#/definitions/EventLevelConfig"
+            },
+            "condition": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          },
+          "required": ["level", "condition"]
+        }
+      ]
+    },
+    "Spans": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be defaulted in future to `spec_compliant`, eventually removed in future.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SpanMode"
+            }
+          ]
+        },
+        "default_attribute_requirement_level": {
+          "description": "The attributes to include by default in spans based on their level as specified in the otel semantic conventions and Apollo documentation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DefaultAttributeRequirementLevel"
+            }
+          ]
+        },
+        "router": {
+          "description": "Configuration of router spans.\nLog events inherit attributes from the containing span, so attributes configured here will be included on log events for a request.\nRouter spans contain http request and response information and therefore contain http specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterSpans"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Configuration of supergraph spans.\nSupergraph spans contain information about the graphql request and response and therefore contain graphql specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphSpans"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Attributes to include on the subgraph span.\nSubgraph spans contain information about the subgraph request and response and therefore contain subgraph specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphSpans"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Attributes to include on the connector span.\nConnector spans contain information about the connector request and response and therefore contain connector specific attributes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorSpans"
+            }
+          ]
+        },
+        "http_client": {
+          "description": "Attributes to include on the HTTP client span.\nHTTP client spans contain information about HTTP requests made to subgraphs, including any changes made by Rhai scripts.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpClientSpans"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpanMode": {
+      "description": "Span mode to create new or deprecated spans",
+      "oneOf": [
+        {
+          "description": "Keep the request span as root span and deprecated attributes. This option will eventually removed.",
+          "type": "string",
+          "const": "deprecated"
+        },
+        {
+          "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be the default in future.",
+          "type": "string",
+          "const": "spec_compliant"
+        }
+      ]
+    },
+    "DefaultAttributeRequirementLevel": {
+      "oneOf": [
+        {
+          "description": "No default attributes set on spans, you have to set it one by one in the configuration to enable some attributes",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Attributes that are marked as required in otel semantic conventions and apollo documentation will be included (default)",
+          "type": "string",
+          "const": "required"
+        },
+        {
+          "description": "Attributes that are marked as required or recommended in otel semantic conventions and apollo documentation will be included",
+          "type": "string",
+          "const": "recommended"
+        }
+      ]
+    },
+    "RouterSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the router span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithConditionalRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterAttributesWithConditionalRouterSelector": {
+      "description": "Common attributes for http server and client.\nSee https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
+      "type": "object",
+      "properties": {
+        "dd.trace_id": {
+          "description": "The datadog trace ID.\nThis can be output in logs and used to correlate traces in Datadog.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trace_id": {
+          "description": "The OpenTelemetry trace ID.\nThis can be output in logs.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "baggage": {
+          "description": "All key values from trace baggage.",
+          "type": ["boolean", "null"],
+          "default": null
+        },
+        "error.type": {
+          "description": "Describes a class of error the operation ended with.\nExamples:\n\n* timeout\n* name_resolution_error\n* 500\n\nRequirement level: Conditionally Required: If request has ended with an error.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.body.size": {
+          "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.method": {
+          "description": "HTTP request method.\nExamples:\n\n* GET\n* POST\n* HEAD\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.body.size": {
+          "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size.\nExamples:\n\n* 3495\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.response.status_code": {
+          "description": "HTTP response status code.\nExamples:\n\n* 200\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.name": {
+          "description": "OSI application layer or non-OSI equivalent.\nExamples:\n\n* http\n* spdy\n\nRequirement level: Recommended: if not default (http).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.protocol.version": {
+          "description": "Version of the protocol specified in network.protocol.name.\nExamples:\n\n* 1.0\n* 1.1\n* 2\n* 3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.transport": {
+          "description": "OSI transport layer.\nExamples:\n\n* tcp\n* udp\n\nRequirement level: Conditionally Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.type": {
+          "description": "OSI network layer or non-OSI equivalent.\nExamples:\n\n* ipv4\n* ipv6\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.route": {
+          "description": "The matched route (path template in the format used by the respective server framework).\nExamples:\n\n* /graphql\n\nRequirement level: Conditionally Required: If and only if it’s available",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.address": {
+          "description": "Local socket address. Useful in case of a multi-IP host.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.local.port": {
+          "description": "Local socket port. Useful in case of a multi-port host.\nExamples:\n\n* 65123\n\nRequirement level: Opt-In",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.address": {
+          "description": "Peer address of the network connection - IP address or Unix domain socket name.\nExamples:\n\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "network.peer.port": {
+          "description": "Peer port number of the network connection.\nExamples:\n\n* 65123\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.address": {
+          "description": "Name of the local HTTP server that received the request.\nExamples:\n\n* example.com\n* 10.1.2.80\n* /tmp/my.sock\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "server.port": {
+          "description": "Port of the local HTTP server that received the request.\nExamples:\n\n* 80\n* 8080\n* 443\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.path": {
+          "description": "The URI path component\nExamples:\n\n* /search\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.query": {
+          "description": "The URI query component\nExamples:\n\n* q=OpenTelemetry\n\nRequirement level: Conditionally Required: If and only if one was received/sent.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url.scheme": {
+          "description": "The URI scheme component identifying the used protocol.\nExamples:\n\n* http\n* https\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "user_agent.original": {
+          "description": "Value of the HTTP User-Agent header sent by the client.\nExamples:\n\n* CERN-LineMode/2.15\n* libwww/2.17b3\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalRouterSelector"
+      }
+    },
+    "ConditionalRouterSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RouterSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          }
+        }
+      ]
+    },
+    "SupergraphSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the supergraph span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithConditionalSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedSupergraphAttributesWithConditionalSupergraphSelector": {
+      "description": "Attributes for Cost",
+      "type": "object",
+      "properties": {
+        "graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.estimated": {
+          "description": "The estimated cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "The actual cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cost.result": {
+          "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalSupergraphSelector"
+      }
+    },
+    "ConditionalSupergraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SupergraphSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          }
+        }
+      ]
+    },
+    "SubgraphSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the subgraph span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithConditionalSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedSubgraphAttributesWithConditionalSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph\nExamples:\n\n* products\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.document": {
+          "description": "The GraphQL document being executed.\nExamples:\n\n* `query findBookById { bookById(id: ?) { name } }`\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.name": {
+          "description": "The name of the operation being executed.\nExamples:\n\n* findBookById\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraph.graphql.operation.type": {
+          "description": "The type of the operation being executed.\nExamples:\n\n* query\n* subscription\n* mutation\n\nRequirement level: Recommended",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "http.request.resend_count": {
+          "description": "The number of times the request has been resent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalSubgraphSelector"
+      }
+    },
+    "ConditionalSubgraphSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SubgraphSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          }
+        }
+      ]
+    },
+    "ConnectorSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the connector span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConditionalConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedConnectorAttributesWithConditionalConnectorSelector": {
+      "type": "object",
+      "properties": {
+        "subgraph.name": {
+          "description": "The name of the subgraph containing the connector\nExamples:\n\n* posts\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.source.name": {
+          "description": "The name of the source for this connector, if defined\nExamples:\n\n* posts_api\n\nRequirement level: Conditionally Required: If the connector has a source defined",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.http.method": {
+          "description": "The HTTP method for the connector\nExamples:\n\n* GET\n* POST\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connector.url.template": {
+          "description": "The connector URL template, relative to the source base URL if one is defined\nExamples:\n\n* /users/{$this.id!}/post\n\nRequirement level: Required",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalConnectorSelector"
+      }
+    },
+    "ConditionalConnectorSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConnectorSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          }
+        }
+      ]
+    },
+    "HttpClientSpans": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Custom attributes that are attached to the HTTP client span.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedHttpClientAttributesWithConditionalHttpClientSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedHttpClientAttributesWithConditionalHttpClientSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ConditionalHttpClientSelector"
+      }
+    },
+    "ConditionalHttpClientSelector": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HttpClientSelector"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "condition": {
+              "$ref": "#/definitions/ConditionHttpClientSelector"
+            }
+          }
+        }
+      ]
+    },
+    "HttpClientSelector": {
+      "anyOf": [
+        {
+          "description": "A header from the HTTP request",
+          "type": "object",
+          "properties": {
+            "request_header": {
+              "description": "The name of the request header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["request_header"]
+        },
+        {
+          "description": "A header from the HTTP response",
+          "type": "object",
+          "properties": {
+            "response_header": {
+              "description": "The name of the response header.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["response_header"]
+        }
+      ]
+    },
+    "ConditionHttpClientSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HttpClientSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/HttpClientSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionHttpClientSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionHttpClientSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionHttpClientSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "HttpClientSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/HttpClientSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "InstrumentsConfig": {
+      "type": "object",
+      "properties": {
+        "default_requirement_level": {
+          "description": "The attributes and instruments to include by default in instruments based on their level as specified in the otel semantic conventions and Apollo documentation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DefaultAttributeRequirementLevel"
+            }
+          ]
+        },
+        "router": {
+          "description": "Router service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "supergraph": {
+          "description": "Supergraph service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph service instruments. For more information see documentation on Router lifecycle.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "connector": {
+          "description": "Connector service instruments.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "graphql": {
+          "description": "GraphQL response field instruments.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedGraphQLInstrumentsConfigWithInstrument"
+            }
+          ]
+        },
+        "cache": {
+          "description": "Cache instruments",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedCacheInstrumentsConfigWithInstrument"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtendedRouterInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.server.request.duration": {
+          "description": "Histogram of server request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "http.server.active_requests": {
+          "description": "Counter of active requests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentActiveRequestsAttributes"
+            }
+          ]
+        },
+        "http.server.request.body.size": {
+          "description": "Histogram of server request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "http.server.response.body.size": {
+          "description": "Histogram of server response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "apollo.router.overhead": {
+          "description": "Histogram of router overhead (time not spent in subgraph requests)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterOverheadAttributesWithRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument"
+      }
+    },
+    "Instrument": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouterValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionRouterSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "InstrumentType": {
+      "oneOf": [
+        {
+          "description": "A monotonic counter https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums",
+          "type": "string",
+          "const": "counter"
+        },
+        {
+          "description": "A histogram https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram",
+          "type": "string",
+          "const": "histogram"
+        }
+      ]
+    },
+    "RouterValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/RouterSelector"
+        }
+      ]
+    },
+    "Standard": {
+      "type": "string",
+      "enum": ["duration", "unit"]
+    },
+    "StandardInstrumentExtendedRouterAttributesWithRouterSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedRouterAttributesWithRouterSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "StandardInstrumentActiveRequestsAttributes": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ActiveRequestsAttributes"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ActiveRequestsAttributes": {
+      "type": "object",
+      "properties": {
+        "http.request.method": {
+          "description": "The HTTP request method",
+          "type": "boolean",
+          "default": false
+        },
+        "server.address": {
+          "description": "The server address",
+          "type": "boolean",
+          "default": false
+        },
+        "server.port": {
+          "description": "The server port",
+          "type": "boolean",
+          "default": false
+        },
+        "url.scheme": {
+          "description": "The URL scheme",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "StandardInstrumentExtendedRouterOverheadAttributesWithRouterSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedRouterOverheadAttributesWithRouterSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedRouterOverheadAttributesWithRouterSelector": {
+      "description": "Empty attributes struct for router overhead - no standard attributes, only custom selectors",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/RouterSelector"
+      }
+    },
+    "ExtendedSupergraphInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "cost.estimated": {
+          "description": "A histogram of the estimated cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "cost.actual": {
+          "description": "A histogram of the actual cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "cost.delta": {
+          "description": "A histogram of the delta between the estimated and actual cost of the operation using the currently configured cost model",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument2"
+      }
+    },
+    "Instrument2": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SupergraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSupergraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "SupergraphValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/Event5"
+        },
+        {
+          "$ref": "#/definitions/SupergraphSelector"
+        }
+      ]
+    },
+    "Event5": {
+      "oneOf": [
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "string",
+          "const": "event_duration"
+        },
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "string",
+          "const": "event_unit"
+        },
+        {
+          "description": "For every supergraph response payload (including subscription events and defer events)",
+          "type": "object",
+          "properties": {
+            "event_custom": {
+              "$ref": "#/definitions/SupergraphSelector"
+            }
+          },
+          "required": ["event_custom"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "StandardInstrumentExtendedSupergraphAttributesWithSupergraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedSupergraphAttributesWithSupergraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedSubgraphInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.client.request.duration": {
+          "description": "Histogram of client request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "http.client.request.body.size": {
+          "description": "Histogram of client request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "http.client.response.body.size": {
+          "description": "Histogram of client response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument3"
+      }
+    },
+    "Instrument3": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "SubgraphValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/SubgraphSelector"
+        }
+      ]
+    },
+    "StandardInstrumentExtendedSubgraphAttributesWithSubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedSubgraphAttributesWithSubgraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedConnectorInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "http.client.request.duration": {
+          "description": "Histogram of client request duration",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "http.client.request.body.size": {
+          "description": "Histogram of client request body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "http.client.response.body.size": {
+          "description": "Histogram of client response body size",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument4"
+      }
+    },
+    "Instrument4": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionConnectorSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "ConnectorValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Standard"
+        },
+        {
+          "$ref": "#/definitions/ConnectorSelector"
+        }
+      ]
+    },
+    "StandardInstrumentExtendedConnectorAttributesWithConnectorSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedConnectorAttributesWithConnectorSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedGraphQLInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "list.length": {
+          "description": "A histogram of the length of a selected field in the GraphQL response",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        },
+        "field.execution": {
+          "description": "A counter of the number of times a field is used.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument5"
+      }
+    },
+    "Instrument5": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphQLValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionGraphQLSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "GraphQLValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StandardUnit"
+        },
+        {
+          "$ref": "#/definitions/GraphQLSelector"
+        }
+      ]
+    },
+    "StandardUnit": {
+      "type": "string",
+      "enum": ["unit"]
+    },
+    "GraphQLSelector": {
+      "anyOf": [
+        {
+          "description": "If the field is a list, the length of the list",
+          "type": "object",
+          "properties": {
+            "list_length": {
+              "$ref": "#/definitions/ListLength"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["list_length"]
+        },
+        {
+          "description": "The GraphQL field name",
+          "type": "object",
+          "properties": {
+            "field_name": {
+              "$ref": "#/definitions/FieldName"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["field_name"]
+        },
+        {
+          "description": "The GraphQL field type",
+          "type": "object",
+          "properties": {
+            "field_type": {
+              "$ref": "#/definitions/FieldType"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["field_type"]
+        },
+        {
+          "description": "The GraphQL type name",
+          "type": "object",
+          "properties": {
+            "type_name": {
+              "$ref": "#/definitions/TypeName"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["type_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "operation_name": {
+              "description": "The operation name from the query.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OperationName"
+                }
+              ]
+            },
+            "default": {
+              "description": "Optional default value.",
+              "type": ["string", "null"]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["operation_name"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "static": {
+              "description": "A static value",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AttributeValue"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": ["static"]
+        }
+      ]
+    },
+    "ListLength": {
+      "oneOf": [
+        {
+          "description": "The length of the list",
+          "type": "string",
+          "const": "value"
+        }
+      ]
+    },
+    "FieldName": {
+      "oneOf": [
+        {
+          "description": "The GraphQL field name",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "FieldType": {
+      "oneOf": [
+        {
+          "description": "The GraphQL field name",
+          "type": "string",
+          "const": "name"
+        },
+        {
+          "description": "The GraphQL field type\n- `bool`\n- `number`\n- `scalar`\n- `object`\n- `list`",
+          "type": "string",
+          "const": "type"
+        }
+      ]
+    },
+    "TypeName": {
+      "oneOf": [
+        {
+          "description": "The GraphQL type name",
+          "type": "string",
+          "const": "string"
+        }
+      ]
+    },
+    "ExtendedGraphQLAttributesWithGraphQLSelector": {
+      "type": "object",
+      "properties": {
+        "graphql.field.name": {
+          "description": "The GraphQL field name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.field.type": {
+          "description": "The GraphQL field type",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.list.length": {
+          "description": "If the field is a list, the length of the list",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.operation.name": {
+          "description": "The GraphQL operation name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "graphql.type.name": {
+          "description": "The GraphQL type name",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/GraphQLSelector"
+      }
+    },
+    "ConditionGraphQLSelector": {
+      "description": "Specify a condition for when an [instrument][] should be mutated or an [event][] should be triggered.\n\n[instrument]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/instruments\n[event]: https://www.apollographql.com/docs/graphos/routing/observability/telemetry/instrumentation/events",
+      "oneOf": [
+        {
+          "description": "A condition to check a selection against a value.",
+          "type": "object",
+          "properties": {
+            "eq": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["eq"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be greater than the second selection.",
+          "type": "object",
+          "properties": {
+            "gt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["gt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The first selection must be less than the second selection.",
+          "type": "object",
+          "properties": {
+            "lt": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GraphQLSelectorOrValue"
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "required": ["lt"],
+          "additionalProperties": false
+        },
+        {
+          "description": "A condition to check a selection against a selector.",
+          "type": "object",
+          "properties": {
+            "exists": {
+              "$ref": "#/definitions/GraphQLSelector"
+            }
+          },
+          "required": ["exists"],
+          "additionalProperties": false
+        },
+        {
+          "description": "All sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "all": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionGraphQLSelector"
+              }
+            }
+          },
+          "required": ["all"],
+          "additionalProperties": false
+        },
+        {
+          "description": "At least one sub-conditions must be true.",
+          "type": "object",
+          "properties": {
+            "any": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ConditionGraphQLSelector"
+              }
+            }
+          },
+          "required": ["any"],
+          "additionalProperties": false
+        },
+        {
+          "description": "The sub-condition must not be true",
+          "type": "object",
+          "properties": {
+            "not": {
+              "$ref": "#/definitions/ConditionGraphQLSelector"
+            }
+          },
+          "required": ["not"],
+          "additionalProperties": false
+        },
+        {
+          "description": "Static true condition",
+          "type": "string",
+          "const": "true"
+        },
+        {
+          "description": "Static false condition",
+          "type": "string",
+          "const": "false"
+        }
+      ]
+    },
+    "GraphQLSelectorOrValue": {
+      "anyOf": [
+        {
+          "description": "A constant value.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AttributeValue"
+            }
+          ]
+        },
+        {
+          "description": "Selector to extract a value from the pipeline.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GraphQLSelector"
+            }
+          ]
+        }
+      ]
+    },
+    "StandardInstrumentExtendedGraphQLAttributesWithGraphQLSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedGraphQLAttributesWithGraphQLSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "ExtendedCacheInstrumentsConfigWithInstrument": {
+      "type": "object",
+      "properties": {
+        "apollo.router.operations.entity.cache": {
+          "description": "A counter of times we have a cache hit or cache miss (deprecated)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "apollo.router.response.cache": {
+          "description": "A counter of times we have a cache hit or cache miss",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/Instrument6"
+      }
+    },
+    "Instrument6": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type of instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The value of the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubgraphValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "The description of the instrument.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The units of the instrument, e.g. \"ms\", \"bytes\", \"requests\".",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Attributes to include on the instrument.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExtendedCacheAttributesWithSubgraphSelector"
+            }
+          ]
+        },
+        "condition": {
+          "description": "The instrument conditions.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConditionSubgraphSelector"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type", "value", "description", "unit"]
+    },
+    "ExtendedCacheAttributesWithSubgraphSelector": {
+      "type": "object",
+      "properties": {
+        "graphql.type.name": {
+          "description": "Entity type",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StandardAttribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/SubgraphSelector"
+      }
+    },
+    "StandardInstrumentExtendedCacheAttributesWithSubgraphSelector": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ExtendedCacheAttributesWithSubgraphSelector"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["attributes"]
+        }
+      ]
+    },
+    "TrafficShapingConfig": {
+      "description": "Configuration for the traffic shaping plugin",
+      "type": "object",
+      "properties": {
+        "router": {
+          "description": "Applied at the router level",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RouterShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "all": {
+          "description": "Applied on all subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "Applied on specific subgraphs",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SubgraphShaping"
+          }
+        },
+        "connector": {
+          "description": "Applied on specific subgraphs",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ConnectorsShapingConfig"
+            }
+          ]
+        },
+        "deduplicate_variables": {
+          "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
+          "type": ["boolean", "null"],
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RouterShaping": {
+      "type": "object",
+      "properties": {
+        "concurrency_limit": {
+          "description": "The global concurrency limit",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for incoming requests",
+          "type": "string",
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "RateLimitConf": {
+      "type": "object",
+      "properties": {
+        "capacity": {
+          "description": "Number of requests allowed",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1
+        },
+        "interval": {
+          "description": "Per interval",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["capacity", "interval"]
+    },
+    "SubgraphShaping": {
+      "description": "Traffic shaping options",
+      "type": "object",
+      "properties": {
+        "deduplicate_query": {
+          "description": "Enable query deduplication",
+          "type": ["boolean", "null"]
+        },
+        "compression": {
+          "description": "Enable compression for subgraphs (available compressions are deflate, br, gzip)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Compression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for incoming requests",
+          "type": "string",
+          "default": null
+        },
+        "experimental_http2": {
+          "description": "Enable HTTP2 for subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "DNS resolution strategy for subgraphs",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Compression": {
+      "oneOf": [
+        {
+          "description": "gzip",
+          "type": "string",
+          "const": "gzip"
+        },
+        {
+          "description": "deflate",
+          "type": "string",
+          "const": "deflate"
+        },
+        {
+          "description": "brotli",
+          "type": "string",
+          "const": "br"
+        },
+        {
+          "description": "identity",
+          "type": "string",
+          "const": "identity"
+        }
+      ]
+    },
+    "ConnectorsShapingConfig": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "Applied on all connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConnectorShaping"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "Applied on specific connector sources",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ConnectorShaping"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConnectorShaping": {
+      "type": "object",
+      "properties": {
+        "compression": {
+          "description": "Enable compression for connectors (available compressions are deflate, br, gzip)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Compression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "global_rate_limit": {
+          "description": "Enable global rate limiting",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RateLimitConf"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Enable timeout for connectors requests",
+          "type": "string",
+          "default": null
+        },
+        "experimental_http2": {
+          "description": "Enable HTTP2 for connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Http2Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dns_resolution_strategy": {
+          "description": "DNS resolution strategy for connectors",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DnsResolutionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Batching": {
+      "description": "Configuration for Batching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Batching (disabled by default)",
+          "type": "boolean",
+          "default": false
+        },
+        "mode": {
+          "description": "Batching mode",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BatchingMode"
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph options for batching",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SubgraphCommonBatchingConfigConfiguration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maximum_size": {
+          "description": "Maximum size for a batch",
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0,
+          "default": null
+        }
+      },
+      "additionalProperties": false,
+      "required": ["mode"]
+    },
+    "BatchingMode": {
+      "oneOf": [
+        {
+          "description": "batch_http_link",
+          "type": "string",
+          "const": "batch_http_link"
+        }
+      ]
+    },
+    "SubgraphCommonBatchingConfigConfiguration": {
+      "description": "Configuration options pertaining to the subgraph server component.",
+      "type": "object",
+      "properties": {
+        "all": {
+          "description": "options applying to all subgraphs",
+          "default": {
+            "enabled": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommonBatchingConfig"
+            }
+          ]
+        },
+        "subgraphs": {
+          "description": "per subgraph options",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CommonBatchingConfig"
+          },
+          "default": {}
+        }
+      }
+    },
+    "CommonBatchingConfig": {
+      "description": "Common options for configuring subgraph batching",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether this batching config should be enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"]
+    }
+  }
+}


### PR DESCRIPTION
This adds the schema's for Apollo's Router version `2.8.2` and `2.9.0`.
`2.9.0` was released last friday (28 Nov '25).
Also see https://www.apollographql.com/docs/graphos/routing/changelog