### PR TITLE
feat: add Maestro Flow JSON Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4084,6 +4084,17 @@
       "url": "https://raw.githubusercontent.com/akiomik/mado/refs/heads/main/pkg/json-schema/mado.json"
     },
     {
+      "name": "Maestro Flow",
+      "description": "Maestro mobile and web UI test flow (YAML)",
+      "fileMatch": [
+        "**/.maestro/**/*.yaml",
+        "**/.maestro/**/*.yml",
+        "**/*.flow.yaml",
+        "**/*.flow.yml"
+      ],
+      "url": "https://www.schemastore.org/maestro-flow.json"
+    },
+    {
       "name": "MapEHR Mapping",
       "description": "Mapping for MapEHR.com",
       "fileMatch": [".map.yml", ".map.yaml", ".map.json"],

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -306,6 +306,7 @@
     // JSON schema 2019-09 and 2020-12 are not well supported by many IDEs and should not be used
     "jsone.json",
     "license-report-config.json",
+    "maestro-flow.json",
     "openweather.current.json",
     "openweather.roadrisk.json",
     "openhab-5.1.json",

--- a/src/schemas/json/maestro-flow.json
+++ b/src/schemas/json/maestro-flow.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://json.schemastore.org/maestro-flow.json",
+  "$defs": {
+    "flowConfiguration": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "appId": {
+          "type": "string",
+          "title": "Application ID",
+          "description": "Android package name or iOS bundle ID under test. May use ${ENV_VAR} interpolation.",
+          "examples": ["com.example.app", "${APP_ID}"]
+        },
+        "url": {
+          "type": "string",
+          "title": "Web URL under test",
+          "description": "For web flows, the starting URL (see Maestro web testing docs).",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable flow name for reports."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tags for filtering and organization."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Default environment variables for this flow (${VAR_NAME} in commands)."
+        },
+        "onFlowStart": {
+          "$ref": "#/$defs/commandList",
+          "description": "Commands run before the main flow body; failure fails the flow."
+        },
+        "onFlowComplete": {
+          "$ref": "#/$defs/commandList",
+          "description": "Commands run after the main flow (e.g. teardown)."
+        }
+      }
+    },
+    "commandList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/commandStep" },
+      "description": "Sequence of Maestro commands executed in order."
+    },
+    "commandStep": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/bareCommandName",
+          "description": "Shorthand step with no parameters (YAML scalar list item)."
+        },
+        {
+          "$ref": "#/$defs/commandObject",
+          "description": "Single-key object: command name -> arguments map, string, or null."
+        }
+      ]
+    },
+    "bareCommandName": {
+      "type": "string",
+      "title": "Bare command",
+      "description": "Commands that need no argument object. Maestro accepts many more; list is indicative.",
+      "examples": [
+        "launchApp",
+        "hideKeyboard",
+        "back",
+        "stopApp",
+        "clearState",
+        "clearKeychain",
+        "waitForAnimationToEnd",
+        "takeScreenshot",
+        "startRecording",
+        "stopRecording"
+      ]
+    },
+    "commandObject": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/commandValue"
+      },
+      "propertyNames": {
+        "type": "string",
+        "description": "Maestro command name (typically camelCase, e.g. tapOn, runFlow)."
+      }
+    },
+    "commandValue": {
+      "title": "Command arguments",
+      "description": "Depends on the command: omitted/null, boolean, string selector, number, array of nested steps, or parameter object.",
+      "oneOf": [
+        { "type": "null" },
+        { "type": "boolean" },
+        { "type": "number" },
+        { "type": "string" },
+        { "type": "array", "items": { "$ref": "#/$defs/commandStep" } },
+        { "$ref": "#/$defs/argumentMap" }
+      ]
+    },
+    "argumentMap": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Command-specific parameters. Commands: https://docs.maestro.dev/reference/commands-available/ — Selectors: https://docs.maestro.dev/reference/selectors — Conditions (when): https://docs.maestro.dev/maestro-flows/flow-control-and-logic/conditions — runFlow: https://docs.maestro.dev/reference/commands-available/runflow — launchApp: https://docs.maestro.dev/reference/commands-available/launchapp — extendedWaitUntil: https://docs.maestro.dev/reference/commands-available/extendedwaituntil"
+    }
+  },
+  "title": "Maestro Flow",
+  "description": "YAML flow file for Maestro (mobile & web UI automation). A single file is usually two YAML documents separated by ---: (1) flow configuration, (2) command list. Assign this schema to *.flow.yaml or **/.maestro/**/*.yaml. Official docs: https://docs.maestro.dev/",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/flowConfiguration",
+      "description": "First document: app/url, env, tags, hooks."
+    },
+    {
+      "$ref": "#/$defs/commandList",
+      "description": "Second document: ordered list of Maestro commands."
+    }
+  ]
+}

--- a/src/test/maestro-flow/flow-commands.yaml
+++ b/src/test/maestro-flow/flow-commands.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: sign_in
+    timeout: 30000
+- tapOn:
+    id: sign_in
+- inputText: user@example.test
+- hideKeyboard
+- assertVisible: Home
+- runFlow:
+    label: dismiss onboarding
+    when:
+      visible: Skip
+    commands:
+      - tapOn: Skip

--- a/src/test/maestro-flow/flow-header.yaml
+++ b/src/test/maestro-flow/flow-header.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+appId: com.example.maestro
+name: sample flow
+tags:
+  - e2e
+env:
+  API_URL: https://api.example.test


### PR DESCRIPTION
## Summary

Adds a JSON Schema for [Maestro](https://docs.maestro.dev/) flow YAML files (mobile/web UI automation).

## Details

- **Schema**: `src/schemas/json/maestro-flow.json` — `oneOf` for (1) flow configuration (`appId`, `url`, `env`, hooks) and (2) command list, matching the usual two-document Maestro file shape.
- **Tests**: `src/test/maestro-flow/` — separate YAML samples for header vs commands (`YAML.parse` reads a single document per test file).
- **Catalog**: `fileMatch` includes `**/.maestro/**` and `**/*.flow.yaml` / `.yml` (Maestro naming convention).
- **highSchemaVersion**: schema uses draft 2020-12 (same pattern as `yamllint.json`).

## References

- https://docs.maestro.dev/
- https://docs.maestro.dev/examples/recipes/check-the-clipboard-content
