### PR TITLE
Adding `upload` type to `github-issue-forms`

### DIFF
--- a/src/schemas/json/github-issue-forms.json
+++ b/src/schemas/json/github-issue-forms.json
@@ -7,7 +7,14 @@
     "type": {
       "description": "A form item type\nhttps://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#keys",
       "type": "string",
-      "enum": ["checkboxes", "dropdown", "input", "markdown", "textarea", "upload"]
+      "enum": [
+        "checkboxes",
+        "dropdown",
+        "input",
+        "markdown",
+        "textarea",
+        "upload"
+      ]
     },
     "id": {
       "type": "string",

--- a/src/test/github-issue-forms/official-example_3.yml
+++ b/src/test/github-issue-forms/official-example_3.yml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../../schemas/json/github-issue-forms.json
 name: Bug Report
 description: File a bug report.
-title: "[Bug]: "
-labels: ["bug", "triage"]
-projects: ["octo-org/1", "octo-org/44"]
+title: '[Bug]: '
+labels: ['bug', 'triage']
+projects: ['octo-org/1', 'octo-org/44']
 assignees:
   - octocat
 type: bug
@@ -26,7 +26,7 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened!"
+      value: 'A bug happened!'
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

It's now possible to use an `upload` type in GitHub issue templates, this pull request adds it to the schema following their documentation.

This example was failing:
```yaml
body:
  - type: upload
    id: screenshots
    attributes:
      label: Upload screenshots
      description: If applicable, add screenshots to help explain your problem.
    validations:
      required: false
```

Documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#upload
