### PR TITLE
Add 3 more `FormatStyle` values for `.clang-tidy`

### DIFF
--- a/src/schemas/json/clang-tidy.json
+++ b/src/schemas/json/clang-tidy.json
@@ -90,7 +90,17 @@
       "description": "Style for formatting code around applied fixes.",
       "oneOf": [
         {
-          "enum": ["none", "file", "llvm", "google", "webkit", "mozilla", "chromium", "microsoft", "gnu"],
+          "enum": [
+            "none",
+            "file",
+            "llvm",
+            "google",
+            "webkit",
+            "mozilla",
+            "chromium",
+            "microsoft",
+            "gnu"
+          ],
           "type": "string"
         },
         {


### PR DESCRIPTION
The previous values were only the ones listed in the docs for clang-tidy itself, but it references to check clang-format for the actual values. Clang-format also supports `chromium`, `microsoft` and `gnu`.

I also checked in source and I was unable to find anything that indicated that clang-tidy doesn't support these values as well.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
