### PR TITLE
fix: update URLs after org rename from 4lando to lando-community

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -871,9 +871,9 @@
     },
     {
       "name": "Lando (landofile)",
-      "description": "The configuration file for a Lando app. Documentation: https://github.com/4lando/lando-spec",
+      "description": "The configuration file for a Lando app. Documentation: https://github.com/lando-community/lando-spec",
       "fileMatch": [".lando.yml", ".lando.*.yml"],
-      "url": "https://4lando.github.io/lando-spec/landofile-spec.json"
+      "url": "https://lando-community.github.io/lando-spec/landofile-spec.json"
     },
     {
       "name": "latexindent configuration",


### PR DESCRIPTION
The `4lando` GitHub org was renamed to `lando-community`. While GitHub redirects repository URLs automatically, **GitHub Pages URLs do not redirect** — meaning `4lando.github.io` returns 404.

This updates all references from `4lando` to `lando-community` to fix broken URLs.

The most critical change: the Lando schema URL (`4lando.github.io/lando-spec/landofile-spec.json`) is a 404, breaking IDE validation for all Lando users.