### PR TITLE
Add new Serilog log-level "Off"

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -815,7 +815,8 @@
             "Information",
             "Warning",
             "Error",
-            "Fatal"
+            "Fatal",
+            "Off"
           ]
         },
         "LoggingLevelSwitch": {


### PR DESCRIPTION
Log level "Off" was introduced in Serilog at https://github.com/nblumhardt/serilog/commit/9b92c29c282b9cc6a7bfb540c470e8417ae594e7 

However for some time Serilog did not support this log level when reading appsetting.json configuration (see https://github.com/serilog/serilog/issues/2212).

Fix for that was introduced in https://github.com/serilog/serilog-settings-configuration/pull/465/

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
