### PR TITLE
feat: add 'hint' property to chisel-slices schema

### DIFF
--- a/src/schemas/json/chisel-slices.json
+++ b/src/schemas/json/chisel-slices.json
@@ -50,6 +50,12 @@
               "description": "A Starlark expression to modify the file contents.",
               "examples": ["foo = content.read(\"/path/to/temporary/content\")"]
             },
+            "hint": {
+              "type": "string",
+              "description": "Concise and unopinionated discriminator to describe the slice. No special chars, trailing punctuation, and it must be sentence case.",
+              "examples": ["Non-standard timezones"],
+              "pattern": "^(?=[A-Z])[a-zA-Z0-9.,;()\\s]*[^.,;!?: \\W]$"
+            },
             "contents": {
               "type": "object",
               "description": "Files to include in the slice. Supports glob patterns.",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Update the `chisel-slices` schema to support the newly introduced field `hint` -> https://documentation.ubuntu.com/chisel/en/latest/reference/chisel-releases/slice-definitions/#slices-name-hint