### PR TITLE
fix: directly use tox.json

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -328,7 +328,7 @@
     "partial-poe.json", // pyproject.json[tool.poe]
     "partial-poetry.json", // pyproject.json[tool.poetry]
     "partial-repo-review.json", // pyproject.json[tool.repo-review]
-    "partial-tox.json", // pyproject.json[tool.tox]
+    "partial-tox.json", // classic pyproject.json[tool.tox]
     "tox.json",
     "partial-eslint-plugins.json", // eslintrc.json[rules.*]
     "partial-fusion-pack-metadata.json", // minecraft-pack-mcmeta.json[fusion]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -1053,7 +1053,7 @@
           "description": "Tombi is a toolkit for TOML; providing a formatter/linter and language server"
         },
         "tox": {
-          "$ref": "https://json.schemastore.org/partial-tox.json",
+          "$ref": "https://json.schemastore.org/tox.json",
           "title": "Testing Framework",
           "description": "Standardized automated testing of Python packages"
         },


### PR DESCRIPTION
This is testing the idea I proposed in https://github.com/SchemaStore/schemastore/pull/5402 to simplify usage of tox in pyproject.toml. The `partial` schemas are only needed if there isn't a matching custom file.
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
