### PR TITLE
Correct the URL for cg-workshop

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -614,7 +614,7 @@
       "name": "Cloud.gov Workshop Configuration",
       "description": "Configuration for IaC managed resources in Cloud.gov Workshop",
       "fileMatch": ["cg-workshop.yml", "**/cg-workshop/*.yml"],
-      "url": "https://workshop.cloud.gov/workshop/workshop-schemas/-/raw/main/cg-workhshop.schema.json"
+      "url": "https://workshop.cloud.gov/workshop/workshop-schemas/-/raw/main/cg-workshop.schema.json"
     },
     {
       "name": "cmdx.yaml",


### PR DESCRIPTION
PR https://github.com/SchemaStore/schemastore/pull/5196 had a typo in the target URL. This corrects that mistake.