### PR TITLE
Sync Bunfig Schema with Latest Docs

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -94,6 +94,41 @@
       "type": "boolean",
       "default": true
     },
+    "env": {
+      "$comment": "https://bun.sh/docs/runtime/bunfig#env",
+      "description": "Configure automatic `.env` file loading. By default, Bun automatically loads `.env` files.\nhttps://bun.sh/docs/runtime/bunfig#env",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "file": {
+              "description": "Enable or disable automatic default `.env` file loading.\nhttps://bun.sh/docs/runtime/bunfig#env",
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "console": {
+      "$comment": "https://bun.sh/docs/runtime/bunfig#console",
+      "description": "Configure console output behavior.\nhttps://bun.sh/docs/runtime/bunfig#console",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "depth": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#console-depth",
+          "description": "Set the default depth for `console.log()` object inspection. Default `2`\nhttps://bun.sh/docs/runtime/bunfig#console-depth",
+          "type": "integer",
+          "minimum": 0,
+          "default": 2,
+          "examples": [3]
+        }
+      }
+    },
     "test": {
       "$comment": "https://bun.sh/docs/runtime/bunfig#test-runner",
       "description": "Test runner\nhttps://bun.sh/docs/runtime/bunfig#test-runner",
@@ -121,6 +156,14 @@
             }
           ],
           "examples": [["./setup.ts"]]
+        },
+        "pathIgnorePatterns": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-pathignorepatterns",
+          "description": "Exclude files and directories from test discovery using glob patterns. Can be a single string pattern or an array of patterns.\nhttps://bun.sh/docs/runtime/bunfig#test-pathignorepatterns",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "smol": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#test-smol",
@@ -175,6 +218,67 @@
           "description": "Set path where coverage reports will be saved. Please notice, that it works only for persistent `coverageReporter` like `lcov`\nhttps://bun.sh/docs/runtime/bunfig#test-coveragedir",
           "type": "string",
           "default": "coverage"
+        },
+        "randomize": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-randomize",
+          "description": "Run tests in random order. Default `false`\nhttps://bun.sh/docs/runtime/bunfig#test-randomize",
+          "type": "boolean",
+          "default": false
+        },
+        "seed": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-seed",
+          "description": "Set the random seed for test randomization. This requires `randomize` to be `true`.\nhttps://bun.sh/docs/runtime/bunfig#test-seed",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [2444615283]
+        },
+        "rerunEach": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-reruneach",
+          "description": "Re-run each test file a specified number of times. Default `0` (run once).\nhttps://bun.sh/docs/runtime/bunfig#test-reruneach",
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "examples": [3]
+        },
+        "retry": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-retry",
+          "description": "Default retry count for all tests. Failed tests will be retried up to this many times. Default `0` (no retries).\nhttps://bun.sh/docs/runtime/bunfig#test-retry",
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "examples": [3]
+        },
+        "concurrentTestGlob": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-concurrenttestglob",
+          "description": "Glob pattern for test files that should run with concurrent test execution enabled.\nhttps://bun.sh/docs/runtime/bunfig#test-concurrenttestglob",
+          "type": "string",
+          "examples": ["**/concurrent-*.test.ts"]
+        },
+        "onlyFailures": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-onlyfailures",
+          "description": "When enabled, only failed tests are displayed in the output. Default `false`\nhttps://bun.sh/docs/runtime/bunfig#test-onlyfailures",
+          "type": "boolean",
+          "default": false
+        },
+        "reporter": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#test-reporter",
+          "description": "Configure the test reporter settings.\nhttps://bun.sh/docs/runtime/bunfig#test-reporter",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dots": {
+              "$comment": "https://bun.sh/docs/runtime/bunfig#test-reporter-dots",
+              "description": "Enable the dots reporter. Default `false`\nhttps://bun.sh/docs/runtime/bunfig#test-reporter-dots",
+              "type": "boolean",
+              "default": false
+            },
+            "junit": {
+              "$comment": "https://bun.sh/docs/runtime/bunfig#test-reporter-junit",
+              "description": "Enable JUnit XML reporting and set the output file path.\nhttps://bun.sh/docs/runtime/bunfig#test-reporter-junit",
+              "type": "string",
+              "examples": ["test-results.xml"]
+            }
+          }
         },
         "timeout": {
           "$comment": "https://bun.com/docs/test/configuration#default-timeout",
@@ -289,6 +393,12 @@
             "https://username:password@registry.npmjs.org",
             { "url": "https://registry.npmjs.org", "token": "123456" }
           ]
+        },
+        "linkWorkspacePackages": {
+          "$comment": "https://bun.sh/docs/runtime/bunfig#install-linkworkspacepackages",
+          "description": "Whether to link workspace packages from the monorepo root to their respective `node_modules` directories. Default `true`\nhttps://bun.sh/docs/runtime/bunfig#install-linkworkspacepackages",
+          "type": "boolean",
+          "default": true
         },
         "scopes": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-scopes",

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -14,6 +14,10 @@ jsxImportSource = "react"
 logLevel = "debug" # "debug" | "warn" | "error"
 
 telemetry = false
+env = false
+
+[console]
+depth = 3
 
 [define]
 # Replace any usage of "process.env.bagel" with the string `lox`.
@@ -35,6 +39,7 @@ optional = true
 peer = true
 production = false
 registry = "https://registry.npmjs.org"
+linkWorkspacePackages = true
 # The CA certificate as a string
 ca = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
 # A path to a CA certificate file. The file can contain multiple certificates.
@@ -71,10 +76,22 @@ silent = true
 
 [test]
 coverage = false
+coveragePathIgnorePatterns = ["**/*.spec.ts", "src/utils/**"]
 coverageSkipTestFiles = false
 # to require 90% line-level and function-level coverage
 coverageThreshold = 0.9
+concurrentTestGlob = "**/concurrent-*.test.ts"
+onlyFailures = true
 preload = ["./setup.ts"]
+pathIgnorePatterns = ["vendor/**", "submodules/**", "fixtures/**"]
+randomize = true
+rerunEach = 3
+retry = 3
 root = "./__tests__"
+seed = 2444615283
 smol = true
 timeout = 10000
+
+[test.reporter]
+dots = true
+junit = "test-results.xml"


### PR DESCRIPTION
## Summary
This PR updates Bun configuration support to match the latest `bunfig.toml` [docs](https://bun.sh/docs/runtime/bunfig).

## What Changed
- Updated [`bunfig` JSON schema](/Users/rin/GitHub/schemastore/src/schemas/json/bunfig.json) with newly documented options.
- Updated [`bunfig` TOML test fixture](/Users/rin/GitHub/schemastore/src/test/bunfig/bunfig.toml) to include examples for the new fields.

## New Schema Coverage
- Top-level:
  - `env` (boolean or object with `file`)
  - `console.depth`
- `[test]`:
  - `pathIgnorePatterns`
  - `randomize`
  - `seed`
  - `rerunEach`
  - `retry`
  - `concurrentTestGlob`
  - `onlyFailures`
  - `[test.reporter].dots`
  - `[test.reporter].junit`
- `[install]`:
  - `linkWorkspacePackages`

## Validation
- `jq empty src/schemas/json/bunfig.json`
- `node ./cli.js check`

Closes #4797 
In regards to #4923, I could not find documentation for this property.