### PR TITLE
Add Barba-CV JSON schema (external)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -651,7 +651,7 @@
     },
     {
       "name": "Barba-CV",
-      "description": "Open JSON schema for deterministic CV / resume data",
+      "description": "Deterministic CV / resume data format",
       "fileMatch": ["barba-cv.json"],
       "url": "https://raw.githubusercontent.com/Eurobotics-Association/barba-cv/main/schema/barba-cv.schema.json"
     },


### PR DESCRIPTION
This PR adds the Barba-CV JSON schema to the catalog.

Barba-CV is an open JSON schema designed to represent CV / resume data
in a deterministic and machine-readable format.

Schema URL:
https://raw.githubusercontent.com/Eurobotics-Association/barba-cv/main/schema/barba-cv.schema.json

Use case:
- AI-based CV parsing
- ATS interoperability
- structured resume data exchange

The schema is self-hosted and publicly accessible.

No tests required for external schema entry.
