### PR TITLE
Update vCluster config schema URL

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8404,7 +8404,7 @@
         "vcluster.yaml",
         "vcluster.yml"
       ],
-      "url": "https://raw.githubusercontent.com/loft-sh/vcluster-config/main/vcluster.schema.json"
+      "url": "https://raw.githubusercontent.com/loft-sh/vcluster/main/chart/values.schema.json"
     },
     {
       "name": "well-known-fursona",


### PR DESCRIPTION
The vCluster config schema moved back into the main vcluster repo.

Thanks in advance!
