### PR TITLE
Add cursor agent environment config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9531,6 +9531,12 @@
         "**/text2confl.yml"
       ],
       "url": "https://raw.githubusercontent.com/zeldigas/text2confl/refs/heads/master/docs/config.schema.json"
+    },
+    {
+      "name": "Cursor Agent Environment",
+      "description": "Cursor cloud agent environment configuration",
+      "fileMatch": ["**/.cursor/environment.json"],
+      "url": "https://cursor.com/schemas/environment.schema.json"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a catalog entry for Cursor's cloud agent environment config: [`environment.json` specification](https://cursor.com/docs/cloud-agent/setup#the-environmentjson-spec)