### PR TITLE
Add `artifact-metadata` property to `permissions` portion of `github-workflow` schema

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -162,6 +162,9 @@
         "actions": {
           "$ref": "#/definitions/permissions-level"
         },
+        "artifact-metadata": {
+          "$ref": "#/definitions/permissions-level"
+        },
         "attestations": {
           "$ref": "#/definitions/permissions-level"
         },


### PR DESCRIPTION
The new [`artifact-metadata` granular permission](https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/) is now generally available.