### PR TITLE
(pyproject) Update poe schema 

### DIFF
--- a/src/schemas/json/partial-poe.json
+++ b/src/schemas/json/partial-poe.json
@@ -229,6 +229,11 @@
         {
           "type": "object",
           "properties": {
+            "empty_glob": {
+              "default": "pass",
+              "description": "Determines how to handle glob patterns with no matches. The default is 'pass', which causes unmatched patterns to be passed through to the command (just like in bash). Setting it to 'null' will replace an unmatched pattern with nothing, and setting it to 'fail' will cause the task to fail with an error if there are no matches.",
+              "enum": ["pass", "null", "fail"]
+            },
             "cmd": {
               "title": "Command to execute",
               "description": "Executes a single command as a subprocess without a shell. Supports glob patterns for file matching, parameter expansion, and pattern matching. Environment variable templating is also supported within the command.",
@@ -367,6 +372,55 @@
         }
       ]
     },
+    "parallel_task": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/standard_options"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default_item_type": {
+              "default": "ref",
+              "description": "Change the default item type that strings in the sequence are interpreted as.",
+              "type": "string"
+            },
+            "ignore_fail": {
+              "description": "If true then the failure (or non-zero return value) of one task in the parallel group does not abort the execution.",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "enum": ["return_zero", "return_non_zero"],
+                  "type": "string"
+                }
+              ]
+            },
+            "prefix": {
+              "default": "{name}",
+              "description": "Set the prefix applied to each line of output from subtasks. By default this is the task name.",
+              "type": "string"
+            },
+            "prefix_max": {
+              "default": 16,
+              "description": "Set the maximum width of the prefix. Longer prefixes will be truncated.",
+              "type": "integer"
+            },
+            "prefix_template": {
+              "default": "{color_start}{prefix}{color_end} |",
+              "description": "Specifies a template for how the prefix is applied after truncating it to the prefix_max length.",
+              "type": "string"
+            },
+            "parallel": {
+              "$ref": "#/definitions/tasks_array",
+              "description": "A subtask is defined by an array of tasks or command names to be run multiple tasks concurrently. Each subtask can be a command name, a command, script, reference to another task, or another sequence."
+            }
+          },
+          "required": ["parallel"]
+        }
+      ]
+    },
     "shell_task": {
       "allOf": [
         {
@@ -479,6 +533,9 @@
         },
         {
           "$ref": "#/definitions/sequence_task"
+        },
+        {
+          "$ref": "#/definitions/parallel_task"
         },
         {
           "$ref": "#/definitions/expr_task"


### PR DESCRIPTION
## Standard task options

Move the definitions of several options into `definitions`.

https://poethepoet.natn.io/tasks/options.html

### incompatibility between `use_exec` and `capture_stdout`

Add support for the incompatibility between `use_exec` and `capture_stdout`.

```toml
# valid
[tool.poe.tasks.test-quick]
cmd = "echo 1"
use_exec = false
capture_stdout = "result.txt"
```

```toml
# invalid
[tool.poe.tasks.test-quick]
cmd = "echo 1"
use_exec = true
capture_stdout = "result.txt"
```

### `verbosity`

Add task level verbosity.

```toml
[tool.poe]
verbosity = 1 # exists

[tool.poe.tasks.test-quick]
cmd = "echo 1"
verbosity = 2 # new
```

### `help` is not null

```toml
[tool.poe.tasks.test-quick]
cmd = "echo 1"
help = "Any message"
```


## parallel tasks

Add `parallel` tasks

https://poethepoet.natn.io/tasks/task_types/parallel.html