### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.63

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -121,6 +121,48 @@
               "description": "Custom spinner message displayed while the hook runs"
             }
           }
+        },
+        {
+          "type": "object",
+          "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hooks",
+          "additionalProperties": false,
+          "required": ["type", "url"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Hook type",
+              "const": "http"
+            },
+            "url": {
+              "type": "string",
+              "description": "URL to POST hook input JSON to. Endpoint must accept POST requests and return JSON.",
+              "minLength": 1
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Custom HTTP headers (e.g., Authorization: Bearer token). Values support $VAR_NAME or ${VAR_NAME} interpolation."
+            },
+            "allowedEnvVars": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "List of environment variable names permitted for interpolation in headers. If not set, no env var interpolation is allowed."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Optional timeout in seconds (default: 30)",
+              "exclusiveMinimum": 0
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "Custom spinner message displayed while the hook runs"
+            }
+          }
         }
       ]
     },
@@ -159,6 +201,11 @@
       "examples": ["/bin/generate_temp_api_key.sh"],
       "minLength": 1
     },
+    "autoMemoryEnabled": {
+      "type": "boolean",
+      "description": "Enable automatic memory saves that capture useful context to .claude/memory/. Also configurable via CLAUDE_CODE_DISABLE_AUTO_MEMORY environment variable (set to 1 to disable, 0 to enable). See https://code.claude.com/docs/en/memory#auto-memory",
+      "default": true
+    },
     "autoUpdatesChannel": {
       "type": "string",
       "enum": ["stable", "latest"],
@@ -187,7 +234,7 @@
     "env": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Environment variables to set for Claude Code sessions. Many environment variables provide settings dimensions not available as dedicated settings.json properties (e.g., thinking tokens, prompt caching, bash timeouts, shell configuration). See https://code.claude.com/docs/en/settings#environment-variables for the full list. UNDOCUMENTED: CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS (plugin marketplace git timeout in ms, default 120000, see https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151).",
+      "description": "Environment variables to set for Claude Code sessions. Many environment variables provide settings dimensions not available as dedicated settings.json properties (e.g., thinking tokens, prompt caching, bash timeouts, shell configuration). See https://code.claude.com/docs/en/settings#environment-variables for the full list.\nUNDOCUMENTED: CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS (plugin marketplace git timeout in ms, default 120000, see https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151).\nUNDOCUMENTED: ENABLE_CLAUDEAI_MCP_SERVERS (set to false to opt out of claude.ai MCP servers, see https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163).",
       "examples": [
         {
           "ANTHROPIC_MODEL": "claude-opus-4-1",
@@ -1098,6 +1145,37 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable sandboxed bash"
+        },
+        "filesystem": {
+          "type": "object",
+          "description": "Filesystem access control for sandboxed commands. See https://code.claude.com/docs/en/sandboxing#filesystem-isolation",
+          "properties": {
+            "allowWrite": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Paths where subprocesses are allowed to write. Supports prefixes: // (absolute), ~/ (home directory), / (relative to settings file), ./ or no prefix (relative path)"
+            },
+            "denyWrite": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Paths where subprocesses are explicitly denied write access. Takes precedence over allowWrite"
+            },
+            "denyRead": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Paths where subprocesses are explicitly denied read access"
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -17,6 +17,16 @@
           {
             "command": "osascript -e 'display notification \"Claude task complete\" with title \"Claude Code\"'",
             "type": "command"
+          },
+          {
+            "allowedEnvVars": ["WEBHOOK_SECRET"],
+            "headers": {
+              "X-Hook-Secret": "$WEBHOOK_SECRET"
+            },
+            "statusMessage": "Sending notification webhook",
+            "timeout": 15,
+            "type": "http",
+            "url": "http://localhost:8080/hooks/notification"
           }
         ]
       }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -8,6 +8,7 @@
     "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
     "pr": ""
   },
+  "autoMemoryEnabled": false,
   "autoUpdatesChannel": "latest",
   "availableModels": ["sonnet", "haiku"],
   "awsAuthRefresh": "aws sso login --profile myprofile",
@@ -93,6 +94,16 @@
             "command": "osascript -e 'display notification \"Task completed\" with title \"Claude Code\"'",
             "timeout": 3,
             "type": "command"
+          },
+          {
+            "allowedEnvVars": ["HOOK_TOKEN"],
+            "headers": {
+              "Authorization": "Bearer $HOOK_TOKEN"
+            },
+            "statusMessage": "Notifying webhook",
+            "timeout": 10,
+            "type": "http",
+            "url": "https://hooks.example.com/session-end"
           }
         ]
       }
@@ -166,6 +177,11 @@
     "enableWeakerNestedSandbox": false,
     "enabled": true,
     "excludedCommands": ["docker", "git"],
+    "filesystem": {
+      "allowWrite": ["~/.kube", "//tmp/build"],
+      "denyRead": ["~/.ssh/id_rsa"],
+      "denyWrite": ["//etc", "//usr"]
+    },
     "network": {
       "allowAllUnixSockets": false,
       "allowLocalBinding": true,


### PR DESCRIPTION
## Schema

- Add HTTP hook handler type (`type: "http"`) with `url`, `headers`, `allowedEnvVars`, `timeout`, `statusMessage` fields, as per [hooks documentation](https://code.claude.com/docs/en/hooks#http-hooks) ([v2.1.63](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163))
- Add `autoMemoryEnabled` boolean property (default `true`) with `CLAUDE_CODE_DISABLE_AUTO_MEMORY` env var reference, as per [memory documentation](https://code.claude.com/docs/en/memory#auto-memory) ([v2.1.59](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2159))
- Add `sandbox.filesystem` object with `allowWrite`, `denyWrite`, `denyRead` path arrays, as per [sandboxing documentation](https://code.claude.com/docs/en/sandboxing#filesystem-isolation)
- Add UNDOCUMENTED `ENABLE_CLAUDEAI_MCP_SERVERS` env var reference — set to `false` to opt out of claude.ai MCP servers ([v2.1.63](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163))
- Update `env` description to reference [settings#environment-variables](https://code.claude.com/docs/en/settings#environment-variables) instead of model-config subset, and note that many env vars provide settings dimensions not available as dedicated settings.json properties
- Add UNDOCUMENTED `CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS` env var reference — plugin marketplace git timeout in ms, default 120000 ([v2.1.51](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2151))
- Update `model` description with per-class env var references (`ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, etc.)
- Update `effortLevel` description with `CLAUDE_CODE_EFFORT_LEVEL` env var reference
- Update `autoUpdatesChannel` description with `DISABLE_AUTOUPDATER=1` reference

## Tests

- Add `autoMemoryEnabled: false` to modern-complete-config.json (non-default value for coverage)
- Add HTTP hook examples to modern-complete-config.json and hooks-complete.json
- Add `sandbox.filesystem` with sample paths to modern-complete-config.json
- Changes made to pass coverage gate: autoMemoryEnabled test completeness and default value coverage

## Negative tests

- No changes needed — existing negative tests cover hook type validation

## Skipped

- Network env vars (HTTPS_PROXY, NODE_EXTRA_CA_CERTS, etc.) — standard system/Node.js vars, not Claude Code settings.json properties
- 9 undocumented tools in permissionRule pattern (ExitPlanMode, KillShell, LS, LSP, ToolSearch, Task*) — may be intentionally undocumented internals, no removal
- Supersedes #5406 (v2.1.52 sync, now closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)