### PR TITLE
Add raid profile and raid repo remote schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9619,6 +9619,18 @@
       "description": "Configuration file for Qwen Code",
       "fileMatch": ["**/.qwen/settings.json"],
       "url": "https://www.schemastore.org/qwen-code-settings.json"
+    },
+    {
+      "name": "Raid Profile",
+      "description": "Definition for one or more Raid Profiles",
+      "fileMatch": ["*.raid.yaml", "*.raid.yml", "*.raid.json"],
+      "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-profile.schema.json"
+    },
+    {
+      "name": "Raid Repo Configuration",
+      "description": "Definition for a single repository",
+      "fileMatch": ["raid.yaml", "raid.yml", "raid.json"],
+      "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-repo.schema.json"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds support for Raid configuration files to the JSON catalog, enabling schema validation for both Raid profiles and repository configuration files.

**Schema additions:**

* Added a schema for Raid Profile files (`*.raid.yaml`, `*.raid.yml`, `*.raid.json`) with a reference to the official schema URL.
* Added a schema for Raid Repo Configuration files (`raid.yaml`, `raid.yml`, `raid.json`) with a reference to the official schema URL.