### PR TITLE
fix: allow 2-letter topics in pubspec.yaml

### DIFF
--- a/src/schemas/json/pubspec.json
+++ b/src/schemas/json/pubspec.json
@@ -305,7 +305,7 @@
       "maxItems": 5,
       "items": {
         "type": "string",
-        "pattern": "^[a-z][a-z0-9-]{1,30}[a-z0-9]$"
+        "pattern": "^[a-z][a-z0-9-]{0,30}[a-z0-9]$"
       },
       "examples": [
         ["network", "http"],

--- a/src/test/pubspec/pubspec.yaml
+++ b/src/test/pubspec/pubspec.yaml
@@ -6,6 +6,7 @@ repository: https://example.com/repo.git
 version: 0.3.1-foobar.2.0
 publish_to: 'none'
 topics:
+  - ui
   - yaml
 
 environment:


### PR DESCRIPTION
The current pubspec.yaml schema requires topics to be at least 3 characters long:

<img width="838" height="257" alt="image" src="https://github.com/user-attachments/assets/6c8290d6-563e-433b-b898-2176b13c5fc4" />

But the `ui` topic is valid and also popular with 369 packages including first-party Flutter packages: https://pub.dev/packages?q=topic%3Aui

I've just modified the regex to accept 2 letter topics.