### PR TITLE
Add Cloud.gov Workshop configuration schema to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -613,10 +613,7 @@
     {
       "name": "Cloud.gov Workshop Configuration",
       "description": "Configuration for IaC managed resources in Cloud.gov Workshop",
-      "fileMatch": [
-        "cg-workshop.yml",
-        "**/cg-workshop/*.yml"
-      ],
+      "fileMatch": ["cg-workshop.yml", "**/cg-workshop/*.yml"],
       "url": "https://workshop.cloud.gov/workshop/workshop-schemas/-/raw/main/cg-workhshop.schema.json"
     },
     {


### PR DESCRIPTION
Adds support for `cg-workshop.yml` and `cg-workshop/*.yml` files used by [Cloud.gov Workshop](https://cloud.gov/workshop) for management of resources in code. This schema support `namespaces` and `users` (managed by Workshop operations) as well as `projects` and `subgroups` (managed by Workshop customers).
