### PR TITLE
Add Knowledge Unit schema (IETF draft-farley-acta-knowledge-units)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3939,7 +3939,7 @@
       "name": "Knowledge Unit",
       "description": "Verified knowledge artifact produced through multi-model deliberation (IETF Internet-Draft: draft-farley-acta-knowledge-units)",
       "fileMatch": ["ku-*.json", "knowledge-unit.json", "**/ku/*.json"],
-      "url": "https://raw.githubusercontent.com/VeritasActa/drafts/main/knowledge-unit.schema.json"
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/knowledge-unit.json"
     },
     {
       "name": "kontinuous-values.yaml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3936,6 +3936,12 @@
       "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
     },
     {
+      "name": "Knowledge Unit",
+      "description": "Verified knowledge artifact produced through multi-model deliberation (IETF Internet-Draft: draft-farley-acta-knowledge-units)",
+      "fileMatch": ["ku-*.json", "knowledge-unit.json", "**/ku/*.json"],
+      "url": "https://raw.githubusercontent.com/VeritasActa/drafts/main/knowledge-unit.schema.json"
+    },
+    {
       "name": "kontinuous-values.yaml",
       "description": "Kontinuous values.yaml configuration files",
       "fileMatch": [

--- a/src/schemas/json/knowledge-unit.json
+++ b/src/schemas/json/knowledge-unit.json
@@ -72,7 +72,10 @@
             "required": ["claim"],
             "properties": {
               "claim": { "type": "string" },
-              "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+              "confidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"]
+              },
               "evidence": { "type": "string" },
               "source_refs": {
                 "type": "array",
@@ -241,7 +244,13 @@
           },
           "relation": {
             "type": "string",
-            "enum": ["supports", "contradicts", "refines", "extends", "depends_on"]
+            "enum": [
+              "supports",
+              "contradicts",
+              "refines",
+              "extends",
+              "depends_on"
+            ]
           },
           "claims": {
             "type": "array",

--- a/src/schemas/json/knowledge-unit.json
+++ b/src/schemas/json/knowledge-unit.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://veritasacta.com/schemas/knowledge-unit-v1.json",
+  "title": "Knowledge Unit",
+  "description": "A verified knowledge artifact produced through structured multi-model deliberation, as defined in draft-farley-acta-knowledge-units-00 (IETF Internet-Draft).",
+  "type": "object",
+  "required": [
+    "id",
+    "version",
+    "canonical_question",
+    "consensus_level",
+    "agreed",
+    "models_used",
+    "process_template",
+    "status",
+    "fresh_until",
+    "receipt_sig",
+    "receipt_kid",
+    "receipt_hash"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^ku-[a-z0-9]{12}$",
+      "description": "Unique identifier. Format: ku- followed by 12 alphanumeric characters."
+    },
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version number. Current version is 1."
+    },
+    "canonical_question": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The definitive question this KU answers."
+    },
+    "domain": {
+      "type": "string",
+      "enum": [
+        "technology",
+        "science",
+        "health",
+        "policy",
+        "economics",
+        "agent_security",
+        "agent_governance",
+        "research",
+        "engineering"
+      ],
+      "description": "Topic classification."
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+$"
+      },
+      "description": "Additional classification labels for cross-domain discovery."
+    },
+    "consensus_level": {
+      "type": "string",
+      "enum": ["unanimous", "strong", "split", "divergent"],
+      "description": "Structural classification of agreement among participating models."
+    },
+    "agreed": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "required": ["claim"],
+            "properties": {
+              "claim": { "type": "string" },
+              "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+              "evidence": { "type": "string" },
+              "source_refs": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        ]
+      },
+      "description": "Points where all participating models converge."
+    },
+    "disputed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["claim", "positions"],
+        "properties": {
+          "claim": { "type": "string" },
+          "positions": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          },
+          "significance": {
+            "type": "string",
+            "enum": ["core", "framing", "edge_case"]
+          }
+        }
+      },
+      "description": "Points where models diverge, with per-model positions."
+    },
+    "uncertain": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "object",
+            "required": ["claim"],
+            "properties": {
+              "claim": { "type": "string" },
+              "reason": { "type": "string" }
+            }
+          }
+        ]
+      },
+      "description": "Points that no model could resolve with confidence."
+    },
+    "synthesis": {
+      "type": "string",
+      "description": "Editorial summary. NOT canonical - the agreed/disputed/uncertain arrays are authoritative."
+    },
+    "models_used": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 2,
+      "description": "Model identifiers (provider/model format)."
+    },
+    "roster_version": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601 date of the model roster snapshot."
+    },
+    "roster_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "SHA-256 hash of the sorted models_used array."
+    },
+    "process_template": {
+      "type": "string",
+      "default": "3-round",
+      "description": "Deliberation process template used."
+    },
+    "total_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total tokens consumed across all rounds and models."
+    },
+    "total_cost_cents": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total API cost in US cents."
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["uri", "content_hash", "ingested_at"],
+        "properties": {
+          "uri": { "type": "string" },
+          "title": { "type": "string" },
+          "content_hash": {
+            "type": "string",
+            "pattern": "^sha256:[a-f0-9]{64}$"
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "description": "Source documents with content hashes for freshness validation."
+    },
+    "source_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Primary source URL (backwards compatibility)."
+    },
+    "source_title": {
+      "type": "string",
+      "description": "Primary source title (backwards compatibility)."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["active", "stale", "superseded"],
+      "description": "Current lifecycle state."
+    },
+    "fresh_until": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime after which this KU should be considered potentially stale."
+    },
+    "volatility": {
+      "type": "string",
+      "enum": ["stable", "evolving", "volatile"],
+      "default": "evolving",
+      "description": "Expected rate of change for this knowledge domain."
+    },
+    "supersedes": {
+      "type": ["string", "null"],
+      "pattern": "^ku-[a-z0-9]{12}$",
+      "description": "ID of the KU this KU replaces."
+    },
+    "parent_ku_id": {
+      "type": ["string", "null"],
+      "pattern": "^ku-[a-z0-9]{12}$",
+      "description": "ID of a parent KU from which this question was derived."
+    },
+    "published_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime of publication."
+    },
+    "receipt_sig": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{128}$",
+      "description": "Aggregate Ed25519 signature over the receipt chain hash."
+    },
+    "receipt_kid": {
+      "type": "string",
+      "description": "Key identifier for the signing key."
+    },
+    "receipt_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "SHA-256 hash of the chained per-round receipt hashes."
+    },
+    "relations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["target_ku_id", "relation"],
+        "properties": {
+          "target_ku_id": {
+            "type": "string",
+            "pattern": "^ku-[a-z0-9]{12}$"
+          },
+          "relation": {
+            "type": "string",
+            "enum": ["supports", "contradicts", "refines", "extends", "depends_on"]
+          },
+          "claims": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "description": "Typed relations to other Knowledge Units."
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/knowledge-unit/valid-full.json
+++ b/src/test/knowledge-unit/valid-full.json
@@ -1,10 +1,4 @@
 {
-  "id": "ku-abc123def456",
-  "version": 1,
-  "canonical_question": "What are the security implications of MCP tool delegation?",
-  "domain": "agent_security",
-  "tags": ["mcp", "tool-delegation", "access-control"],
-  "consensus_level": "split",
   "agreed": [
     {
       "claim": "Unrestricted tool delegation creates privilege escalation risks",
@@ -13,55 +7,63 @@
     },
     "Cedar-style policy languages provide declarative tool governance"
   ],
+  "canonical_question": "What are the security implications of MCP tool delegation?",
+  "consensus_level": "split",
   "disputed": [
     {
       "claim": "Whether human-in-the-loop approval is necessary for all tool calls",
       "positions": {
         "anthropic/claude-opus-4": "Required for destructive actions, optional for read-only",
-        "openai/gpt-5": "Required for all actions in regulated environments",
-        "deepseek/deepseek-r2": "Only required when the action exceeds a configurable risk threshold"
+        "deepseek/deepseek-r2": "Only required when the action exceeds a configurable risk threshold",
+        "openai/gpt-5": "Required for all actions in regulated environments"
       },
       "significance": "core"
     }
   ],
+  "domain": "agent_security",
+  "fresh_until": "2026-07-06T00:00:00Z",
+  "id": "ku-abc123def456",
+  "models_used": [
+    "anthropic/claude-opus-4",
+    "openai/gpt-5",
+    "deepseek/deepseek-r2"
+  ],
+  "parent_ku_id": null,
+  "process_template": "3-round",
+  "published_at": "2026-04-06T12:00:00Z",
+  "receipt_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "receipt_kid": "sb:issuer:de073ae64e43",
+  "receipt_sig": "d9ac58e7a399f3d4905ad564b5801e78cb5ea9ae96f229eea8d70770635780e6b63e47a40be5c02865ede2cd5fb4885093997daa4d86a194ab28a5f5316df20a",
+  "relations": [
+    {
+      "claims": [
+        "Unrestricted tool delegation creates privilege escalation risks"
+      ],
+      "relation": "refines",
+      "target_ku_id": "ku-oldversion1234"
+    }
+  ],
+  "roster_version": "2026-04-06",
+  "sources": [
+    {
+      "content_hash": "sha256:a3f8c91e4d7b2c6f8e9d0a1b3c5e7f9a2b4d6e8f0a2c4e6a8b0c2d4e6f8a0b2",
+      "ingested_at": "2026-04-01T10:00:00Z",
+      "title": "MCP Security Analysis",
+      "uri": "https://example.com/mcp-security-analysis.pdf"
+    }
+  ],
+  "status": "active",
+  "supersedes": "ku-oldversion1234",
+  "synthesis": "All models agree that unrestricted tool delegation is dangerous. The core disagreement is where to draw the line on human approval requirements.",
+  "tags": ["mcp", "tool-delegation", "access-control"],
+  "total_cost_cents": 12.5,
+  "total_tokens": 45000,
   "uncertain": [
     {
       "claim": "Whether current policy languages are expressive enough for multi-agent delegation chains",
       "reason": "rapidly evolving area"
     }
   ],
-  "synthesis": "All models agree that unrestricted tool delegation is dangerous. The core disagreement is where to draw the line on human approval requirements.",
-  "models_used": [
-    "anthropic/claude-opus-4",
-    "openai/gpt-5",
-    "deepseek/deepseek-r2"
-  ],
-  "roster_version": "2026-04-06",
-  "process_template": "3-round",
-  "total_tokens": 45000,
-  "total_cost_cents": 12.5,
-  "sources": [
-    {
-      "uri": "https://example.com/mcp-security-analysis.pdf",
-      "title": "MCP Security Analysis",
-      "content_hash": "sha256:a3f8c91e4d7b2c6f8e9d0a1b3c5e7f9a2b4d6e8f0a2c4e6a8b0c2d4e6f8a0b2",
-      "ingested_at": "2026-04-01T10:00:00Z"
-    }
-  ],
-  "status": "active",
-  "fresh_until": "2026-07-06T00:00:00Z",
-  "volatility": "evolving",
-  "supersedes": "ku-oldversion1234",
-  "parent_ku_id": null,
-  "published_at": "2026-04-06T12:00:00Z",
-  "receipt_sig": "d9ac58e7a399f3d4905ad564b5801e78cb5ea9ae96f229eea8d70770635780e6b63e47a40be5c02865ede2cd5fb4885093997daa4d86a194ab28a5f5316df20a",
-  "receipt_kid": "sb:issuer:de073ae64e43",
-  "receipt_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "relations": [
-    {
-      "target_ku_id": "ku-oldversion1234",
-      "relation": "refines",
-      "claims": ["Unrestricted tool delegation creates privilege escalation risks"]
-    }
-  ]
+  "version": 1,
+  "volatility": "evolving"
 }

