### PR TITLE
Update JSON schema to remove 'description' requirement

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -963,7 +963,6 @@
           }
         }
       ],
-      "required": ["description"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
Removed 'description' from required properties in GitHub workflow workflow_dispatch JSON schema.

It's not needed according to my tests and https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#example-usage-of-the-inputs-context-in-a-manually-triggered-workflow

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
