### PR TITLE
Upgrade appsettings.json schema to draft-07

### DIFF
--- a/src/schemas/json/appsettings.json
+++ b/src/schemas/json/appsettings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/appsettings.json",
   "definitions": {
     "webOptimizer": {
       "title": "web optimizer",
@@ -939,7 +940,6 @@
       }
     }
   },
-  "$id": "https://json.schemastore.org/appsettings.json",
   "patternProperties": {
     "^WebOptimizer$": {
       "$ref": "#/definitions/webOptimizer"


### PR DESCRIPTION
Update to JSON Schema Draft 7 to enable more modern schema keywords (for example, `if`), via the [`JsonSchemaSegment`](https://github.com/dotnet/aspnetcore/issues/53737) feature. This change directly supports ongoing work by the Azure SDK team (see https://github.com/Azure/azure-sdk-for-net/issues/55538). Draft 7 schema support is available in Visual Studio 2022 17.3 and later, per https://developercommunity.visualstudio.com/t/support-json-schema-draft-06-draft-07/796216. It's also available in the VS Code 1.22 ([August 2018](https://github.com/microsoft/vscode/issues/46322#issuecomment-423515014)) release and later. /cc: @eerhardt @m-nash