### PR TITLE
update dotnet download to cdn endpoint

### DIFF
--- a/src/negative_test/dotnet-releases-index/invalid-null-eol-date.json
+++ b/src/negative_test/dotnet-releases-index/invalid-null-eol-date.json
@@ -8,7 +8,7 @@
       "latest-runtime": "7.0.0-preview.1.22076.8",
       "latest-sdk": "7.0.100-preview.1.22110.4",
       "product": ".NET",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/7.0/releases.json",
       "security": false,
       "support-phase": "preview"
     },
@@ -20,7 +20,7 @@
       "latest-runtime": "6.0.2",
       "latest-sdk": "6.0.200",
       "product": ".NET",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/6.0/releases.json",
       "security": true,
       "support-phase": "lts"
     },
@@ -32,7 +32,7 @@
       "latest-runtime": "5.0.14",
       "latest-sdk": "5.0.405",
       "product": ".NET",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/5.0/releases.json",
       "security": true,
       "support-phase": "maintenance"
     },
@@ -44,7 +44,7 @@
       "latest-runtime": "3.1.22",
       "latest-sdk": "3.1.416",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/3.1/releases.json",
       "security": true,
       "support-phase": "lts"
     },
@@ -56,7 +56,7 @@
       "latest-runtime": "3.0.3",
       "latest-sdk": "3.0.103",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/3.0/releases.json",
       "security": false,
       "support-phase": "eol"
     },
@@ -68,7 +68,7 @@
       "latest-runtime": "2.1.30",
       "latest-sdk": "2.1.818",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.1/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -80,7 +80,7 @@
       "latest-runtime": "2.2.8",
       "latest-sdk": "2.2.207",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.2/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -92,7 +92,7 @@
       "latest-runtime": "2.0.9",
       "latest-sdk": "2.1.202",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.0/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -104,7 +104,7 @@
       "latest-runtime": "1.1.13",
       "latest-sdk": "1.1.14",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/1.1/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -116,7 +116,7 @@
       "latest-runtime": "1.0.16",
       "latest-sdk": "1.1.14",
       "product": ".NET Core",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/1.0/releases.json",
       "security": true,
       "support-phase": "eol"
     }

--- a/src/test/dotnet-releases-index/latest.json
+++ b/src/test/dotnet-releases-index/latest.json
@@ -9,7 +9,7 @@
       "latest-sdk": "8.0.100-preview.5.23303.2",
       "product": ".NET",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/8.0/releases.json",
       "security": false,
       "support-phase": "preview"
     },
@@ -22,7 +22,7 @@
       "latest-sdk": "7.0.304",
       "product": ".NET",
       "release-type": "sts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/7.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/7.0/releases.json",
       "security": true,
       "support-phase": "active"
     },
@@ -35,7 +35,7 @@
       "latest-sdk": "6.0.410",
       "product": ".NET",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/6.0/releases.json",
       "security": true,
       "support-phase": "active"
     },
@@ -48,7 +48,7 @@
       "latest-sdk": "5.0.408",
       "product": ".NET",
       "release-type": "sts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/5.0/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -61,7 +61,7 @@
       "latest-sdk": "3.1.426",
       "product": ".NET Core",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/3.1/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -74,7 +74,7 @@
       "latest-sdk": "3.0.103",
       "product": ".NET Core",
       "release-type": "sts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/3.0/releases.json",
       "security": false,
       "support-phase": "eol"
     },
@@ -87,7 +87,7 @@
       "latest-sdk": "2.1.818",
       "product": ".NET Core",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.1/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -100,7 +100,7 @@
       "latest-sdk": "2.2.207",
       "product": ".NET Core",
       "release-type": "sts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.2/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.2/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -113,7 +113,7 @@
       "latest-sdk": "2.1.202",
       "product": ".NET Core",
       "release-type": "sts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/2.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/2.0/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -126,7 +126,7 @@
       "latest-sdk": "1.1.14",
       "product": ".NET Core",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.1/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/1.1/releases.json",
       "security": true,
       "support-phase": "eol"
     },
@@ -139,7 +139,7 @@
       "latest-sdk": "1.1.14",
       "product": ".NET Core",
       "release-type": "lts",
-      "releases.json": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/1.0/releases.json",
+      "releases.json": "https://builds.dotnet.microsoft.com//dotnet/release-metadata/1.0/releases.json",
       "security": true,
       "support-phase": "eol"
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

In late 2024, .NET updated the install and download domain to `builds.dotnet.microsoft.com`, backed by a new CDN provider. See [dotnet/announcements#336](https://github.com/dotnet/announcements/issues/336) for details. 

It is recommended that all downloads and installations utilize this endpoint rather than directly accessing the backing storage account. Additionally, anonymous public access pattern is no longer aligned with Microsoft's secure access initiatives and will be discontinued in the future.