### PR TITLE
add Espanso schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9256,7 +9256,7 @@
     },
     {
       "name": "Espanso match.yml",
-      "description": "define HOW Espanso does",
+      "description": "define WHAT Espanso does",
       "url": "https://raw.githubusercontent.com/espanso/espanso/refs/heads/dev/schemas/match.schema.json"
     },
     {


### PR DESCRIPTION
from [espanso/espanso](https://github.com/espanso/espanso)'s about section:

> A Privacy-first, Cross-platform Text Expander written in Rust

descriptions adapted from https://espanso.org/docs/configuration/basics/#the-config-directory and https://espanso.org/docs/configuration/basics/#the-match-directory