### PR TITLE
fix(schema): resolve linting issues in abc-supply-plan schemas

### DIFF
--- a/src/schemas/json/abc-supply-plan-1.0.0.json
+++ b/src/schemas/json/abc-supply-plan-1.0.0.json
@@ -49,7 +49,7 @@
       "x-abcIsAcyclic": true
     }
   },
-  "required": [ "planDate", "planNotes", "abcMaterialsMap", "recipeMap" ],
+  "required": ["planDate", "planNotes", "abcMaterialsMap", "recipeMap"],
   "additionalProperties": false,
   "type": "object",
   "definitions": {
@@ -114,7 +114,7 @@
           "description": "Determines if the material is a node where capacity constraints are applied"
         },
         "inventoryMethod": {
-          "enum": [ "TargetMFC", "MinimumInventory" ],
+          "enum": ["TargetMFC", "MinimumInventory"],
           "title": "Inventory Method",
           "description": "The method used for managing inventory levels, either target months forward coverage or minimum inventory"
         },
@@ -225,17 +225,17 @@
           "description": "Adjustments made to account for expired materials, reducing quantities"
         },
         "timeAggregateType": {
-          "enum": [ "Annual", "Quarterly", "Monthly" ],
+          "enum": ["Annual", "Quarterly", "Monthly"],
           "title": "Time Aggregate Type",
           "description": "The aggregation level for planning and reporting, e.g., annual, quarterly, or monthly"
         },
         "showQuantitiesAs": {
-          "enum": [ "Units", "Lots", "Cost" ],
+          "enum": ["Units", "Lots", "Cost"],
           "title": "Show Quantities As",
           "description": "Defines how quantities are represented, e.g., in units, lots, or cost"
         },
         "expiryAnalysisType": {
-          "enum": [ "Expiration", "Stopship" ],
+          "enum": ["Expiration", "Stopship"],
           "title": "Expiry Analysis Type",
           "description": "Determines the type of analysis to be performed on expiry data, focusing on expiration or stopship scenarios"
         },
@@ -290,7 +290,7 @@
           "description": "The yield percentage of the recipe, indicating efficiency"
         }
       },
-      "required": [ "recipe", "percentAllocations", "percentYield" ],
+      "required": ["recipe", "percentAllocations", "percentYield"],
       "additionalProperties": false
     },
     "PositiveDateMap": {
@@ -373,7 +373,7 @@
           ]
         }
       },
-      "required": [ "startDate", "endDate" ],
+      "required": ["startDate", "endDate"],
       "additionalProperties": true
     },
     "PercentValueConstraints": {
@@ -389,7 +389,7 @@
           "maximum": 1
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "PercentTimeDependentValue": {
@@ -427,7 +427,7 @@
           "description": "An integer value that cannot be negative, typically representing quantities or counts in a time-dependent context"
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "NonNegativeIntegerTimeDependentValue": {

--- a/src/schemas/json/abc-supply-plan-2.0.0.json
+++ b/src/schemas/json/abc-supply-plan-2.0.0.json
@@ -124,7 +124,7 @@
           "description": "Determines if the material is a node where capacity constraints are applied"
         },
         "inventoryMethod": {
-          "enum": [ "TargetMFC", "MinimumInventory" ],
+          "enum": ["TargetMFC", "MinimumInventory"],
           "title": "Inventory Method",
           "description": "The method used for managing inventory levels, either target months forward coverage or minimum inventory"
         },
@@ -235,17 +235,17 @@
           "description": "Adjustments made to account for expired materials, reducing quantities"
         },
         "timeAggregateType": {
-          "enum": [ "Annual", "Quarterly", "Monthly" ],
+          "enum": ["Annual", "Quarterly", "Monthly"],
           "title": "Time Aggregate Type",
           "description": "The aggregation level for planning and reporting, e.g., annual, quarterly, or monthly"
         },
         "showQuantitiesAs": {
-          "enum": [ "Units", "Lots", "Cost" ],
+          "enum": ["Units", "Lots", "Cost"],
           "title": "Show Quantities As",
           "description": "Defines how quantities are represented, e.g., in units, lots, or cost"
         },
         "expiryAnalysisType": {
-          "enum": [ "Expiration", "Stopship" ],
+          "enum": ["Expiration", "Stopship"],
           "title": "Expiry Analysis Type",
           "description": "Determines the type of analysis to be performed on expiry data, focusing on expiration or stopship scenarios"
         },
@@ -300,7 +300,7 @@
           "description": "The yield percentage of the recipe, indicating efficiency"
         }
       },
-      "required": [ "recipe", "percentAllocations", "percentYield" ],
+      "required": ["recipe", "percentAllocations", "percentYield"],
       "additionalProperties": false
     },
     "PositiveDateMap": {
@@ -383,7 +383,7 @@
           ]
         }
       },
