### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.76

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LS|LSP|MultiEdit|NotebookEdit|NotebookRead|Read|Skill|Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|NotebookEdit|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -14,14 +14,12 @@
         "Bash(ls*)",
         "Bash(git * main)",
         "Edit",
-        "MultiEdit",
         "Edit(/src/**/*.ts)",
         "Read(./.env)",
         "Read(./secrets/**)",
         "Read(//Users/alice/secrets/**)",
         "Read(~/Documents/*.pdf)",
         "Agent(Explore)",
-        "Task(Explore)",
         "WebFetch",
         "WebFetch(domain:example.com)",
         "mcp__puppeteer",
@@ -383,11 +381,22 @@
       "description": "Restrict which models users can select. When defined at multiple settings levels (user, project, etc.), arrays are merged and deduplicated. See https://code.claude.com/docs/en/model-config#restrict-model-selection",
       "examples": [["sonnet", "haiku"]]
     },
+    "modelOverrides": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Map Anthropic model IDs to provider-specific model IDs such as Bedrock inference profile ARNs, Vertex AI version names, or Foundry deployment names. Each model picker entry uses its mapped value when calling the provider API. Unknown keys are ignored. See https://code.claude.com/docs/en/model-config#override-model-ids-per-version",
+      "examples": [
+        {
+          "claude-opus-4-6": "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/opus-prod"
+        }
+      ]
+    },
     "effortLevel": {
       "type": "string",
       "enum": ["low", "medium", "high"],
-      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Opus 4.6 defaults to medium effort for Max and Team subscribers. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level",
-      "default": "high"
+      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Defaults vary by model and plan (Opus 4.6 defaults to medium for Max and Team subscribers). Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
       "type": "boolean",
@@ -398,6 +407,13 @@
       "type": "boolean",
       "description": "Require per-session opt-in for fast mode. When true, fast mode does not persist across sessions and users must enable it with /fast each session. Useful for controlling costs. See https://code.claude.com/docs/en/fast-mode",
       "default": false
+    },
+    "feedbackSurveyRate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Probability (0–1) that the session quality survey appears when eligible. A value of 0.05 means 5% of eligible sessions. See https://code.claude.com/docs/en/settings",
+      "examples": [0.05]
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
@@ -608,6 +624,27 @@
         "PreCompact": {
           "type": "array",
           "description": "Hooks that run before the context is compacted",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "PostCompact": {
+          "type": "array",
+          "description": "Hooks that run after the context is compacted. See https://code.claude.com/docs/en/hooks",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "Elicitation": {
+          "type": "array",
+          "description": "Hooks that run when an MCP server requests user input during a tool call. See https://code.claude.com/docs/en/hooks",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "ElicitationResult": {
+          "type": "array",
+          "description": "Hooks that run after a user responds to an MCP elicitation, before the response is sent back to the server. See https://code.claude.com/docs/en/hooks",
           "items": {
             "$ref": "#/$defs/hookMatcher"
           }
@@ -1119,7 +1156,7 @@
     },
     "outputStyle": {
       "type": "string",
-      "description": "Controls the output style for assistant responses. See https://code.claude.com/docs/en/output-styles",
+      "description": "Controls the output style for assistant responses. Built-in styles: default, Explanatory, Learning. Custom styles can be added in ~/.claude/output-styles/ or .claude/output-styles/. See https://code.claude.com/docs/en/output-styles",
       "examples": ["default", "Explanatory", "Learning"],
       "minLength": 1
     },
@@ -1172,7 +1209,7 @@
             },
             "allowManagedDomainsOnly": {
               "type": "boolean",
-              "description": "(Managed settings only) Only allowedDomains and WebFetch(domain:...) allow rules from managed settings are respected. User, project, local, and flag settings domains are ignored. Denied domains are still respected from all sources."
+              "description": "(Managed settings only) Only allowedDomains and WebFetch(domain:...) allow rules from managed settings are respected. User, project, local, and flag settings domains are ignored. Denied domains are still respected from all sources. Non-allowed domains are automatically blocked without user prompts."
             }
           },
           "additionalProperties": false
@@ -1332,6 +1369,22 @@
       "enum": ["auto", "in-process", "tmux"],
       "description": "How agent team teammates display: \"auto\" picks split panes in tmux or iTerm2, in-process otherwise. Agent teams are experimental and disabled by default. Enable them by adding CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to your settings.json or environment. See https://code.claude.com/docs/en/agent-teams",
       "default": "auto"
+    },
+    "worktree": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configuration for --worktree sessions. See https://code.claude.com/docs/en/settings",
+      "properties": {
+        "sparsePaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Directories to check out in each worktree via git sparse-checkout (cone mode). Only the listed paths are written to disk, which is faster in large monorepos.",
+          "examples": [["packages/my-app", "shared/utils"]]
+        }
+      }
     },
     "pluginTrustMessage": {
       "type": "string",

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -12,6 +12,26 @@
         "matcher": "user_settings"
       }
     ],
