### PR TITLE
Add oxfmt and oxlint

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9376,13 +9376,13 @@
     },
     {
       "name": "oxfmt",
-      "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem.",
+      "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem",
       "fileMatch": [".oxfmtrc.json"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json"
     },
     {
       "name": "oxlint",
-      "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack.",
+      "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack",
       "fileMatch": [".oxlintrc.json"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxlint/configuration_schema.json"
     }


### PR DESCRIPTION
This PR adds json schema for [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) from remote source.

/cc @Boshen