### PR TITLE
Update Claude Code settings schema for v2.1.19

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -249,7 +249,7 @@
     },
     "model": {
       "type": "string",
-      "description": "Override the default model used by Claude Code"
+      "description": "Override the default model used by Claude Code. See https://code.claude.com/docs/en/model-config"
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
@@ -262,7 +262,7 @@
         "type": "string",
         "minLength": 1
       },
-      "description": "List of approved MCP servers from .mcp.json",
+      "description": "List of approved MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
       "examples": [["memory", "github"]]
     },
     "disabledMcpjsonServers": {
@@ -271,7 +271,7 @@
         "type": "string",
         "minLength": 1
       },
-      "description": "List of rejected MCP servers from .mcp.json",
+      "description": "List of rejected MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
       "examples": [["filesystem"]]
     },
     "allowedMcpServers": {
@@ -288,7 +288,7 @@
         "required": ["serverName"],
         "additionalProperties": false
       },
-      "description": "Enterprise allowlist of MCP servers that can be used. Applies to all scopes including enterprise servers from managed-mcp.json. If undefined, all servers are allowed. If empty array, no servers are allowed. Denylist takes precedence - if a server is on both lists, it is denied."
+      "description": "Enterprise allowlist of MCP servers that can be used. Applies to all scopes including enterprise servers from managed-mcp.json. If undefined, all servers are allowed. If empty array, no servers are allowed. Denylist takes precedence - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#managed-mcp-configuration"
     },
     "deniedMcpServers": {
       "type": "array",
@@ -304,7 +304,7 @@
         "required": ["serverName"],
         "additionalProperties": false
       },
-      "description": "Enterprise denylist of MCP servers that are explicitly blocked. If a server is on the denylist, it will be blocked across all scopes including enterprise. Denylist takes precedence over allowlist - if a server is on both lists, it is denied."
+      "description": "Enterprise denylist of MCP servers that are explicitly blocked. If a server is on the denylist, it will be blocked across all scopes including enterprise. Denylist takes precedence over allowlist - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#managed-mcp-configuration"
     },
     "hooks": {
       "type": "object",
@@ -924,7 +924,7 @@
         },
         "additionalProperties": false
       },
-      "description": "Per-plugin configuration including MCP server user configs, keyed by plugin ID (plugin@marketplace format)"
+      "description": "Per-plugin configuration including MCP server user configs, keyed by plugin ID (plugin@marketplace format). See https://code.claude.com/docs/en/plugins"
     }
   },
   "title": "Claude Code Settings"


### PR DESCRIPTION
## Summary

- Add `SubagentStart` hook type (runs when a subagent is spawned)
- Add `Setup` hook type (runs during `--init`, `--init-only`, or `--maintenance`)
- Update `PostToolUseFailure` and `PermissionRequest` descriptions (now documented in official docs)
- Add documentation links to more schema properties (`model`, MCP server settings, `pluginConfigs`)

## Test plan

- [x] JSON validates with `jq`
- [x] Pre-commit hooks pass (prettier, codespell)

🤖 Generated with [Claude Code](https://claude.ai/code)