### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.69

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
-      "pattern": "^((Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|LSP|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|LSP|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -20,6 +20,7 @@
         "Read(./secrets/**)",
         "Read(//Users/alice/secrets/**)",
         "Read(~/Documents/*.pdf)",
+        "Agent(Explore)",
         "Task(Explore)",
         "WebFetch",
         "WebFetch(domain:example.com)",
@@ -264,6 +265,11 @@
         }
       }
     },
+    "includeGitInstructions": {
+      "type": "boolean",
+      "description": "Include built-in git commit and PR workflow instructions in Claude's system prompt. Also configurable via CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS environment variable (set to 1 to disable). See https://code.claude.com/docs/en/settings#available-settings",
+      "default": true
+    },
     "includeCoAuthoredBy": {
       "type": "boolean",
       "description": "DEPRECATED. Use 'attribution' instead. Whether to include the co-authored-by Claude byline in git commits and pull requests (default: true)",
@@ -317,7 +323,7 @@
             "dontAsk",
             "plan"
           ],
-          "description": "Default permission mode.\n\"default\": prompts on first use.\n\"acceptEdits\": auto-accepts file edits.\n\"plan\": read-only, no modifications.\n\"delegate\": coordination-only for agent team leads (agent teams are experimental; enable via CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).\n\"dontAsk\": auto-denies unless pre-approved via permissions.\n\"bypassPermissions\": skips all prompts (use only in isolated environments).\nSee https://code.claude.com/docs/en/permissions"
+          "description": "Default permission mode.\n\"default\": prompts on first use.\n\"acceptEdits\": auto-accepts file edits.\n\"plan\": read-only, no modifications.\nUNDOCUMENTED. \"delegate\": coordination-only for agent team leads (agent teams are experimental; enable via CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).\n\"dontAsk\": auto-denies unless pre-approved via permissions.\n\"bypassPermissions\": skips all prompts (use only in isolated environments).\nSee https://code.claude.com/docs/en/permissions"
         },
         "disableBypassPermissionsMode": {
           "type": "string",
@@ -366,12 +372,17 @@
     "effortLevel": {
       "type": "string",
       "enum": ["low", "medium", "high"],
-      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
+      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Opus 4.6 defaults to medium effort for Max and Team subscribers. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
       "default": "high"
     },
     "fastMode": {
       "type": "boolean",
       "description": "Enable fast mode for Opus 4.6 (research preview). Fast mode uses the same model with 2.5x faster output at higher per-token cost. Requires extra usage enabled. Alternatively, toggle with /fast command. See https://code.claude.com/docs/en/fast-mode",
+      "default": false
+    },
+    "fastModePerSessionOptIn": {
+      "type": "boolean",
+      "description": "Require per-session opt-in for fast mode. When true, fast mode does not persist across sessions and users must enable it with /fast each session. Useful for controlling costs. See https://code.claude.com/docs/en/fast-mode",
       "default": false
     },
     "enableAllProjectMcpServers": {
@@ -599,6 +610,13 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "InstructionsLoaded": {
+          "type": "array",
+          "description": "Hooks that run when a CLAUDE.md or .claude/rules/*.md file is loaded into context. Fires at session start and when files are lazily loaded (e.g., nested traversal, path glob match). No decision control; used for audit logging and observability. Does not support matchers. See https://code.claude.com/docs/en/hooks#instructionsloaded",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "ConfigChange": {
           "type": "array",
           "description": "Hooks that run when settings, managed settings, or skill files change during a session. Supports matchers: user_settings, project_settings, local_settings, policy_settings, skills. Command handlers only. Exit code 2 blocks the change (except policy_settings which is audit-only). See https://code.claude.com/docs/en/hooks#configchange",
@@ -646,7 +664,7 @@
     },
     "allowManagedPermissionRulesOnly": {
       "type": "boolean",
-      "description": "(Managed settings only) Prevent user and project settings from defining allow, ask, or deny permission rules. Only rules in managed settings apply. See https://code.claude.com/docs/en/settings"
+      "description": "(Managed settings only) Prevent user and project settings from defining allow, ask, or deny permission rules. Only rules in managed settings apply. See https://code.claude.com/docs/en/settings#permission-settings"
     },
     "statusLine": {
       "type": "object",
@@ -1008,6 +1026,22 @@
             },
             "required": ["source", "path"],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "Identifies the marketplace source type",
+                "const": "pathPattern"
+              },
+              "pathPattern": {
+                "type": "string",
+                "description": "Regex pattern to match file or directory paths for marketplace sources"
+              }
+            },
+            "required": ["source", "pathPattern"],
+            "additionalProperties": false
           }
         ]
       },
