### PR TITLE
fix(schema): fixed linting issues in appsscript.json and asconfig-schema.json

### DIFF
--- a/src/schemas/json/appsscript.json
+++ b/src/schemas/json/appsscript.json
@@ -5,14 +5,14 @@
     "homepageTrigger": {
       "title": "homepage trigger",
       "type": "object",
-      "description": "The Google Workspace add-on manifest configuration for homepage triggers.",
+      "description": "The Google Workspace add-on manifest configuration for homepage triggers",
       "properties": {
         "enabled": {
-          "description": "Whether or not homepage (non-contextual) cards are enabled in Calendar. Defaults to true.",
+          "description": "Whether or not homepage (non-contextual) cards are enabled in Calendar. Defaults to true",
           "type": "boolean"
         },
         "runFunction": {
-          "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects.",
+          "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects",
           "type": "string"
         }
       }
@@ -20,42 +20,41 @@
   },
   "properties": {
     "runtimeVersion": {
-      "description": "Version of the server to use when executing this project.",
-      "type": "string",
+      "description": "Version of the server to use when executing this project",
       "enum": ["STABLE", "V8", "DEPRECATED_ES5"],
       "default": "STABLE"
     },
     "timeZone": {
-      "description": "The script time zone in one of the available ZoneId values such as \"America/Denver\".",
+      "description": "The script time zone in one of the available ZoneId values such as \"America/Denver\"",
       "type": "string",
       "default": "America/New_York"
     },
     "dependencies": {
       "title": "dependencies",
-      "description": "A list of advanced services and libraries.",
+      "description": "A list of advanced services and libraries",
       "type": "object",
       "properties": {
         "enabledAdvancedServices": {
-          "description": "The list of advanced services enabled for use by the script project.",
+          "description": "The list of advanced services enabled for use by the script project",
           "type": "array",
           "items": {
             "title": "advanced service",
-            "description": "A single advanced service.",
+            "description": "A single advanced service",
             "type": "object",
             "required": ["userSymbol", "serviceId", "version"],
             "properties": {
               "userSymbol": {
-                "description": "The identifier used to refer to this service in the code of the Apps Script project.",
+                "description": "The identifier used to refer to this service in the code of the Apps Script project",
                 "type": "string",
                 "default": "Sheets"
               },
               "serviceId": {
-                "description": "The identifier of the service that is shown in the API discovery document (e.g., drive).",
+                "description": "The identifier of the service that is shown in the API discovery document (e.g., drive)",
                 "type": "string",
                 "default": "sheets"
               },
               "version": {
-                "description": "The enabled version of the service (e.g., \"v1\").",
+                "description": "The enabled version of the service (e.g., \"v1\")",
                 "type": "string",
                 "default": "v4"
               }
@@ -63,33 +62,33 @@
           }
         },
         "libraries": {
-          "description": "The list of libraries used by the script project.",
+          "description": "The list of libraries used by the script project",
           "type": "array",
           "items": {
             "title": "library",
-            "description": "A single library.",
+            "description": "A single library",
             "type": "object",
             "required": ["userSymbol", "libraryId", "version"],
             "properties": {
               "userSymbol": {
-                "description": "The label that is used in the script project code to refer to this library.",
+                "description": "The label that is used in the script project code to refer to this library",
                 "type": "string",
                 "default": "OAuth2"
               },
               "libraryId": {
-                "description": "The script ID of the library's script project. You can find a script ID in the library script's URL or in the script editor by selecting **File > Project properties**.",
+                "description": "The script ID of the library's script project. You can find a script ID in the library script's URL or in the script editor by selecting **File > Project properties**",
                 "type": "string",
                 "default": "1B7FSrk5Zi6L1rSxxTDgDEUsPzlukDsi4KGuTMorsTQHhGBzBkMun4iDF",
                 "maxLength": 57,
                 "minLength": 57
               },
               "version": {
-                "description": "The version of the library that is used by the script. This is either a version number or stable, meaning the last version created.",
+                "description": "The version of the library that is used by the script. This is either a version number or stable, meaning the last version created",
                 "type": "string",
                 "default": "41"
               },
               "developmentMode": {
-                "description": "If true, version is ignored and the script uses the current library project saved code, even if that code has not been saved to a new version.",
+                "description": "If true, version is ignored and the script uses the current library project saved code, even if that code has not been saved to a new version",
                 "type": "boolean",
                 "default": true
               }
@@ -100,30 +99,27 @@
     },
     "webapp": {
       "title": "script",
-      "description": "The script project's web app configuration. Only used if the project is deployed as a web app.",
+      "description": "The script project's web app configuration. Only used if the project is deployed as a web app",
       "type": "object",
       "properties": {
         "access": {
-          "description": "The levels of permission for running the web app.",
-          "type": "string",
+          "description": "The levels of permission for running the web app",
           "enum": ["MYSELF", "DOMAIN", "ANYONE", "ANYONE_ANONYMOUS"],
           "default": "MYSELF"
         },
         "executeAs": {
-          "description": "The identity under which the web app executes.",
-          "type": "string",
+          "description": "The identity under which the web app executes",
           "enum": ["USER_ACCESSING", "USER_DEPLOYING"],
           "default": "USER_DEPLOYING"
         }
       }
     },
     "exceptionLogging": {
-      "description": "The location where exceptions are logged.",
-      "type": "string",
+      "description": "The location where exceptions are logged",
       "enum": ["NONE", "STACKDRIVER"]
     },
     "oauthScopes": {
-      "description": "The definition of authorization scopes used by the script project.",
+      "description": "The definition of authorization scopes used by the script project",
       "type": "array",
       "items": {
         "type": "string",
@@ -131,7 +127,7 @@
       }
     },
     "urlFetchWhitelist": {
-      "description": "A list of HTTPS URL prefixes. If present, any URL endpoint fetched must match one of the prefixes in this list. This can help to protect user data.",
+      "description": "A list of HTTPS URL prefixes. If present, any URL endpoint fetched must match one of the prefixes in this list. This can help to protect user data",
       "type": "array",
       "items": {
         "type": "string",
@@ -140,41 +136,40 @@
     },
     "executionApi": {
       "title": "api options",
-      "description": "The script project's API executable configuration. Only used if the project is deployed for API execution.",
+      "description": "The script project's API executable configuration. Only used if the project is deployed for API execution",
       "type": "object",
       "properties": {
         "access": {
-          "description": "Determines who has permission to run the script from the API.",
-          "type": "string",
+          "description": "Determines who has permission to run the script from the API",
           "enum": ["MYSELF", "DOMAIN", "ANYONE", "ANYONE_ANONYMOUS"]
         }
       }
     },
     "sheets": {
       "title": "sheet manifest",
-      "description": "Defines manifest values specific to Sheets.",
+      "description": "Defines manifest values specific to Sheets",
       "type": "object",
       "properties": {
         "macros": {
-          "description": "A list of defined macros and their associated properties.",
+          "description": "A list of defined macros and their associated properties",
           "type": "array",
           "items": {
             "title": "macros",
-            "description": "A defined macros and it's associated properties.",
+            "description": "A defined macros and it's associated properties",
             "type": "object",
             "properties": {
               "menuName": {
-                "description": "The name of the macro as it appears in the Google Sheets UI.",
+                "description": "The name of the macro as it appears in the Google Sheets UI",
                 "type": "string",
                 "default": "My Macro"
               },
               "functionName": {
-                "description": "The name of the Apps Script function that executes the macro. By default this matches the menuName for functions automatically created, but this is not a requirement.",
+                "description": "The name of the Apps Script function that executes the macro. By default this matches the menuName for functions automatically created, but this is not a requirement",
                 "type": "string",
                 "default": "myFunction"
               },
               "defaultShortcut": {
-                "description": "Defines the keyboard shortcut that executes the macro. This must be of the form Ctrl+Alt+Shift+Number, where Number is a single-digit. Macros without shortcuts can only be executed from the Tools > Macros menu.",
+                "description": "Defines the keyboard shortcut that executes the macro. This must be of the form Ctrl+Alt+Shift+Number, where Number is a single-digit. Macros without shortcuts can only be executed from the Tools > Macros menu",
                 "type": "string",
                 "default": "Ctrl+Alt+Shift+1"
               }
@@ -186,20 +181,20 @@
     },
     "dataStudio": {
       "title": "add-on manifest",
-      "description": "Data Studio add-on manifest.",
+      "description": "Data Studio add-on manifest",
       "type": "object",
       "properties": {
         "name": {
-          "description": "Display name for add-on.",
+          "description": "Display name for add-on",
           "type": "string"
         },
         "logoUrl": {
-          "description": "URL for logo image of add-on.",
+          "description": "URL for logo image of add-on",
           "type": "string",
           "format": "hostname"
         },
         "company": {
-          "description": "Company name for the add-on.",
+          "description": "Company name for the add-on",
           "type": "string"
         },
         "addonUrl": {
@@ -211,47 +206,46 @@
           "format": "hostname"
         },
         "supportUrl": {
-          "description": "URL for support information of the add-on.",
+          "description": "URL for support information of the add-on",
           "type": "string",
           "format": "hostname"
         },
         "description": {
-          "description": "Short description about the add-on.",
+          "description": "Short description about the add-on",
           "type": "string"
         },
         "sources": {
-          "description": "List of sources or services that can be accessed with this add-on.",
+          "description": "List of sources or services that can be accessed with this add-on",
           "type": "array",
           "items": {
-            "description": "A single source type.",
+            "description": "A single source type",
             "type": "string"
           }
         },
         "templates": {
           "title": "templates",
-          "description": "Map of template name to report ID.",
+          "description": "Map of template name to report ID",
           "type": "object"
         },
         "shortDescription": {
-          "description": "Even shorter description used in gallery cards. Only a maximum of 114 characters will be shown on the card.",
+          "description": "Even shorter description used in gallery cards. Only a maximum of 114 characters will be shown on the card",
           "type": "string"
         },
         "authType": {
-          "description": "List of AuthTypes supported.",
+          "description": "List of AuthTypes supported",
           "type": "array",
           "items": {
-            "description": "Types of Authorization supported by the add-on.",
-            "type": "string",
+            "description": "Types of Authorization supported by the add-on",
             "enum": ["NONE", "KEY", "USER_PASS", "OAUTH2"]
           }
         },
         "privacyPolicyUrl": {
-          "description": "Url for privacy policy information about the add-on.",
+          "description": "Url for privacy policy information about the add-on",
           "type": "string",
           "format": "hostname"
         },
         "termsOfServiceUrl": {
-          "description": "Url for terms of service information about the add-on.",
+          "description": "Url for terms of service information about the add-on",
           "type": "string",
           "format": "hostname"
         }
@@ -265,29 +259,29 @@
       "properties": {
         "common": {
           "title": "common options",
-          "description": "Common properties between all G Suite add-on types.",
+          "description": "Common properties between all G Suite add-on types",
           "type": "object",
           "properties": {
             "name": {
-              "description": "The add-on name.",
+              "description": "The add-on name",
               "type": "string"
             },
             "logoUrl": {
-              "description": "The logo URL.",
+              "description": "The logo URL",
               "type": "string",
               "format": "uri"
             },
             "layoutProperties": {
               "title": "layout options",
-              "description": "Layout properties.",
+              "description": "Layout properties",
               "type": "object",
               "properties": {
                 "primaryColor": {
-                  "description": "The color of toolbar. Defaults to grey (#424242).",
+                  "description": "The color of toolbar. Defaults to grey (#424242)",
                   "type": "string"
                 },
                 "secondaryColor": {
-                  "description": "The default color of buttons. Defaults to the primary color (if it is set); otherwise defaults to blue (#2196F3).",
+                  "description": "The default color of buttons. Defaults to the primary color (if it is set); otherwise defaults to blue (#2196F3)",
                   "type": "string"
                 }
               }
@@ -298,7 +292,7 @@
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Whether or not homepage (non-contextual) cards are enabled. Defaults to true.",
+                  "description": "Whether or not homepage (non-contextual) cards are enabled. Defaults to true",
                   "type": "boolean"
                 },
                 "runFunctions": {
@@ -316,7 +310,7 @@
                 "type": "object",
                 "properties": {
                   "label": {
-                    "description": "The action label.",
+                    "description": "The action label",
                     "type": "string"
                   },
                   "openLink": {
@@ -325,17 +319,17 @@
                     "format": "hostname"
                   },
                   "runFunction": {
-                    "description": "Required for each defined universal action if openLink is not present. If provided, the name of the Apps Script function that executes when the user selects this action.",
+                    "description": "Required for each defined universal action if openLink is not present. If provided, the name of the Apps Script function that executes when the user selects this action",
                     "type": "string"
                   }
                 }
               }
             },
             "openLinkUrlPrefixes": {
-              "description": "Link prefixes.",
+              "description": "Link prefixes",
               "type": "array",
               "items": {
-                "description": "A link prefix.",
+                "description": "A link prefix",
                 "type": "string"
               }
             },
@@ -348,24 +342,24 @@
         },
         "gmail": {
           "title": "add-on metadata",
-          "description": "Gmail add-on metadata.",
+          "description": "Gmail add-on metadata",
           "type": "object",
           "properties": {
             "contextualTriggers": {
-              "description": "Contextual triggers.",
+              "description": "Contextual triggers",
               "type": "array",
               "items": {
                 "title": "contextual trigger",
-                "description": "A contextual trigger.",
+                "description": "A contextual trigger",
                 "type": "object",
                 "properties": {
                   "onTriggerFunction": {
-                    "description": "The name of the Apps Script function that executes when this contextual trigger fires (that is, when a message is opened in Gmail). The function specified here must build and return an array of Card objects.",
+                    "description": "The name of the Apps Script function that executes when this contextual trigger fires (that is, when a message is opened in Gmail). The function specified here must build and return an array of Card objects",
                     "type": "string"
                   },
                   "unconditional": {
                     "title": "unconditional",
-                    "description": "Used to specify that the contextual trigger is fired for all Gmail messages. This is currently the only option, so this should always be an empty object.",
+                    "description": "Used to specify that the contextual trigger is fired for all Gmail messages. This is currently the only option, so this should always be an empty object",
                     "type": "object"
                   }
                 }
@@ -373,15 +367,15 @@
             },
             "homepageTrigger": {
               "title": "homepage trigger",
-              "description": "The trigger function specification for creating the add-on homepage in the Gmail host.",
+              "description": "The trigger function specification for creating the add-on homepage in the Gmail host",
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Whether or not homepage (non-contextual) cards are enabled in Gmail. Defaults to true.",
+                  "description": "Whether or not homepage (non-contextual) cards are enabled in Gmail. Defaults to true",
                   "type": "boolean"
                 },
                 "runFunction": {
-                  "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects.",
+                  "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects",
                   "type": "string"
                 }
               }
@@ -390,20 +384,20 @@
         },
         "calendar": {
           "title": "calendar metadata",
-          "description": "Calendar add-on metadata.",
+          "description": "Calendar add-on metadata",
           "type": "object",
           "properties": {
             "homepageTrigger": {
               "title": "homepage trigger",
-              "description": "The trigger function specification for creating the add-on homepage in the Calendar host.",
+              "description": "The trigger function specification for creating the add-on homepage in the Calendar host",
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Whether or not homepage (non-contextual) cards are enabled in Calendar. Defaults to true.",
+                  "description": "Whether or not homepage (non-contextual) cards are enabled in Calendar. Defaults to true",
                   "type": "boolean"
                 },
                 "runFunction": {
-                  "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects.",
+                  "description": "The name of the function to run when this trigger fires. You must implement this function in your add-on project. This function must build and return an array of Card objects",
                   "type": "string"
                 }
               }
@@ -432,14 +426,13 @@
             },
             "eventAccess": {
               "description": "Handler access to Calendar event",
-              "type": "string",
               "enum": ["METADATA", "READ", "WRITE", "READ_WRITE"]
             }
           }
         },
         "sheets": {
           "title": "add-on options",
-          "description": "Configurations for the Google Workspace Add-on's appearance and behavior within the Sheets host application.",
+          "description": "Configurations for the Google Workspace Add-on's appearance and behavior within the Sheets host application",
           "type": "object",
           "properties": {
             "homepageTrigger": {
@@ -448,7 +441,7 @@
             "onFileScopeGrantedTrigger": {
               "title": "contextual trigger",
               "type": "object",
-              "description": "A configuration for a contextual trigger that fires when the add-on presents the request file scope dialog.",
+              "description": "A configuration for a contextual trigger that fires when the add-on presents the request file scope dialog",
               "properties": {
                 "runFunction": {
                   "type": "string"

--- a/src/schemas/json/asconfig-schema.json
+++ b/src/schemas/json/asconfig-schema.json
@@ -24,7 +24,6 @@
       ]
     },
     "webAssemblyFeatures": {
-      "type": "string",
       "enum": [
         "sign-extension",
         "mutable-globals",
@@ -45,39 +44,39 @@
       "additionalProperties": false,
       "properties": {
         "optimize": {
-          "description": "Optimizes the module.",
+          "description": "Optimizes the module",
           "type": "boolean"
         },
         "optimizeLevel": {
-          "description": "How much to focus on optimizing code.",
+          "description": "How much to focus on optimizing code",
           "type": "number",
           "minimum": 0,
           "maximum": 3
         },
         "shrinkLevel": {
-          "description": "How much to focus on shrinking code size.",
+          "description": "How much to focus on shrinking code size",
           "type": "number",
           "minimum": 0,
           "maximum": 2
         },
         "converge": {
-          "description": "Re-optimizes until no further improvements can be made.",
+          "description": "Re-optimizes until no further improvements can be made",
           "type": "boolean"
         },
         "baseDir": {
           "$ref": "#/definitions/nonEmptyString",
-          "description": "Specifies the base directory of input and output files."
+          "description": "Specifies the base directory of input and output files"
         },
         "outFile": {
           "$ref": "#/definitions/nonEmptyString",
-          "description": "Specifies the WebAssembly output file (.wasm)."
+          "description": "Specifies the WebAssembly output file (.wasm)"
         },
         "textFile": {
           "$ref": "#/definitions/nonEmptyString",
-          "description": "Specifies the WebAssembly text output file (.wat)."
+          "description": "Specifies the WebAssembly text output file (.wat)"
         },
         "bindings": {
-          "description": "Specified the bindings to generate.",
+          "description": "Specified the bindings to generate",
           "definitions": {
             "bindings": {
               "enum": ["esm", "raw"]
@@ -97,7 +96,7 @@
           ]
         },
         "sourceMap": {
-          "description": "Enables source map generation. Optionally takes the URL.",
+          "description": "Enables source map generation. Optionally takes the URL",
           "anyOf": [
             {
               "type": "boolean"
@@ -108,10 +107,9 @@
           ]
         },
         "runtime": {
-          "description": "Specifies the runtime variant to include in the program.",
+          "description": "Specifies the runtime variant to include in the program",
           "anyOf": [
             {
-              "type": "string",
               "enum": ["incremental", "minimal", "stub"]
             },
             {
@@ -120,88 +118,87 @@
           ]
         },
         "noUnsafe": {
-          "description": "Disallows the use of unsafe features in user code.",
+          "description": "Disallows the use of unsafe features in user code",
           "type": "boolean"
         },
         "debug": {
-          "description": "Enables debug information in emitted binaries.",
+          "description": "Enables debug information in emitted binaries",
           "type": "boolean"
         },
         "noAssert": {
-          "description": "Replaces assertions with just their value without trapping.",
+          "description": "Replaces assertions with just their value without trapping",
           "type": "boolean"
         },
         "noEmit": {
-          "description": "Performs compilation as usual but does not emit code.",
+          "description": "Performs compilation as usual but does not emit code",
           "type": "boolean"
         },
         "importMemory": {
-          "description": "Imports the memory provided as 'env.memory'.",
+          "description": "Imports the memory provided as 'env.memory'",
           "type": "boolean"
         },
         "noExportMemory": {
-          "description": "Does not export the memory as 'memory'.",
+          "description": "Does not export the memory as 'memory'",
           "type": "boolean"
         },
         "initialMemory": {
-          "description": "Sets the initial memory size in pages.",
+          "description": "Sets the initial memory size in pages",
           "type": "number"
         },
         "maximumMemory": {
-          "description": "Sets the maximum memory size in pages.",
+          "description": "Sets the maximum memory size in pages",
           "type": "number"
         },
         "sharedMemory": {
-          "description": "Declare memory as shared. Requires maximumMemory.",
+          "description": "Declare memory as shared. Requires maximumMemory",
           "type": "number"
         },
         "zeroFilledMemory": {
-          "description": "Assume that imported memory is zero filled. Requires importMemory.",
+          "description": "Assume that imported memory is zero filled. Requires importMemory",
           "type": "boolean"
         },
         "memoryBase": {
-          "description": "Sets the start offset of compiler-generated static memory.",
+          "description": "Sets the start offset of compiler-generated static memory",
           "type": "number"
         },
         "importTable": {
-          "description": "Imports the function table provided as 'env.table'.",
+          "description": "Imports the function table provided as 'env.table'",
           "type": "boolean"
         },
         "exportTable": {
-          "description": "Exports the function table as 'table'.",
+          "description": "Exports the function table as 'table'",
           "type": "boolean"
         },
         "exportStart": {
           "$ref": "#/definitions/nonEmptyString",
-          "description": "Exports the start function instead of calling it implicitly."
+          "description": "Exports the start function instead of calling it implicitly"
         },
         "lib": {
           "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings",
-          "description": "Adds one or multiple paths to custom library components."
+          "description": "Adds one or multiple paths to custom library components"
         },
         "path": {
           "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings",
-          "description": "Adds one or multiple paths to package resolution."
+          "description": "Adds one or multiple paths to package resolution"
         },
         "use": {
           "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings",
-          "description": "Aliases a global object under another name."
+          "description": "Aliases a global object under another name"
         },
         "trapMode": {
-          "description": "Sets the trap mode to use.",
-          "type": "string",
+          "description": "Sets the trap mode to use",
           "enum": ["allow", "clamp", "js"]
         },
         "runPasses": {
           "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings",
-          "description": "Specifies additional Binaryen passes to run."
+          "description": "Specifies additional Binaryen passes to run"
         },
         "noValidate": {
-          "description": "Skips validating the module using Binaryen.",
+          "description": "Skips validating the module using Binaryen",
           "type": "boolean"
         },
         "enable": {
-          "description": "Enables WebAssembly features that are disabled by default.",
+          "description": "Enables WebAssembly features that are disabled by default",
           "anyOf": [
             {
               "$ref": "#/definitions/webAssemblyFeatures"
@@ -216,7 +213,7 @@
           ]
         },
         "disable": {
-          "description": "Disables WebAssembly features that are enabled by default.",
+          "description": "Disables WebAssembly features that are enabled by default",
           "anyOf": [
             {
               "$ref": "#/definitions/webAssemblyFeatures"
@@ -232,42 +229,42 @@
         },
         "transform": {
           "$ref": "#/definitions/nonEmptyStringOrArrayOfNonEmptyStrings",
-          "description": "Specifies the path to a custom transform to 'require'."
+          "description": "Specifies the path to a custom transform to 'require'"
         },
         "pedantic": {
-          "description": "Make yourself sad for no good reason.",
+          "description": "Make yourself sad for no good reason",
           "type": "boolean"
         },
         "stats": {
-          "description": "Prints measuring information on I/O and compile times.",
+          "description": "Prints measuring information on I/O and compile times",
           "type": "boolean"
         },
         "noColors": {
-          "description": "Disables terminal colors.",
+          "description": "Disables terminal colors",
           "type": "boolean"
         },
         "exportRuntime": {
-          "description": "Exports the runtime helpers (__new, __collect etc.).",
+          "description": "Exports the runtime helpers (__new, __collect etc.)",
           "type": "boolean"
         },
         "stackSize": {
-          "description": "Exports the runtime helpers (__new, __collect etc.).",
+          "description": "Exports the runtime helpers (__new, __collect etc.)",
           "type": "number",
           "minimum": 0
         },
         "lowMemoryLimit": {
-          "description": "Enforces very low (<64k) memory constraints.",
+          "description": "Enforces very low (<64k) memory constraints",
           "type": "number",
           "minimum": 0
         },
         "tableBase": {
-          "description": "Sets the start offset of emitted table elements.",
+          "description": "Sets the start offset of emitted table elements",
           "type": "number",
           "minimum": 0
         },
         "wasm": {
           "$ref": "#/definitions/nonEmptyString",
-          "description": "Uses the specified Wasm binary of the compiler."
+          "description": "Uses the specified Wasm binary of the compiler"
         }
       }
     }


### PR DESCRIPTION
Description
This PR addresses schema linting and formatting inconsistencies in the following files:

* appsscript.json
* asconfig-schema.json

The updates focus exclusively on metadata cleanup and stylistic normalization, without introducing any structural or validation changes to the schemas.

* Removed trailing punctuation across multiple description fields to comply with SchemaStore style guidelines.
* Standardized formatting of arrays and object properties to improve readability and consistency.
* Resolved minor lint warnings reported by schema validation tooling.
* Maintained all existing validation rules, references, defaults, and schema semantics.

Before and after:
*appsscript.json:* 

https://github.com/user-attachments/assets/b03c0300-f2ba-4209-8301-c52ce274b228



*asconfig-schema.json:* 

https://github.com/user-attachments/assets/50180754-0a65-4c9d-8290-62298d083ff9



Note: This PR was generated with assistance from the jsonschema CLI, developed by a member of the JSON Schema TSC. The editor extension used is built on the same CLI.
