### PR TITLE
Update schemas according to 🐊Putout v41

### DIFF
--- a/src/schemas/json/putout.json
+++ b/src/schemas/json/putout.json
@@ -60,7 +60,34 @@
         "apply-at": {
           "$ref": "#/definitions/rule"
         },
-        "apply-destructuring": {
+        "destructuring": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/apply-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/apply-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/split-nested": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/merge-properties": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/extract-properties": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/extract-properties-equal-deep": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/extract-properties-not-equal-deep": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/remove-useless-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/remove-useless-arguments": {
           "$ref": "#/definitions/rule"
         },
         "return": {
@@ -162,9 +189,6 @@
         "conditions/remove-constant": {
           "$ref": "#/definitions/rule"
         },
-        "conditions/remove-boolean": {
-          "$ref": "#/definitions/rule"
-        },
         "conditions/remove-useless-else": {
           "$ref": "#/definitions/rule"
         },
@@ -175,15 +199,6 @@
           "$ref": "#/definitions/rule"
         },
         "label/remove-unused": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-apply-to-spread": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-arguments-to-rest": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-array-copy-to-slice": {
           "$ref": "#/definitions/rule"
         },
         "convert-bitwise-to-logical": {
@@ -198,19 +213,13 @@
         "convert-is-nan-to-number-is-nan": {
           "$ref": "#/definitions/rule"
         },
-        "convert-math-pow": {
+        "math/apply-exponential": {
           "$ref": "#/definitions/rule"
         },
-        "convert-mock-require-to-mock-import": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-object-assign-to-merge-spread": {
+        "tape/convert-mock-require-to-mock-import": {
           "$ref": "#/definitions/rule"
         },
         "convert-quotes-to-backticks": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-spread-to-array-from": {
           "$ref": "#/definitions/rule"
         },
         "convert-template-to-string": {
@@ -226,9 +235,6 @@
           "$ref": "#/definitions/rule"
         },
         "eslint": {
-          "$ref": "#/definitions/rule"
-        },
-        "extract-object-properties": {
           "$ref": "#/definitions/rule"
         },
         "extract-sequence-expressions": {
@@ -268,9 +274,6 @@
           "$ref": "#/definitions/rule"
         },
         "maybe": {
-          "$ref": "#/definitions/rule"
-        },
-        "merge-destructuring-properties": {
           "$ref": "#/definitions/rule"
         },
         "parens": {
@@ -358,9 +361,6 @@
           "$ref": "#/definitions/rule"
         },
         "putout/add-args": {
-          "$ref": "#/definitions/rule"
-        },
-        "putout/add-index-to-import": {
           "$ref": "#/definitions/rule"
         },
         "putout/add-push": {
@@ -492,7 +492,7 @@
         "regexp": {
           "$ref": "#/definitions/rule"
         },
-        "remove-boolean-from-assertions": {
+        "conditions/remove-boolean": {
           "$ref": "#/definitions/rule"
         },
         "remove-boolean-from-logical-expressions": {
@@ -532,6 +532,9 @@
           "$ref": "#/definitions/rule"
         },
         "esm": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/add-index-to-import": {
           "$ref": "#/definitions/rule"
         },
         "esm/remove-empty-import": {
@@ -582,7 +585,37 @@
         "remove-unreachable-code": {
           "$ref": "#/definitions/rule"
         },
-        "remove-unreferenced-variables": {
+        "variables": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/convert-const-to-let": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-unused": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-useless-assignment": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-useless-declarations": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-useless-duplicates": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-useless-rename": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-unreferenced": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/extract-keyword": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/split-declarations": {
           "$ref": "#/definitions/rule"
         },
         "remove-unused-expressions": {
@@ -594,10 +627,22 @@
         "remove-unused-types": {
           "$ref": "#/definitions/rule"
         },
-        "remove-unused-variables": {
+        "arguments": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-arguments": {
+        "arguments/apply-json-parse": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/apply-rest": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/remove-useless-from-method": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/remove-unused": {
           "$ref": "#/definitions/rule"
         },
         "remove-useless-array": {
@@ -630,7 +675,22 @@
         "remove-useless-operand": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-spread": {
+        "spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/convert-object-assign-to-merge-spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/simplify-nested": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/convert-apply-to-spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/remove-useless-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/remove-useless-object": {
           "$ref": "#/definitions/rule"
         },
         "remove-useless-template-expressions": {
@@ -643,9 +703,6 @@
           "$ref": "#/definitions/rule"
         },
         "remove-useless-types-from-constants": {
-          "$ref": "#/definitions/rule"
-        },
-        "remove-useless-variables": {
           "$ref": "#/definitions/rule"
         },
         "reuse-duplicate-init": {
@@ -673,12 +730,6 @@
           "$ref": "#/definitions/rule"
         },
         "simplify-ternary": {
-          "$ref": "#/definitions/rule"
-        },
-        "split-nested-destructuring": {
-          "$ref": "#/definitions/rule"
-        },
-        "split-variable-declarations": {
           "$ref": "#/definitions/rule"
         },
         "tape": {


### PR DESCRIPTION
Update schemas according to 🐊[Putout v41](https://github.com/coderaiser/putout/releases/tag/v41.0.0).