@@ -1134,6 +1168,11 @@
           "description": "Automatically allow bash commands without prompting when they run in the sandbox. Only applies to commands that will run sandboxed.",
           "default": true
         },
+        "enableWeakerNetworkIsolation": {
+          "type": "boolean",
+          "description": "macOS only. Allow access to the system TLS trust service (com.apple.trustd.agent) in the sandbox. Required for Go-based tools like gh, gcloud, and terraform to verify TLS certificates when using httpProxyPort with a MITM proxy and custom CA. Reduces security by opening a potential data exfiltration path. Default: false. See https://code.claude.com/docs/en/settings#sandbox-settings",
+          "default": false
+        },
         "enableWeakerNestedSandbox": {
           "type": "boolean",
           "description": "Enable weaker sandbox mode for unprivileged docker environments where --proc mounting fails. This significantly reduces the strength of the sandbox and should only be used when this risk is acceptable.Default: false (secure)."
@@ -1209,7 +1248,7 @@
     },
     "spinnerTipsOverride": {
       "type": "object",
-      "description": "Customize the tips displayed in the spinner while Claude is working. See https://code.claude.com/docs/en/settings",
+      "description": "Customize the tips displayed in the spinner while Claude is working. See https://code.claude.com/docs/en/settings#available-settings",
       "properties": {
         "excludeDefault": {
           "type": "boolean",
@@ -1261,6 +1300,11 @@
       "enum": ["auto", "in-process", "tmux"],
       "description": "How agent team teammates display: \"auto\" picks split panes in tmux or iTerm2, in-process otherwise. Agent teams are experimental and disabled by default. Enable them by adding CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to your settings.json or environment. See https://code.claude.com/docs/en/agent-teams",
       "default": "auto"
+    },
+    "pluginTrustMessage": {
+      "type": "string",
+      "description": "(Managed settings only) Custom message appended to the plugin trust warning shown before installation. Use to provide organization-specific context about approved plugins. See https://code.claude.com/docs/en/settings#plugin-settings",
+      "minLength": 1
     },
     "pluginConfigs": {
       "type": "object",
@@ -1441,6 +1485,22 @@
               }
             },
             "required": ["source", "hostPattern"]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "pathPattern",
+                "description": "Block marketplace by file/directory path pattern matching"
+              },
+              "pathPattern": {
+                "type": "string",
+                "description": "Regex pattern to match file or directory paths for marketplace sources"
+              }
+            },
+            "required": ["source", "pathPattern"]
           }
         ]
       }

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -11,6 +11,16 @@
         "matcher": "user_settings"
       }
     ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Instructions: loaded' >> /tmp/claude-instructions.log",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [

--- a/src/test/claude-code-settings/managed-settings.json
+++ b/src/test/claude-code-settings/managed-settings.json
@@ -24,6 +24,10 @@
       "source": "hostPattern"
     },
     {
+      "pathPattern": "^/restricted/.*",
+      "source": "pathPattern"
+    },
+    {
       "source": "git",
       "url": "https://github.com/untrusted-org/plugins.git"
     }
@@ -38,6 +42,7 @@
     "allow": ["Bash(git:*)", "Read"],
     "deny": ["Bash(rm:*)"]
   },
+  "pluginTrustMessage": "All plugins have been reviewed by our security team. Proceed with trust.",
   "sandbox": {
     "enabled": true,
     "network": {

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -13,6 +13,12 @@
   "availableModels": ["sonnet", "haiku"],
   "awsAuthRefresh": "aws sso login --profile myprofile",
   "awsCredentialExport": "/bin/generate_aws_grant.sh",
+  "blockedMarketplaces": [
+    {
+      "pathPattern": "^/untrusted/.*",
+      "source": "pathPattern"
+    }
+  ],
   "cleanupPeriodDays": 60,
   "companyAnnouncements": ["Welcome to the team!"],
   "disableAllHooks": false,
@@ -37,6 +43,7 @@
     }
   },
   "fastMode": true,
