### PR TITLE
Add deepmatch schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1630,10 +1630,10 @@
       "name": "DeepMatch deeplinks spec",
       "description": "DeepMatch deeplinks YAML configuration file",
       "fileMatch": [
-        ".deeplinks.yml",
-        "*.deeplinks.yml",
-        ".deeplinks.yaml",
-        "*.deeplinks.yaml"
+        "**/.deeplinks.yml",
+        "**/*.deeplinks.yml",
+        "**/.deeplinks.yaml",
+        "**/*.deeplinks.yaml"
       ],
       "url": "https://raw.githubusercontent.com/aouledissa/deep-match/main/schemas/deeplinks.schema.json"
     },


### PR DESCRIPTION
## Add schema for DeepMatch deeplinks configuration files

  ### Description
  This adds JSON Schema support for [DeepMatch](https://github.com/aouledissa/deep-match), an Android deeplink toolkit that uses YAML configuration files to define deeplink specifications.

  ### Details
  - **Project**: DeepMatch (Android deeplink toolkit)
  - **Repository**: https://github.com/aouledissa/deep-match
  - **Documentation**: https://aouledissa.com/deep-match/deeplink-specs/
  - **Schema**: https://raw.githubusercontent.com/aouledissa/deep-match/main/schemas/deeplinks.schema.json

  ### File patterns
  The schema applies to deeplink configuration files at any directory level:
  - `**/.deeplinks.yml` - root deeplinks configuration
  - `**/*.deeplinks.yml` - variant-specific deeplinks (e.g., `profile.deeplinks.yml`, `src/debug/config.deeplinks.yml`)
  - `**/.deeplinks.yaml` - root deeplinks configuration (YAML extension)
  - `**/*.deeplinks.yaml` - variant-specific deeplinks (YAML extension)