### PR TITLE
add bento stream configuration file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9205,10 +9205,7 @@
     {
       "name": "Bento",
       "description": "Bento stream configuration file",
-      "fileMatch": [
-        "bento.json",
-        "bento.yml",
-        "bento.yaml"      ],
+      "fileMatch": ["bento.json", "bento.yml", "bento.yaml"],
       "url": "https://raw.githubusercontent.com/warpstreamlabs/bento/refs/heads/main/resources/schemastore/bento.json"
     }
   ]


### PR DESCRIPTION
Following the advice [How to add a json schema file thats self-hosted](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal) - for the tool: [Bento](https://github.com/warpstreamlabs/bento)