### PR TITLE
Add XenForo addon.json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6981,7 +6981,7 @@
     {
       "name": "XenForo add-on manifest",
       "description": "A manifest describing a XenForo add-on",
-      "fileMatch": ["**/src/addons/*/*/addon.json"],
+      "fileMatch": ["**/src/addons/**/addon.json"],
       "url": "https://docs.xenforo.com/schema/addon.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6981,9 +6981,7 @@
     {
       "name": "XenForo add-on manifest",
       "description": "A manifest describing a XenForo add-on",
-      "fileMatch": [
-        "**/src/addons/**/addon.json"
-      ],
+      "fileMatch": ["**/src/addons/**/addon.json"],
       "url": "https://docs.xenforo.com/schema/addon.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6979,6 +6979,14 @@
       "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },
     {
+      "name": "XenForo add-on manifest",
+      "description": "A manifest describing a XenForo add-on",
+      "fileMatch": [
+        "**/src/addons/**/addon.json"
+      ],
+      "url": "https://docs.xenforo.com/schema/addon.schema.json"
+    },
+    {
       "name": "JSON-stat 2.0",
       "description": "JSON-stat 2.0",
       "url": "https://json-stat.org/format/schema/2.0/"

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6981,7 +6981,7 @@
     {
       "name": "XenForo add-on manifest",
       "description": "A manifest describing a XenForo add-on",
-      "fileMatch": ["**/src/addons/**/addon.json"],
+      "fileMatch": [],
       "url": "https://docs.xenforo.com/schema/addon.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6981,7 +6981,7 @@
     {
       "name": "XenForo add-on manifest",
       "description": "A manifest describing a XenForo add-on",
-      "fileMatch": ["**/src/addons/**/addon.json"],
+      "fileMatch": ["**/src/addons/*/*/addon.json"],
       "url": "https://docs.xenforo.com/schema/addon.schema.json"
     },
     {


### PR DESCRIPTION
This adds a schema for XenForo [`addon.json` files](https://docs.xenforo.com/devs/add-on-structure#addonjson-file). We may land support for naming them `addon.xf.json` in the future to allow resolution from add-on root folders.