--- a/src/test/knowledge-unit/valid-full.json
+++ b/src/test/knowledge-unit/valid-full.json
@@ -1,0 +1,67 @@
+{
+  "id": "ku-abc123def456",
+  "version": 1,
+  "canonical_question": "What are the security implications of MCP tool delegation?",
+  "domain": "agent_security",
+  "tags": ["mcp", "tool-delegation", "access-control"],
+  "consensus_level": "split",
+  "agreed": [
+    {
+      "claim": "Unrestricted tool delegation creates privilege escalation risks",
+      "confidence": "high",
+      "evidence": "Multiple documented CVEs in MCP server implementations"
+    },
+    "Cedar-style policy languages provide declarative tool governance"
+  ],
+  "disputed": [
+    {
+      "claim": "Whether human-in-the-loop approval is necessary for all tool calls",
+      "positions": {
+        "anthropic/claude-opus-4": "Required for destructive actions, optional for read-only",
+        "openai/gpt-5": "Required for all actions in regulated environments",
+        "deepseek/deepseek-r2": "Only required when the action exceeds a configurable risk threshold"
+      },
+      "significance": "core"
+    }
+  ],
+  "uncertain": [
+    {
+      "claim": "Whether current policy languages are expressive enough for multi-agent delegation chains",
+      "reason": "rapidly evolving area"
+    }
+  ],
+  "synthesis": "All models agree that unrestricted tool delegation is dangerous. The core disagreement is where to draw the line on human approval requirements.",
+  "models_used": [
+    "anthropic/claude-opus-4",
+    "openai/gpt-5",
+    "deepseek/deepseek-r2"
+  ],
+  "roster_version": "2026-04-06",
+  "process_template": "3-round",
+  "total_tokens": 45000,
+  "total_cost_cents": 12.5,
+  "sources": [
+    {
+      "uri": "https://example.com/mcp-security-analysis.pdf",
+      "title": "MCP Security Analysis",
+      "content_hash": "sha256:a3f8c91e4d7b2c6f8e9d0a1b3c5e7f9a2b4d6e8f0a2c4e6a8b0c2d4e6f8a0b2",
+      "ingested_at": "2026-04-01T10:00:00Z"
+    }
+  ],
+  "status": "active",
+  "fresh_until": "2026-07-06T00:00:00Z",
+  "volatility": "evolving",
+  "supersedes": "ku-oldversion1234",
+  "parent_ku_id": null,
+  "published_at": "2026-04-06T12:00:00Z",
+  "receipt_sig": "d9ac58e7a399f3d4905ad564b5801e78cb5ea9ae96f229eea8d70770635780e6b63e47a40be5c02865ede2cd5fb4885093997daa4d86a194ab28a5f5316df20a",
+  "receipt_kid": "sb:issuer:de073ae64e43",
+  "receipt_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "relations": [
+    {
+      "target_ku_id": "ku-oldversion1234",
+      "relation": "refines",
+      "claims": ["Unrestricted tool delegation creates privilege escalation risks"]
+    }
+  ]
+}

