### PR TITLE
feat(rumdl): host schema locally for direct URL access

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5540,7 +5540,7 @@
       "name": "rumdl",
       "description": "Configuration file for rumdl, a fast Markdown linter and formatter",
       "fileMatch": [".rumdl.toml", "rumdl.toml"],
-      "url": "https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/rumdl.json"
     },
     {
       "name": "rustfmt",

--- a/src/schemas/json/rumdl.json
+++ b/src/schemas/json/rumdl.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/rumdl.json",
+  "title": "Config",
+  "description": "rumdl configuration for linting Markdown files. Rules can be configured individually using [MD###] sections with rule-specific options.",
+  "type": "object",
+  "properties": {
+    "global": {
+      "$ref": "#/definitions/GlobalConfig",
+      "description": "Global configuration options",
+      "default": {
+        "enable": [],
+        "disable": [],
+        "exclude": [],
+        "include": [],
+        "respect-gitignore": true,
+        "line-length": 80,
+        "fixable": [],
+        "unfixable": [],
+        "flavor": "standard",
+        "force-exclude": false,
+        "cache": true
+      }
+    },
+    "per-file-ignores": {
+      "description": "Per-file rule ignores: maps file patterns to lists of rules to ignore\nExample: { \"README.md\": [\"MD033\"], \"docs/**/*.md\": [\"MD013\"] }",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "default": {}
+    },
+    "per-file-flavor": {
+      "description": "Per-file flavor overrides: maps file patterns to Markdown flavors\nExample: { \"docs/**/*.md\": MkDocs, \"**/*.mdx\": MDX }\nUses IndexMap to preserve config file order for \"first match wins\" semantics",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/MarkdownFlavor"
+      },
+      "default": {}
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/RuleConfig"
+  },
+  "definitions": {
+    "GlobalConfig": {
+      "description": "Global configuration options",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "description": "Enabled rules",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "disable": {
+          "description": "Disabled rules",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "exclude": {
+          "description": "Files to exclude",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "include": {
+          "description": "Files to include",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "respect-gitignore": {
+          "description": "Respect .gitignore files when scanning directories",
+          "type": "boolean",
+          "default": true
+        },
+        "line-length": {
+          "$ref": "#/definitions/LineLength",
+          "description": "Global line length setting (used by MD013 and other rules if not overridden)",
+          "default": 80
+        },
+        "output-format": {
+          "description": "Output format for linting results (e.g., \"text\", \"json\", \"pylint\", etc.)",
+          "type": ["string", "null"]
+        },
+        "fixable": {
+          "description": "Rules that are allowed to be fixed when --fix is used\nIf specified, only these rules will be fixed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "unfixable": {
+          "description": "Rules that should never be fixed, even when --fix is used\nTakes precedence over fixable",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "flavor": {
+          "$ref": "#/definitions/MarkdownFlavor",
+          "description": "Markdown flavor/dialect to use (mkdocs, gfm, commonmark, etc.)\nWhen set, adjusts parsing and validation rules for that specific Markdown variant",
+          "default": "standard"
+        },
+        "force-exclude": {
+          "description": "[DEPRECATED] Whether to enforce exclude patterns for explicitly passed paths.\nThis option is deprecated as of v0.0.156 and has no effect.\nExclude patterns are now always respected, even for explicitly provided files.\nThis prevents duplication between rumdl config and tool configs like pre-commit.",
+          "type": "boolean",
+          "deprecated": true,
+          "default": false
+        },
+        "cache-dir": {
+          "description": "Directory to store cache files (default: .rumdl_cache)\nCan also be set via --cache-dir CLI flag or RUMDL_CACHE_DIR environment variable",
+          "type": ["string", "null"]
+        },
+        "cache": {
+          "description": "Whether caching is enabled (default: true)\nCan also be disabled via --no-cache CLI flag",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "LineLength": {
+      "description": "A line length value that can be 0 (meaning no limit) or a positive value (≥1)\n\nMany configuration values for line length need to support both:\n- 0: Special value meaning \"no line length limit\"\n- ≥1: Actual line length limit\n\nThis type enforces those constraints at deserialization time.",
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "MarkdownFlavor": {
+      "description": "Markdown flavor/dialect. Accepts: standard, gfm, mkdocs, mdx, quarto. Aliases: commonmark/github map to standard, qmd/rmd/rmarkdown map to quarto.",
+      "type": "string",
+      "enum": [
+        "standard",
+        "gfm",
+        "github",
+        "commonmark",
+        "mkdocs",
+        "mdx",
+        "quarto",
+        "qmd",
+        "rmd",
+        "rmarkdown"
+      ]
+    },
+    "RuleConfig": {
+      "description": "Represents a rule-specific configuration",
+      "type": "object",
+      "properties": {
+        "severity": {
+          "description": "Severity override for this rule (Error, Warning, or Info)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Severity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "Severity": {
+      "type": "string",
+      "enum": ["error", "warning", "info"]
+    }
+  }
+}


### PR DESCRIPTION
Hosts the rumdl JSON schema locally to enable direct URL access at https://json.schemastore.org/rumdl.json

The previous PR (#5052) added rumdl to the catalog with an external URL pointing to GitHub. This worked for catalog-based tooling, but the direct SchemaStore URL returned 404. Hosting the schema locally enables:
- `$schema` references in config files
- Validators that don't consult the catalog
- CDN-backed reliable access

**Changes:**
- Add `src/schemas/json/rumdl.json`
- Update catalog entry URL from external GitHub raw URL to local schema

**Related Links:**
- Project repository: https://github.com/rvben/rumdl
- Original catalog PR: #5052