### PR TITLE
Update tox JSON Schema to 4.49.0

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -41,9 +41,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "product"
-            ],
+            "required": ["product"],
             "properties": {
               "product": {
                 "type": "array",
@@ -57,9 +55,7 @@
                     },
                     {
                       "type": "object",
-                      "required": [
-                        "prefix"
-                      ],
+                      "required": ["prefix"],
                       "properties": {
                         "prefix": {
                           "type": "string"
@@ -78,9 +74,7 @@
                       "minProperties": 1,
                       "maxProperties": 1,
                       "not": {
-                        "required": [
-                          "prefix"
-                        ]
+                        "required": ["prefix"]
                       },
                       "additionalProperties": {
                         "type": "array",
@@ -151,9 +145,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "product"
-              ],
+              "required": ["product"],
               "properties": {
                 "product": {
                   "type": "array",
@@ -167,9 +159,7 @@
                       },
                       {
                         "type": "object",
-                        "required": [
-                          "prefix"
-                        ],
+                        "required": ["prefix"],
                         "properties": {
                           "prefix": {
                             "type": "string"
@@ -188,9 +178,7 @@
                         "minProperties": 1,
                         "maxProperties": 1,
                         "not": {
-                          "required": [
-                            "prefix"
-                          ]
+                          "required": ["prefix"]
                         },
                         "additionalProperties": {
                           "type": "array",
@@ -304,9 +292,7 @@
               },
               {
                 "type": "object",
-                "required": [
-                  "product"
-                ],
+                "required": ["product"],
                 "properties": {
                   "product": {
                     "type": "array",
@@ -320,9 +306,7 @@
                         },
                         {
                           "type": "object",
-                          "required": [
-                            "prefix"
-                          ],
+                          "required": ["prefix"],
                           "properties": {
                             "prefix": {
                               "type": "string"
@@ -341,9 +325,7 @@
                           "minProperties": 1,
                           "maxProperties": 1,
                           "not": {
-                            "required": [
-                              "prefix"
-                            ]
+                            "required": ["prefix"]
                           },
                           "additionalProperties": {
                             "type": "array",
@@ -675,8 +657,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "type": "object",
       "$ref": "#/properties/env_run_base",
+      "type": "object",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -742,9 +724,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace"
-          ],
+          "required": ["replace"],
           "additionalProperties": false
         },
         {
@@ -776,10 +756,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace",
-            "of"
-          ],
+          "required": ["replace", "of"],
           "additionalProperties": false
         }
       ]


### PR DESCRIPTION
Updates tox's JSON Schema to [6c452bbe2e936f7fd5cfa02ea66ca44dd0adb948](https://github.com/tox-dev/tox/commit/6c452bbe2e936f7fd5cfa02ea66ca44dd0adb948) (release 4.49.0).