### PR TITLE
Add Python 3.14 to Black

### DIFF
--- a/src/schemas/json/partial-black.json
+++ b/src/schemas/json/partial-black.json
@@ -28,7 +28,8 @@
           "py310",
           "py311",
           "py312",
-          "py313"
+          "py313",
+          "py314"
         ]
       },
       "description": "Python versions that should be supported by Black's output. You should include all versions that your code supports. By default, Black will infer target versions from the project metadata in pyproject.toml. If this does not yield conclusive results, Black will use per-file auto-detection."


### PR DESCRIPTION
Black has supported Python 3.14 since v25.11.0 (specifically psf/black#4804).

Running the check

```bash
node ./cli.js check --schema-name=partial-black.json
```

returned all successful tests:

```
===== VALIDATE PRECONDITIONS =====
✔️ Directory structure conforms to expected layout
✔️ catalog.json validates against its schema
✔️ catalog.json has no fields that break guidelines
✔️ catalog.json has no duplicate "fileMatch" values
✔️ catalog.json has no invalid schema URLs
✔️ catalog.json has all local entries that exist in file total
✔️ schema-validation.jsonc validates against its schema
✔️ schema-validation.jsonc has no invalid schema names
✔️ schema-validation.jsonc has no invalid schema URLs
✔️ schema-validation.jsonc has no invalid skiptest[] entries
===== VALIDATE SCHEMAS =====
✔️ Completed "pre-checks"
✔️ Completed "Ajv validation"
===== REPORT =====
Out of 1767 TOTAL schemas:
- 752 (43%) are SchemaStore URLs
- 1015 (57%) are External URLs

Out of 744 TESTED schemas:
- 282 (38%) are validated with Ajv's strict mode
- 537 (72%) have tests
- 138 (19%) have negative tests

Out of 1 TESTED schemas:
- Total  2020-12: 0
- Total  2019-09: 0
- Total draft-07: 1
- Total draft-06: 0
- Total draft-04: 0
- Total draft-03: 0
```

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