--- a/src/test/knowledge-unit/valid-full.json
+++ b/src/test/knowledge-unit/valid-full.json
@@ -40,20 +40,20 @@
         "Unrestricted tool delegation creates privilege escalation risks"
       ],
       "relation": "refines",
-      "target_ku_id": "ku-oldversion1234"
+      "target_ku_id": "ku-oldversion12"
     }
   ],
   "roster_version": "2026-04-06",
   "sources": [
     {
-      "content_hash": "sha256:a3f8c91e4d7b2c6f8e9d0a1b3c5e7f9a2b4d6e8f0a2c4e6a8b0c2d4e6f8a0b2",
+      "content_hash": "sha256:a3f8c91e4d7b2c6f8e9d0a1b3c5e7f9a2b4d6e8f0a2c4e6a8b0c2d4e6f8a0b2c",
       "ingested_at": "2026-04-01T10:00:00Z",
       "title": "MCP Security Analysis",
       "uri": "https://example.com/mcp-security-analysis.pdf"
     }
   ],
   "status": "active",
-  "supersedes": "ku-oldversion1234",
+  "supersedes": "ku-oldversion12",
   "synthesis": "All models agree that unrestricted tool delegation is dangerous. The core disagreement is where to draw the line on human approval requirements.",
   "tags": ["mcp", "tool-delegation", "access-control"],
   "total_cost_cents": 12.5,

