### PR TITLE
feat: add Awesome Repositories schema (self-hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -477,6 +477,16 @@
       "url": "https://www.schemastore.org/avro-avsc.json"
     },
     {
+      "name": "Awesome Repositories",
+      "description": "Configuration for awesome repository catalogs with categories",
+      "fileMatch": [
+        "awesome-repositories.json",
+        "awesome-repositories.yaml",
+        "awesome-repositories.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/abordage/schemas/main/schemas/awesome-repositories/awesome-repositories.schema.json"
+    },
+    {
       "name": "AWS AppConfig Feature Flags-v1",
       "description": "AWS CDK AppConfig Feature Flags",
       "fileMatch": ["*.appConfig.featureFlags.json"],


### PR DESCRIPTION
## Summary

Add a new self-hosted schema for validating awesome repository catalogs.

## Schema Details

- **Name**: Awesome Repositories
- **Description**: Configuration for awesome repository catalogs with categories
- **URL**: https://raw.githubusercontent.com/abordage/schemas/main/schemas/awesome-repositories/awesome-repositories.schema.json
- **File matches**: `awesome-repositories.json`, `awesome-repositories.yaml`, `awesome-repositories.yml`

## Schema Purpose

This schema validates YAML/JSON files containing structured catalogs of repositories organized by categories and subcategories. Useful for maintaining curated lists of repositories (similar to "awesome" lists).

## Documentation

- Schema repository: https://github.com/abordage/schemas
- Documentation: https://github.com/abordage/schemas/blob/main/docs/awesome-repositories.md

## Checklist

- [x] Schema uses `draft-07`
- [x] Schema has valid `$id` and `$schema` fields
- [x] Schema URL is accessible
- [x] `fileMatch` patterns are specific (not generic)