### PR TITLE
fix `verbosity_assertions` in the non-ini config format

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -1032,10 +1032,6 @@
               "pattern": "^[0-9]+$"
             },
             {
-              "type": "integer",
-              "minimum": 0
-            },
-            {
               "type": "string",
               "enum": ["auto"]
             }


### PR DESCRIPTION
`verbosity_assertions` in the new config format does not accept integers. attempting to set it to an int results in the following error at runtime:

```
config option 'verbosity_assertions' expects a string, got int: 2
```
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
