### PR TITLE
Added ZAPP schema v1.8.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3304,7 +3304,7 @@
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
       "fileMatch": ["zapp.yaml", "zapp.yml", "zapp.json"],
-      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.7.0.json",
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.8.0.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json",
         "1.1.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.1.0.json",
@@ -3314,7 +3314,8 @@
         "1.4.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.4.0.json",
         "1.5.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.5.0.json",
         "1.6.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.6.0.json",
-        "1.7.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.7.0.json"
+        "1.7.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.7.0.json",
+        "1.8.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.8.0.json"
       }
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

A new version of the JSON schema first introduced with this PR: https://github.com/SchemaStore/schemastore/pull/2860 and most recently updated with https://github.com/SchemaStore/schemastore/pull/5075

This schema is used by free development tools provided by IBM: https://ibm.github.io/zopeneditor-about/Docs/zapp.html