### PR TITLE
Add Applicant Profile Protocol (APP) schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -66,6 +66,12 @@
       "url": "https://www.schemastore.org/accelerator.json"
     },
     {
+      "name": "Applicant Profile Protocol",
+      "description": "Structured JSON format for professional profiles, resumes, and CVs with skills, experience, education, and certifications",
+      "fileMatch": ["*.app.json"],
+      "url": "https://app-protocol.org/schema/app-1.0.json"
+    },
+    {
       "name": "gRPC API Gateway & OpenAPI Config",
       "description": "Config file for gRPC API Gateway & OpenAPI v3.1 generation",
       "fileMatch": [


### PR DESCRIPTION
- Schema URL: https://app-protocol.org/schema/app-1.0.json
- File pattern: *.app.json
- Description: Structured JSON format for professional profiles, resumes, and CVs

The Applicant Profile Protocol (APP) is an open, JSON-based standard for representing professional profiles with comprehensive support for skills, experience, education, certifications, projects, and languages.

Features:
- JSON Schema validation (draft 2020-12)
- Export to JSON Resume, Europass XML, HR-XML
- Semantic layer support via JSON-LD
- Protocol version management
- Comprehensive field definitions

Documentation: https://app-protocol.org/spec/1.0
Repository: https://github.com/caglarorhan/Applicant-Profile-Protocol
npm package: applicant-profile-protocol

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
