### PR TITLE
Update target default and add es2025

### DIFF
--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -608,7 +608,7 @@
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
-              "default": "es3",
+              "default": "es5",
               "anyOf": [
                 {
                   "enum": [
@@ -625,11 +625,12 @@
                     "es2022",
                     "es2023",
                     "es2024",
+                    "es2025",
                     "esnext"
                   ]
                 },
                 {
-                  "pattern": "^([Ee][Ss]([356]|(20(1[56789]|2[01234]))|[Nn][Ee][Xx][Tt]))$"
+                  "pattern": "^([Ee][Ss]([356]|(20(1[56789]|2[012345]))|[Nn][Ee][Xx][Tt]))$"
                 }
               ],
               "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"


### PR DESCRIPTION
This commit updates the default value for target to "es5" and adds "es2025" as an allowed value for target.

TypeScript documentation for this setting:
https://www.typescriptlang.org/tsconfig/#target