### PR TITLE
Add nested oxlint and oxfmt config files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9529,13 +9529,13 @@
     {
       "name": "oxfmt",
       "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem",
-      "fileMatch": [".oxfmtrc.json"],
+      "fileMatch": ["**/.oxfmtrc.json"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json"
     },
     {
       "name": "oxlint",
       "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack",
-      "fileMatch": [".oxlintrc.json"],
+      "fileMatch": ["**/.oxlintrc.json"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxlint/configuration_schema.json"
     },
     {


### PR DESCRIPTION
Oxlint supports [nested configuration files](https://oxc.rs/docs/guide/usage/linter/nested-config.html), and oxfmt has [an open issue to possibly support this](https://github.com/oxc-project/oxc/issues/19509) in the future.

This PR adds double-globs to the file matchers for both tools.