### PR TITLE
Add WireMock's message stub mapping schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8585,6 +8585,19 @@
       "url": "https://raw.githubusercontent.com/wiremock/wiremock/refs/heads/master/schemas/wiremock-stub-mapping-or-mappings.json"
     },
     {
+      "name": "WireMock message stub mapping",
+      "description": "WireMock single or multiple async message stub mapping JSON. See https://wiremock.org/docs/messaging/stubbing/",
+      "fileMatch": [
+        "wiremock-message-stub-mapping.yml",
+        "wiremock-message-stub-mapping.yaml",
+        "message-stubs.json",
+        "message-stub-mappings.json",
+        "message-stubs.yaml",
+        "message-stub-mappings.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/wiremock/wiremock/refs/heads/master/schemas/wiremock-message-stub-mapping-or-mappings.json"
+    },
+    {
       "name": "WireMock CLI local service configuration",
       "description": "WireMock CLI and Runner local service config file format",
       "fileMatch": ["wiremock.yaml"],


### PR DESCRIPTION
Add JSON schema for WireMock's recently added message/async stubs.