### PR TITLE
Add basedpyright to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -981,6 +981,12 @@
       "url": "https://www.schemastore.org/backportrc.json"
     },
     {
+      "name": "basedpyright",
+      "description": "Basedpyright configuration file",
+      "fileMatch": ["basedpyrightconfig.json"],
+      "url": "https://raw.githubusercontent.com/DetachHead/basedpyright/refs/heads/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"
+    },
+    {
       "name": "batect.yml",
       "description": "Batect configuration file",
       "fileMatch": ["batect.yml", "batect-bundle.yml"],


### PR DESCRIPTION
The goal is actually to add basedpyright to tool.basedpyright in pyproject schema, but apparently I have to add it to the catalog  first to reference it in the pyproject schema, so I'm doing this in 2 parts. This is the first one.