### PR TITLE
Add opentelemetry declarative configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,20 +3,6 @@
   "version": 1,
   "schemas": [
     {
-      "name": "OpenTelemetry Declarative Configuration",
-      "description": "OpenTelemetry schema for configuring SDKs and instrumentation in a declarative manner",
-      "fileMatch": [
-        "opentelemetry*.yaml",
-        "opentelemetry*.yml",
-        "otel*.yaml",
-        "otel*.yml"
-      ],
-      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json",
-      "versions": {
-        "1.0.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json"
-      }
-    },
-    {
       "name": "release-hub.json",
       "description": "Configuration file for Release Hub",
       "fileMatch": [
@@ -4532,6 +4518,20 @@
       "description": "OpenRewrite resource descriptors",
       "fileMatch": ["**/META-INF/rewrite/*.yml"],
       "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
+    },
+    {
+      "name": "OpenTelemetry Declarative Configuration",
+      "description": "OpenTelemetry declarative configuration for SDKs and instrumentation",
+      "fileMatch": [
+        "opentelemetry*.yaml",
+        "opentelemetry*.yml",
+        "otel*.yaml",
+        "otel*.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json",
+      "versions": {
+        "1.0.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json"
+      }
     },
     {
       "name": "Open Data Contract Standard (ODCS)",


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-configuration/issues/468.

Context:

- [OpenTelemetry declarative configuration](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/configuration#declarative-configuration) is a config interface for OpenTelemetry SDKs, aimed at being language agnostic and more expressive than env vars
- We recently marked it as stable in the opentelemetry specification: https://github.com/open-telemetry/opentelemetry-specification/pull/4568
- The JSON schema lives in [opentelemetry-configuration/opentelemetry_configuration.json](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/opentelemetry_configuration.json)

We think it would be a great addition to SchemaStore!

cc @open-telemetry/configuration-approvers (i.e. @tsloughter, @codeboten, @brettmc, @MrAlias, @marcalff)