### PR TITLE
Update schemas for problem package format (Kattis/CLICS)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5037,10 +5037,28 @@
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-step.schema.json"
     },
     {
+      "name": "Problem package format",
+      "description": "Problem package metadata for programming tasks in the Kattis/CLICS problem package format",
+      "fileMatch": ["problem.yml", "problem.yaml"],
+      "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/problem_yaml_schema.json"
+    },
+    {
       "name": "Problem package generators",
       "description": "Generators for programming tasks in the Kattis/CLICS problem package format",
       "fileMatch": ["generators.yml", "generators.yaml"],
-      "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/master/support/schemas/generators_yaml_schema.json"
+      "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/generators_yaml_schema.json"
+    },
+    {
+      "name": "Problem package submissions",
+      "description": "Submissions metadata for programming tasks in the Kattis/CLICS problem package format",
+      "fileMatch": ["submissions.yml", "submissions.yaml"],
+      "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/submissions_yaml_schema.json"
+    },
+    {
+      "name": "Problem package test group metadata",
+      "description": "Test group metadata for programming tasks in the Kattis/CLICS problem package format",
+      "fileMatch": ["test_group.yml", "test_group.yaml"],
+      "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/test_group_yaml_schema.json"
     },
     {
       "name": "project.json",


### PR DESCRIPTION
* Update the reference to the generators.yaml schema hosted in the BAPCtools repo after reorganisation for migration to Python Package Index.

Add schema schemas onsistent with upcoming 2025-09 specification for

* problem.yaml

* submissions.yaml

* test_group.yaml

See https://www.kattis.com/problem-package-format/spec/2025-09.html 

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
