### PR TITLE
Update Claude Code settings schema with missing settings and fixes

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -17,6 +17,8 @@
         "Edit(/src/**/*.ts)",
         "Read(./.env)",
         "Read(./secrets/**)",
+        "Read(/Users/alice/secrets/**)",
+        "Read(~/Documents/*.pdf)",
         "WebFetch",
         "WebFetch(domain:example.com)",
         "mcp__github__search_repositories"

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -230,7 +230,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Tool usage permissions configuration",
+      "description": "Tool usage permissions configuration. See https://code.claude.com/docs/en/iam#configuring-permissions",
       "examples": [
         {
           "allow": ["Bash(git add:*)"],
@@ -251,7 +251,7 @@
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
-      "description": "Whether to automatically approve all MCP servers in the project",
+      "description": "Whether to automatically approve all MCP servers in the project. See https://code.claude.com/docs/en/mcp",
       "examples": [true]
     },
     "enabledMcpjsonServers": {
@@ -307,7 +307,7 @@
     "hooks": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Custom commands to run before/after tool executions",
+      "description": "Custom commands to run before/after tool executions. See https://code.claude.com/docs/en/hooks",
       "examples": [
         {
           "PostToolUse": [
@@ -476,7 +476,7 @@
           }
         ]
       },
-      "description": "Enabled plugins using plugin-id@marketplace-id format. Example: { \"formatter@anthropic-tools\": true }. Also supports extended format with version constraints."
+      "description": "Enabled plugins using plugin-id@marketplace-id format. Example: { \"formatter@anthropic-tools\": true }. See https://code.claude.com/docs/en/plugins"
     },
     "extraKnownMarketplaces": {
       "type": "object",
@@ -604,7 +604,7 @@
         "required": ["source"],
         "additionalProperties": false
       },
-      "description": "Additional marketplaces to make available for this repository. Typically used in repository .claude/settings.json to ensure team members have required plugin sources."
+      "description": "Additional marketplaces to make available for this repository. Typically used in repository .claude/settings.json to ensure team members have required plugin sources. See https://code.claude.com/docs/en/plugin-marketplaces"
     },
     "strictKnownMarketplaces": {
       "type": "array",
@@ -769,7 +769,7 @@
     },
     "outputStyle": {
       "type": "string",
-      "description": "Controls the output style for assistant responses",
+      "description": "Controls the output style for assistant responses. See https://code.claude.com/docs/en/output-styles",
       "examples": ["default", "Explanatory", "Learning"],
       "minLength": 1
     },
@@ -779,6 +779,7 @@
     },
     "sandbox": {
       "type": "object",
+      "description": "Sandbox execution configuration. See https://code.claude.com/docs/en/sandboxing",
       "properties": {
         "network": {
           "type": "object",
@@ -863,7 +864,7 @@
     },
     "alwaysThinkingEnabled": {
       "type": "boolean",
-      "description": "Whether extended thinking is always enabled (default: false)"
+      "description": "Enable extended thinking by default for all sessions. Typically configured via the /config command rather than editing directly. See https://code.claude.com/docs/en/common-workflows#use-extended-thinking-thinking-mode"
     },
     "companyAnnouncements": {
       "type": "array",

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4,19 +4,22 @@
   "$defs": {
     "permissionRule": {
       "type": "string",
-      "description": "Tool permission rule",
-      "pattern": "^((Bash|BashOutput|Edit|ExitPlanMode|Glob|Grep|KillShell|NotebookEdit|Read|Skill|SlashCommand|Task|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "description": "Tool permission rule. See https://code.claude.com/docs/en/settings#permission-rule-syntax",
+      "pattern": "^((Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|NotebookEdit|Read|Skill|Task|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
+        "Bash",
+        "Bash(npm run build)",
         "Bash(git commit:*)",
-        "Bash(npm run lint:*)",
+        "Bash(npm run:*)",
+        "Bash(ls*)",
+        "Bash(git * main)",
+        "Edit",
         "Edit(/src/**/*.ts)",
-        "mcp__github__search_repositories",
-        "Read(*.env)",
-        "Read(//Users/alice/secrets/**)",
-        "Read(~/Documents/*.pdf)",
+        "Read(./.env)",
+        "Read(./secrets/**)",
         "WebFetch",
-        "WebFetch(domain:github.com)",
-        "Read(//tmp/**/*)"
+        "WebFetch(domain:example.com)",
+        "mcp__github__search_repositories"
       ]
     },
     "hookCommand": {
@@ -89,7 +92,7 @@
       }
     }
   },
-  "description": "Configuration settings for Claude Code. Learn more: https://docs.claude.com/en/docs/claude-code/settings",
+  "description": "Configuration settings for Claude Code. Learn more: https://code.claude.com/docs/en/settings",
   "allowTrailingCommas": true,
   "additionalProperties": true,
   "type": "object",
@@ -103,6 +106,12 @@
       "description": "Path to a script that outputs authentication values",
       "examples": ["/bin/generate_temp_api_key.sh"],
       "minLength": 1
+    },
+    "autoUpdatesChannel": {
+      "type": "string",
+      "enum": ["stable", "latest"],
+      "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release",
+      "default": "latest"
     },
     "awsCredentialExport": {
       "type": "string",
@@ -141,9 +150,35 @@
         }
       }
     },
