### PR TITLE
HTMLHint: Change type to anyOf for attributes in htmlhint.json

### DIFF
--- a/src/schemas/json/htmlhint.json
+++ b/src/schemas/json/htmlhint.json
@@ -9,10 +9,7 @@
     },
     "attr-lowercase": {
       "description": "Attribute name must be lowercase.",
-      "anyOf": [
-        { "type": "boolean" },
-        { "type": "array" }
-      ],
+      "anyOf": [{ "type": "boolean" }, { "type": "array" }],
       "default": false
     },
     "attr-no-duplication": {
@@ -37,10 +34,7 @@
     },
     "attr-value-no-duplication": {
       "description": "Class attributes should not contain duplicate values. Other attributes can be checked via configuration.",
-      "anyOf": [
-        { "type": "boolean" },
-        { "type": "array" }
-      ],
+      "anyOf": [{ "type": "boolean" }, { "type": "array" }],
       "default": false
     },
     "attr-value-not-empty": {


### PR DESCRIPTION
These rules accept boolean OR an array.

- https://htmlhint.com/rules/attr-lowercase/
- https://htmlhint.com/rules/attr-value-no-duplication/

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
