### PR TITLE
update: tombi.json

### DIFF
--- a/src/schemas/json/tombi.json
+++ b/src/schemas/json/tombi.json
@@ -18,26 +18,6 @@
       ],
       "default": "v1.0.0"
     },
-    "include": {
-      "title": "File patterns to include",
-      "description": "**🚧 Deprecated 🚧**\\\nPlease use `files.include` instead.",
-      "type": ["array", "null"],
-      "items": {
-        "type": "string"
-      },
-      "deprecated": true,
-      "minItems": 1
-    },
-    "exclude": {
-      "title": "File patterns to exclude",
-      "description": "**🚧 Deprecated 🚧**\\\nPlease use `files.exclude` instead.",
-      "type": ["array", "null"],
-      "items": {
-        "type": "string"
-      },
-      "deprecated": true,
-      "minItems": 1
-    },
     "files": {
       "anyOf": [
         {
@@ -49,7 +29,6 @@
       ]
     },
     "format": {
-      "title": "Formatter options",
       "anyOf": [
         {
           "$ref": "#/definitions/FormatOptions"
@@ -60,7 +39,6 @@
       ]
     },
     "lint": {
-      "title": "Linter options",
       "anyOf": [
         {
           "$ref": "#/definitions/LintOptions"
@@ -71,7 +49,6 @@
       ]
     },
     "lsp": {
-      "title": "Language Server options",
       "anyOf": [
         {
           "$ref": "#/definitions/LspOptions"
@@ -81,24 +58,10 @@
         }
       ]
     },
-    "server": {
-      "title": "Language Server options",
-      "description": "**🚧 Deprecated 🚧**\\\nPlease use `lsp` instead.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/LspOptions"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "deprecated": true
-    },
     "schema": {
-      "title": "Schema options",
       "anyOf": [
         {
-          "$ref": "#/definitions/SchemaOptions"
+          "$ref": "#/definitions/SchemaOverviewOptions"
         },
         {
           "type": "null"
@@ -106,21 +69,37 @@
       ]
     },
     "schemas": {
-      "title": "Schema catalog items",
+      "title": "Schema items",
       "type": ["array", "null"],
       "items": {
-        "$ref": "#/definitions/Schema"
+        "$ref": "#/definitions/SchemaItem"
+      }
+    },
+    "overrides": {
+      "title": "Override config items",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/definitions/OverrideItem"
       }
     }
   },
   "additionalProperties": false,
-  "x-tombi-toml-version": "v1.1.0-preview",
+  "x-tombi-toml-version": "v1.1.0",
   "x-tombi-table-keys-order": "schema",
   "definitions": {
     "TomlVersion": {
       "title": "TOML version",
-      "type": "string",
-      "enum": ["v1.0.0", "v1.1.0-preview"]
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["v1.0.0", "v1.1.0"]
+        },
+        {
+          "type": "string",
+          "const": "v1.1.0-preview",
+          "deprecated": true
+        }
+      ]
     },
     "FilesOptions": {
       "title": "Files options",
@@ -151,7 +130,6 @@
     },
     "FormatOptions": {
       "title": "Formatter options",
-      "description": "To avoid needless discussion of formatting rules,\nwe do not currently have a configuration item for formatting.",
       "type": "object",
       "properties": {
         "rules": {
@@ -164,160 +142,6 @@
               "type": "null"
             }
           ]
-        },
-        "array-bracket-space-width": {
-          "title": "The number of spaces inside the brackets of a single line array.",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.array-bracket-space-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ArrayBracketSpaceWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 0
-        },
-        "array-element-space-width": {
-          "title": "The number of spaces after the comma in a single line array.",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.array-comma-space-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ArrayCommaSpaceWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 1
-        },
-        "date-time-delimiter": {
-          "title": "The delimiter between date and time",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.date-time-delimiter` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DateTimeDelimiter"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": "T"
-        },
-        "indent-style": {
-          "title": "The style of indentation",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.indent-style` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IndentStyle"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": "space"
-        },
-        "indent-width": {
-          "title": "The number of spaces per indentation level",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.indent-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IndentWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 2
-        },
-        "inline-table-brace-space-width": {
-          "title": "The number of spaces inside the brackets of a single line inline table.",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.inline-table-brace-space-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/InlineTableBraceSpaceWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 1
-        },
-        "inline-table-element-space-width": {
-          "title": "The number of spaces after the comma in a single line inline table.",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.inline-table-comma-space-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/InlineTableCommaSpaceWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 1
-        },
-        "line-ending": {
-          "title": "The type of line ending",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.line-ending` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LineEnding"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": "lf"
-        },
-        "line-width": {
-          "title": "The maximum line width",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.line-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LineWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 80
-        },
-        "quote-style": {
-          "title": "The preferred quote character for strings",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.quote-style` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/QuoteStyle"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": "double"
-        },
-        "trailing-comment-space-width": {
-          "title": "The number of spaces before the trailing comment.",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `format.rules.trailing-comment-space-width` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TrailingCommentSpaceWidth"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": 2
         }
       },
       "additionalProperties": false,
