### PR TITLE
Add schemas for supporting CloudCannon configuration files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -773,8 +773,8 @@
       "url": "https://github.com/cloudcannon/configuration-types/releases/latest/download/cloudcannon-collections.schema.json"
     },
     {
-      "name": "CloudCannon Configuration (Schemas)",
-      "description": "Supporting configuration file for CloudCannon containing Collection Schema definitions",
+      "name": "CloudCannon Configuration (Collection Structures)",
+      "description": "Supporting configuration file for CloudCannon containing Collection Structure definitions",
       "fileMatch": [
         "cloudcannon.schemas.yml",
         "cloudcannon.schemas.yaml",


### PR DESCRIPTION
In addition to our current configuration schema, we've recently added support for a few more configuration files, each with their own schema.

Here's the [documentation](https://cloudcannon.com/documentation/articles/why-split-your-configuration-file/) for the new feature.