### PR TITLE
Drop editorconfig EOL configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,19 +28,16 @@ indent_size = 4
 indent_style = tab
 
 [Web.config]
-end_of_line = crlf
 charset = utf-8
 indent_style = space
 indent_size = 4
 insert_final_newline = true
 
 [packages.config]
-end_of_line = crlf
 charset = utf-8-bom
 indent_style = space
 indent_size = 2
 insert_final_newline = false
 
 [.editorconfig]
-end_of_line = crlf
 charset = utf-8


### PR DESCRIPTION
#5311 introduced these settings.

The `.gitattributes` configures `text=auto`. This means text files will use, unless already committed differently in the repo, auto-convert line endings.

My VS created mixed line endings even when duplicating existing lines.

For now, revert the EOL configuration to restore previous behavior consistent to the gitattributes configuration.

IMO, it would be preferable to use intentional EOL configuration without depending on auto-conversion, which has complex conditions and is error-prone. But this change does not do that (yet).
