### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.42

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4,7 +4,7 @@
   "$defs": {
     "permissionRule": {
       "type": "string",
-      "description": "Tool permission rule. See https://code.claude.com/docs/en/settings#permission-rule-syntax",
+      "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
       "pattern": "^((Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|LSP|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
@@ -53,6 +53,10 @@
             "async": {
               "type": "boolean",
               "description": "Run this hook asynchronously without blocking Claude Code"
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "Custom spinner message displayed while the hook runs"
             }
           }
         },
@@ -80,6 +84,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "Custom spinner message displayed while the hook runs"
             }
           }
         },
@@ -107,6 +115,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 60)",
               "exclusiveMinimum": 0
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "Custom spinner message displayed while the hook runs"
             }
           }
         }
@@ -120,7 +132,7 @@
       "properties": {
         "matcher": {
           "type": "string",
-          "description": "Optional pattern to match tool names, case-sensitive (only applicable for PreToolUse and PostToolUse)"
+          "description": "Optional pattern to match event contexts, case-sensitive. Behavior depends on event type. See https://code.claude.com/docs/en/hooks#matcher-patterns for event-specific details and examples"
         },
         "hooks": {
           "type": "array",
@@ -277,7 +289,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Tool usage permissions configuration. See https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings",
+      "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
       "examples": [
         {
           "allow": ["Bash(git add:*)"],
@@ -295,6 +307,14 @@
     "model": {
       "type": "string",
       "description": "Override the default model used by Claude Code. See https://code.claude.com/docs/en/model-config"
+    },
+    "availableModels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Restrict which models users can select. When defined, users can only switch between these model options. See https://code.claude.com/docs/en/model-config#restrict-model-selection",
+      "examples": [["sonnet", "haiku"]]
     },
     "effortLevel": {
       "type": "string",

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -26,6 +26,7 @@
         "hooks": [
           {
             "command": "git diff",
+            "statusMessage": "Reviewing changes",
             "type": "command"
           }
         ],
@@ -57,6 +58,7 @@
         "hooks": [
           {
             "command": "echo 'About to write file' >> /tmp/claude-log.txt",
+            "statusMessage": "Preparing to write file",
             "type": "command"
           }
         ],
@@ -109,6 +111,7 @@
         "hooks": [
           {
             "prompt": "Check if all tasks are complete before stopping: $ARGUMENTS",
+            "statusMessage": "Verifying task completion",
             "timeout": 30,
             "type": "prompt"
           }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -8,6 +8,7 @@
     "pr": ""
   },
   "autoUpdatesChannel": "stable",
+  "availableModels": ["sonnet", "haiku"],
   "cleanupPeriodDays": 60,
   "disabledMcpjsonServers": ["untrusted-server"],
   "effortLevel": "high",


### PR DESCRIPTION
## Summary

- Add `availableModels` property to restrict model selection (v2.1.37+)
- Add `statusMessage` field to all hook handler types (command, prompt, agent)
- Update `matcher` description with link to hooks#matcher-patterns for event-specific behavior
- Add links to settings#tools-available-to-claude in permissionRule and permissions descriptions
- Add test coverage for new properties

## Skipped

- `once` hook field: only applies to skills frontmatter, not settings file
- `outputStyle` enum constraint: custom output styles are supported

## Test plan

- [x] `node ./cli.js check --schema-name claude-code-settings.json` passes
- [x] Test files updated with `statusMessage` examples (PreToolUse, PostToolUse, Stop hooks)
- [x] Test files updated with `availableModels` example

🤖 Generated with [Claude Code](https://claude.ai/code)