### PR TITLE
Update tox JSON Schema to 4.50.0

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -41,9 +41,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "product"
-            ],
+            "required": ["product"],
             "properties": {
               "product": {
                 "type": "array",
@@ -57,9 +55,7 @@
                     },
                     {
                       "type": "object",
-                      "required": [
-                        "prefix"
-                      ],
+                      "required": ["prefix"],
                       "properties": {
                         "prefix": {
                           "type": "string"
@@ -78,9 +74,7 @@
                       "minProperties": 1,
                       "maxProperties": 1,
                       "not": {
-                        "required": [
-                          "prefix"
-                        ]
+                        "required": ["prefix"]
                       },
                       "additionalProperties": {
                         "type": "array",
@@ -151,9 +145,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "product"
-              ],
+              "required": ["product"],
               "properties": {
                 "product": {
                   "type": "array",
@@ -167,9 +159,7 @@
                       },
                       {
                         "type": "object",
-                        "required": [
-                          "prefix"
-                        ],
+                        "required": ["prefix"],
                         "properties": {
                           "prefix": {
                             "type": "string"
@@ -188,9 +178,7 @@
                         "minProperties": 1,
                         "maxProperties": 1,
                         "not": {
-                          "required": [
-                            "prefix"
-                          ]
+                          "required": ["prefix"]
                         },
                         "additionalProperties": {
                           "type": "array",
@@ -304,9 +292,7 @@
               },
               {
                 "type": "object",
-                "required": [
-                  "product"
-                ],
+                "required": ["product"],
                 "properties": {
                   "product": {
                     "type": "array",
@@ -320,9 +306,7 @@
                         },
                         {
                           "type": "object",
-                          "required": [
-                            "prefix"
-                          ],
+                          "required": ["prefix"],
                           "properties": {
                             "prefix": {
                               "type": "string"
@@ -341,9 +325,7 @@
                           "minProperties": 1,
                           "maxProperties": 1,
                           "not": {
-                            "required": [
-                              "prefix"
-                            ]
+                            "required": ["prefix"]
                           },
                           "additionalProperties": {
                             "type": "array",
@@ -679,8 +661,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "type": "object",
       "$ref": "#/properties/env_run_base",
+      "type": "object",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -746,9 +728,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace"
-          ],
+          "required": ["replace"],
           "additionalProperties": false
         },
         {
@@ -780,10 +760,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace",
-            "of"
-          ],
+          "required": ["replace", "of"],
           "additionalProperties": false
         }
       ]


### PR DESCRIPTION
Updates tox's JSON Schema to [db1362d7ba99776d5e5d40d8f1f71b7dbf5bf149](https://github.com/tox-dev/tox/commit/db1362d7ba99776d5e5d40d8f1f71b7dbf5bf149) (release 4.50.0).