### PR TITLE
Add stsAccess configuration to tunnelhub schema 

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -118,6 +118,21 @@
               "required": ["lambdaLayers"]
             }
           }
+        },
+        "stsAccess": {
+          "additionalProperties": false,
+          "properties": {
+            "assumeRoles": {
+              "items": {
+                "pattern": "^arn:aws:iam::\\d{12}:role/[a-zA-Z0-9+=,.@_-]+$",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": ["assumeRoles"],
+          "type": "object"
         }
       },
       "required": ["runtimeEngine", "entrypoint", "runtime", "memorySize"],


### PR DESCRIPTION
## Summary
- Add `stsAccess` property to the `configuration` object in tunnelhub.json schema
- Include validation for AWS IAM role ARNs with regex pattern
- Require at least one ARN in the `assumeRoles` array
- Set `additionalProperties: false` to restrict undefined properties

This enables support for AWS STS assume role configuration in TunnelHub deployments.