### PR TITLE
Add Hashgraph Online skill manifest schema catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5,7 +5,11 @@
     {
       "name": "Hashgraph Online Skill Manifest",
       "description": "Manifest for Hashgraph Online Registry Broker skill packages",
-      "fileMatch": ["**/.hol/skill.json", "**/hol/skill.json", "hol-skill.json"],
+      "fileMatch": [
+        "**/.hol/skill.json",
+        "**/hol/skill.json",
+        "hol-skill.json"
+      ],
       "url": "https://raw.githubusercontent.com/hashgraph-online/skill-publish/main/schemas/skill.schema.json"
     },
     {


### PR DESCRIPTION
## Summary
- add a catalog entry for the Hashgraph Online skill manifest schema
- map common manifest filenames (`skill.json`, `hol-skill.json`, and `**/.hol/skill.json`)
- point to the canonical published schema in `hashgraph-online/registry-broker-skills`

## Validation
- `node ./cli.js check`

Closes #5405
