### PR TITLE
Add nexus-rpc-gen schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9558,10 +9558,7 @@
     {
       "name": "nexus-rpc-gen",
       "description": "nexus-rpc-gen configuration for generating Nexus RPC service stubs",
-      "fileMatch": [
-        "*.nexusrpc.yaml",
-        "*.nexusrpc.yml"
-      ],
+      "fileMatch": ["*.nexusrpc.yaml", "*.nexusrpc.yml"],
       "url": "https://raw.githubusercontent.com/nexus-rpc/nexus-rpc-gen/main/schemas/nexus-rpc-gen.json"
     }
   ]


### PR DESCRIPTION
This pr adds a catalog entry for [NexusRPC definition files](https://github.com/nexus-rpc/nexus-rpc-gen/blob/main/schemas/nexus-rpc-gen.json)