### PR TITLE
Update Claude Code settings schema for v2.1.37

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,12 +5,12 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule. See https://code.claude.com/docs/en/settings#permission-rule-syntax",
-      "pattern": "^((Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|SlashCommand|Task|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|Task|TaskOutput|TodoWrite|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
-        "Bash(git commit:*)",
-        "Bash(npm run:*)",
+        "Bash(git commit *)",
+        "Bash(npm run *)",
         "Bash(ls*)",
         "Bash(git * main)",
         "Edit",
@@ -18,11 +18,12 @@
         "Edit(/src/**/*.ts)",
         "Read(./.env)",
         "Read(./secrets/**)",
-        "Read(/Users/alice/secrets/**)",
+        "Read(//Users/alice/secrets/**)",
         "Read(~/Documents/*.pdf)",
-        "SlashCommand(/clear)",
+        "Task(Explore)",
         "WebFetch",
         "WebFetch(domain:example.com)",
+        "mcp__puppeteer",
         "mcp__github__search_repositories"
       ]
     },
@@ -57,7 +58,7 @@
         },
         {
           "type": "object",
-          "description": "LLM prompt hook",
+          "description": "LLM prompt hook. See https://code.claude.com/docs/en/hooks#prompt-based-hooks",
           "additionalProperties": false,
           "required": ["type", "prompt"],
           "properties": {
@@ -71,14 +72,41 @@
               "description": "Prompt to evaluate with LLM. Use $ARGUMENTS placeholder for hook input JSON.",
               "minLength": 1
             },
+            "model": {
+              "type": "string",
+              "description": "Model to use for evaluation. Defaults to a fast model"
+            },
             "timeout": {
               "type": "number",
-              "description": "Optional timeout in seconds",
+              "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Agent hook with multi-turn tool access for verification. See https://code.claude.com/docs/en/hooks#agent-based-hooks",
+          "additionalProperties": false,
+          "required": ["type", "prompt"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Hook type",
+              "const": "agent"
             },
-            "async": {
-              "type": "boolean",
-              "description": "Run this hook asynchronously without blocking Claude Code"
+            "prompt": {
+              "type": "string",
+              "description": "Prompt describing what to verify. Use $ARGUMENTS placeholder for hook input JSON.",
+              "minLength": 1
+            },
+            "model": {
+              "type": "string",
+              "description": "Model to use for evaluation. Defaults to a fast model"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Optional timeout in seconds (default: 60)",
+              "exclusiveMinimum": 0
             }
           }
         }
@@ -222,8 +250,15 @@
         },
         "defaultMode": {
           "type": "string",
-          "enum": ["acceptEdits", "bypassPermissions", "default", "plan"],
-          "description": "Default permission mode when Claude Code needs access"
+          "enum": [
+            "acceptEdits",
+            "bypassPermissions",
+            "default",
+            "delegate",
+            "dontAsk",
+            "plan"
+          ],
+          "description": "Default permission mode.\n\"default\": prompts on first use.\n\"acceptEdits\": auto-accepts file edits.\n\"plan\": read-only, no modifications.\n\"delegate\": coordination-only for agent team leads (agent teams are experimental; enable via CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).\n\"dontAsk\": auto-denies unless pre-approved via permissions.\n\"bypassPermissions\": skips all prompts (use only in isolated environments).\nSee https://code.claude.com/docs/en/permissions"
         },
         "disableBypassPermissionsMode": {
           "type": "string",
@@ -242,7 +277,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Tool usage permissions configuration. See https://code.claude.com/docs/en/iam#configuring-permissions",
+      "description": "Tool usage permissions configuration. See https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings",
       "examples": [
         {
           "allow": ["Bash(git add:*)"],
@@ -260,6 +295,12 @@
     "model": {
       "type": "string",
       "description": "Override the default model used by Claude Code. See https://code.claude.com/docs/en/model-config"
+    },
+    "effortLevel": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
+      "default": "high"
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
@@ -407,9 +448,23 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "TeammateIdle": {
+          "type": "array",
+          "description": "Hooks that run when an agent team teammate is about to go idle. Exit code 2 sends feedback and keeps the teammate working. Does not support matchers. Agent teams are experimental. See https://code.claude.com/docs/en/hooks#teammateidle",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "TaskCompleted": {
+          "type": "array",
+          "description": "Hooks that run when a task is being marked as completed. Exit code 2 prevents completion and sends feedback. Does not support matchers. See https://code.claude.com/docs/en/hooks#taskcompleted",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "Setup": {
           "type": "array",
-          "description": "Hooks that run during repository initialization (--init, --init-only) or maintenance (--maintenance)",
+          "description": "UNDOCUMENTED. Hooks that run during repository initialization (--init, --init-only) or maintenance (--maintenance)",
           "items": {
             "$ref": "#/$defs/hookMatcher"
           }
@@ -437,6 +492,10 @@
     "allowManagedHooksOnly": {
       "type": "boolean",
       "description": "(Managed settings only) Prevent loading of user, project, and plugin hooks. Only allows managed hooks and SDK hooks. See https://code.claude.com/docs/en/settings#hook-configuration"
+    },
+    "allowManagedPermissionRulesOnly": {
+      "type": "boolean",
+      "description": "(Managed settings only) Prevent user and project settings from defining allow, ask, or deny permission rules. Only rules in managed settings apply. See https://code.claude.com/docs/en/settings"
     },
     "statusLine": {
       "type": "object",
@@ -960,6 +1019,11 @@
       "description": "Show turn duration messages after responses (e.g., \"Cooked for 1m 6s\"). Set to false to hide these messages (default: true)",
       "default": true
     },
+    "prefersReducedMotion": {
+      "type": "boolean",
+      "description": "Reduce or disable UI animations (spinners, shimmer, flash effects) for accessibility",
+      "default": false
+    },
     "alwaysThinkingEnabled": {
       "type": "boolean",
       "description": "Enable extended thinking by default for all sessions. Typically configured via the /config command rather than editing directly. See https://code.claude.com/docs/en/common-workflows#use-extended-thinking-thinking-mode"
@@ -971,6 +1035,12 @@
         "minLength": 1
       },
       "description": "Company announcements to display at startup (one will be randomly selected if multiple are provided)"
+    },
+    "teammateMode": {
+      "type": "string",
+      "enum": ["auto", "in-process", "tmux"],
+      "description": "How agent team teammates display: \"auto\" picks split panes in tmux or iTerm2, in-process otherwise. Agent teams are experimental and disabled by default. Enable them by adding CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to your settings.json or environment. See https://code.claude.com/docs/en/agent-teams",
+      "default": "auto"
     },
     "pluginConfigs": {
       "type": "object",

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -10,6 +10,17 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Permission requested' >> /tmp/claude-permissions.log",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
     "PostToolUse": [
       {
         "hooks": [
@@ -19,6 +30,16 @@
           }
         ],
         "matcher": "Edit"
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Tool failure' >> /tmp/claude-errors.log",
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreCompact": [
@@ -73,14 +94,36 @@
         ]
       }
     ],
+    "Setup": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Repository setup' >> /tmp/claude-setup.log",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
-            "command": "echo 'Claude finished' | tee -a /tmp/claude-session.log",
-            "type": "command"
+            "prompt": "Check if all tasks are complete before stopping: $ARGUMENTS",
+            "timeout": 30,
+            "type": "prompt"
           }
         ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Subagent spawned' >> /tmp/claude-subagent.log",
+            "type": "command"
+          }
+        ],
+        "matcher": "Explore"
       }
     ],
     "SubagentStop": [
@@ -92,7 +135,29 @@
             "type": "command"
           }
         ],