+  "fastModePerSessionOptIn": true,
   "fileSuggestion": {
     "command": "~/.claude/file-suggestion.sh",
     "type": "command"
@@ -53,6 +60,16 @@
           }
         ],
         "matcher": "user_settings"
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Instructions loaded' >> ~/.claude-code/instructions.log",
+            "type": "command"
+          }
+        ]
       }
     ],
     "PermissionRequest": [
@@ -130,6 +147,7 @@
     ]
   },
   "includeCoAuthoredBy": true,
+  "includeGitInstructions": false,
   "language": "english",
   "model": "opus",
   "otelHeadersHelper": "/usr/local/bin/otel-headers.sh",
@@ -137,6 +155,7 @@
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
     "allow": [
+      "Agent(Explore)",
       "Bash(git:*)",
       "Bash(npm:*)",
       "Edit",
@@ -169,12 +188,14 @@
       }
     }
   },
+  "pluginTrustMessage": "All plugins from our internal marketplace are pre-approved by the security team.",
   "prefersReducedMotion": true,
   "respectGitignore": false,
   "sandbox": {
     "allowUnsandboxedCommands": false,
     "autoAllowBashIfSandboxed": false,
     "enableWeakerNestedSandbox": false,
+    "enableWeakerNetworkIsolation": true,
     "enabled": true,
     "excludedCommands": ["docker", "git"],
     "filesystem": {

--- a/src/test/claude-code-settings/permissions-advanced.json
+++ b/src/test/claude-code-settings/permissions-advanced.json
@@ -2,6 +2,7 @@
   "permissions": {
     "additionalDirectories": ["~/Documents/shared-projects", "//tmp"],
     "allow": [
+      "Agent(Explore)",
       "Glob",
       "Grep",
       "Read(~/projects/**)",


### PR DESCRIPTION
## Schema

- Add `sandbox.enableWeakerNetworkIsolation` (boolean, macOS only) — Allows Go tools (gh, gcloud, terraform) to verify TLS certificates with MITM proxy. See [sandboxing docs](https://code.claude.com/docs/en/settings#sandbox-settings) (v2.1.69)
- Add `includeGitInstructions` (boolean, default true) — Control built-in git workflow instructions in system prompt. Env var: `CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS`. See [settings](https://code.claude.com/docs/en/settings#available-settings) (v2.1.69)
- Add `pluginTrustMessage` (string, managed-only) — Custom org-specific context in plugin trust warning. See [settings](https://code.claude.com/docs/en/settings#plugin-settings) (v2.1.69)
- Add `fastModePerSessionOptIn` (boolean, default false) — Require per-session \`/fast\` opt-in instead of persisting. See [fast-mode docs](https://code.claude.com/docs/en/fast-mode) (v2.1.69)
- Add \`Agent\` tool to \`permissionRule\` pattern — Control subagent access with \`Agent(Explore)\`, \`Agent(Plan)\`, etc. See [permissions docs](https://code.claude.com/docs/en/permissions#agent-subagents) (v2.1.69)
- Add \`InstructionsLoaded\` hook event — Fires when CLAUDE.md or .claude/rules/*.md loaded. No matchers, no decision control. See [hooks docs](https://code.claude.com/docs/en/hooks#instructionsloaded) (v2.1.69)
- Add \`pathPattern\` source type to \`strictKnownMarketplaces\` and \`blockedMarketplaces\` — Regex-matching for file/directory marketplace paths. See [marketplace docs](https://code.claude.com/docs/en/settings#strictknownmarketplaces) (v2.1.69)
- Add UNDOCUMENTED prefix to \`delegate\` permission mode — Experimental agent teams feature (requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag)
- Enhance \`effortLevel\` description to note Max/Team subscribers default to medium effort (v2.1.68)
- Update settings.json doc links with section anchors for better navigation (#permission-settings, #available-settings, #sandbox-settings, #plugin-settings)

## Tests

- Add all new properties to modern-complete-config.json for comprehensive coverage
- Add InstructionsLoaded hook to hooks-complete.json (all hook types now covered)
- Add pluginTrustMessage and pathPattern examples to managed-settings.json
- Add Agent(Explore) permission example to permissions-advanced.json

## Coverage

✅ All 8 coverage checks passing
✅ Test completeness: 55/55 top-level properties covered
✅ Default value coverage: All 19 properties with defaults tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)