### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.29

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -847,18 +847,6 @@
               },
               "description": "Allow Unix domain sockets for local IPC (SSH agent, Docker, etc.). Provide an array of specific paths. Defaults to blocking if not specified"
             },
-            "allowAllUnixSockets": {
-              "type": "boolean",
-              "description": "Allow all Unix socket connections in sandbox (default: false)",
-              "default": false
-            },
-            "allowedDomains": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Array of domains to allow for outbound network traffic in sandbox. Supports wildcards (e.g., '*.example.com')"
-            },
             "allowLocalBinding": {
               "type": "boolean",
               "description": "Allow binding to local network addresses (e.g., localhost ports). Defaults to false if not specified"
@@ -961,27 +949,6 @@
       "type": "boolean",
       "description": "Show tips in the spinner while Claude is working. Set to false to disable tips (default: true)",
       "default": true
-    },
-    "spinnerVerbs": {
-      "type": "object",
-      "description": "Customize the action verbs shown in the spinner and turn duration messages (e.g., 'Pondering', 'Crafting')",
-      "additionalProperties": false,
-      "properties": {
-        "mode": {
-          "type": "string",
-          "enum": ["replace", "append"],
-          "description": "Whether to replace default verbs or append to them",
-          "default": "append"
-        },
-        "verbs": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          },
-          "description": "Custom action verbs to use in spinner messages"
-        }
-      }
     },
     "terminalProgressBarEnabled": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
- ~~Add `spinnerVerbs` setting for customizing spinner action verbs (v2.1.23)~~ *(introduced in PR #5332)*
- ~~Add `sandbox.network.allowAllUnixSockets` for allowing all Unix sockets in sandbox~~ *(introduced in PR #5332)*
- ~~Add `sandbox.network.allowedDomains` for domain allowlist in sandbox networking~~ *(introduced in PR #5332)*
- Add test coverage for previously untested settings (backfill from v2.1.19 PR):
  - `allowManagedHooksOnly` - restrict hooks to Claude-managed only
  - `alwaysThinkingEnabled` - enable thinking mode by default
  - `spinnerTipsEnabled` - show tips in spinner messages
  - Additional hook event examples: `PermissionRequest`, `PostToolUseFailure`
  - Comprehensive sandbox configuration properties:
    - `sandbox.allowUnsandboxedCommands` - allow commands outside sandbox
    - `sandbox.autoAllowBashIfSandboxed` - auto-approve Bash when sandboxed
    - `sandbox.enableWeakerNestedSandbox` - weaker nested sandbox mode
    - `sandbox.enabled` - enable/disable sandbox
    - `sandbox.excludedCommands` - commands excluded from sandbox
    - `sandbox.network.allowUnixSockets` - specific Unix socket paths
    - `sandbox.network.httpProxyPort` - HTTP proxy port configuration

## Test plan
- [x] Schema validates with `node ./cli.js check --schema-name claude-code-settings.json`
- [x] Test file `modern-complete-config.json` updated with new and missing settings

🤖 Generated with [Claude Code](https://claude.ai/code)