### PR TITLE
Update `dependabot-2.0.json` schema to match current Dependabot features

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -4,581 +4,7 @@
   "additionalProperties": false,
   "definitions": {
     "timezone": {
-      "type": "string",
-      "enum": [
-        "Africa/Abidjan",
-        "Africa/Accra",
-        "Africa/Addis_Ababa",
-        "Africa/Algiers",
-        "Africa/Asmara",
-        "Africa/Asmera",
-        "Africa/Bamako",
-        "Africa/Bangui",
-        "Africa/Banjul",
-        "Africa/Bissau",
-        "Africa/Blantyre",
-        "Africa/Brazzaville",
-        "Africa/Bujumbura",
-        "Africa/Cairo",
-        "Africa/Casablanca",
-        "Africa/Ceuta",
-        "Africa/Conakry",
-        "Africa/Dakar",
-        "Africa/Dar_es_Salaam",
-        "Africa/Djibouti",
-        "Africa/Douala",
-        "Africa/El_Aaiun",
-        "Africa/Freetown",
-        "Africa/Gaborone",
-        "Africa/Harare",
-        "Africa/Johannesburg",
-        "Africa/Juba",
-        "Africa/Kampala",
-        "Africa/Khartoum",
-        "Africa/Kigali",
-        "Africa/Kinshasa",
-        "Africa/Lagos",
-        "Africa/Libreville",
-        "Africa/Lome",
-        "Africa/Luanda",
-        "Africa/Lubumbashi",
-        "Africa/Lusaka",
-        "Africa/Malabo",
-        "Africa/Maputo",
-        "Africa/Maseru",
-        "Africa/Mbabane",
-        "Africa/Mogadishu",
-        "Africa/Monrovia",
-        "Africa/Nairobi",
-        "Africa/Ndjamena",
-        "Africa/Niamey",
-        "Africa/Nouakchott",
-        "Africa/Ouagadougou",
-        "Africa/Porto-Novo",
-        "Africa/Sao_Tome",
-        "Africa/Timbuktu",
-        "Africa/Tripoli",
-        "Africa/Tunis",
-        "Africa/Windhoek",
-        "America/Adak",
-        "America/Anchorage",
-        "America/Anguilla",
-        "America/Antigua",
-        "America/Araguaina",
-        "America/Argentina/Buenos_Aires",
-        "America/Argentina/Catamarca",
-        "America/Argentina/ComodRivadavia",
-        "America/Argentina/Cordoba",
-        "America/Argentina/Jujuy",
-        "America/Argentina/La_Rioja",
-        "America/Argentina/Mendoza",
-        "America/Argentina/Rio_Gallegos",
-        "America/Argentina/Salta",
-        "America/Argentina/San_Juan",
-        "America/Argentina/San_Luis",
-        "America/Argentina/Tucuman",
-        "America/Argentina/Ushuaia",
-        "America/Aruba",
-        "America/Asuncion",
-        "America/Atikokan",
-        "America/Atka",
-        "America/Bahia",
-        "America/Bahia_Banderas",
-        "America/Barbados",
-        "America/Belem",
-        "America/Belize",
-        "America/Blanc-Sablon",
-        "America/Boa_Vista",
-        "America/Bogota",
-        "America/Boise",
-        "America/Buenos_Aires",
-        "America/Cambridge_Bay",
-        "America/Campo_Grande",
-        "America/Cancun",
-        "America/Caracas",
-        "America/Catamarca",
-        "America/Cayenne",
-        "America/Cayman",
-        "America/Chicago",
-        "America/Chihuahua",
-        "America/Coral_Harbour",
-        "America/Cordoba",
-        "America/Costa_Rica",
-        "America/Creston",
-        "America/Cuiaba",
-        "America/Curacao",
-        "America/Danmarkshavn",
-        "America/Dawson",
-        "America/Dawson_Creek",
-        "America/Denver",
-        "America/Detroit",
-        "America/Dominica",
-        "America/Edmonton",
-        "America/Eirunepe",
-        "America/El_Salvador",
-        "America/Ensenada",
-        "America/Fort_Nelson",
-        "America/Fort_Wayne",
-        "America/Fortaleza",
-        "America/Glace_Bay",
-        "America/Godthab",
-        "America/Goose_Bay",
-        "America/Grand_Turk",
-        "America/Grenada",
-        "America/Guadeloupe",
-        "America/Guatemala",
-        "America/Guayaquil",
-        "America/Guyana",
-        "America/Halifax",
-        "America/Havana",
-        "America/Hermosillo",
-        "America/Indiana/Indianapolis",
-        "America/Indiana/Knox",
-        "America/Indiana/Marengo",
-        "America/Indiana/Petersburg",
-        "America/Indiana/Tell_City",
-        "America/Indiana/Vevay",
-        "America/Indiana/Vincennes",
-        "America/Indiana/Winamac",
-        "America/Indianapolis",
-        "America/Inuvik",
-        "America/Iqaluit",
-        "America/Jamaica",
-        "America/Jujuy",
-        "America/Juneau",
-        "America/Kentucky/Louisville",
-        "America/Kentucky/Monticello",
-        "America/Knox_IN",
-        "America/Kralendijk",
-        "America/La_Paz",
-        "America/Lima",
-        "America/Los_Angeles",
-        "America/Louisville",
-        "America/Lower_Princes",
-        "America/Maceio",
-        "America/Managua",
-        "America/Manaus",
-        "America/Marigot",
-        "America/Martinique",
-        "America/Matamoros",
-        "America/Mazatlan",
-        "America/Mendoza",
-        "America/Menominee",
-        "America/Merida",
-        "America/Metlakatla",
-        "America/Mexico_City",
-        "America/Miquelon",
-        "America/Moncton",
-        "America/Monterrey",
-        "America/Montevideo",
-        "America/Montreal",
-        "America/Montserrat",
-        "America/Nassau",
-        "America/New_York",
-        "America/Nipigon",
-        "America/Nome",
-        "America/Noronha",
-        "America/North_Dakota/Beulah",
-        "America/North_Dakota/Center",
-        "America/North_Dakota/New_Salem",
-        "America/Nuuk",
-        "America/Ojinaga",
-        "America/Panama",
-        "America/Pangnirtung",
-        "America/Paramaribo",
-        "America/Phoenix",
-        "America/Port-au-Prince",
-        "America/Port_of_Spain",
-        "America/Porto_Acre",
-        "America/Porto_Velho",
-        "America/Puerto_Rico",
-        "America/Punta_Arenas",
-        "America/Rainy_River",
-        "America/Rankin_Inlet",
-        "America/Recife",
-        "America/Regina",
-        "America/Resolute",
-        "America/Rio_Branco",
-        "America/Rosario",
-        "America/Santa_Isabel",
-        "America/Santarem",
-        "America/Santiago",
-        "America/Santo_Domingo",
-        "America/Sao_Paulo",
-        "America/Scoresbysund",
-        "America/Shiprock",
-        "America/Sitka",
-        "America/St_Barthelemy",
-        "America/St_Johns",
-        "America/St_Kitts",
-        "America/St_Lucia",
-        "America/St_Thomas",
-        "America/St_Vincent",
-        "America/Swift_Current",
-        "America/Tegucigalpa",
-        "America/Thule",
-        "America/Thunder_Bay",
-        "America/Tijuana",
-        "America/Toronto",
-        "America/Tortola",
-        "America/Vancouver",
-        "America/Virgin",
-        "America/Whitehorse",
-        "America/Winnipeg",
-        "America/Yakutat",
-        "America/Yellowknife",
-        "Antarctica/Casey",
-        "Antarctica/Davis",
-        "Antarctica/DumontDUrville",
-        "Antarctica/Macquarie",
-        "Antarctica/Mawson",
-        "Antarctica/McMurdo",
-        "Antarctica/Palmer",
-        "Antarctica/Rothera",
-        "Antarctica/South_Pole",
-        "Antarctica/Syowa",
-        "Antarctica/Troll",
-        "Antarctica/Vostok",
-        "Arctic/Longyearbyen",
-        "Asia/Aden",
-        "Asia/Almaty",
-        "Asia/Amman",
-        "Asia/Anadyr",
-        "Asia/Aqtau",
-        "Asia/Aqtobe",
-        "Asia/Ashgabat",
-        "Asia/Ashkhabad",
-        "Asia/Atyrau",
-        "Asia/Baghdad",
-        "Asia/Bahrain",
-        "Asia/Baku",
-        "Asia/Bangkok",
-        "Asia/Barnaul",
-        "Asia/Beirut",
-        "Asia/Bishkek",
-        "Asia/Brunei",
-        "Asia/Calcutta",
-        "Asia/Chita",
-        "Asia/Choibalsan",
-        "Asia/Chongqing",
-        "Asia/Chungking",
-        "Asia/Colombo",
-        "Asia/Dacca",
-        "Asia/Damascus",
-        "Asia/Dhaka",
-        "Asia/Dili",
-        "Asia/Dubai",
-        "Asia/Dushanbe",
-        "Asia/Famagusta",
-        "Asia/Gaza",
-        "Asia/Harbin",
-        "Asia/Hebron",
-        "Asia/Ho_Chi_Minh",
-        "Asia/Hong_Kong",
-        "Asia/Hovd",
-        "Asia/Irkutsk",
-        "Asia/Istanbul",
-        "Asia/Jakarta",
-        "Asia/Jayapura",
-        "Asia/Jerusalem",
-        "Asia/Kabul",
-        "Asia/Kamchatka",
-        "Asia/Karachi",
-        "Asia/Kashgar",
-        "Asia/Kathmandu",
-        "Asia/Katmandu",
-        "Asia/Khandyga",
-        "Asia/Kolkata",
-        "Asia/Krasnoyarsk",
-        "Asia/Kuala_Lumpur",
-        "Asia/Kuching",
-        "Asia/Kuwait",
-        "Asia/Macao",
-        "Asia/Macau",
-        "Asia/Magadan",
-        "Asia/Makassar",
-        "Asia/Manila",
-        "Asia/Muscat",
-        "Asia/Nicosia",
-        "Asia/Novokuznetsk",
-        "Asia/Novosibirsk",
-        "Asia/Omsk",
-        "Asia/Oral",
-        "Asia/Phnom_Penh",
-        "Asia/Pontianak",
-        "Asia/Pyongyang",
-        "Asia/Qatar",
-        "Asia/Qostanay",
-        "Asia/Qyzylorda",
-        "Asia/Rangoon",
-        "Asia/Riyadh",
-        "Asia/Saigon",
-        "Asia/Sakhalin",
-        "Asia/Samarkand",
-        "Asia/Seoul",
-        "Asia/Shanghai",
-        "Asia/Singapore",
-        "Asia/Srednekolymsk",
-        "Asia/Taipei",
-        "Asia/Tashkent",
-        "Asia/Tbilisi",
-        "Asia/Tehran",
-        "Asia/Tel_Aviv",
-        "Asia/Thimbu",
-        "Asia/Thimphu",
-        "Asia/Tokyo",
-        "Asia/Tomsk",
-        "Asia/Ujung_Pandang",
-        "Asia/Ulaanbaatar",
-        "Asia/Ulan_Bator",
-        "Asia/Urumqi",
-        "Asia/Ust-Nera",
-        "Asia/Vientiane",
-        "Asia/Vladivostok",
-        "Asia/Yakutsk",
-        "Asia/Yangon",
-        "Asia/Yekaterinburg",
-        "Asia/Yerevan",
-        "Atlantic/Azores",
-        "Atlantic/Bermuda",
-        "Atlantic/Canary",
-        "Atlantic/Cape_Verde",
-        "Atlantic/Faeroe",
-        "Atlantic/Faroe",
-        "Atlantic/Jan_Mayen",
-        "Atlantic/Madeira",
-        "Atlantic/Reykjavik",
-        "Atlantic/South_Georgia",
-        "Atlantic/St_Helena",
-        "Atlantic/Stanley",
-        "Australia/ACT",
-        "Australia/Adelaide",
-        "Australia/Brisbane",
-        "Australia/Broken_Hill",
-        "Australia/Canberra",
-        "Australia/Currie",
-        "Australia/Darwin",
-        "Australia/Eucla",
-        "Australia/Hobart",
-        "Australia/LHI",
-        "Australia/Lindeman",
-        "Australia/Lord_Howe",
-        "Australia/Melbourne",
-        "Australia/North",
-        "Australia/NSW",
-        "Australia/Perth",
-        "Australia/Queensland",
-        "Australia/South",
-        "Australia/Sydney",
-        "Australia/Tasmania",
-        "Australia/Victoria",
-        "Australia/West",
-        "Australia/Yancowinna",
-        "Brazil/Acre",
-        "Brazil/DeNoronha",
-        "Brazil/East",
-        "Brazil/West",
-        "Canada/Atlantic",
-        "Canada/Central",
-        "Canada/Eastern",
-        "Canada/Mountain",
-        "Canada/Newfoundland",
-        "Canada/Pacific",
-        "Canada/Saskatchewan",
-        "Canada/Yukon",
-        "Chile/Continental",
-        "Chile/EasterIsland",
-        "Cuba",
-        "Egypt",
-        "Eire",
-        "Etc/GMT",
-        "Etc/GMT+0",
-        "Etc/GMT+1",
-        "Etc/GMT+10",
-        "Etc/GMT+11",
-        "Etc/GMT+12",
-        "Etc/GMT+2",
-        "Etc/GMT+3",
-        "Etc/GMT+4",
-        "Etc/GMT+5",
-        "Etc/GMT+6",
-        "Etc/GMT+7",
-        "Etc/GMT+8",
-        "Etc/GMT+9",
-        "Etc/GMT-0",
-        "Etc/GMT-1",
-        "Etc/GMT-10",
-        "Etc/GMT-11",
-        "Etc/GMT-12",
-        "Etc/GMT-13",
-        "Etc/GMT-14",
-        "Etc/GMT-2",
-        "Etc/GMT-3",
-        "Etc/GMT-4",
-        "Etc/GMT-5",
-        "Etc/GMT-6",
-        "Etc/GMT-7",
-        "Etc/GMT-8",
-        "Etc/GMT-9",
-        "Etc/GMT0",
-        "Etc/Greenwich",
-        "Etc/UCT",
-        "Etc/Universal",
-        "Etc/UTC",
-        "Etc/Zulu",
-        "Europe/Amsterdam",
-        "Europe/Andorra",
-        "Europe/Astrakhan",
-        "Europe/Athens",
-        "Europe/Belfast",
-        "Europe/Belgrade",
-        "Europe/Berlin",
-        "Europe/Bratislava",
-        "Europe/Brussels",
-        "Europe/Bucharest",
-        "Europe/Budapest",
-        "Europe/Busingen",
-        "Europe/Chisinau",
-        "Europe/Copenhagen",
-        "Europe/Dublin",
-        "Europe/Gibraltar",
-        "Europe/Guernsey",
-        "Europe/Helsinki",
-        "Europe/Isle_of_Man",
-        "Europe/Istanbul",
-        "Europe/Jersey",
-        "Europe/Kaliningrad",
-        "Europe/Kiev",
-        "Europe/Kirov",
-        "Europe/Kyiv",
-        "Europe/Lisbon",
-        "Europe/Ljubljana",
-        "Europe/London",
-        "Europe/Luxembourg",
-        "Europe/Madrid",
-        "Europe/Malta",
-        "Europe/Mariehamn",
-        "Europe/Minsk",
-        "Europe/Monaco",
-        "Europe/Moscow",
-        "Europe/Nicosia",
-        "Europe/Oslo",
-        "Europe/Paris",
-        "Europe/Podgorica",
-        "Europe/Prague",
-        "Europe/Riga",
-        "Europe/Rome",
-        "Europe/Samara",
-        "Europe/San_Marino",
-        "Europe/Sarajevo",
-        "Europe/Saratov",
-        "Europe/Simferopol",
-        "Europe/Skopje",
-        "Europe/Sofia",
-        "Europe/Stockholm",
-        "Europe/Tallinn",
-        "Europe/Tirane",
-        "Europe/Tiraspol",
-        "Europe/Ulyanovsk",
-        "Europe/Uzhgorod",
-        "Europe/Vaduz",
-        "Europe/Vatican",
-        "Europe/Vienna",
-        "Europe/Vilnius",
-        "Europe/Volgograd",
-        "Europe/Warsaw",
-        "Europe/Zagreb",
-        "Europe/Zaporozhye",
-        "Europe/Zurich",
-        "GB",
-        "GB-Eire",
-        "Hongkong",
-        "Iceland",
-        "Indian/Antananarivo",
-        "Indian/Chagos",
-        "Indian/Christmas",
-        "Indian/Cocos",
-        "Indian/Comoro",
-        "Indian/Kerguelen",
-        "Indian/Mahe",
-        "Indian/Maldives",
-        "Indian/Mauritius",
-        "Indian/Mayotte",
-        "Indian/Reunion",
-        "Iran",
-        "Israel",
-        "Jamaica",
-        "Japan",
-        "Kwajalein",
-        "Libya",
-        "Mexico/BajaNorte",
-        "Mexico/BajaSur",
-        "Mexico/General",
-        "Navajo",
-        "NZ",
-        "NZ-CHAT",
-        "Pacific/Apia",
-        "Pacific/Auckland",
-        "Pacific/Bougainville",
-        "Pacific/Chatham",
-        "Pacific/Chuuk",
-        "Pacific/Easter",
-        "Pacific/Efate",
-        "Pacific/Enderbury",
-        "Pacific/Fakaofo",
-        "Pacific/Fiji",
-        "Pacific/Funafuti",
-        "Pacific/Galapagos",
-        "Pacific/Gambier",
-        "Pacific/Guadalcanal",
-        "Pacific/Guam",
-        "Pacific/Honolulu",
-        "Pacific/Johnston",
-        "Pacific/Kanton",
-        "Pacific/Kiritimati",
-        "Pacific/Kosrae",
-        "Pacific/Kwajalein",
-        "Pacific/Majuro",
-        "Pacific/Marquesas",
-        "Pacific/Midway",
-        "Pacific/Nauru",
-        "Pacific/Niue",
-        "Pacific/Norfolk",
-        "Pacific/Noumea",
-        "Pacific/Pago_Pago",
-        "Pacific/Palau",
-        "Pacific/Pitcairn",
-        "Pacific/Pohnpei",
-        "Pacific/Ponape",
-        "Pacific/Port_Moresby",
-        "Pacific/Rarotonga",
-        "Pacific/Saipan",
-        "Pacific/Samoa",
-        "Pacific/Tahiti",
-        "Pacific/Tarawa",
-        "Pacific/Tongatapu",
-        "Pacific/Truk",
-        "Pacific/Wake",
-        "Pacific/Wallis",
-        "Pacific/Yap",
-        "Poland",
-        "Portugal",
-        "PRC",
-        "ROC",
-        "Singapore",
-        "US/Alaska",
-        "US/Aleutian",
-        "US/Arizona",
-        "US/Central",
-        "US/East-Indiana",
-        "US/Eastern",
-        "US/Hawaii",
-        "US/Indiana-Starke",
-        "US/Michigan",
-        "US/Mountain",
-        "US/Pacific",
-        "US/Samoa"
-      ]
+      "$ref": "https://json.schemastore.org/base.json#/definitions/timezone"
     },
     "dependency-type": {
       "type": "string",
@@ -670,6 +96,7 @@
         "nuget",
         "opentofu",
         "pip",
+        "pre-commit",
         "pub",
         "rust-toolchain",
         "swift",
@@ -720,8 +147,12 @@
               }
             },
             "anyOf": [
-              { "required": ["dependency-name"] },
-              { "required": ["dependency-type"] }
+              {
+                "required": ["dependency-name"]
+              },
+              {
+                "required": ["dependency-type"]
+              }
             ],
             "additionalProperties": false
           }
