### PR TITLE
Add configuration for zizmor static analysis tool

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9086,13 +9086,13 @@
     {
       "name": "zizmor",
       "description": "Configuration file for zizmor, a static analysis tool for GitHub Actions",
-      "url": "https://raw.githubusercontent.com/woodruffw/zizmor/main/support/zizmor.schema.json",
       "fileMatch": [
         "**/zizmor.yml",
         "**/zizmor.yaml",
         "**/.github/zizmor.yml",
         "**/.github/zizmor.yaml"
-      ]
+      ],
+      "url": "https://raw.githubusercontent.com/woodruffw/zizmor/main/support/zizmor.schema.json"
     },
     {
       "name": "Changepacks",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Summary

Add schema for [zizmor](https://github.com/woodruffw/zizmor) configuration files.

zizmor is a static analysis tool for GitHub Actions workflows that detects security vulnerabilities and best practice violations.

## Details

- **Schema URL**: https://raw.githubusercontent.com/woodruffw/zizmor/main/support/zizmor.schema.json
- **JSON Schema version**: Draft-07

## Test plan

- [x] Ran `node cli.js check` - all validations passed