-      "required": [ "startDate", "endDate" ],
+      "required": ["startDate", "endDate"],
       "additionalProperties": true
     },
     "PercentValueConstraints": {
@@ -399,7 +399,7 @@
           "maximum": 1
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "PercentTimeDependentValue": {
@@ -437,7 +437,7 @@
           "description": "An integer value that cannot be negative, typically representing quantities or counts in a time-dependent context"
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "NonNegativeIntegerTimeDependentValue": {

--- a/src/schemas/json/abc-supply-plan-3.0.0.json
+++ b/src/schemas/json/abc-supply-plan-3.0.0.json
@@ -126,7 +126,7 @@
           "description": "Determines if the material is a node where capacity constraints are applied"
         },
         "inventoryMethod": {
-          "enum": [ "TargetMFC", "MinimumInventory" ],
+          "enum": ["TargetMFC", "MinimumInventory"],
           "title": "Inventory Method",
           "description": "The method used for managing inventory levels, either target months forward coverage or minimum inventory"
         },
@@ -242,17 +242,17 @@
           "description": "Adjustments made to account for expired materials, reducing quantities"
         },
         "timeAggregateType": {
-          "enum": [ "Annual", "Quarterly", "Monthly" ],
+          "enum": ["Annual", "Quarterly", "Monthly"],
           "title": "Time Aggregate Type",
           "description": "The aggregation level for planning and reporting, e.g., annual, quarterly, or monthly"
         },
         "showQuantitiesAs": {
-          "enum": [ "Units", "Lots", "Cost" ],
+          "enum": ["Units", "Lots", "Cost"],
           "title": "Show Quantities As",
           "description": "Defines how quantities are represented, e.g., in units, lots, or cost"
         },
         "expiryAnalysisType": {
-          "enum": [ "Expiration", "Stopship" ],
+          "enum": ["Expiration", "Stopship"],
           "title": "Expiry Analysis Type",
           "description": "Determines the type of analysis to be performed on expiry data, focusing on expiration or stopship scenarios"
         },
@@ -296,7 +296,7 @@
           "description": "Unique identifier of the recipe"
         },
         "allocationMethod": {
-          "enum": [ "PercentAllocation", "PriorityAllocation" ],
+          "enum": ["PercentAllocation", "PriorityAllocation"],
           "title": "Consumption Allocation",
           "description": "Method for allocating downstream consumption to upstream materials"
         },
@@ -406,7 +406,7 @@
           ]
         }
       },
-      "required": [ "startDate", "endDate" ],
+      "required": ["startDate", "endDate"],
       "additionalProperties": true
     },
     "PercentValueConstraints": {
@@ -422,7 +422,7 @@
           "maximum": 1
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "PercentTimeDependentValue": {
@@ -460,7 +460,7 @@
           "description": "An integer value that cannot be negative, typically representing quantities or counts in a time-dependent context"
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "NonNegativeIntegerTimeDependentValue": {
@@ -498,7 +498,7 @@
           "description": "A non-negative number, used in various contexts to represent quantities or counts"
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "NonNegativeNumberTimeDependentValue": {
@@ -536,7 +536,7 @@
           "description": "An integer value that must be positive, typically representing quantities or counts in contexts where zero is not a valid value"
         }
       },
-      "required": [ "timeDependentValue" ],
+      "required": ["timeDependentValue"],
       "additionalProperties": true
     },
     "PositiveIntegerTimeDependentValue": {


### PR DESCRIPTION
Fixed JSON schema linting issues in the `abc-supply-plan` schemas for versions:
- 1.0.0
- 2.0.0
- 3.0.0

The changes bring the schemas into compliance with SchemaStore linting rules without altering their intended structure or semantics.

- Normalized formatting and ordering
- Fixed lint violations reported by the schema linter
- No functional or breaking changes introduced

### Before and after:
*`abc-supply-plan-1.0.0 :`

https://github.com/user-attachments/assets/657b613b-d231-43c0-95f8-8cf3614a9265



*`abc-supply-plan-2.0.0 :`

https://github.com/user-attachments/assets/0ec466ed-98d5-47eb-98a6-7bc0f27f0856



*`abc-supply-plan-3.0.0 :`

https://github.com/user-attachments/assets/66c0e9ff-3b80-45e8-9deb-f9225e476514


Note: This PR was created with the help of [jsonschema cli](https://www.npmjs.com/package/@sourcemeta/jsonschema), created by a member of TSC of JSON Schema committee. The [extension](https://marketplace.visualstudio.com/items?itemName=sourcemeta.sourcemeta-studio) used is based on the same cli