@@ -758,9 +189,15 @@
             }
           },
           "anyOf": [
-            { "required": ["prefix"] },
-            { "required": ["prefix-development"] },
-            { "required": ["include"] }
+            {
+              "required": ["prefix"]
+            },
+            {
+              "required": ["prefix-development"]
+            },
+            {
+              "required": ["include"]
+            }
           ],
           "additionalProperties": false
         },
@@ -771,38 +208,42 @@
             "default-days": {
               "description": "Default cooldown period for dependencies without specific rules (optional).",
               "type": "integer",
-              "minimum": 0
+              "minimum": 1,
+              "maximum": 90
             },
             "semver-major-days": {
               "description": "Cooldown period for major version updates (optional, applies only to package managers supporting SemVer).",
               "type": "integer",
-              "minimum": 0
+              "minimum": 1,
+              "maximum": 90
             },
             "semver-minor-days": {
               "description": "Cooldown period for minor version updates (optional, applies only to package managers supporting SemVer).",
               "type": "integer",
-              "minimum": 0
+              "minimum": 1,
+              "maximum": 90
             },
             "semver-patch-days": {
               "description": "Cooldown period for patch version updates (optional, applies only to package managers supporting SemVer).",
               "type": "integer",
-              "minimum": 0
+              "minimum": 0,
+              "maximum": 90
             },
             "include": {
-              "description": "List of dependencies to apply cooldown (up to 150 items). Supports wildcards (`*`).",
+              "description": "List of dependencies to apply cooldown. Supports wildcards (`*`).",
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "maxItems": 150
+              "maxItems": 100
             },
             "exclude": {
-              "description": "List of dependencies excluded from cooldown (up to 150 items). Supports wildcards (`*`).",
+              "description": "List of dependencies excluded from cooldown. Supports wildcards (`*`).",
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "maxItems": 150
+              "maxItems": 100
             }
           },
           "additionalProperties": false
