### PR TITLE
Update schemas according to 🐊Putout v42

### DIFF
--- a/src/schemas/json/putout.json
+++ b/src/schemas/json/putout.json
@@ -57,109 +57,79 @@
       "description": "🐊Putout comes with a large number of rules. You can modify which rules your project uses.",
       "type": "object",
       "properties": {
+        "apply-arrow": {
+          "$ref": "#/definitions/rule"
+        },
         "apply-at": {
           "$ref": "#/definitions/rule"
         },
-        "destructuring": {
+        "apply-dot-notation": {
           "$ref": "#/definitions/rule"
         },
-        "destructuring/apply-array": {
+        "apply-flat-map": {
           "$ref": "#/definitions/rule"
         },
-        "destructuring/apply-object": {
+        "apply-global-this": {
           "$ref": "#/definitions/rule"
         },
-        "destructuring/split-nested": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/merge-properties": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/extract-properties": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/extract-properties-equal-deep": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/extract-properties-not-equal-deep": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/remove-useless-object": {
-          "$ref": "#/definitions/rule"
-        },
-        "destructuring/remove-useless-arguments": {
-          "$ref": "#/definitions/rule"
-        },
-        "return": {
-          "$ref": "#/definitions/rule"
-        },
-        "return/apply-early": {
-          "$ref": "#/definitions/rule"
-        },
-        "return/simplify-boolean": {
-          "$ref": "#/definitions/rule"
-        },
-        "return/convert-from-break": {
-          "$ref": "#/definitions/rule"
-        },
-        "return/remove-useless": {
-          "$ref": "#/definitions/rule"
-        },
-        "apply-montag": {
-          "$ref": "#/definitions/rule"
-        },
-        "apply-nullish-coalescing": {
-          "$ref": "#/definitions/rule"
-        },
-        "math": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/apply-numeric-separators": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/apply-exponentiation": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/apply-multiplication": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/convert-sqrt-to-hypot": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/declare": {
-          "$ref": "#/definitions/rule"
-        },
-        "math/remove-unchanged-zero-declarations": {
+        "apply-overrides": {
           "$ref": "#/definitions/rule"
         },
         "apply-shorthand-properties": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch": {
+        "apply-starts-with": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/await": {
+        "apply-template-literals": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/async": {
+        "arguments/apply-json-parse": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/sync": {
+        "arguments": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/declare": {
+        "arguments/apply-rest": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/args": {
+        "arguments/convert-expression-to-arguments": {
           "$ref": "#/definitions/rule"
         },
-        "try-catch/expand-args": {
+        "arguments/remove-duplicate": {
           "$ref": "#/definitions/rule"
         },
-        "browserlist": {
+        "arguments/remove-empty": {
           "$ref": "#/definitions/rule"
         },
-        "cloudcmd": {
+        "arguments/remove-unused": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
+        "arguments/remove-useless-form-method": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-arrow-function": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-comparison": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/convert-to-declaration": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/simplify": {
+          "$ref": "#/definitions/rule"
+        },
+        "assignment/split": {
+          "$ref": "#/definitions/rule"
+        },
+        "conditions/add-return": {
           "$ref": "#/definitions/rule"
         },
         "conditions": {
@@ -168,7 +138,16 @@
         "conditions/apply-comparison-order": {
           "$ref": "#/definitions/rule"
         },
+        "conditions/apply-consistent-blocks": {
+          "$ref": "#/definitions/rule"
+        },
+        "conditions/apply-equal": {
+          "$ref": "#/definitions/rule"
+        },
         "conditions/apply-if": {
+          "$ref": "#/definitions/rule"
+        },
+        "conditions/convert-arrow-to-condition": {
           "$ref": "#/definitions/rule"
         },
         "conditions/convert-comparison-to-boolean": {
@@ -183,25 +162,31 @@
         "conditions/merge-if-statements": {
           "$ref": "#/definitions/rule"
         },
-        "conditions/simplify": {
+        "conditions/merge-if-with-else": {
           "$ref": "#/definitions/rule"
         },
-        "conditions/remove-constant": {
+        "conditions/remove-boolean": {
+          "$ref": "#/definitions/rule"
+        },
+        "conditions/remove-same-values-condition": {
           "$ref": "#/definitions/rule"
         },
         "conditions/remove-useless-else": {
           "$ref": "#/definitions/rule"
         },
-        "label": {
+        "conditions/remove-useless-loop-condition": {
           "$ref": "#/definitions/rule"
         },
-        "label/convert-to-object": {
+        "conditions/remove-zero": {
           "$ref": "#/definitions/rule"
         },
-        "label/remove-unused": {
+        "conditions/reverse-condition": {
           "$ref": "#/definitions/rule"
         },
-        "convert-bitwise-to-logical": {
+        "conditions/simplify": {
+          "$ref": "#/definitions/rule"
+        },
+        "conditions/wrap-with-block": {
           "$ref": "#/definitions/rule"
         },
         "convert-concat-to-flat": {
@@ -210,22 +195,16 @@
         "convert-index-of-to-includes": {
           "$ref": "#/definitions/rule"
         },
-        "convert-is-nan-to-number-is-nan": {
+        "convert-object-entries-to-array-entries": {
           "$ref": "#/definitions/rule"
         },
-        "math/apply-exponential": {
+        "convert-object-entries-to-object-keys": {
           "$ref": "#/definitions/rule"
         },
-        "tape/convert-mock-require-to-mock-import": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-quotes-to-backticks": {
+        "convert-object-keys-to-object-entries": {
           "$ref": "#/definitions/rule"
         },
         "convert-template-to-string": {
-          "$ref": "#/definitions/rule"
-        },
-        "convert-throw": {
           "$ref": "#/definitions/rule"
         },
         "convert-to-arrow-function": {
@@ -234,64 +213,259 @@
         "declare": {
           "$ref": "#/definitions/rule"
         },
-        "eslint": {
+        "declare-before-reference": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/apply-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/apply-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/convert-object-to-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/extract-properties-equal-deep": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/extract-properties-not-equal-deep": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/merge-properties": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/remove-useless-arguments": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/remove-useless-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/remove-useless-variables": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/split-call": {
+          "$ref": "#/definitions/rule"
+        },
+        "destructuring/split-nested": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/apply-default-import": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/apply-export-from": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/apply-import-attributes": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/convert-assert-to-with": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/declare-imports-first": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/group-imports-by-source": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/merge-declaration-with-export": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/merge-duplicate-imports/join": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/merge-duplicate-imports/rename": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/merge-export-declarations": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-empty-export": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-empty-import": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-quotes-from-import-assertions": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/remove-useless-export-specifiers": {
+          "$ref": "#/definitions/rule"
+        },
+        "esm/sort-imports-by-specifiers": {
           "$ref": "#/definitions/rule"
         },
         "extract-sequence-expressions": {
           "$ref": "#/definitions/rule"
         },
-        "for-of/for": {
+        "for-of/add-missing-declaration": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of": {
           "$ref": "#/definitions/rule"
         },
         "for-of/for-each": {
           "$ref": "#/definitions/rule"
         },
-        "for-of/for-in": {
+        "for-of/for-entries": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/for-entries-n": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/for-in-negative": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/for-in-positive": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/for-length": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/for-n": {
           "$ref": "#/definitions/rule"
         },
         "for-of/map": {
           "$ref": "#/definitions/rule"
         },
-        "for-of/remove-useless": {
+        "for-of/reduce": {
           "$ref": "#/definitions/rule"
         },
         "for-of/remove-unused-variables": {
           "$ref": "#/definitions/rule"
         },
+        "for-of/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
         "for-of/remove-useless-array-from": {
           "$ref": "#/definitions/rule"
         },
-        "github": {
+        "for-of/remove-useless-variables": {
+          "$ref": "#/definitions/rule"
+        },
+        "for-of/to-for-n": {
+          "$ref": "#/definitions/rule"
+        },
+        "generators/add-missing-star": {
+          "$ref": "#/definitions/rule"
+        },
+        "generators": {
+          "$ref": "#/definitions/rule"
+        },
+        "generators/convert-multiply-to-generator": {
+          "$ref": "#/definitions/rule"
+        },
+        "gitignore/add": {
           "$ref": "#/definitions/rule"
         },
         "gitignore": {
           "$ref": "#/definitions/rule"
         },
-        "jest": {
+        "gitignore/sort": {
           "$ref": "#/definitions/rule"
         },
-        "madrun": {
+        "labels/convert-to-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "labels": {
+          "$ref": "#/definitions/rule"
+        },
+        "labels/remove-unused": {
+          "$ref": "#/definitions/rule"
+        },
+        "logical-expressions/convert-bitwise-to-logical": {
+          "$ref": "#/definitions/rule"
+        },
+        "logical-expressions": {
+          "$ref": "#/definitions/rule"
+        },
+        "logical-expressions/remove-boolean": {
+          "$ref": "#/definitions/rule"
+        },
+        "logical-expressions/remove-duplicates": {
+          "$ref": "#/definitions/rule"
+        },
+        "logical-expressions/simplify": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/apply-exponentiation": {
+          "$ref": "#/definitions/rule"
+        },
+        "math": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/apply-multiplication": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/apply-numeric-separators": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/convert-sqrt-to-hypot": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "math/remove-unchanged-zero-declarations": {
+          "$ref": "#/definitions/rule"
+        },
+        "maybe/array": {
           "$ref": "#/definitions/rule"
         },
         "maybe": {
           "$ref": "#/definitions/rule"
         },
-        "parens": {
+        "maybe/declare": {
           "$ref": "#/definitions/rule"
         },
-        "parens/add-missing": {
+        "maybe/empty-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "maybe/fn": {
+          "$ref": "#/definitions/rule"
+        },
+        "maybe/noop": {
+          "$ref": "#/definitions/rule"
+        },
+        "merge-duplicate-functions": {
+          "$ref": "#/definitions/rule"
+        },
+        "montag/apply": {
+          "$ref": "#/definitions/rule"
+        },
+        "montag": {
+          "$ref": "#/definitions/rule"
+        },
+        "montag/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "new/add-missing": {
+          "$ref": "#/definitions/rule"
+        },
+        "new": {
+          "$ref": "#/definitions/rule"
+        },
+        "new/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/add-node-prefix": {
           "$ref": "#/definitions/rule"
         },
         "nodejs": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/convert-esm-to-commonjs": {
-          "$ref": "#/definitions/rule"
-        },
-        "nodejs/convert-commonjs-to-esm": {
+        "nodejs/convert-buffer-to-buffer-alloc": {
           "$ref": "#/definitions/rule"
         },
         "nodejs/convert-dirname-to-url": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/convert-exports-to-module-exports": {
           "$ref": "#/definitions/rule"
         },
         "nodejs/convert-fs-promises": {
@@ -300,34 +474,58 @@
         "nodejs/convert-promisify-to-fs-promises": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/convert-top-level-return": {
+        "nodejs/convert-url-to-dirname": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/declare-after-require": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/group-require-by-id": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/remove-illegal-strict-mode": {
           "$ref": "#/definitions/rule"
         },
         "nodejs/remove-process-exit": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/add-missing-strict-mode": {
+        "nodejs/remove-top-level-process-exit": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/remove-useless-strict-mode": {
+        "nodejs/remove-useless-promisify": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/rename-file-mjs-to-js": {
+        "optional-chaining/convert-logical-to-optional": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/cjs-file": {
+        "optional-chaining": {
           "$ref": "#/definitions/rule"
         },
-        "nodejs/mjs-file": {
+        "optional-chaining/convert-optional-assign-to-logical": {
           "$ref": "#/definitions/rule"
         },
-        "npmignore": {
+        "parens/add-missing-for-assign": {
           "$ref": "#/definitions/rule"
         },
-        "package-json": {
+        "parens": {
           "$ref": "#/definitions/rule"
         },
-        "postcss": {
+        "parens/add-missing-for-awai": {
+          "$ref": "#/definitions/rule"
+        },
+        "parens/add-missing-for-template": {
+          "$ref": "#/definitions/rule"
+        },
+        "parens/remove-useless-for-await": {
+          "$ref": "#/definitions/rule"
+        },
+        "parens/remove-useless-for-params": {
+          "$ref": "#/definitions/rule"
+        },
+        "promises/add-missing-async": {
           "$ref": "#/definitions/rule"
         },
         "promises": {
@@ -336,16 +534,19 @@
         "promises/add-missing-await": {
           "$ref": "#/definitions/rule"
         },
-        "promises/apply-top-level-await": {
+        "promises/apply-await-import": {
           "$ref": "#/definitions/rule"
         },
-        "promises/apply-await-import": {
+        "promises/apply-top-level-await": {
           "$ref": "#/definitions/rule"
         },
         "promises/convert-new-promise-to-async": {
           "$ref": "#/definitions/rule"
         },
         "promises/convert-reject-to-throw": {
+          "$ref": "#/definitions/rule"
+        },
+        "promises/convert-resolve-to-async": {
           "$ref": "#/definitions/rule"
         },
         "promises/remove-useless-async": {
@@ -357,16 +558,46 @@
         "promises/remove-useless-resolve": {
           "$ref": "#/definitions/rule"
         },
+        "promises/remove-useless-variables": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-await-to-progress": {
+          "$ref": "#/definitions/rule"
+        },
         "putout": {
           "$ref": "#/definitions/rule"
         },
-        "putout/add-args": {
+        "putout/add-crawl-file": {
           "$ref": "#/definitions/rule"
         },
-        "putout/add-push": {
+        "putout/add-path-arg-to-fix": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-path-arg-to-match": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-path-arg-to-visitors": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-places-to-compare-places": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-push-arg": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-test-args": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-track-file": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/add-traverse-args": {
           "$ref": "#/definitions/rule"
         },
         "putout/apply-async-formatter": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-create-nested-directory": {
           "$ref": "#/definitions/rule"
         },
         "putout/apply-create-test": {
@@ -375,19 +606,67 @@
         "putout/apply-declare": {
           "$ref": "#/definitions/rule"
         },
+        "putout/apply-desturcturing": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-engine-node-version": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-exports-to-add-args": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-exports-to-match-files": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-exports-to-rename-files": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-fixture-name-to-message": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-for-of-to-track-file": {
+          "$ref": "#/definitions/rule"
+        },
         "putout/apply-insert-after": {
           "$ref": "#/definitions/rule"
         },
         "putout/apply-insert-before": {
           "$ref": "#/definitions/rule"
         },
-        "putout/apply-namaspace-specifier": {
+        "putout/apply-lowercase-to-node-builders": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-namespace-specifier": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-parens": {
           "$ref": "#/definitions/rule"
         },
         "putout/apply-processors-destructuring": {
           "$ref": "#/definitions/rule"
         },
         "putout/apply-remove": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-rename": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-report": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-short-processors": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-transform-with-options": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-traverser-to-ignore": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/apply-vars": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/check-declare": {
           "$ref": "#/definitions/rule"
         },
         "putout/check-match": {
@@ -411,7 +690,13 @@
         "putout/convert-find-to-traverse": {
           "$ref": "#/definitions/rule"
         },
+        "putout/convert-get-file-content-to-read-file-content": {
+          "$ref": "#/definitions/rule"
+        },
         "putout/convert-get-rule-to-require": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/convert-include-to-traverse": {
           "$ref": "#/definitions/rule"
         },
         "putout/convert-match-to-function": {
@@ -426,13 +711,25 @@
         "putout/convert-number-to-numeric": {
           "$ref": "#/definitions/rule"
         },
+        "putout/convert-plugins-element-to-tuple": {
+          "$ref": "#/definitions/rule"
+        },
         "putout/convert-process-to-find": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/convert-progress-to-track-file": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/convert-push-object-to-push-path": {
           "$ref": "#/definitions/rule"
         },
         "putout/convert-putout-test-to-create-test": {
           "$ref": "#/definitions/rule"
         },
         "putout/convert-replace-to-function": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/convert-replace-to-traverse": {
           "$ref": "#/definitions/rule"
         },
         "putout/convert-replace-with": {
@@ -453,6 +750,9 @@
         "putout/convert-traverse-to-replace": {
           "$ref": "#/definitions/rule"
         },
+        "putout/convert-traverse-to-scan": {
+          "$ref": "#/definitions/rule"
+        },
         "putout/convert-url-to-dirname": {
           "$ref": "#/definitions/rule"
         },
@@ -462,13 +762,31 @@
         "putout/declare": {
           "$ref": "#/definitions/rule"
         },
+        "putout/declare-path-variable": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/declare-template-variables": {
+          "$ref": "#/definitions/rule"
+        },
         "putout/includer": {
           "$ref": "#/definitions/rule"
         },
-        "putout/insert-rust": {
+        "putout/move-require-on-top-level": {
           "$ref": "#/definitions/rule"
         },
-        "putout/move-require-on-top-level": {
+        "putout/remove-empty-array-from-process": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/remove-empty-object-from-transform": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/remove-message-from-no-report-after-transform": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/remove-unused-get-properties-argument": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout/remove-useless-printer-option": {
           "$ref": "#/definitions/rule"
         },
         "putout/rename-operate-to-operator": {
@@ -483,19 +801,46 @@
         "putout/shorten-imports": {
           "$ref": "#/definitions/rule"
         },
-        "putout-config": {
+        "putout/simplify-replace-template": {
           "$ref": "#/definitions/rule"
         },
-        "react-hooks": {
+        "regexp/apply-character-class": {
           "$ref": "#/definitions/rule"
         },
         "regexp": {
           "$ref": "#/definitions/rule"
         },
-        "conditions/remove-boolean": {
+        "regexp/apply-ends-with": {
           "$ref": "#/definitions/rule"
         },
-        "remove-boolean-from-logical-expressions": {
+        "regexp/apply-global-regexp-to-replace-all": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/apply-literal-notation": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/apply-starts-with": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/convert-replace-to-replace-all": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/convert-to-string": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/optimize": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/remove-duplicates-from-character-class": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/remove-useless-escape": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/remove-useless-group": {
+          "$ref": "#/definitions/rule"
+        },
+        "regexp/remove-useless-regexp": {
           "$ref": "#/definitions/rule"
         },
         "remove-console": {
@@ -507,73 +852,25 @@
         "remove-duplicate-case": {
           "$ref": "#/definitions/rule"
         },
-        "remove-duplicate-interface-keys": {
-          "$ref": "#/definitions/rule"
-        },
         "remove-duplicate-keys": {
-          "$ref": "#/definitions/rule"
-        },
-        "remove-duplicates-from-logical-expressions": {
-          "$ref": "#/definitions/rule"
-        },
-        "remove-duplicates-from-union": {
-          "$ref": "#/definitions/rule"
-        },
-        "remove-empty": {
           "$ref": "#/definitions/rule"
         },
         "remove-empty/argument": {
           "$ref": "#/definitions/rule"
         },
+        "remove-empty": {
+          "$ref": "#/definitions/rule"
+        },
         "remove-empty/block": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-empty/nested-pattern": {
           "$ref": "#/definitions/rule"
         },
         "remove-empty/pattern": {
           "$ref": "#/definitions/rule"
         },
-        "esm": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/add-index-to-import": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/remove-empty-import": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/remove-empty-export": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/convert-assert-to-with": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/group-imports-by-source": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/declare-imports-first": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/remove-quotes-from-import-assertions": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/merge-duplicate-imports": {
-          "$ref": "#/definitions/rule"
-        },
-        "esm/sort-imports-by-specifier": {
-          "$ref": "#/definitions/rule"
-        },
-        "optional-chaining": {
-          "$ref": "#/definitions/rule"
-        },
-        "optional-chaining/convert-optional-assign-to-logical": {
-          "$ref": "#/definitions/rule"
-        },
-        "optional-chaining/convert-optional-to-logical": {
-          "$ref": "#/definitions/rule"
-        },
-        "optional-chaining/convert-logical-assign-to-optional": {
-          "$ref": "#/definitions/rule"
-        },
-        "optional-chaining/convert-logical-to-optional": {
+        "remove-empty/static-block": {
           "$ref": "#/definitions/rule"
         },
         "remove-iife": {
@@ -585,10 +882,163 @@
         "remove-unreachable-code": {
           "$ref": "#/definitions/rule"
         },
+        "remove-unused-expressions": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-unused-private-fields": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-array-constructor": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-array-entries": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-assign": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-constructor": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-continue": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-delete": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-escape": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-functions": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-map": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-object-from-entries": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-operand": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-push": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-replace": {
+          "$ref": "#/definitions/rule"
+        },
+        "remove-useless-template-expressions": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/apply-early": {
+          "$ref": "#/definitions/rule"
+        },
+        "return": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/convert-from-break": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/convert-from-continue": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/merge-with-next-sibling": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/remove-useless": {
+          "$ref": "#/definitions/rule"
+        },
+        "return/simplify-boolean": {
+          "$ref": "#/definitions/rule"
+        },
+        "simplify-ternary/spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "simplify-ternary": {
+          "$ref": "#/definitions/rule"
+        },
+        "simplify-ternary/value": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/convert-apply-to-spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/convert-object-assign-to-merge-spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/remove-useless-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "spread/simplify-nested": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/apply-destructuring": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/args": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/async": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/await": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/expand-args": {
+          "$ref": "#/definitions/rule"
+        },
+        "try-catch/sync": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/apply-is-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "types": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/convert-typeof-to-is-type": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/remove-double-negations": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/remove-useless-constructor": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/remove-useless-conversion": {
+          "$ref": "#/definitions/rule"
+        },
+        "types/remove-useless-typeof": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/apply-declarations-order": {
+          "$ref": "#/definitions/rule"
+        },
         "variables": {
           "$ref": "#/definitions/rule"
         },
         "variables/convert-const-to-let": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/extract-keywords": {
+          "$ref": "#/definitions/rule"
+        },
+        "variables/remove-unreferenced": {
           "$ref": "#/definitions/rule"
         },
         "variables/remove-unused": {
@@ -609,130 +1059,364 @@
         "variables/remove-useless-rename": {
           "$ref": "#/definitions/rule"
         },
-        "variables/remove-unreferenced": {
-          "$ref": "#/definitions/rule"
-        },
-        "variables/extract-keyword": {
+        "variables/reuse-duplicate-init": {
           "$ref": "#/definitions/rule"
         },
         "variables/split-declarations": {
           "$ref": "#/definitions/rule"
         },
-        "remove-unused-expressions": {
+        "convert-quotes-to-backticks": {
           "$ref": "#/definitions/rule"
         },
-        "remove-unused-private-fields": {
+        "madrun/add-cut-env": {
           "$ref": "#/definitions/rule"
         },
-        "remove-unused-types": {
+        "madrun": {
           "$ref": "#/definitions/rule"
         },
-        "arguments": {
+        "madrun/add-fix-lint": {
           "$ref": "#/definitions/rule"
         },
-        "arguments/apply-json-parse": {
+        "madrun/add-function": {
           "$ref": "#/definitions/rule"
         },
-        "arguments/apply-rest": {
+        "madrun/add-missing-quotes-to-watcher": {
           "$ref": "#/definitions/rule"
         },
-        "arguments/remove-useless": {
+        "madrun/add-run": {
           "$ref": "#/definitions/rule"
         },
-        "arguments/remove-useless-from-method": {
+        "madrun/call-run": {
           "$ref": "#/definitions/rule"
         },
-        "arguments/remove-unused": {
+        "madrun/convert-args-to-scripts": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-array": {
+        "madrun/convert-cut-env-to-run": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-array-constructor": {
+        "madrun/convert-lint-lib": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-array-entries": {
+        "madrun/convert-nyc-to-c8": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-constructor": {
+        "madrun/convert-run-argument": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-continue": {
+        "madrun/convert-run-to-cut-env": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-escape": {
+        "madrun/convert-to-async": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-functions": {
+        "madrun/declare": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-map": {
+        "madrun/remove-check-duplicates-from-test": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-new": {
+        "madrun/remove-putout": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-operand": {
+        "madrun/remove-useless-array-in-run": {
           "$ref": "#/definitions/rule"
         },
-        "spread": {
+        "madrun/remove-useless-string-conversion": {
           "$ref": "#/definitions/rule"
         },
-        "spread/convert-object-assign-to-merge-spread": {
+        "madrun/rename-eslint-to-putout": {
           "$ref": "#/definitions/rule"
         },
-        "spread/simplify-nested": {
+        "madrun/rename-series-to-run": {
           "$ref": "#/definitions/rule"
         },
-        "spread/convert-apply-to-spread": {
+        "madrun/set-lint-dot": {
           "$ref": "#/definitions/rule"
         },
-        "spread/remove-useless-array": {
+        "madrun/set-report-lcov": {
           "$ref": "#/definitions/rule"
         },
-        "spread/remove-useless-object": {
+        "nodejs/convert-commonjs-to-esm/common": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-template-expressions": {
+        "nodejs/convert-commonjs-to-esm/exports": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-templates": {
+        "nodejs/convert-commonjs-to-esm/require": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-type-conversion": {
+        "npmignore/add": {
           "$ref": "#/definitions/rule"
         },
-        "remove-useless-types-from-constants": {
+        "npmignore": {
           "$ref": "#/definitions/rule"
         },
-        "reuse-duplicate-init": {
+        "npmignore/sort": {
           "$ref": "#/definitions/rule"
         },
-        "assignment": {
+        "coverage/add-to-exclude": {
           "$ref": "#/definitions/rule"
         },
-        "assignment/simplify": {
+        "coverage": {
           "$ref": "#/definitions/rule"
         },
-        "assignment/split": {
+        "coverage/sort-ignore": {
           "$ref": "#/definitions/rule"
         },
-        "assignment/convert-to-arrow-function": {
+        "putout-config/apply-arguments": {
           "$ref": "#/definitions/rule"
         },
-        "assignment/convert-to-comparison": {
+        "putout-config": {
           "$ref": "#/definitions/rule"
         },
-        "assignment/convert-to-declaration": {
+        "putout-config/apply-assignment": {
           "$ref": "#/definitions/rule"
         },
-        "simplify-logical-expressions": {
+        "putout-config/apply-conditions": {
           "$ref": "#/definitions/rule"
         },
-        "simplify-ternary": {
+        "putout-config/apply-coverage": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-destructuring": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-esm": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-for-of": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-labels": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-math": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-nodejs": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-optional-chaining": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-parens": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-promises": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-return": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-spread": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-tape": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-types": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/apply-variables": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/convert-boolean-to-string": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/move-formatter-up": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/remove-empty": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/rename-rules": {
+          "$ref": "#/definitions/rule"
+        },
+        "putout-config/sort-ignore": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/add-putout": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/apply-create-eslint-config": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/apply-define-config": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/apply-dir-to-flat": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/apply-match-to-flat": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/apply-safe-align": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-export-match-to-declaration": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-files-to-array": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-ide-to-safe": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-node-to-n": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-plugins-array-to-object": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/convert-require-to-import": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/move-putout-to-end-of-extends": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-create-eslint-config-with-one-argument": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-no-missing": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-no-unpublished-require": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-no-unsupported-features": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-overrides-with-empty-rules": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-parser-options": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-spread-from-create-eslint-config": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-suffix-config": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-useless-define-config": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-useless-match-to-flat": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-useless-properties": {
+          "$ref": "#/definitions/rule"
+        },
+        "eslint/remove-useless-slice": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/add-type": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/apply-https-to-repository-url": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/apply-js-extension": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/remove-commit-type": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/remove-duplicate-keywords": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/remove-imports-nesting": {
+          "$ref": "#/definitions/rule"
+        },
+        "package-json/remove-nyc": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/add-args": {
           "$ref": "#/definitions/rule"
         },
         "tape": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/add-stop-all": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/add-t-end": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/apply-destructuring": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/apply-stub": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/apply-with-name": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-called-with-args": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-called-with-no-args-to-called-with": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-called-with-to-called-with-no-args": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-deep-equal-to-equal": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-does-not-throw-to-try-catch": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-emitter-to-promise": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-equal-to-called-once": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-equal-to-deep-equal": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-equal-to-not-ok": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-equal-to-ok": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-equals-to-equal": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-match-regexp-to-string": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-ok-to-called-with": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-ok-to-match": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-tape-to-supertape": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/convert-throws-to-try-catch": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/declare": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/jest": {
+          "$ref": "#/definitions/rule"
+        },
+        "tape/remove-default-messages": {
           "$ref": "#/definitions/rule"
         },
         "tape/remove-only": {
@@ -741,25 +1425,28 @@
         "tape/remove-skip": {
           "$ref": "#/definitions/rule"
         },
-        "travis": {
+        "tape/remove-useless-not-called-args": {
           "$ref": "#/definitions/rule"
         },
-        "types": {
+        "tape/remove-useless-t-end": {
           "$ref": "#/definitions/rule"
         },
-        "types/convert-typeof-to-is-type": {
+        "tape/switch-expected-with-result": {
           "$ref": "#/definitions/rule"
         },
-        "types/remove-useless-conversion": {
+        "tape/sync-with-name": {
           "$ref": "#/definitions/rule"
         },
-        "types/remove-double-negations": {
+        "nodejs/add-missing-strict-mode": {
           "$ref": "#/definitions/rule"
         },
-        "types/remove-useless-typeof": {
+        "nodejs/remove-useless-strict-mode": {
           "$ref": "#/definitions/rule"
         },
-        "types/apply-is-array": {
+        "nodejs/convert-esm-to-commonjs": {
+          "$ref": "#/definitions/rule"
+        },
+        "nodejs/convert-commonjs-to-esm": {
           "$ref": "#/definitions/rule"
         },
         "typescript": {
@@ -793,9 +1480,6 @@
           "$ref": "#/definitions/rule"
         },
         "typescript/remove-useless-types-from-constants": {
-          "$ref": "#/definitions/rule"
-        },
-        "webpack": {
           "$ref": "#/definitions/rule"
         }
       }


### PR DESCRIPTION
Update schemas according to 🐊[Putout v42](https://github.com/coderaiser/putout/releases/tag/v42.0.0).