--- a/src/test/knowledge-unit/valid-minimal.json
+++ b/src/test/knowledge-unit/valid-minimal.json
@@ -1,0 +1,23 @@
+{
+  "id": "ku-z36vuoreb2k3",
+  "version": 1,
+  "canonical_question": "Are LLMs approaching a capability plateau?",
+  "consensus_level": "strong",
+  "agreed": [
+    "LLMs have not yet plateaued on reasoning benchmarks",
+    "Scaling laws continue to hold for compute",
+    "Data quality matters more than data quantity"
+  ],
+  "models_used": [
+    "anthropic/claude-opus-4",
+    "openai/gpt-5",
+    "google/gemini-2.5-pro",
+    "deepseek/deepseek-r2"
+  ],
+  "process_template": "3-round",
+  "status": "active",
+  "fresh_until": "2026-07-06T00:00:00Z",
+  "receipt_sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b",
+  "receipt_kid": "sb:issuer:de073ae64e43",
+  "receipt_hash": "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+}

--- a/src/test/knowledge-unit/valid-minimal.json
+++ b/src/test/knowledge-unit/valid-minimal.json
@@ -1,13 +1,13 @@
 {
-  "id": "ku-z36vuoreb2k3",
-  "version": 1,
-  "canonical_question": "Are LLMs approaching a capability plateau?",
-  "consensus_level": "strong",
   "agreed": [
     "LLMs have not yet plateaued on reasoning benchmarks",
     "Scaling laws continue to hold for compute",
     "Data quality matters more than data quantity"
   ],
+  "canonical_question": "Are LLMs approaching a capability plateau?",
+  "consensus_level": "strong",
+  "fresh_until": "2026-07-06T00:00:00Z",
+  "id": "ku-z36vuoreb2k3",
   "models_used": [
     "anthropic/claude-opus-4",
     "openai/gpt-5",
@@ -15,9 +15,9 @@
     "deepseek/deepseek-r2"
   ],
   "process_template": "3-round",
-  "status": "active",
-  "fresh_until": "2026-07-06T00:00:00Z",
-  "receipt_sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b",
+  "receipt_hash": "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730",
   "receipt_kid": "sb:issuer:de073ae64e43",
-  "receipt_hash": "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730"
+  "receipt_sig": "3da3162da83e2c99968f91059c5f56209f44a69c269a058ed7c2f0b80110ad878da25b86cf053386f31483001bfe50f3eca57d67f14f8114e629b3bd40dec30b",
+  "status": "active",
+  "version": 1
 }


### PR DESCRIPTION
## Summary

Adds the Knowledge Unit JSON Schema, defined by IETF Internet-Draft [draft-farley-acta-knowledge-units-00](https://datatracker.ietf.org/doc/draft-farley-acta-knowledge-units/).

Knowledge Units are verified knowledge artifacts produced through structured multi-model deliberation. The format captures:
- Structured consensus (agreed/disputed/uncertain claims with per-model positions)
- Source provenance (content hashes for freshness validation)
- Lifecycle management (active/stale/superseded with typed operations)
- Cryptographic receipt binding (Ed25519 signatures per deliberation round)
- Inter-KU relations (supports/contradicts/refines/extends/depends_on)

## File matches
- `ku-*.json`
- `knowledge-unit.json`
- `**/ku/*.json`

## Schema source
- Hosted at: https://github.com/VeritasActa/drafts/blob/main/knowledge-unit.schema.json
- IETF Draft: https://datatracker.ietf.org/doc/draft-farley-acta-knowledge-units/
- Reference implementation: https://acta.today/wiki (50+ Knowledge Units)
- Companion draft: [draft-farley-acta-signed-receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)

## Tests
- `valid-minimal.json` - Required fields only
- `valid-full.json` - All fields including disputed claims, sources, relations