### PR TITLE
Update minecraft-pack-mcmeta.json to match latest schema

### DIFF
--- a/src/schemas/json/minecraft-pack-mcmeta.json
+++ b/src/schemas/json/minecraft-pack-mcmeta.json
@@ -8,7 +8,27 @@
       "description": "https://minecraft.wiki/w/Pack_format",
       "type": "integer",
       "minimum": 1,
-      "maximum": 81
+      "maximum": 101
+    },
+    "packFormatMajorMinor": {
+      "description": "A pack format version, specified as a single integer (major version) or an array of one or two integers ([major] or [major, minor]). Omitting the minor version is equal to specifying minor version 0.\nhttps://minecraft.wiki/w/Pack_format",
+      "oneOf": [
+        {
+          "type": "integer",
+          "description": "Major version as an integer. Interpreted as [major, 0].",
+          "minimum": 1
+        },
+        {
+          "type": "array",
+          "description": "An array of [major] or [major, minor] version integers. The minor version is optional and assumed to be 0 if not specified.",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "minItems": 1,
+          "maxItems": 2
+        }
+      ]
     },
     "packFormatRange": {
       "anyOf": [
@@ -38,6 +58,17 @@
         }
       ]
     },
+    "textComponent": {
+      "description": "A Minecraft text component (raw JSON text).\nhttps://minecraft.wiki/w/Raw_JSON_text_format",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
     "resourceLocation": {
       "description": "An identifier of a game object\nhttps://minecraft.wiki/w/Resource_location",
       "type": "string",
@@ -50,21 +81,44 @@
       "type": "object",
       "properties": {
         "description": {
+          "$ref": "#/definitions/textComponent",
           "title": "description",
-          "description": "A text component that appears when hovering over the pack's name in the list given by the `/datapack list` command, or when viewing the pack in the Create World screen.",
-          "type": "string"
+          "description": "A text component that appears when hovering over the pack's name in the list given by the `/datapack list` command, or when viewing the pack in the Create World screen."
         },
         "pack_format": {
           "$ref": "#/definitions/packFormat",
-          "description": "Determines the version(s) of Minecraft that this pack is compatible with."
+          "description": "Determines the version(s) of Minecraft that this pack is compatible with. Optional when supported formats do not include 82 (data pack) or 65 (resource pack) or below, but required otherwise."
+        },
+        "min_format": {
+          "$ref": "#/definitions/packFormatMajorMinor",
+          "description": "Describes the minimum supported pack format version. Can be an integer or an array of one or two integers ([major] or [major, minor])."
+        },
+        "max_format": {
+          "$ref": "#/definitions/packFormatMajorMinor",
+          "description": "Describes the maximum supported pack format version. Can be an integer or an array of one or two integers ([major] or [major, minor])."
         },
         "supported_formats": {
           "$ref": "#/definitions/packFormatRange",
-          "description": "Describes a range for pack formats that this pack supports. The range has to include the value of `pack.pack_format`."
+          "description": "DEPRECATED. The major versions this pack supports. Has to match the major versions specified in min_format and max_format.\nRequired when the pack declares support for versions either below data pack format 82 or resource pack format 65.\nMust be absent otherwise."
         }
       },
       "additionalProperties": false,
-      "required": ["description", "pack_format"]
+      "required": ["description"],
+      "anyOf": [
+        {
+          "properties": {
+            "pack_format": {}
+          },
+          "required": ["pack_format"]
+        },
+        {
+          "properties": {
+            "min_format": {},
+            "max_format": {}
+          },
+          "required": ["min_format", "max_format"]
+        }
+      ]
     },
     "features": {
       "description": "Section for selecting experimental features.",
@@ -121,18 +175,41 @@
             "description": "An overlay.",
             "type": "object",
             "properties": {
-              "formats": {
-                "$ref": "#/definitions/packFormatRange",
-                "description": "A range of pack formats when this overlay should be active."
-              },
               "directory": {
                 "description": "The directory to overlay for the respective versions.",
                 "type": "string",
                 "pattern": "[a-z0-9_-]+"
+              },
+              "min_format": {
+                "$ref": "#/definitions/packFormatMajorMinor",
+                "description": "Describes the minimum pack format version to which this overlay applies. As integer or one or two element integer array."
+              },
+              "max_format": {
+                "$ref": "#/definitions/packFormatMajorMinor",
+                "description": "Describes the minimum pack format version to which this overlay applies. As integer or one or two element integer array."
+              },
+              "formats": {
+                "$ref": "#/definitions/packFormatRange",
+                "description": "DEPRECATED. A range of major pack format versions to which this overlay applies. Has to match the major versions specified in min_format and max_format.\nRequired when the pack declares support for versions either below data pack format 82 or resource pack format 65.\nMust be absent otherwise."
               }
             },
             "additionalProperties": false,
-            "required": ["formats", "directory"]
+            "required": ["directory"],
+            "anyOf": [
+              {
+                "properties": {
+                  "formats": {}
+                },
+                "required": ["formats"]
+              },
+              {
+                "properties": {
+                  "min_format": {},
+                  "max_format": {}
+                },
+                "required": ["min_format", "max_format"]
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
Updates the schema to the latest versions requirements, including updating the maximum pack format version, several deprecation warnings and adding newly required entries ("min_format" and "max_format").
It also adds the possibility for the pack description to be a text component instead of only allowing a string.