+    "attribution": {
+      "type": "object",
+      "description": "Customize attribution for git commits and pull requests. See https://code.claude.com/docs/en/settings#attribution-settings",
+      "additionalProperties": false,
+      "properties": {
+        "commit": {
+          "type": "string",
+          "description": "Attribution for git commits, including any trailers. Empty string hides commit attribution"
+        },
+        "pr": {
+          "type": "string",
+          "description": "Attribution for pull request descriptions. Empty string hides pull request attribution"
+        }
+      }
+    },
     "includeCoAuthoredBy": {
       "type": "boolean",
-      "description": "Whether to include Claude's co-authored by attribution in commits and PRs (defaults to true)",
+      "description": "DEPRECATED. Use 'attribution' instead. Whether to include the co-authored-by Claude byline in git commits and pull requests (default: true)",
+      "default": true
+    },
+    "plansDirectory": {
+      "type": "string",
+      "description": "Customize where plan files are stored. Path is relative to project root (default: ~/.claude/plans)",
+      "default": "~/.claude/plans",
+      "examples": ["./plans"]
+    },
+    "respectGitignore": {
+      "type": "boolean",
+      "description": "Control whether the @ file picker respects .gitignore patterns. When true (default), files matching .gitignore patterns are excluded from suggestions",
       "default": true
     },
     "permissions": {
@@ -204,6 +239,11 @@
           "defaultMode": "default"
         }
       ]
+    },
+    "language": {
+      "type": "string",
+      "description": "Preferred language for Claude's responses",
+      "examples": ["japanese", "spanish", "french"]
     },
     "model": {
       "type": "string",
@@ -354,6 +394,10 @@
       "type": "boolean",
       "description": "Disable all hooks and statusLine execution"
     },
+    "allowManagedHooksOnly": {
+      "type": "boolean",
+      "description": "(Managed settings only) Prevent loading of user, project, and plugin hooks. Only allows managed hooks and SDK hooks. See https://code.claude.com/docs/en/settings#hook-configuration"
+    },
     "statusLine": {
       "type": "object",
       "properties": {
@@ -370,11 +414,33 @@
       },
       "required": ["type", "command"],
       "additionalProperties": false,
-      "description": "Custom status line display configuration",
+      "description": "Custom status line display configuration. See https://code.claude.com/docs/en/statusline",
       "examples": [
         {
           "type": "command",
           "command": "~/.claude/statusline.sh"
+        }
+      ]
+    },
+    "fileSuggestion": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute for file suggestions"
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "description": "Configure a custom script for @ file autocomplete. See https://code.claude.com/docs/en/settings#file-suggestion-settings",
+      "examples": [
+        {
+          "type": "command",
+          "command": "~/.claude/file-suggestion.sh"
         }
       ]
     },
@@ -526,6 +592,134 @@
       },
       "description": "Additional marketplaces to make available for this repository. Typically used in repository .claude/settings.json to ensure team members have required plugin sources."
     },