@@ -354,7 +178,7 @@
         },
         "date-time-delimiter": {
           "title": "The delimiter between date and time",
-          "description": "In accordance with [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), you can use `T` or space character between date and time.\n\n- `T`: Example: `2001-01-01T00:00:00`\n- `space`: Example: `2001-01-01 00:00:00`\n- `preserve`: Preserve the original delimiter.",
+          "description": "In accordance with [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), you can use `T` or space character between date and time.\n\n- `T`: Use `T` between date and time like `2001-01-01T00:00:00`\n- `space`: Use space between date and time like `2001-01-01 00:00:00`\n- `preserve`: Preserve the original delimiter.",
           "anyOf": [
             {
               "$ref": "#/definitions/DateTimeDelimiter"
@@ -380,11 +204,11 @@
         },
         "indent-sub-tables": {
           "title": "Whether to indent the sub-tables",
-          "description": "If `true`, the sub-table will be indented.\n\n```toml\n[table]\n    [table.sub-table]\n        key = \"value\"\n# ^^  <- this\n```",
+          "description": "If `true`, the sub-table will be indented.\n\n```toml\n[table]\n    [table.sub-table]\n    key = \"value\"\n# ^^  <- this\n```",
           "type": ["boolean", "null"],
           "default": false
         },
-        "indent-table-key-values": {
+        "indent-table-key-value-pairs": {
           "title": "Whether to indent the table key-value pairs",
           "description": "If `true`, the table key-value pairs will be indented.\n\n```toml\n[table]\n    key = \"value\"\n# ^^  <- this\n```",
           "type": ["boolean", "null"],
@@ -429,11 +253,23 @@
           ],
           "default": 1
         },
-        "key-value-equal-alignment": {
-          "title": "Whether to align the equal sign in the key-value pairs.",
-          "description": "If `true`, the equal sign in the key-value pairs will be aligned.\n\n⚠️ **WARNING** ⚠️\\\nThis feature does **not** apply to key-value pairs inside single line inline tables.\n\n```toml\n# BEFORE\nkey = \"value1\"\nkey2 = \"value2\"\nkey3.key4 = \"value3\"\n\n# AFTER\nkey       = \"value1\"\nkey2      = \"value2\"\nkey3.key4 = \"value3\"\n```",
+        "key-value-equals-sign-alignment": {
+          "title": "Whether to align the equals sign in the key-value pairs.",
+          "description": "If `true`, the equals sign in the key-value pairs will be aligned.\n\n⚠️ **WARNING** ⚠️\\\nThis feature does **not** apply to key-value pairs inside single line inline tables.\n\n```toml\n# BEFORE\nkey = \"value1\"\nkey2 = \"value2\"\nkey3.key4 = \"value3\"\n\n# AFTER\nkey       = \"value1\"\nkey2      = \"value2\"\nkey3.key4 = \"value3\"\n```",
           "type": ["boolean", "null"],
           "default": false
+        },
+        "string-quote-style": {
+          "title": "The preferred quote character for strings",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringQuoteStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "double"
         },
         "trailing-comment-alignment": {
           "title": "Whether to align the trailing comments in the key-value pairs.",
@@ -441,12 +277,12 @@
           "type": ["boolean", "null"],
           "default": false
         },
-        "key-value-equal-space-width": {
-          "title": "The number of spaces after the equal in a key-value pair.",
+        "key-value-equals-sign-space-width": {
+          "title": "The number of spaces around the equals sign in a key-value pair.",
           "description": "```toml\nkey = \"value\"\n#  ^ ^  <- this\n```",
           "anyOf": [
             {
-              "$ref": "#/definitions/KeyValueEqualSpaceWidth"
+              "$ref": "#/definitions/KeyValueEqualsSignSpaceWidth"
             },
             {
               "type": "null"
@@ -465,7 +301,7 @@
               "type": "null"
             }
           ],
-          "default": "lf"
+          "default": "auto"
         },
         "line-width": {
           "title": "The maximum line width",
@@ -479,18 +315,6 @@
             }
           ],
           "default": 80
-        },
-        "quote-style": {
-          "title": "The preferred quote character for strings",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/QuoteStyle"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "double"
         },
         "trailing-comment-space-width": {
           "title": "The number of spaces before the trailing comment.",
@@ -563,23 +387,7 @@
       "minimum": 0,
       "maximum": 255
     },
-    "KeyValueEqualSpaceWidth": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0,
-      "maximum": 255
-    },
-    "LineEnding": {
-      "type": "string",
-      "enum": ["lf", "crlf"]
-    },
-    "LineWidth": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 1,
-      "maximum": 255
-    },
-    "QuoteStyle": {
+    "StringQuoteStyle": {
       "description": "The preferred quote character for strings.",
       "oneOf": [
         {
@@ -599,6 +407,31 @@
         }
       ]
     },
+    "KeyValueEqualsSignSpaceWidth": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "LineEnding": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["lf", "crlf"]
+        },
+        {
+          "description": "Automatically detects the line ending style from the source file.",
+          "type": "string",
+          "const": "auto"
+        }
+      ]
+    },
+    "LineWidth": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 1,
+      "maximum": 255
+    },
     "TrailingCommentSpaceWidth": {
       "type": "integer",
       "format": "uint8",
@@ -606,6 +439,7 @@
       "maximum": 255
     },
     "LintOptions": {
+      "title": "Linter options",
       "type": "object",
       "properties": {
         "rules": {
@@ -679,6 +513,7 @@
       "enum": ["off", "warn", "error"]
     },
     "LspOptions": {
+      "title": "Language Server options",
       "type": "object",
       "properties": {
         "code-action": {
@@ -713,19 +548,6 @@
               "type": "null"
             }
           ]
-        },
-        "diagnostics": {
-          "title": "Diagnostic Feature options",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `lsp.diagnostic` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LspDiagnostic"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true
         },
         "document-link": {
           "title": "Document Link Feature options",
@@ -952,19 +774,12 @@
               "type": "null"
             }
           ]
-        },
-        "throttle-seconds": {
-          "title": "Throttle interval in seconds",
-          "description": "**🚧 Deprecated 🚧**\\\nDon't need to use this option.",
-          "type": ["integer", "null"],
-          "format": "uint64",
-          "minimum": 0,
-          "deprecated": true
         }
       },
       "additionalProperties": false
     },