-        "matcher": "Task"
+        "matcher": "Explore"
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "prompt": "Verify all tests pass and code meets requirements before marking task complete: $ARGUMENTS",
+            "timeout": 120,
+            "type": "agent"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "command": "npm test",
+            "timeout": 120,
+            "type": "command"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -10,6 +10,7 @@
   "autoUpdatesChannel": "stable",
   "cleanupPeriodDays": 60,
   "disabledMcpjsonServers": ["untrusted-server"],
+  "effortLevel": "high",
   "enableAllProjectMcpServers": true,
   "env": {
     "ANTHROPIC_MODEL": "claude-3-5-sonnet-20241022",
@@ -77,6 +78,7 @@
   },
   "includeCoAuthoredBy": true,
   "language": "english",
+  "model": "opus",
   "outputStyle": "Explanatory",
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
@@ -104,6 +106,7 @@
     ]
   },
   "plansDirectory": "./plans",
+  "prefersReducedMotion": false,
   "respectGitignore": true,
   "sandbox": {
     "allowUnsandboxedCommands": false,
@@ -127,5 +130,6 @@
     "mode": "append",
     "verbs": ["Analyzing", "Building"]
   },
+  "teammateMode": "auto",
   "terminalProgressBarEnabled": true
 }


### PR DESCRIPTION
## Summary

- Add `prefersReducedMotion` (boolean) — accessibility setting for UI animations (v2.1.30)
- Add `effortLevel` (low/medium/high) — Opus 4.6 adaptive reasoning control (v2.1.31)
- Add `teammateMode` (auto/in-process/tmux) — agent teams display mode (v2.1.32)
- Add `allowManagedPermissionRulesOnly` (boolean) — enterprise managed settings companion to `allowManagedHooksOnly`
- Add `TeammateIdle` and `TaskCompleted` hook events — agent teams quality gates (v2.1.33)
- Add `agent` hook handler type with multi-turn tool access for verification hooks (v2.1.33)
- Add `model` property to `prompt` and `agent` hook types
- Expand `defaultMode` enum with `delegate` (agent teams) and `dontAsk` modes, add per-mode descriptions
- Remove `SlashCommand` from permissionRule pattern and examples — renamed to `Skill` since Oct 2025, per #5332 discussion
- Add `TaskOutput` to permissionRule pattern — undocumented but functional tool permission
- Fix deprecated `:*` suffix syntax in permission examples to space-star format
- Fix `Read` absolute path example to use `//` prefix
- Add `Task(Explore)` and `mcp__puppeteer` permission rule examples
- Fix broken permissions link (`iam` 404 → `permissions` + `settings`)
- Mark `Setup` hook as UNDOCUMENTED — not in lifecycle table at docs/en/hooks

## Test plan

- [x] `node ./cli.js check --schema-name claude-code-settings.json` passes
- [x] All 17 test files validate against updated schema
- [x] Schema changes verified against Claude Code docs by review agent
- [x] Test file semantic accuracy verified against docs (hook types per event, matcher values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)