+    "strictKnownMarketplaces": {
+      "type": "array",
+      "description": "(Managed settings only) Allowlist of plugin marketplaces users can add. Undefined = no restrictions, empty array = lockdown. Uses exact matching for source specifications. See https://code.claude.com/docs/en/settings#strictknownmarketplaces",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "github"
+              },
+              "repo": {
+                "type": "string",
+                "description": "GitHub repository in owner/repo format"
+              },
+              "ref": {
+                "type": "string",
+                "description": "Git branch, tag, or SHA"
+              },
+              "path": {
+                "type": "string",
+                "description": "Subdirectory path"
+              }
+            },
+            "required": ["source", "repo"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "git"
+              },
+              "url": {
+                "type": "string",
+                "description": "Full git repository URL"
+              },
+              "ref": {
+                "type": "string",
+                "description": "Git branch, tag, or SHA"
+              },
+              "path": {
+                "type": "string",
+                "description": "Subdirectory path"
+              }
+            },
+            "required": ["source", "url"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "url"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Direct URL to marketplace.json"
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "HTTP headers for authenticated access"
+              }
+            },
+            "required": ["source", "url"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "npm"
+              },
+              "package": {
+                "type": "string",
+                "description": "NPM package name (supports scoped packages)"
+              }
+            },
+            "required": ["source", "package"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "file"
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute path to marketplace.json file"
+              }
+            },
+            "required": ["source", "path"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "directory"
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute path to directory containing .claude-plugin/marketplace.json"
+              }
+            },
+            "required": ["source", "path"],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "examples": [
+        [
+          { "source": "github", "repo": "acme-corp/approved-plugins" },
+          { "source": "npm", "package": "@acme-corp/compliance-plugins" }
+        ]
+      ]
+    },
     "skippedMarketplaces": {
       "type": "array",
       "items": {
@@ -640,7 +834,18 @@
     },
     "spinnerTipsEnabled": {
       "type": "boolean",
-      "description": "Whether to show tips in the spinner"
+      "description": "Show tips in the spinner while Claude is working. Set to false to disable tips (default: true)",
+      "default": true
+    },
+    "terminalProgressBarEnabled": {
+      "type": "boolean",
+      "description": "Enable the terminal progress bar that shows progress in supported terminals like Windows Terminal and iTerm2 (default: true)",
+      "default": true
+    },
+    "showTurnDuration": {
+      "type": "boolean",
+      "description": "Show turn duration messages after responses (e.g., \"Cooked for 1m 6s\"). Set to false to hide these messages (default: true)",
+      "default": true
     },
     "alwaysThinkingEnabled": {
       "type": "boolean",

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -339,6 +339,20 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "PostToolUseFailure": {
+          "type": "array",
+          "description": "UNDOCUMENTED. Hooks that run after a tool fails",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "PermissionRequest": {
+          "type": "array",
+          "description": "UNDOCUMENTED. Hooks that run when a permission is requested",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "Notification": {
           "type": "array",
           "description": "Hooks that trigger on notifications",

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -16,8 +16,8 @@
     "PROJECT_ROOT": "/home/user/projects"
   },
   "fileSuggestion": {
-    "type": "command",
-    "command": "~/.claude/file-suggestion.sh"
+    "command": "~/.claude/file-suggestion.sh",
+    "type": "command"
   },
   "forceLoginMethod": "claudeai",
   "hooks": {

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "apiKeyHelper": "/usr/local/bin/claude-auth-helper",
+  "attribution": {
+    "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
+    "pr": ""
+  },
+  "autoUpdatesChannel": "stable",
   "cleanupPeriodDays": 60,
   "disabledMcpjsonServers": ["untrusted-server"],
   "enableAllProjectMcpServers": true,
@@ -9,6 +14,10 @@
     "ANTHROPIC_SMALL_FAST_MODEL": "claude-3-5-haiku-20241022",
     "CLAUDE_LOG_LEVEL": "debug",
     "PROJECT_ROOT": "/home/user/projects"
+  },
+  "fileSuggestion": {
+    "type": "command",
+    "command": "~/.claude/file-suggestion.sh"
   },
   "forceLoginMethod": "claudeai",
   "hooks": {
@@ -36,6 +45,7 @@
     ]
   },
   "includeCoAuthoredBy": true,
+  "language": "english",
   "outputStyle": "Explanatory",
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
@@ -61,5 +71,9 @@
       "Write(/etc/**)",
       "Write(/System/**)"
     ]
-  }
+  },
+  "plansDirectory": "./plans",
+  "respectGitignore": true,
+  "showTurnDuration": true,
+  "terminalProgressBarEnabled": true
 }


### PR DESCRIPTION
## Summary

- Add 10 missing settings from official documentation: `language`, `autoUpdatesChannel`, `attribution`, `fileSuggestion`, `terminalProgressBarEnabled`, `showTurnDuration`, `plansDirectory`, `respectGitignore`, `allowManagedHooksOnly`, `strictKnownMarketplaces`
- Fix documentation URL (`docs.claude.com` → `code.claude.com`)
- Mark `includeCoAuthoredBy` as `DEPRECATED.` per SchemaStore guidelines
- Fix permission rule pattern: remove undocumented `BashOutput`/`SlashCommand` tools
- Add documentation links and default values throughout
- Update test file with coverage for new settings

## Test plan

- [x] Ran `node ./cli.js check --schema-name=claude-code-settings.json` - all validations pass
- [x] Updated `src/test/claude-code-settings/modern-complete-config.json` with new settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)