### PR TITLE
Tell Tombi to sort Cargo.toml lints better

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -360,7 +360,10 @@
         }
       },
       "additionalProperties": true,
-      "x-tombi-table-keys-order": "version-sort"
+      "x-tombi-table-keys-order": {
+        "properties": "schema",
+        "additionalProperties": "version-sort"
+      }
     },
     "Lto": {
       "title": "Lto",


### PR DESCRIPTION
Rust, Rustdoc, Clippy makes sense, progressing from the compiler itself to the surrounding tools. The previous Clippy, Rust, Rustdoc, in contrast, is a bit odd.

I think this is the right setting to make it do that, but I'm not sure.