@@ -876,13 +317,29 @@
                 },
                 "minItems": 1,
                 "uniqueItems": true
+              },
+              "group-by": {
+                "description": "Configure how dependencies are grouped within this group.",
+                "type": "string",
+                "enum": ["dependency-name"]
               }
             },
             "anyOf": [
-              { "required": ["dependency-type"] },
-              { "required": ["patterns"] },
-              { "required": ["exclude-patterns"] },
-              { "required": ["update-types"] }
+              {
+                "required": ["dependency-type"]
+              },
+              {
+                "required": ["patterns"]
+              },
+              {
+                "required": ["exclude-patterns"]
+              },
+              {
+                "required": ["update-types"]
+              },
+              {
+                "required": ["group-by"]
+              }
             ],
             "additionalProperties": false
           },
@@ -904,18 +361,31 @@
               },
               "versions": {
                 "description": "Use to ignore specific versions or ranges of versions. If you want to define a range, use the standard pattern for the package manager.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "minItems": 1,
-                "uniqueItems": true
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                  }
+                ]
               }
             },
             "anyOf": [
-              { "required": ["dependency-name"] },
-              { "required": ["update-types"] },
-              { "required": ["versions"] }
+              {
+                "required": ["dependency-name"]
+              },
+              {
+                "required": ["update-types"]
+              },
+              {
+                "required": ["versions"]
+              }
             ],
             "additionalProperties": false
           }