-    "SchemaOptions": {
+    "SchemaOverviewOptions": {
+      "title": "Schema overview options",
       "type": "object",
       "properties": {
         "enabled": {
@@ -1006,16 +821,6 @@
       "x-tombi-table-keys-order": "schema"
     },
     "SchemaCatalog": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/NewSchemaCatalog"
-        },
-        {
-          "$ref": "#/definitions/SchemaCatalogOld"
-        }
-      ]
-    },
-    "NewSchemaCatalog": {
       "type": "object",
       "properties": {
         "paths": {
@@ -1037,49 +842,14 @@
       "description": "Generic value that can be either single or multiple",
       "type": "string"
     },
-    "SchemaCatalogOld": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "title": "The schema catalog path or url",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `schema.catalog.paths` instead.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OneOrMany"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "deprecated": true,
-          "default": "https://www.schemastore.org/api/json/catalog.json"
-        }
-      },
-      "additionalProperties": false
-    },
-    "OneOrMany": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SchemaCatalogPath"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SchemaCatalogPath"
-          }
-        }
-      ]
-    },
-    "Schema": {
+    "SchemaItem": {
+      "title": "Schema item",
       "anyOf": [
         {
           "$ref": "#/definitions/RootSchema"
         },
         {
           "$ref": "#/definitions/SubSchema"
-        },
-        {
-          "$ref": "#/definitions/OldSubSchema"
         }
       ]
     },
@@ -1123,7 +893,7 @@
         "root": {
           "title": "The accessors to apply the sub schema",
           "type": "string",
-          "examples": ["tools.tombi", "items[0].name"],
+          "examples": ["tool.tombi", "items[0].name"],
           "minLength": 1
         },
         "path": {
@@ -1144,34 +914,128 @@
       "required": ["root", "path", "include"],
       "x-tombi-table-keys-order": "schema"
     },
-    "OldSubSchema": {
-      "title": "The schema for the old sub value",
-      "description": "This is for backward compatibility.",
+    "OverrideItem": {
+      "title": "Override config item",
       "type": "object",
       "properties": {
-        "path": {
-          "title": "The sub schema path",
-          "type": "string"
+        "files": {
+          "title": "Files options to override",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OverrideFilesOptions"
+            }
+          ]
         },
+        "format": {
+          "title": "Format options to override",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OverrideFormatOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lint": {
+          "title": "Lint options to override",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OverrideLintOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["files"],
+      "x-tombi-table-keys-order": "schema"
+    },
+    "OverrideFilesOptions": {
+      "title": "Files options to override",
+      "type": "object",
+      "properties": {
         "include": {
-          "title": "The file match pattern of the sub schema",
-          "description": "The file match pattern to include the target to apply the sub schema.\nSupports glob pattern.",
+          "title": "File patterns to include",
+          "description": "The file match pattern to include in formatting and linting.\nSupports glob pattern.",
           "type": "array",
           "items": {
             "type": "string"
           },
           "minItems": 1
         },
-        "root-keys": {
-          "title": "The keys to apply the sub schema",
-          "description": "**🚧 Deprecated 🚧**\\\nPlease use `schemas[*].root` instead.",
-          "type": "string",
-          "deprecated": true,
-          "minLength": 1
+        "exclude": {
+          "title": "File patterns to exclude",
+          "description": "The file match pattern to exclude from formatting and linting.\nSupports glob pattern.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         }
       },
       "additionalProperties": false,
-      "required": ["path", "include", "root-keys"],
+      "required": ["include"],
+      "x-tombi-table-keys-order": "schema"
+    },
+    "OverrideFormatOptions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Format enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rules": {
+          "title": "Format rules",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FormatRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "x-tombi-table-keys-order": "schema"
+    },
+    "OverrideLintOptions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Lint enabled",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rules": {
+          "title": "Lint rules",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LintRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
       "x-tombi-table-keys-order": "schema"
     }
   }


### PR DESCRIPTION
remove deprecated properties and update schema references in tombi.json

- Removed deprecated "include", "exclude", and "server" properties.
- Updated references for "schema" and "files" properties.
- Changed "x-tombi-toml-version" to "v1.1.0" and adjusted "TomlVersion" definition to include the new versioning scheme.
- Enhanced "schemas" and "overrides" sections for better clarity and structure.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
