### PR TITLE
fix(tsconfig): Allow "module" Node20 (capital N)

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -384,7 +384,7 @@
                   ]
                 },
                 {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]1[68]|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee]|[Pp][Rr][Ee][Ss][Ee][Rr][Vv][Ee])$"
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee](1[68]|20)|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee]|[Pp][Rr][Ee][Ss][Ee][Rr][Vv][Ee])$"
                 }
               ],
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"

--- a/src/test/tsconfig/tsconfig-node20.json
+++ b/src/test/tsconfig/tsconfig-node20.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "module": "Node20"
+  }
+}


### PR DESCRIPTION
There used to be no case-insensitive option for node20, only node16 and node18. This PR makes node20 also be case-insensitive

Before:

<img width="708" height="153" alt="image" src="https://github.com/user-attachments/assets/94b1aa89-5f09-4895-b97b-57862a5e5f3c" />

<img width="228" height="66" alt="image" src="https://github.com/user-attachments/assets/934ee104-e04b-4c09-8f63-3efead0a3908" />

After:

<img width="229" height="74" alt="image" src="https://github.com/user-attachments/assets/7512e224-810c-4532-83bc-bc7339b8d52c" />