@@ -940,6 +410,12 @@
           "type": "integer",
           "minimum": 1
         },
+        "name": {
+          "description": "A name for the update configuration.",
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 100
+        },
         "open-pull-requests-limit": {
           "description": "Limit number of open pull requests for version updates",
           "type": "integer",
@@ -951,8 +427,12 @@
           "description": "Package manager to use",
           "type": "string",
           "anyOf": [
-            { "$ref": "#/definitions/package-ecosystem-values" },
-            { "minLength": 1 }
+            {
+              "$ref": "#/definitions/package-ecosystem-values"
+            },
+            {
+              "minLength": 1
+            }
           ]
         },
         "pull-request-branch-name": {
@@ -1081,8 +561,12 @@
         },
         {
           "oneOf": [
-            { "required": ["directories"] },
-            { "required": ["directory"] }
+            {
+              "required": ["directories"]
+            },
+            {
+              "required": ["directory"]
+            }
           ]
         },
         {
@@ -1112,6 +596,7 @@
                 "composer-repository",
                 "docker-registry",
                 "git",
+                "goproxy-server",
                 "hex-organization",
                 "hex-repository",
                 "helm-registry",
@@ -1162,6 +647,50 @@
             },
             "public-key-fingerprint": {
               "description": "",
+              "type": "string"
+            },
+            "registry": {
+              "description": "The name of the cargo registry.",
+              "type": "string"
+            },
+            "tenant-id": {
+              "description": "The tenant ID for Azure OIDC authentication.",
+              "type": "string"
+            },
+            "client-id": {
+              "description": "The client ID for Azure OIDC authentication.",
+              "type": "string"
+            },
+            "jfrog-oidc-provider-name": {
+              "description": "The JFrog OIDC provider name for authentication.",
+              "type": "string"
+            },
+            "identity-mapping-name": {
+              "description": "The identity mapping name for JFrog OIDC authentication.",
+              "type": "string"
+            },
+            "audience": {
+              "description": "The audience for OIDC or AWS authentication.",
+              "type": "string"
+            },
+            "aws-region": {
+              "description": "The AWS region for AWS CodeArtifact authentication.",
+              "type": "string"
+            },
+            "account-id": {
+              "description": "The AWS account ID for AWS CodeArtifact authentication.",
+              "type": "string"
+            },
+            "role-name": {
+              "description": "The AWS role name for AWS CodeArtifact authentication.",
+              "type": "string"
+            },
+            "domain": {
+              "description": "The domain for AWS CodeArtifact authentication.",
+              "type": "string"
+            },
+            "domain-owner": {
+              "description": "The domain owner for AWS CodeArtifact authentication.",
               "type": "string"
             }
           },
