### PR TITLE
Update ui5/manifest repository url

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6345,7 +6345,7 @@
         "**/src/main/webapp/manifest.json",
         "**/src/manifest.json"
       ],
-      "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
+      "url": "https://raw.githubusercontent.com/UI5/manifest/main/schema.json"
     },
     {
       "name": "ui5.yaml",


### PR DESCRIPTION
UI5 Manifest (AppDescriptor Schema) repository has been moved:
- from http://github.com/SAP/ui5-manifest 
- to https://github.com/UI5/manifest.