+    "Elicitation": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'MCP elicitation requested' >> /tmp/claude-mcp.log",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "ElicitationResult": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Elicitation result received' >> /tmp/claude-mcp.log",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "InstructionsLoaded": [
       {
         "hooks": [
@@ -51,6 +71,16 @@
           }
         ],
         "matcher": "Bash"
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Post compact hook' >> /tmp/claude-session.log",
+            "type": "command"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -49,6 +49,7 @@
   },
   "fastMode": true,
   "fastModePerSessionOptIn": true,
+  "feedbackSurveyRate": 0.05,
   "fileSuggestion": {
     "command": "~/.claude/file-suggestion.sh",
     "type": "command"
@@ -156,6 +157,9 @@
   "includeGitInstructions": false,
   "language": "english",
   "model": "opus",
+  "modelOverrides": {
+    "claude-opus-4-6": "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/opus-prod"
+  },
   "otelHeadersHelper": "/usr/local/bin/otel-headers.sh",
   "outputStyle": "Explanatory",
   "permissions": {
@@ -238,5 +242,8 @@
     "type": "command"
   },
   "teammateMode": "tmux",
-  "terminalProgressBarEnabled": false
+  "terminalProgressBarEnabled": false,
+  "worktree": {
+    "sparsePaths": ["packages/my-app", "shared/utils"]
+  }
 }


### PR DESCRIPTION
## Schema

- Add `feedbackSurveyRate` (number 0–1) for enterprise session quality survey control, as per [settings documentation](https://code.claude.com/docs/en/settings) ([v2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- Add `modelOverrides` (object, string→string) to map Anthropic model IDs to provider-specific values like Bedrock ARNs, Vertex names, or Foundry deployments, as per [model-config documentation](https://code.claude.com/docs/en/model-config#override-model-ids-per-version)
- Add `worktree.sparsePaths` (array of strings) for git sparse-checkout in large monorepos, as per [settings documentation](https://code.claude.com/docs/en/settings) ([v2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- Add `PostCompact` hook event — fires after context compaction completes, as per [hooks documentation](https://code.claude.com/docs/en/hooks) ([v2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- Add `Elicitation` hook event — fires when an MCP server requests user input during a tool call, as per [hooks documentation](https://code.claude.com/docs/en/hooks) ([v2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- Add `ElicitationResult` hook event — fires after user responds to an MCP elicitation, as per [hooks documentation](https://code.claude.com/docs/en/hooks) ([v2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- Remove undocumented `effortLevel` default value ("high" was never documented as default); update description with tier-dependent defaults (Opus 4.6 defaults to medium for Max/Team) and `/effort auto` reference ([v2.1.68](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2168))
- Update `outputStyle` description to mention custom styles support in `~/.claude/output-styles/` or `.claude/output-styles/`, as per [output-styles documentation](https://code.claude.com/docs/en/output-styles#create-a-custom-output-style)
- Update `allowManagedDomainsOnly` description to clarify that non-allowed domains are automatically blocked without user prompts ([v2.1.74](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2174))
- Remove `LS`, `MultiEdit`, `NotebookRead`, `Task` from permissionRule pattern — unverified tools from original community PR #4798, not found in tools-reference docs or ToolSearch. Also remove `MultiEdit` and `Task(Explore)` from permissionRule examples
- Add `claudeMdExcludes` — glob patterns for excluding CLAUDE.md files in monorepos, as per [memory documentation](https://code.claude.com/docs/en/memory#exclude-specific-claudemd-files). Not in changelog; documented feature missed in prior syncs.
- Add `allowedHttpHookUrls` — URL pattern allowlist for HTTP hooks, as per [settings documentation](https://code.claude.com/docs/en/settings#hook-configuration). HTTP hooks added in [v2.1.63](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163); this security setting missed since then.
- Add `httpHookAllowedEnvVars` — env var name allowlist for HTTP hook header interpolation, as per [settings documentation](https://code.claude.com/docs/en/settings#hook-configuration). Same origin as `allowedHttpHookUrls`.

## Tests

- Add `feedbackSurveyRate`, `modelOverrides`, `worktree` to `modern-complete-config.json` for full coverage
- Add `PostCompact`, `Elicitation`, `ElicitationResult` hook examples to `hooks-complete.json`
- Add `allowedHttpHookUrls` and `httpHookAllowedEnvVars` to `hooks-complete.json` (from #5451 base)
- Add all 3 HTTP hook properties to `modern-complete-config.json` (from #5451 base)
- Changes made to pass coverage gate: 3 uncovered top-level properties (feedbackSurveyRate, modelOverrides, worktree)

## Negative tests

- No changes needed — no new enums, patterns, or required fields added

## Skipped

- `KillShell` in permissionRule pattern: not in tools-reference docs but verified present in tool harness — kept as undocumented internal tool
- `$schema` URL 301 redirect (http→https): SchemaStore CLI validator only accepts `http://json-schema.org/draft-07/schema#`
- Network env vars (HTTPS_PROXY, NODE_EXTRA_CA_CERTS, etc.): standard system/Node.js vars, not Claude Code settings.json properties
- No changelog-driven schema changes in v2.1.70–v2.1.71 (bug fixes only, from #5451)
- `voice:pushToTalk` (v2.1.71): keybinding, not a settings.json property (from #5451)
- Supersedes #5451 (v2.1.71 sync, now draft/closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)