### PR TITLE
feat: update chisel-slices schema to allow null type essentials

### DIFF
--- a/src/schemas/json/chisel-slices.json
+++ b/src/schemas/json/chisel-slices.json
@@ -28,7 +28,7 @@
       "patternProperties": {
         "^.+$": {
           "description": "The name of the dependency slice part.",
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": false,
           "properties": {
             "arch": {
@@ -78,7 +78,7 @@
               "patternProperties": {
                 "^.+$": {
                   "description": "The name of the dependency slice part.",
-                  "type": "object",
+                  "type": ["object", "null"],
                   "additionalProperties": false,
                   "properties": {
                     "arch": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

make the type of pattern more permissive to allow not only

```yaml
essential:
  libc_libs: {}
```

but also

```yaml
essential:
  libc_libs:
```

- follow up from https://github.com/SchemaStore/schemastore/pull/5448