### PR TITLE
Update jsxImportSource description in tsconfig and jsconfig

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -341,10 +341,10 @@
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. `React.Fragment` or `Fragment`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.",
               "type": ["string", "null"],
               "default": "react",
-              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
+              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -344,10 +344,10 @@
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. `React.Fragment` or `Fragment`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.",
               "type": ["string", "null"],
               "default": "react",
-              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
+              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",


### PR DESCRIPTION
Update `jsx: react-jsx` as `jsx: react-jsx*` in the description. This follows the same description [as in TypeScript](https://github.com/microsoft/TypeScript/blob/5026c6675cbbfd493011616639595084f899d513/src/compiler/diagnosticMessages.json#L6285) directly. While this seems like a typo at first, the `*` means that it matches either `react-jsx` or `react-jsxdev`. The latter is an acceptable value for the [`jsx` option](https://www.typescriptlang.org/tsconfig/#jsx).

Additional context: The `*` initially existed but removed in https://github.com/SchemaStore/schemastore/pull/1860/files#diff-bf533fb90f8f24602f8e770ec458153b3e087c1d657eb8238d5fea8346feadf2L264-R264. I assume that the author thought it was a typo as well.