### PR TITLE
feat: add `runInVpc` property to tunnelhub schema

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -74,6 +74,10 @@
             "type": "string"
           }
         },
+        "runInVpc": {
+          "type": "boolean",
+          "description": "Whether to run Lambda in VPC. If true and vpcConfig is not provided, uses tenant settings or environment variables as fallback."
+        },
         "vpcConfig": {
           "additionalProperties": false,
           "properties": {


### PR DESCRIPTION
 **Summary**
- Add new `runInVpc` boolean property to configuration
- Add descriptive documentation for both `runInVpc` and `vpcConfig`
- Maintain backward compatibility with existing schemas
- Document the hierarchical precedence: vpcConfig > runInVpc > no VPC

 **Changes**
- New `runInVpc` property (boolean, optional)
- Enhanced `vpcConfig` description
- No breaking changes to existing schemas