### PR TITLE
fix(hatch): better support build hooks under tombi strict

### DIFF
--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -441,6 +441,9 @@
         "only-include": {
           "$ref": "#/definitions/OnlyInclude"
         },
+        "hooks": {
+          "$ref": "#/definitions/BuildHooks"
+        },
         "dependencies": {
           "title": "Dependencies",
           "description": "Additional dependencies to install in the environment",
@@ -564,7 +567,8 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Target"
-      }
+      },
+      "x-tombi-additional-key-label": "target_name"
     },
     "Hook": {
       "title": "Build hook",
@@ -618,7 +622,8 @@
           "type": "boolean",
           "default": true
         }
-      }
+      },
+      "additionalProperties": true
     },
     "BuildHooks": {
       "title": "Build Hook Plugins",
@@ -631,7 +636,8 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Hook"
-      }
+      },
+      "x-tombi-additional-key-label": "hook_name"
     },
     "Build": {
       "title": "Build",

--- a/src/test/hatch/version-vcs.toml
+++ b/src/test/hatch/version-vcs.toml
@@ -3,3 +3,5 @@
 source = "vcs"
 [build.hooks.vcs]
 version-file = "_version.py"
+[build.targets.wheel.hooks.vcs]
+version-file = "_version.py"


### PR DESCRIPTION
This improves the compatibility of [hatch build hooks](https://hatch.pypa.io/latest/config/build/#build-hooks) when using Tombi's strict mode.