### PR TITLE
Add missing `forwardAuth` options to Traefik v3 file provider schema

### DIFF
--- a/src/schemas/json/traefik-v3-file-provider.json
+++ b/src/schemas/json/traefik-v3-file-provider.json
@@ -601,6 +601,30 @@
           "items": {
             "type": "string"
           }
+        },
+        "forwardBody": {
+          "type": "boolean",
+          "description": "Sets the forwardBody option to true to send the Body. As body is read inside Traefik before forwarding, this breaks streaming."
+        },
+        "maxBodySize": {
+          "type": "number",
+          "description": "Sets the maxBodySize to limit the body size in bytes. If body is bigger than this, it returns a 401 (unauthorized)."
+        },
+        "maxResponseBodySize": {
+          "type": "number",
+          "description": "Sets the maxResponseBodySize to limit the response body size from the authentication server in bytes."
+        },
+        "headerField": {
+          "type": "string",
+          "description": "Defines a header field to store the authenticated user."
+        },
+        "preserveLocationHeader": {
+          "type": "boolean",
+          "description": "Defines whether to forward the Location header to the client as is or prefix it with the domain name of the authentication server."
+        },
+        "preserveRequestMethod": {
+          "type": "boolean",
+          "description": "Defines whether to preserve the original request method while forwarding the request to the authentication server."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adding missing `forwardAuth` options.

As stated in the Traefik documentation: https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/forwardauth