### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.47

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -348,34 +348,92 @@
     "allowedMcpServers": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "serverName": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]+$",
-            "description": "Name of the MCP server that users are allowed to configure"
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "serverName": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "description": "Name of the MCP server that users are allowed to configure"
+              }
+            },
+            "required": ["serverName"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "serverCommand": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Exact command and arguments used to start stdio servers"
+              }
+            },
+            "required": ["serverCommand"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "serverUrl": {
+                "type": "string",
+                "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
+              }
+            },
+            "required": ["serverUrl"],
+            "additionalProperties": false
           }
-        },
-        "required": ["serverName"],
-        "additionalProperties": false
+        ]
       },
-      "description": "Enterprise allowlist of MCP servers that can be used. Applies to all scopes including enterprise servers from managed-mcp.json. If undefined, all servers are allowed. If empty array, no servers are allowed. Denylist takes precedence - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#managed-mcp-configuration"
+      "description": "Enterprise allowlist of MCP servers that can be used. Applies to all scopes including enterprise servers from managed-mcp.json. If undefined, all servers are allowed. If empty array, no servers are allowed. Denylist takes precedence - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#restriction-options"
     },
     "deniedMcpServers": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "serverName": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]+$",
-            "description": "Name of the MCP server that is explicitly blocked"
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "serverName": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "description": "Name of the MCP server that is explicitly blocked"
+              }
+            },
+            "required": ["serverName"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "serverCommand": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Exact command and arguments used to start stdio servers"
+              }
+            },
+            "required": ["serverCommand"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "serverUrl": {
+                "type": "string",
+                "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
+              }
+            },
+            "required": ["serverUrl"],
+            "additionalProperties": false
           }
-        },
-        "required": ["serverName"],
-        "additionalProperties": false
+        ]
       },
-      "description": "Enterprise denylist of MCP servers that are explicitly blocked. If a server is on the denylist, it will be blocked across all scopes including enterprise. Denylist takes precedence over allowlist - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#managed-mcp-configuration"
+      "description": "Enterprise denylist of MCP servers that are explicitly blocked. If a server is on the denylist, it will be blocked across all scopes including enterprise. Denylist takes precedence over allowlist - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#restriction-options"
     },
     "hooks": {
       "type": "object",
@@ -442,7 +500,7 @@
         },
         "Stop": {
           "type": "array",
-          "description": "Hooks that run when agents finish responding",
+          "description": "Hooks that run when agents finish responding. Does not run on user interrupt",
           "items": {
             "$ref": "#/$defs/hookMatcher"
           }
@@ -1028,6 +1086,28 @@
       "type": "boolean",
       "description": "Show tips in the spinner while Claude is working. Set to false to disable tips (default: true)",
       "default": true
+    },
+    "spinnerTipsOverride": {
+      "type": "object",
+      "description": "Customize the tips displayed in the spinner while Claude is working. See https://code.claude.com/docs/en/settings",
+      "properties": {
+        "excludeDefault": {
+          "type": "boolean",
+          "description": "If true, only show custom tips. If false or absent, custom tips merge with built-in tips",
+          "default": false
+        },
+        "tips": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Custom tip strings to display in the spinner",
+          "minItems": 1
+        }
+      },
+      "required": ["tips"],
+      "additionalProperties": false
     },
     "terminalProgressBarEnabled": {
       "type": "boolean",

--- a/src/test/claude-code-settings/mcp-servers.json
+++ b/src/test/claude-code-settings/mcp-servers.json
@@ -1,5 +1,35 @@
 {
+  "allowedMcpServers": [
+    {
+      "serverName": "github"
+    },
+    {
+      "serverCommand": ["npx", "-y", "@modelcontextprotocol/server-filesystem"]
+    },
+    {
+      "serverUrl": "https://mcp.company.com/*"
+    }
+  ],
+  "deniedMcpServers": [
+    {
+      "serverName": "dangerous-server"
+    },
+    {
+      "serverCommand": ["npx", "-y", "unapproved-package"]
+    },
+    {
+      "serverUrl": "https://*.untrusted.com/*"
+    }
+  ],
   "disabledMcpjsonServers": ["experimental-server", "legacy-api"],
   "enableAllProjectMcpServers": false,
-  "enabledMcpjsonServers": ["filesystem", "github", "database-reader"]
+  "enabledMcpjsonServers": ["filesystem", "github", "database-reader"],
+  "spinnerTipsOverride": {
+    "excludeDefault": true,
+    "tips": [
+      "Remember to test your changes",
+      "Use descriptive commit messages",
+      "Check documentation before implementing"
+    ]
+  }
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -127,6 +127,10 @@
   },
   "showTurnDuration": true,
   "spinnerTipsEnabled": true,
+  "spinnerTipsOverride": {
+    "excludeDefault": false,
+    "tips": ["Check the style guide", "Run tests before committing"]
+  },
   "spinnerVerbs": {
     "mode": "append",
     "verbs": ["Analyzing", "Building"]


### PR DESCRIPTION
## Summary

- Add `spinnerTipsOverride` setting for customizing spinner tips (v2.1.45)
- Expand `allowedMcpServers`/`deniedMcpServers` to support `serverCommand` (stdio) and `serverUrl` (remote with wildcards) restriction types alongside existing `serverName`
- Update `Stop` hook description to note it does not run on user interrupt
- Update tests with new MCP restriction variants and `spinnerTipsOverride` coverage

## Test plan

- [x] `node ./cli.js check --schema-name claude-code-settings.json` passes
- [x] All existing test files still validate
- [x] New test coverage for `spinnerTipsOverride` (both `excludeDefault: true` and `false`)
- [x] New test coverage for `serverCommand` and `serverUrl` MCP restriction variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)