### PR TITLE
Add opencode configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4504,6 +4504,17 @@
       "url": "https://meta.open-rpc.org/"
     },
     {
+      "name": "opencode",
+      "description": "opencode AI coding agent configuration file",
+      "fileMatch": [
+        "opencode.json",
+        "opencode.jsonc",
+        "**/.opencode/opencode.json",
+        "**/.opencode/opencode.jsonc"
+      ],
+      "url": "https://opencode.ai/config.json"
+    },
+    {
       "name": "OpenUtau character yaml",
       "description": "OpenUtau voicebank configuration file, character.yaml",
       "fileMatch": ["character.yaml"],


### PR DESCRIPTION
## Summary
Adds the opencode AI coding agent configuration schema to the catalog.

## Details
- **Schema name**: opencode
- **File patterns**: 
  - `opencode.json`
  - `opencode.jsonc`
  - `**/.opencode/opencode.json`
  - `**/.opencode/opencode.jsonc`
- **Schema URL**: https://opencode.ai/config.json
- **Type**: Remote schema

opencode is an AI coding agent that helps developers write code. This schema provides autocompletion and validation for opencode configuration files in IDEs and editors that use SchemaStore.

## References
- Website: https://opencode.ai
- GitHub: https://github.com/anomalyco/opencode