### PR TITLE
feat(github-workflow): add environment.deployment property

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -253,6 +253,19 @@
           "$comment": "https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-using-environment-name-and-url",
           "description": "A deployment URL",
           "type": "string"
+        },
+        "deployment": {
+          "$comment": "https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments",
+          "description": "Whether to create a deployment for this job. Setting to false lets the job use environment secrets and variables without creating a deployment record. Wait timers and required reviewers still apply.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/expressionSyntax"
+            }
+          ],
+          "default": true
         }
       },
       "required": ["name"],


### PR DESCRIPTION
## What

Adds the `deployment` property to the `environment` definition in the GitHub Actions workflow schema.

The property accepts `true` (default), `false`, or an expression string (`${{ ... }}`).

## Why

GitHub added a `deployment` property to job environments that controls whether a deployment record is created. Setting `deployment: false` allows a job to consume environment secrets and variables without creating a deployment record in the repository — useful when you want protection rules (wait timers, required reviewers) without the deployment tracking overhead.

Documentation: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments

## Changes

- `src/schemas/json/github-workflow.json` — added `deployment` alongside `environment.url` in the `environment` object definition

## Testing

```
$ docker run -it -v $PWD:/workspace -w /workspace node:20 /bin/bash
root@3425c07085c6:/workspace# npm ci
root@3425c07085c6:/workspace# node cli.js check --schema-name=github-workflow.json
```

<img width="759" height="1186" alt="image" src="https://github.com/user-attachments/assets/6831ac99-5794-4a80-8971-61c8d2e19c9d" />
