### PR TITLE
Update Traefik v3 - Add new properties and descriptions

### DIFF
--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -27,6 +27,15 @@
         "certificatesDuration": {
           "type": "integer"
         },
+        "clientResponseHeaderTimeout": {
+          "type": "string"
+        },
+        "clientTimeout": {
+          "type": "string"
+        },
+        "disableCommonName": {
+          "type": "boolean"
+        },
         "dnsChallenge": {
           "$ref": "#/$defs/acmeDNSChallenge"
         },
@@ -34,7 +43,15 @@
           "$ref": "#/$defs/acmeEAB"
         },
         "email": {
-          "type": "string"
+          "type": "string",
+          "description": "Email address used for ACME account registration. This is the contact email for the certificate authority."
+        },
+        "emailAddresses": {
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"],
+          "description": "Email addresses to include in the Certificate Signing Request (CSR). These are different from the ACME registration email and are embedded in the certificate itself."
         },
         "httpChallenge": {
           "$ref": "#/$defs/acmeHTTPChallenge"
@@ -43,6 +60,9 @@
           "type": "string"
         },
         "preferredChain": {
+          "type": "string"
+        },
+        "profile": {
           "type": "string"
         },
         "storage": {
@@ -58,10 +78,12 @@
       "additionalProperties": false,
       "properties": {
         "delayBeforeCheck": {
-          "type": "string"
+          "type": "string",
+          "description": "DEPRECATED. Delay before checking propagation. Use acme.dnsChallenge.propagation.delayBeforeChecks instead."
         },
         "disablePropagationCheck": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "DEPRECATED. Disable propagation check. Use acme.dnsChallenge.propagation.disableChecks instead."
         },
         "propagation": {
           "$ref": "#/$defs/acmePropagation"
@@ -93,6 +115,10 @@
     "acmeHTTPChallenge": {
       "additionalProperties": false,
       "properties": {
+        "delay": {
+          "type": "string",
+          "description": "Delay between the creation of the challenge and the validation (duration format, e.g., 30s, 1m)."
+        },
         "entryPoint": {
           "type": "string"
         }
@@ -119,6 +145,12 @@
     },
     "acmeTLSChallenge": {
       "additionalProperties": false,
+      "properties": {
+        "delay": {
+          "type": "string",
+          "description": "Delay between the creation of the challenge and the validation (duration format, e.g., 30s, 1m)."
+        }
+      },
       "type": "object"
     },
     "consulProviderBuilder": {

--- a/src/test/traefik-v3/example.json
+++ b/src/test/traefik-v3/example.json
@@ -73,6 +73,9 @@
         "caServerName": "foobar",
         "caSystemCertPool": true,
         "certificatesDuration": 42,
+        "clientResponseHeaderTimeout": "42s",
+        "clientTimeout": "42s",
+        "disableCommonName": true,
         "dnsChallenge": {
           "delayBeforeCheck": "42s",
           "disablePropagationCheck": true,
@@ -90,13 +93,18 @@
           "kid": "foobar"
         },
         "email": "foobar",
+        "emailAddresses": ["foobar", "foobar"],
         "httpChallenge": {
+          "delay": "42s",
           "entryPoint": "foobar"
         },
         "keyType": "foobar",
         "preferredChain": "foobar",
+        "profile": "foobar",
         "storage": "foobar",
-        "tlsChallenge": {}
+        "tlsChallenge": {
+          "delay": "42s"
+        }
       },
       "tailscale": {}
     },
@@ -107,6 +115,9 @@
         "caServerName": "foobar",
         "caSystemCertPool": true,
         "certificatesDuration": 42,
+        "clientResponseHeaderTimeout": "42s",
+        "clientTimeout": "42s",
+        "disableCommonName": true,
         "dnsChallenge": {
           "delayBeforeCheck": "42s",
           "disablePropagationCheck": true,
@@ -124,13 +135,18 @@
           "kid": "foobar"
         },
         "email": "foobar",
+        "emailAddresses": ["foobar", "foobar"],
         "httpChallenge": {
+          "delay": "42s",
           "entryPoint": "foobar"
         },
         "keyType": "foobar",
         "preferredChain": "foobar",
+        "profile": "foobar",
         "storage": "foobar",
-        "tlsChallenge": {}
+        "tlsChallenge": {
+          "delay": "42s"
+        }
       },
       "tailscale": {}
     }


### PR DESCRIPTION
Update the Traefik v3 JSON schema to include all ACME configuration options made available in Traefik v3.4.0 through v3.6.7.


Field | Release 
-- |  --
certificatesDuration  | v3.2.0+ 
disableCommonName | v3.6.0+ 
profile | v3.4.0+ 
emailAddresses | v3.4.0+ 
clientTimeout | v3.5.0+ 
clientResponseHeaderTimeout | v3.5.0+
httpChallenge.delay | v3.5.0+
tlsChallenge.delay | v3.6.0+
