### PR TITLE
fix: updates version range for overlay schema

### DIFF
--- a/src/schemas/json/openapi-overlay-1.X.json
+++ b/src/schemas/json/openapi-overlay-1.X.json
@@ -6,7 +6,7 @@
   "required": ["overlay"],
   "properties": {
     "overlay": {
-      "pattern": "^1\\.0\\.",
+      "pattern": "^1\\.(0|1)\\.",
       "type": "string"
     }
   },


### PR DESCRIPTION
follow up to #5286 where this update was missed for version 1.1