### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.71

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -225,6 +225,20 @@
       "examples": ["aws sso login --profile myprofile"],
       "minLength": 1
     },
+    "claudeMdExcludes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Glob patterns for CLAUDE.md files to exclude from loading. Useful in monorepos to skip irrelevant instructions from other teams. Patterns match against absolute file paths. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded. See https://code.claude.com/docs/en/memory#exclude-specific-claudemd-files",
+      "examples": [
+        [
+          "**/monorepo/CLAUDE.md",
+          "/home/user/monorepo/other-team/.claude/rules/**"
+        ]
+      ]
+    },
     "cleanupPeriodDays": {
       "type": "integer",
       "minimum": 0,
@@ -498,6 +512,15 @@
       },
       "description": "Enterprise denylist of MCP servers that are explicitly blocked. If a server is on the denylist, it will be blocked across all scopes including enterprise. Denylist takes precedence over allowlist - if a server is on both lists, it is denied. See https://code.claude.com/docs/en/mcp#restriction-options"
     },
+    "httpHookAllowedEnvVars": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Allowlist of environment variable names HTTP hooks may interpolate into headers. When set, each hook's effective allowedEnvVars is the intersection with this list. Undefined = no restriction. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
+      "examples": [["MY_TOKEN", "HOOK_SECRET"]]
+    },
     "hooks": {
       "type": "object",
       "additionalProperties": false,
@@ -657,6 +680,15 @@
     "disableAllHooks": {
       "type": "boolean",
       "description": "Disable all hooks and statusLine execution. When true in managed settings, user and project-level disableAllHooks cannot override it. See https://code.claude.com/docs/en/hooks#disable-or-remove-hooks"
+    },
+    "allowedHttpHookUrls": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Allowlist of URL patterns that HTTP hooks may target. Supports * as a wildcard. When set, hooks with non-matching URLs are blocked. Undefined = no restriction, empty array = block all HTTP hooks. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
+      "examples": [["https://hooks.example.com/*", "http://localhost:*"]]
     },
     "allowManagedHooksOnly": {
       "type": "boolean",

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -1,4 +1,5 @@
 {
+  "allowedHttpHookUrls": ["https://hooks.example.com/*"],
   "hooks": {
     "ConfigChange": [
       {
@@ -224,5 +225,6 @@
         ]
       }
     ]
-  }
+  },
+  "httpHookAllowedEnvVars": ["WEBHOOK_SECRET"]
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "allowManagedHooksOnly": false,
   "allowManagedPermissionRulesOnly": false,
+  "allowedHttpHookUrls": ["https://hooks.example.com/*", "http://localhost:*"],
   "alwaysThinkingEnabled": false,
   "apiKeyHelper": "/usr/local/bin/claude-auth-helper",
   "attribution": {
@@ -18,6 +19,10 @@
       "pathPattern": "^/untrusted/.*",
       "source": "pathPattern"
     }
+  ],
+  "claudeMdExcludes": [
+    "**/other-team/CLAUDE.md",
+    "/home/user/monorepo/.claude/rules/**"
   ],
   "cleanupPeriodDays": 60,
   "companyAnnouncements": ["Welcome to the team!"],
@@ -146,6 +151,7 @@
       }
     ]
   },
+  "httpHookAllowedEnvVars": ["HOOK_TOKEN", "WEBHOOK_SECRET"],
   "includeCoAuthoredBy": true,
   "includeGitInstructions": false,
   "language": "english",


### PR DESCRIPTION
## Schema

- Add `claudeMdExcludes` — glob patterns for excluding CLAUDE.md files in monorepos, as per [memory documentation](https://code.claude.com/docs/en/memory#exclude-specific-claudemd-files). Not in changelog; documented feature missed in prior syncs.
- Add `allowedHttpHookUrls` — URL pattern allowlist for HTTP hooks, as per [settings documentation](https://code.claude.com/docs/en/settings#hook-configuration). HTTP hooks added in [v2.1.63](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163); this security setting missed since then.
- Add `httpHookAllowedEnvVars` — env var name allowlist for HTTP hook header interpolation, as per [settings documentation](https://code.claude.com/docs/en/settings#hook-configuration). Same origin as `allowedHttpHookUrls`.

## Tests

- Add all 3 new properties to `modern-complete-config.json` for full coverage
- Add `allowedHttpHookUrls` and `httpHookAllowedEnvVars` to `hooks-complete.json` (hook feature-specific test)

## Skipped

- No changelog-driven schema changes in v2.1.70–v2.1.71 (bug fixes only)
- `voice:pushToTalk` (v2.1.71) is a keybinding, not a settings.json property