### PR TITLE
update pyproject tool.pixi schema

### DIFF
--- a/src/schemas/json/partial-pixi.json
+++ b/src/schemas/json/partial-pixi.json
@@ -382,6 +382,7 @@
           "title": "Task",
           "description": "the name of the task to depend on",
           "type": "string",
+          "minLength": 1,
           "pattern": "^[^\\s\\$]+$"
         }
       }
@@ -642,7 +643,8 @@
             }
           },
           "propertyNames": {
-            "description": "A valid task name."
+            "description": "A valid task name.",
+            "minLength": 1
           }
         }
       }
@@ -1842,7 +1844,8 @@
             }
           },
           "propertyNames": {
-            "description": "A valid task name."
+            "description": "A valid task name.",
+            "minLength": 1
           }
         }
       }
@@ -1971,6 +1974,7 @@
                   {
                     "description": "A valid task name.",
                     "type": "string",
+                    "minLength": 1,
                     "pattern": "^[^\\s\\$]+$"
                   }
                 ]
@@ -1982,6 +1986,7 @@
             {
               "description": "A valid task name.",
               "type": "string",
+              "minLength": 1,
               "pattern": "^[^\\s\\$]+$"
             }
           ]
@@ -1995,12 +2000,14 @@
               "items": {
                 "description": "A valid task name.",
                 "type": "string",
+                "minLength": 1,
                 "pattern": "^[^\\s\\$]+$"
               }
             },
             {
               "description": "A valid task name.",
               "type": "string",
+              "minLength": 1,
               "pattern": "^[^\\s\\$]+$"
             }
           ]
@@ -2533,7 +2540,8 @@
         }
       },
       "propertyNames": {
-        "description": "A valid task name."
+        "description": "A valid task name.",
+        "minLength": 1
       }
     },
     "tool": {


### PR DESCRIPTION
Thanks again for maintaining this!

This PR fixes some issues with the `[tool.pixi]` schema fragment for `pyproject.toml` when consumed by `python-fastjsonschema`. This library is used in the (fairly foundational) Python `setuptools` build chain to generate standalone validators.

References:
- continues #5474
- generated from https://github.com/prefix-dev/pixi/pull/5732

Out of scope:
- it might be reasonable to catch these kind of issues earlier with a smoke test here to verify all of the `[tool.*]` schemata with that parser.