### PR TITLE
Add mockd.yaml schema (multi-protocol API mock server)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4266,6 +4266,21 @@
       "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
     },
     {
+      "name": "mockd.yaml",
+      "description": "mockd multi-protocol API mock server configuration file. See https://mockd.io",
+      "fileMatch": [
+        "mockd.yaml",
+        "mockd.yml",
+        "mockd.json",
+        ".mockd.yaml",
+        ".mockd.yml",
+        ".mockd.json",
+        "mocks.yaml",
+        "mocks.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/getmockd/mockd/main/schema/mockd.schema.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],


### PR DESCRIPTION
## Summary

Adds a catalog entry for [mockd](https://mockd.io), a multi-protocol API mock server.

- **Schema location:** Self-hosted at `https://raw.githubusercontent.com/getmockd/mockd/main/schema/mockd.schema.json`
- **File matches:** `mockd.yaml`, `mockd.yml`, `mockd.json`, `.mockd.yaml`, `.mockd.yml`, `.mockd.json`, `mocks.yaml`, `mocks.yml`
- **Schema draft:** Draft-07
- **Coverage:** HTTP, GraphQL, gRPC, WebSocket, MQTT, SSE, SOAP, OAuth mock definitions, stateful resources, custom operations, chaos engineering config, and server settings

### About mockd

mockd is an open-source (Apache 2.0) API mock server that supports 7 protocols from a single binary. Configuration is done via YAML/JSON files, and the schema enables autocompletion and validation in VS Code, JetBrains IDEs, and other editors.

- GitHub: https://github.com/getmockd/mockd
- Website: https://mockd.io
- Schema file: https://github.com/getmockd/mockd/blob/main/schema/mockd.schema.json