### PR TITLE
Add pitcms schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9320,6 +9320,12 @@
       "name": "Espanso config.yml",
       "description": "define HOW Espanso acts",
       "url": "https://raw.githubusercontent.com/espanso/espanso/refs/heads/dev/schemas/config.schema.json"
+    },
+    {
+      "name": "pitcms",
+      "description": "Configuration file for pitcms - a Git-based headless CMS",
+      "fileMatch": ["pitcms.json", "pitcms.jsonc"],
+      "url": "https://pitcms.net/schema/pitcms.schema.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add JSON schema entry for pitcms, a Git-based headless CMS
- Schema is self-hosted at https://pitcms.net/schema/pitcms.schema.json
- File matches: `pitcms.json`, `pitcms.jsonc`

## About pitcms
pitcms is a Git-based headless CMS that stores content in JSON/JSONC configuration files. The schema provides validation and autocompletion for the configuration file structure including collections, fields, and CMS UI settings.

## Checklist
- [x] Schema is publicly accessible
- [x] `fileMatch` patterns are specific to pitcms