### PR TITLE
Add ACP (AI Context Protocol) schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -194,6 +194,24 @@
       }
     },
     {
+      "name": "ACP Cache File",
+      "description": "AI Context Protocol cache file format for storing indexed codebase metadata",
+      "fileMatch": [".acp.cache.json"],
+      "url": "https://acp-protocol.dev/schemas/v1/cache.schema.json"
+    },
+    {
+      "name": "ACP Configuration File",
+      "description": "AI Context Protocol configuration file for project-level settings",
+      "fileMatch": [".acp.config.json"],
+      "url": "https://acp-protocol.dev/schemas/v1/config.schema.json"
+    },
+    {
+      "name": "ACP Variables File",
+      "description": "AI Context Protocol variables file for reusable context variables",
+      "fileMatch": [".acp.vars.json"],
+      "url": "https://acp-protocol.dev/schemas/v1/vars.schema.json"
+    },
+    {
       "name": "AIConfig",
       "description": "AIConfig that is used to store generative AI prompts, models and model parameters",
       "fileMatch": [


### PR DESCRIPTION
## Summary
- Add three schema entries for the AI Context Protocol specification
- ACP Cache File (`.acp.cache.json`) - indexed codebase metadata format
- ACP Configuration File (`.acp.config.json`) - project-level settings
- ACP Variables File (`.acp.vars.json`) - reusable context variables

## Details
The [AI Context Protocol (ACP)](https://acp-protocol.dev) is a specification for providing structured codebase context to AI assistants. These schemas define the file formats used by ACP tooling.

Schemas are self-hosted at `https://acp-protocol.dev/schemas/v1/` and use JSON Schema Draft-07.

## Test plan
- [x] Ran `node cli.js check` - all validations passed
- [x] Catalog entries are in alphabetical order
- [x] URLs are accessible and return valid JSON schemas