### PR TITLE
Add json schema for Instant Python

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3261,6 +3261,12 @@
       "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/ipy-schemas.json"
     },
     {
+      "name": "instant_python_custom_project",
+      "description": "Instant Python Custom Project Structure",
+      "fileMatch": ["main_structure.yml"],
+      "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/main-structure-schema.json"
+    },
+    {
       "name": "ioBroker Configuration",
       "description": "The configuration file of an ioBroker installation",
       "fileMatch": ["iobroker.json", "iobroker-dist.json"],


### PR DESCRIPTION
Add self hosted schemas for [Instant Python](https://pypi.org/project/instant-python/) CLI application. Two schemas have been added:

1. The first one is to offer syntax and yaml fields help when users modify the configuration file that the CLI uses, called `ipy.yml`. The schema is available [here](https://github.com/dimanu-py/instant-python/blob/main/schemas/ipy-schema.json)
2. The second one offers the same features for a specific file users need to create when they want to use a custom project structure called `main_structure.yml`. The schema is available [here](https://github.com/dimanu-py/instant-python/blob/main/schemas/main-structure-schema.json)

The schema will be maintained in the tool repository.
