### PR TITLE
Add clientSecretCertificateKeyVaultReference to staticwebapp.config.json schema

### DIFF
--- a/src/schemas/json/staticwebapp.config.json
+++ b/src/schemas/json/staticwebapp.config.json
@@ -104,6 +104,14 @@
                     "clientSecretSettingName": {
                       "type": "string",
                       "description": "The name of the application setting containing the client secret for the Azure AD app registration"
+                    },
+                    "clientSecretCertificateKeyVaultReference": {
+                      "type": "string",
+                      "description": "A Key Vault reference for the certificate used for certificate-based authentication"
+                    },
+                    "clientSecretCertificateThumbprint": {
+                      "type": "string",
+                      "description": "The thumbprint of the certificate used for certificate-based authentication"
                     }
                   },
                   "additionalProperties": false


### PR DESCRIPTION
## Summary

- Adds `clientSecretCertificateKeyVaultReference` and `clientSecretCertificateThumbprint` properties to the `azureActiveDirectory > registration` object in the `staticwebapp.config.json` schema.
- These properties support certificate-based authentication as an alternative to `clientSecretSettingName` (client secret).

## Context

Microsoft's official documentation lists `clientSecretCertificateKeyVaultReference` and `clientSecretCertificateThumbprint` as valid configuration properties for Azure Active Directory custom authentication:
- https://learn.microsoft.com/en-us/azure/static-web-apps/authentication-custom

The SWA CLI fetches this schema from SchemaStore at deploy time and **rejects valid configurations** that use these properties because they are missing from the schema. This blocks deployments that use certificate-based auth instead of client secrets.

Related issue: https://github.com/Azure/static-web-apps-cli/issues/944

## Test plan

- [ ] Validate that the updated schema still passes SchemaStore CI
- [ ] Confirm a `staticwebapp.config.json` using `clientSecretCertificateKeyVaultReference` and `clientSecretCertificateThumbprint` is accepted by the schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)