@@ -1270,9 +799,15 @@
             }
           },
           "anyOf": [
-            { "required": ["prefix"] },
-            { "required": ["prefix-development"] },
-            { "required": ["include"] }
+            {
+              "required": ["prefix"]
+            },
+            {
+              "required": ["prefix-development"]
+            },
+            {
+              "required": ["include"]
+            }
           ],
           "additionalProperties": false
         },
@@ -1289,6 +824,37 @@
           },
           "required": ["separator"],
           "additionalProperties": false
+        },
+        "open-pull-requests-limit": {
+          "description": "Limit number of open pull requests for version updates.",
+          "type": "integer",
+          "minimum": 0,
+          "default": 5
+        },
+        "update-types": {
+          "description": "Specify the semantic versioning update types for the group.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["major", "minor", "patch"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "dependency-type": {
+          "description": "Specify a dependency type to be included in the group.",
+          "type": "string",
+          "enum": ["production", "development"]
+        },
+        "exclude-patterns": {
+          "description": "Exclude certain dependencies from the group.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "minItems": 1
         }
       },
       "required": ["schedule"]

--- a/src/test/dependabot-2.0/groups.group-by.json
+++ b/src/test/dependabot-2.0/groups.group-by.json
@@ -1,0 +1,18 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "groups": {
+        "by-name": {
+          "group-by": "dependency-name",
+          "patterns": ["*"]
+        }
+      },
+      "package-ecosystem": "npm",
+      "schedule": {
+        "interval": "weekly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/test/dependabot-2.0/ignore-versions-string.json
+++ b/src/test/dependabot-2.0/ignore-versions-string.json
@@ -1,0 +1,22 @@
+{
+  "updates": [
+    {
+      "directory": "/",
+      "ignore": [
+        {
+          "dependency-name": "express",
+          "versions": ">= 5.0"
+        },
+        {
+          "dependency-name": "lodash",
+          "versions": ["4.x", "5.x"]
+        }
+      ],
+      "package-ecosystem": "npm",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/test/dependabot-2.0/pre-commit.json
+++ b/src/test/dependabot-2.0/pre-commit.json
@@ -1,0 +1,13 @@
+{
+  "enable-beta-ecosystems": true,
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "pre-commit",
+      "schedule": {
+        "interval": "weekly"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/test/dependabot-2.0/registries-goproxy.json
+++ b/src/test/dependabot-2.0/registries-goproxy.json
@@ -1,0 +1,21 @@
+{
+  "registries": {
+    "my-goproxy": {
+      "password": "${{ secrets.GOPROXY_PASSWORD }}",
+      "type": "goproxy-server",
+      "url": "https://proxy.example.com",
+      "username": "user"
+    }
+  },
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "gomod",
+      "registries": ["my-goproxy"],
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/test/dependabot-2.0/registries-oidc.json
+++ b/src/test/dependabot-2.0/registries-oidc.json
@@ -1,0 +1,35 @@
+{
+  "registries": {
+    "aws-npm": {
+      "account-id": "111122223333",
+      "aws-region": "us-east-1",
+      "domain": "my-domain",
+      "domain-owner": "111122223333",
+      "role-name": "my-role",
+      "type": "npm-registry",
+      "url": "https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/npm/my-repo/"
+    },
+    "azure-npm": {
+      "client-id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "tenant-id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "type": "npm-registry",
+      "url": "https://pkgs.dev.azure.com/my-org/_packaging/my-feed/npm/registry/"
+    },
+    "jfrog-maven": {
+      "jfrog-oidc-provider-name": "my-provider",
+      "type": "maven-repository",
+      "url": "https://my-org.jfrog.io/artifactory/maven-repo"
+    }
+  },
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "npm",
+      "registries": "*",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}


### PR DESCRIPTION
The schema had fallen behind the actual Dependabot configuration. This brings it up to date with features shipped over the past year or so.

### What changed

**New ecosystem and registry types:**
- `pre-commit` added to `package-ecosystem` (beta, behind `enable-beta-ecosystems`) — [dependabot/dependabot-core#2183](https://github.com/dependabot/dependabot-core/issues/2183)
- `goproxy-server` added to registry `type` enum — [Go private registry support GA](https://github.blog/changelog/2025-09-09-go-private-registry-support-for-dependabot-now-generally-available), [dependabot/dependabot-core#12747](https://github.com/dependabot/dependabot-core/pull/12747)

**OIDC and AWS CodeArtifact registry auth properties:**
- `tenant-id`, `client-id` (Azure OIDC)
- `jfrog-oidc-provider-name`, `identity-mapping-name`, `audience` (JFrog OIDC)
- `aws-region`, `account-id`, `role-name`, `domain`, `domain-owner` (AWS CodeArtifact)
- `registry` (cargo-registry name)
- Ref: [Dependabot now supports OIDC authentication](https://github.blog/changelog/2026-02-03-dependabot-now-supports-oidc-authentication)

**Groups:**
- `group-by` property (`"dependency-name"`) — [Grouped security updates GA](https://github.blog/changelog/2024-03-28-dependabot-grouped-security-updates-generally-available)

**Multi-ecosystem groups:**
- `update-types`, `dependency-type`, `exclude-patterns`, `open-pull-requests-limit` — [Multi-ecosystem support GA](https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support)

**Update definition:**
- `name` property (string, 3-100 chars)

**Constraint fixes:**
- Cooldown: `default-days`/`semver-major-days`/`semver-minor-days` minimum is 1, not 0. All day fields capped at 90. `include`/`exclude` maxItems is 100, not 150. — [Cooldown GA](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age)
- Ignore `versions`: now accepts a string or an array (was array-only), matching actual behavior

**Housekeeping:**
- Replaced the inline timezone enum (~570 lines) with a `$ref` to `base.json#/definitions/timezone`