### PR TITLE
Add Skill to Claude Code settings permission rule pattern

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule",
-      "pattern": "^((Bash|BashOutput|Edit|ExitPlanMode|Glob|Grep|KillShell|NotebookEdit|Read|SlashCommand|Task|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Bash|BashOutput|Edit|ExitPlanMode|Glob|Grep|KillShell|NotebookEdit|Read|Skill|SlashCommand|Task|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash(git commit:*)",
         "Bash(npm run lint:*)",


### PR DESCRIPTION
## Summary

Add `Skill` to the list of valid tools in the `permissionRule` pattern for Claude Code settings schema.

## Details

The Claude Code documentation lists `Skill` as one of the available tools that requires permission:

| Tool | Description | Permission Required |
|------|-------------|-------------------|
| Skill | Executes a skill within the main conversation | Yes |

Users can configure Skill permissions like:

```json
{
  "permissions": {
    "allow": [
      "Skill(*)"
    ]
  }
}
```

However, the current schema's `permissionRule` pattern does not include `Skill`, causing validation warnings when users add Skill-related permission rules.

This PR adds `Skill` to the pattern to match the documented tool list.

## Reference

- Claude Code Settings Documentation: https://code.claude.com/docs/en/settings

