### PR TITLE
Change tmp_path_retention_count type to string

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -997,9 +997,9 @@
           "x-tombi-array-values-order": "ascending"
         },
         "tmp_path_retention_count": {
-          "type": "integer",
+          "type": "string",
           "description": "How many sessions should we keep the tmp_path directories, according to tmp_path_retention_policy.",
-          "default": 3
+          "default": "3"
         },
         "tmp_path_retention_policy": {
           "type": "string",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

The `tmp_path_retention_count` is numeric, but pytest always expects it to be a string. I originally raised https://github.com/pytest-dev/pytest/issues/14092 before realising the issue was here.

This is a deliberate choice, but I don't know why: https://github.com/pytest-dev/pytest/pull/13958