### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.52

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -162,7 +162,7 @@
     "autoUpdatesChannel": {
       "type": "string",
       "enum": ["stable", "latest"],
-      "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release",
+      "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release. Set DISABLE_AUTOUPDATER=1 to disable updates entirely.",
       "default": "latest"
     },
     "awsCredentialExport": {
@@ -187,7 +187,7 @@
     "env": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Environment variables to set for Claude Code sessions. See https://code.claude.com/docs/en/model-config#environment-variables for notable variables like CLAUDE_CODE_DISABLE_1M_CONTEXT (disables 1M token context window variants)",
+      "description": "Environment variables to set for Claude Code sessions. Many environment variables provide settings dimensions not available as dedicated settings.json properties (e.g., thinking tokens, prompt caching, bash timeouts, shell configuration). See https://code.claude.com/docs/en/settings#environment-variables for the full list. UNDOCUMENTED: CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS (plugin marketplace git timeout in ms, default 120000, see https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151).",
       "examples": [
         {
           "ANTHROPIC_MODEL": "claude-opus-4-1",
@@ -306,7 +306,7 @@
     },
     "model": {
       "type": "string",
-      "description": "Override the default model used by Claude Code. See https://code.claude.com/docs/en/model-config"
+      "description": "Override the default model used by Claude Code. For finer control, use environment variables: ANTHROPIC_MODEL (runtime override), ANTHROPIC_DEFAULT_OPUS_MODEL, ANTHROPIC_DEFAULT_SONNET_MODEL, ANTHROPIC_DEFAULT_HAIKU_MODEL (per-class pinning), CLAUDE_CODE_SUBAGENT_MODEL (subagent model). See https://code.claude.com/docs/en/model-config"
     },
     "availableModels": {
       "type": "array",
@@ -319,7 +319,7 @@
     "effortLevel": {
       "type": "string",
       "enum": ["low", "medium", "high"],
-      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
+      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
       "default": "high"
     },
     "fastMode": {


### PR DESCRIPTION
## Schema

- Update `env` description to reference comprehensive [settings#environment-variables](https://code.claude.com/docs/en/settings#environment-variables) page instead of model-config subset, and note that many env vars provide settings dimensions not available as dedicated settings.json properties ([v2.1.51](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151))
- Add UNDOCUMENTED `CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS` env var reference — plugin marketplace git timeout in ms, default 120000 ([v2.1.51](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151))
- Add finer-grained model env var references to `model` description: `ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL` — first env var audit
- Add `CLAUDE_CODE_EFFORT_LEVEL` env var reference to `effortLevel` description — first env var audit
- Add `DISABLE_AUTOUPDATER` env var reference to `autoUpdatesChannel` description — first env var audit

## Tests

- No test changes needed — all changes are description-only (no new properties, enums, types, or constraints)

## Skipped

- `$schema` URL http→https redirect: Schemastore CLI validator only accepts `http://json-schema.org/draft-07/schema#`
- v2.1.51 `startupTimeout` for LSP servers: belongs in `.lsp.json`, not `settings.json`
- v2.1.52: VS Code crash fix only, no schema impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)