### PR TITLE
Update coverageThreshold schema to remove integer type

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -146,7 +146,6 @@
           "$comment": "https://bun.sh/docs/runtime/bunfig#test-coveragethreshold",
           "description": "To specify a coverage threshold. By default, no threshold is set. If your test suite does not meet or exceed this threshold, `bun test` will exit with a non-zero exit code to indicate the failure\nhttps://bun.sh/docs/runtime/bunfig#test-coveragethreshold",
           "oneOf": [
-            { "type": "integer" },
             { "type": "number" },
             {
               "type": "object",


### PR DESCRIPTION
Removed the integer type option from coverageThreshold schema.

<img width="1262" height="482" alt="image" src="https://github.com/user-attachments/assets/ad05bdfe-dd02-4a41-ab65-a1263844dd71" />

We should use number.

number includes integer!

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
