### PR TITLE
Add dualOutput property to traefik-v3 schema

### DIFF
--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -1403,6 +1403,9 @@
         "addInternals": {
           "type": "boolean"
         },
+        "dualOutput": {
+          "type": "boolean"
+        },
         "bufferingSize": {
           "type": "integer"
         },


### PR DESCRIPTION
Traefik 3.7 introduces a new `dualOutput` property for `static.yml` which allows OTLP + stdout logs to be output simultaneously.

This PR updates the schema to support the new property.

### References

- https://github.com/traefik/traefik/pull/12307
- Official [Docs](https://github.com/traefik/traefik/blob/67c64ed9b25fbb90f1086977a62827133a7aa01b/docs/content/reference/install-configuration/observability/logs-and-accesslogs.md?plain=1#L259-L261)

<img width="711" height="301" alt="image" src="https://github.com/user-attachments/assets/9ea8a705-60bc-4c44-adb6-e3d67f80c1b5" />

