### PR TITLE
Update tox JSON Schema to 4.47.2

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -41,7 +41,9 @@
           },
           {
             "type": "object",
-            "required": ["product"],
+            "required": [
+              "product"
+            ],
             "properties": {
               "product": {
                 "type": "array",
@@ -55,7 +57,9 @@
                     },
                     {
                       "type": "object",
-                      "required": ["prefix"],
+                      "required": [
+                        "prefix"
+                      ],
                       "properties": {
                         "prefix": {
                           "type": "string"
@@ -130,7 +134,9 @@
             },
             {
               "type": "object",
-              "required": ["product"],
+              "required": [
+                "product"
+              ],
               "properties": {
                 "product": {
                   "type": "array",
@@ -144,7 +150,9 @@
                       },
                       {
                         "type": "object",
-                        "required": ["prefix"],
+                        "required": [
+                          "prefix"
+                        ],
                         "properties": {
                           "prefix": {
                             "type": "string"
@@ -262,7 +270,9 @@
               },
               {
                 "type": "object",
-                "required": ["product"],
+                "required": [
+                  "product"
+                ],
                 "properties": {
                   "product": {
                     "type": "array",
@@ -276,7 +286,9 @@
                         },
                         {
                           "type": "object",
-                          "required": ["prefix"],
+                          "required": [
+                            "prefix"
+                          ],
                           "properties": {
                             "prefix": {
                               "type": "string"
@@ -612,8 +624,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "$ref": "#/properties/env_run_base",
       "type": "object",
+      "$ref": "#/properties/env_run_base",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -679,7 +691,9 @@
               "type": "boolean"
             }
           },
-          "required": ["replace"],
+          "required": [
+            "replace"
+          ],
           "additionalProperties": false
         },
         {
@@ -711,7 +725,10 @@
               "type": "boolean"
             }
           },
-          "required": ["replace", "of"],
+          "required": [
+            "replace",
+            "of"
+          ],
           "additionalProperties": false
         }
       ]


### PR DESCRIPTION
Updates tox's JSON Schema to [66eb1ea894f3f5d58a245897e99567986ee76785](https://github.com/tox-dev/tox/commit/66eb1ea894f3f5d58a245897e99567986ee76785) (release 4.47.2).