### PR TITLE
feat: add Amazon Bedrock AgentCore schema catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9556,6 +9556,15 @@
       "description": "nexus-rpc-gen configuration for generating Nexus RPC service stubs",
       "fileMatch": ["*.nexusrpc.yaml", "*.nexusrpc.yml"],
       "url": "https://raw.githubusercontent.com/nexus-rpc/nexus-rpc-gen/main/schemas/nexus-rpc-gen.json"
+    },
+    {
+      "name": "AgentCore CLI",
+      "description": "Configuration file for Amazon Bedrock AgentCore CLI projects",
+      "fileMatch": ["**/agentcore/agentcore.json"],
+      "url": "https://schema.agentcore.aws.dev/v1/agentcore.json",
+      "versions": {
+        "1.0": "https://schema.agentcore.aws.dev/v1/agentcore.json"
+      }
     }
   ]
 }


### PR DESCRIPTION
Add schema support for AgentCore CLI config files: https://github.com/aws/agentcore-cli. 

Schema is self-hosted as a redirect to our GitHub here: https://github.com/aws/agentcore-cli/blob/main/schemas/agentcore.schema.v1.json, but the source file may move. 

