### PR TITLE
dependabot-2.0: Make schedule optional in multi-ecosystem groups (#5249)

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1068,7 +1068,16 @@
       },
       "allOf": [
         {
-          "required": ["package-ecosystem", "schedule"]
+          "$comment": "Schedule is required UNLESS multi-ecosystem-group is specified",
+          "if": {
+            "required": ["multi-ecosystem-group"]
+          },
+          "then": {
+            "required": ["package-ecosystem"]
+          },
+          "else": {
+            "required": ["package-ecosystem", "schedule"]
+          }
         },
         {
           "oneOf": [

--- a/src/test/dependabot-2.0/multi-ecosystem-groups.no-schedule-in-updates.yaml
+++ b/src/test/dependabot-2.0/multi-ecosystem-groups.no-schedule-in-updates.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../schemas/json/dependabot-2.0.json
+# Test case: Updates with multi-ecosystem-group but no schedule property
+# The schedule is defined at the group level, so individual updates don't need it
+version: 2
+
+multi-ecosystem-groups:
+  shared-dependencies:
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - automated
+
+updates:
+  # Update without schedule - should be valid when multi-ecosystem-group is present
+  - package-ecosystem: npm
+    directory: /frontend
+    patterns:
+      - '*'
+    multi-ecosystem-group: shared-dependencies
+
+  # Another update without schedule in same group
+  - package-ecosystem: pip
+    directory: /backend
+    patterns:
+      - django
+      - flask
+    multi-ecosystem-group: shared-dependencies
+
+  # Third ecosystem without individual schedule
+  - package-ecosystem: docker
+    directory: /
+    patterns:
+      - nginx
+      - postgres
+    multi-ecosystem-group: shared-dependencies


### PR DESCRIPTION
Updates the schema to allow update entries to omit the schedule property when multi-ecosystem-group is specified. Adds test coverage for this scenario. This change will allow to validate the files such as dependabot.yml file from the dependabot/dependabot-core repository:
https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml

Fixes #5249.
