### PR TITLE
Add `workspaceConcurrency` to `pnpm-workspace.json`

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -654,6 +654,11 @@
       "description": "When set to true, installation will fail if the workspace has cycles.",
       "type": "boolean"
     },
+    "workspaceConcurrency": {
+      "description": "Set the maximum number of tasks to run simultaneously. For unlimited concurrency use Infinity. You can set the value to <= 0 and it will use amount of CPU cores of the host minus the absolute value of the provided number as: max(1, (number of cores) - abs(workspaceConcurrency)).",
+      "type": "number",
+      "default": 4
+    },
     "failIfNoMatch": {
       "type": "boolean",
       "description": "If true, pnpm will fail if no packages match the filter",

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -24,3 +24,6 @@ saveExact: true
 
 # https://pnpm.io/cli/install#--prefer-offline
 preferOffline: true
+
+# https://pnpm.io/cli/run#--workspace-concurrency
+workspaceConcurrency: 5


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Adds the `workspaceConcurrency` setting to the `pnpm-workspace.json` schema.

This setting controls the maximum number of tasks to run simultaneously in a workspace.

Reference: https://pnpm.io/cli/run#--workspace-concurrency