### PR TITLE
Add JSON schema for Rustdoc lints and update Cargo schema references

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -320,6 +320,10 @@
     // Below this line are subschemas that are included from other schema
     "base.json",
     "base-04.json",
+    "cargo-lints-rustdoc.json",
+    "cargo-lints-cargo.json",
+    "cargo-lints-clippy.json",
+    "cargo-lints-rust.json",
     "partial-pyright.json", // pyproject.json[tool.pyright]
     "partial-setuptools.json", // pyproject.json[tool.setuptools]
     "partial-setuptools-scm.json", // pyproject.json[tool.setuptools-scm]
@@ -854,7 +858,13 @@
       "unknownKeywords": ["links"]
     },
     "cargo.json": {
-      "externalSchema": ["base.json"],
+      "externalSchema": [
+        "base.json",
+        "cargo-lints-rust.json",
+        "cargo-lints-rustdoc.json",
+        "cargo-lints-clippy.json",
+        "cargo-lints-cargo.json"
+      ],
       "unknownFormat": ["uint32", "semver", "semver-requirement"]
     },
     "cheatsheets.json": {

--- a/src/schemas/json/cargo-lints-cargo.json
+++ b/src/schemas/json/cargo-lints-cargo.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/cargo-lints-cargo.json",
+  "title": "Cargo Lints",
+  "description": "Lint settings for Cargo individual lints and lint groups.",
+  "type": "object",
+  "properties": {
+    "blanket_hint_mostly_unused": {
+      "$ref": "#/definitions/Lint",
+      "title": "Blanket Hint Mostly Unused",
+      "description": "Checks if `hint-mostly-unused` is being applied to all dependencies.",
+      "default": "warn"
+    },
+    "implicit_minimum_version_req": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Minimum Version Req",
+      "description": "Checks for dependency version requirements that do not explicitly specify a full `major.minor.patch` version requirement.",
+      "default": "allow"
+    },
+    "unknown_lints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unknown Lints",
+      "description": "Checks for unknown lints in the `[lints.cargo]` table.",
+      "default": "warn"
+    },
+    "complexity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Complexity",
+      "description": "Code that does something simple but in a complex way.",
+      "default": "warn"
+    },
+    "correctness": {
+      "$ref": "#/definitions/Lint",
+      "title": "Correctness",
+      "description": "Code that is outright wrong or useless.",
+      "default": "deny"
+    },
+    "nursery": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nursery",
+      "description": "New lints that are still under development.",
+      "default": "allow"
+    },
+    "pedantic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pedantic",
+      "description": "Lints which are rather strict or have occasional false positives.",
+      "default": "allow"
+    },
+    "perf": {
+      "$ref": "#/definitions/Lint",
+      "title": "Perf",
+      "description": "Code that can be written to run faster.",
+      "default": "warn"
+    },
+    "restriction": {
+      "$ref": "#/definitions/Lint",
+      "title": "Restriction",
+      "description": "Lints which prevent the use of Cargo features.",
+      "default": "allow"
+    },
+    "style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Style",
+      "description": "Code that should be written in a more idiomatic way.",
+      "default": "warn"
+    },
+    "suspicious": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious",
+      "description": "Code that is most likely wrong or useless.",
+      "default": "warn"
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/Lint"
+  },
+  "x-tombi-table-keys-order": "version-sort",
+  "x-tombi-additional-key-label": "lint_name",
+  "definitions": {
+    "DetailedLint": {
+      "title": "Detailed Lint",
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/LintLevel"
+        },
+        "priority": {
+          "description": "The priority that controls which lints or lint groups override other lint groups. Lower (particularly negative) numbers have lower priority, being overridden by higher numbers, and show up first on the command-line to tools like rustc.",
+          "type": "integer"
+        }
+      },
+      "x-tombi-table-keys-order": "schema"
+    },
+    "Lint": {
+      "title": "Lint",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LintLevel"
+        },
+        {
+          "$ref": "#/definitions/DetailedLint"
+        }
+      ]
+    },
+    "LintLevel": {
+      "title": "Lint Level",
+      "description": "Specify the lint level for a lint or lint group.",
+      "type": "string",
+      "enum": ["forbid", "deny", "warn", "allow"]
+    }
+  }
+}

--- a/src/schemas/json/cargo-lints-clippy.json
+++ b/src/schemas/json/cargo-lints-clippy.json
@@ -1,0 +1,5069 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/cargo-lints-clippy.json",
+  "title": "Clippy Lints",
+  "description": "Lint settings for Clippy individual lints and lint groups.",
+  "type": "object",
+  "properties": {
+    "absolute_paths": {
+      "$ref": "#/definitions/Lint",
+      "title": "Absolute Paths",
+      "description": "Checks for usage of items through absolute paths, like `std::env::current_dir`.",
+      "default": "allow"
+    },
+    "absurd_extreme_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Absurd Extreme Comparisons",
+      "description": "Checks for comparisons where one side of the relation is either the minimum or maximum value for its type and warns if it involves a case that is always true or always false. Only integer and boolean types are checked.",
+      "default": "deny"
+    },
+    "all": {
+      "$ref": "#/definitions/Lint",
+      "title": "All Clippy Lints",
+      "description": "The whole set of warn-by-default lints using the `clippy` lint group (`#![allow(clippy::all)]`)."
+    },
+    "alloc_instead_of_core": {
+      "$ref": "#/definitions/Lint",
+      "title": "Alloc Instead Of Core",
+      "description": "Finds items imported through `alloc` when available through `core`.",
+      "default": "allow"
+    },
+    "allow_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Allow Attributes",
+      "description": "Checks for usage of the `#[allow]` attribute and suggests replacing it with the `#[expect]` attribute (See RFC 2383)",
+      "default": "allow"
+    },
+    "allow_attributes_without_reason": {
+      "$ref": "#/definitions/Lint",
+      "title": "Allow Attributes Without Reason",
+      "description": "Checks for attributes that allow lints without a reason.",
+      "default": "allow"
+    },
+    "almost_complete_range": {
+      "$ref": "#/definitions/Lint",
+      "title": "Almost Complete Range",
+      "description": "Checks for ranges which almost include the entire range of letters from 'a' to 'z' or digits from '0' to '9', but don't because they're a half open range.",
+      "default": "warn"
+    },
+    "almost_swapped": {
+      "$ref": "#/definitions/Lint",
+      "title": "Almost Swapped",
+      "description": "Checks for `foo = bar; bar = foo` sequences.",
+      "default": "deny"
+    },
+    "approx_constant": {
+      "$ref": "#/definitions/Lint",
+      "title": "Approx Constant",
+      "description": "Checks for floating point literals that approximate constants which are defined in `std::f32::consts` or `std::f64::consts`, respectively, suggesting to use the predefined constant.",
+      "default": "deny"
+    },
+    "arbitrary_source_item_ordering": {
+      "$ref": "#/definitions/Lint",
+      "title": "Arbitrary Source Item Ordering",
+      "description": "Confirms that items are sorted in source files as per configuration.",
+      "default": "allow"
+    },
+    "arc_with_non_send_sync": {
+      "$ref": "#/definitions/Lint",
+      "title": "Arc With Non Send Sync",
+      "description": "This lint warns when you use `Arc` with a type that does not implement `Send` or `Sync`.",
+      "default": "warn"
+    },
+    "arithmetic_side_effects": {
+      "$ref": "#/definitions/Lint",
+      "title": "Arithmetic Side Effects",
+      "description": "Checks any kind of arithmetic operation of any type.",
+      "default": "allow"
+    },
+    "as_conversions": {
+      "$ref": "#/definitions/Lint",
+      "title": "As Conversions",
+      "description": "Checks for usage of `as` conversions.",
+      "default": "allow"
+    },
+    "as_pointer_underscore": {
+      "$ref": "#/definitions/Lint",
+      "title": "As Pointer Underscore",
+      "description": "Checks for the usage of `as *const _` or `as *mut _` conversion using inferred type.",
+      "default": "allow"
+    },
+    "as_ptr_cast_mut": {
+      "$ref": "#/definitions/Lint",
+      "title": "As Ptr Cast Mut",
+      "description": "Checks for the result of a `&self`-taking `as_ptr` being cast to a mutable pointer.",
+      "default": "allow"
+    },
+    "as_underscore": {
+      "$ref": "#/definitions/Lint",
+      "title": "As Underscore",
+      "description": "Checks for the usage of `as _` conversion using inferred type.",
+      "default": "allow"
+    },
+    "assertions_on_constants": {
+      "$ref": "#/definitions/Lint",
+      "title": "Assertions On Constants",
+      "description": "Checks for `assert!(true)` and `assert!(false)` calls.",
+      "default": "warn"
+    },
+    "assertions_on_result_states": {
+      "$ref": "#/definitions/Lint",
+      "title": "Assertions On Result States",
+      "description": "Checks for `assert!(r.is_ok())` or `assert!(r.is_err())` calls.",
+      "default": "allow"
+    },
+    "assign_op_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Assign Op Pattern",
+      "description": "Checks for `a = a op b` or `a = b commutative_op a` patterns.",
+      "default": "warn"
+    },
+    "assign_ops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Assign Ops",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "assigning_clones": {
+      "$ref": "#/definitions/Lint",
+      "title": "Assigning Clones",
+      "description": "Checks for code like `foo = bar.clone();`",
+      "default": "allow"
+    },
+    "async_yields_async": {
+      "$ref": "#/definitions/Lint",
+      "title": "Async Yields Async",
+      "description": "Checks for async blocks that yield values of types that can themselves be awaited.",
+      "default": "deny"
+    },
+    "await_holding_invalid_type": {
+      "$ref": "#/definitions/Lint",
+      "title": "Await Holding Invalid Type",
+      "description": "Allows users to configure types which should not be held across await suspension points.",
+      "default": "warn"
+    },
+    "await_holding_lock": {
+      "$ref": "#/definitions/Lint",
+      "title": "Await Holding Lock",
+      "description": "Checks for calls to `await` while holding a non-async-aware `MutexGuard`.",
+      "default": "warn"
+    },
+    "await_holding_refcell_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Await Holding Refcell Ref",
+      "description": "Checks for calls to `await` while holding a `RefCell`, `Ref`, or `RefMut`.",
+      "default": "warn"
+    },
+    "bad_bit_mask": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bad Bit Mask",
+      "description": "Checks for incompatible bit masks in comparisons.",
+      "default": "deny"
+    },
+    "big_endian_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Big Endian Bytes",
+      "description": "Checks for the usage of the `to_be_bytes` method and/or the function `from_be_bytes`.",
+      "default": "allow"
+    },
+    "bind_instead_of_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bind Instead Of Map",
+      "description": "Checks for usage of `_.and_then(|x| Some(y))`, `_.and_then(|x| Ok(y))` or `_.or_else(|x| Err(y))`.",
+      "default": "warn"
+    },
+    "blanket_clippy_restriction_lints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Blanket Clippy Restriction Lints",
+      "description": "Checks for `warn`/`deny`/`forbid` attributes targeting the whole clippy::restriction category.",
+      "default": "warn"
+    },
+    "blocks_in_conditions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Blocks In Conditions",
+      "description": "Checks for `if` and `match` conditions that use blocks containing an expression, statements or conditions that use closures with blocks.",
+      "default": "warn"
+    },
+    "bool_assert_comparison": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bool Assert Comparison",
+      "description": "This lint warns about boolean comparisons in assert-like macros.",
+      "default": "warn"
+    },
+    "bool_comparison": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bool Comparison",
+      "description": "Checks for expressions of the form `x == true`, `x!= true` and order comparisons such as `x",
+      "default": "warn"
+    },
+    "bool_to_int_with_if": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bool To Int With If",
+      "description": "Instead of using an if statement to convert a bool to an int, this lint suggests using a `from()` function or an `as` coercion.",
+      "default": "allow"
+    },
+    "borrow_as_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Borrow As Ptr",
+      "description": "Checks for the usage of `&expr as *const T` or `&mut expr as *mut T`, and suggest using `&raw const` or `&raw mut` instead.",
+      "default": "allow"
+    },
+    "borrow_deref_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Borrow Deref Ref",
+      "description": "Checks for `&*(&T)`.",
+      "default": "warn"
+    },
+    "borrow_interior_mutable_const": {
+      "$ref": "#/definitions/Lint",
+      "title": "Borrow Interior Mutable Const",
+      "description": "Checks for a borrow of a named constant with interior mutability.",
+      "default": "warn"
+    },
+    "borrowed_box": {
+      "$ref": "#/definitions/Lint",
+      "title": "Borrowed Box",
+      "description": "Checks for usage of `&Box ` anywhere in the code. Check the Box documentation for more information.",
+      "default": "warn"
+    },
+    "box_collection": {
+      "$ref": "#/definitions/Lint",
+      "title": "Box Collection",
+      "description": "Checks for usage of `Box ` where T is a collection such as Vec anywhere in the code. Check the Box documentation for more information.",
+      "default": "warn"
+    },
+    "box_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Box Default",
+      "description": "checks for `Box::new(Default::default())`, which can be written as `Box::default()`.",
+      "default": "warn"
+    },
+    "boxed_local": {
+      "$ref": "#/definitions/Lint",
+      "title": "Boxed Local",
+      "description": "Checks for usage of `Box ` where an unboxed `T` would work fine.",
+      "default": "warn"
+    },
+    "branches_sharing_code": {
+      "$ref": "#/definitions/Lint",
+      "title": "Branches Sharing Code",
+      "description": "Checks if the `if` and `else` block contain shared code that can be moved out of the blocks.",
+      "default": "allow"
+    },
+    "builtin_type_shadow": {
+      "$ref": "#/definitions/Lint",
+      "title": "Builtin Type Shadow",
+      "description": "Warns if a generic shadows a built-in type.",
+      "default": "warn"
+    },
+    "byte_char_slices": {
+      "$ref": "#/definitions/Lint",
+      "title": "Byte Char Slices",
+      "description": "Checks for hard to read slices of byte characters, that could be more easily expressed as a byte string.",
+      "default": "warn"
+    },
+    "bytes_count_to_len": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bytes Count To Len",
+      "description": "It checks for `str::bytes().count()` and suggests replacing it with `str::len()`.",
+      "default": "warn"
+    },
+    "bytes_nth": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bytes Nth",
+      "description": "Checks for the use of `.bytes().nth()`.",
+      "default": "warn"
+    },
+    "cargo": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cargo",
+      "description": "The `clippy::cargo` group gives you suggestions on how to improve your `Cargo.toml` file. This might be especially interesting if you want to publish your crate and are not sure if you have all useful information in your `Cargo.toml`.",
+      "default": "allow"
+    },
+    "cargo_common_metadata": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cargo Common Metadata",
+      "description": "Checks to see if all common metadata is defined in `Cargo.toml`. See: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata",
+      "default": "allow"
+    },
+    "case_sensitive_file_extension_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Case Sensitive File Extension Comparisons",
+      "description": "Checks for calls to `ends_with` with possible file extensions and suggests to use a case-insensitive approach instead.",
+      "default": "allow"
+    },
+    "cast_abs_to_unsigned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Abs To Unsigned",
+      "description": "Checks for usage of the `abs()` method that cast the result to unsigned.",
+      "default": "warn"
+    },
+    "cast_enum_constructor": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Enum Constructor",
+      "description": "Checks for casts from an enum tuple constructor to an integer.",
+      "default": "warn"
+    },
+    "cast_enum_truncation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Enum Truncation",
+      "description": "Checks for casts from an enum type to an integral type that will definitely truncate the value.",
+      "default": "warn"
+    },
+    "cast_lossless": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Lossless",
+      "description": "Checks for casts between numeric types that can be replaced by safe conversion functions.",
+      "default": "allow"
+    },
+    "cast_nan_to_int": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Nan To Int",
+      "description": "Checks for a known NaN float being cast to an integer",
+      "default": "warn"
+    },
+    "cast_possible_truncation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Possible Truncation",
+      "description": "Checks for casts between numeric types that may truncate large values. This is expected behavior, so the cast is `Allow` by default. It suggests user either explicitly ignore the lint, or use `try_from()` and handle the truncation, default, or panic explicitly.",
+      "default": "allow"
+    },
+    "cast_possible_wrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Possible Wrap",
+      "description": "Checks for casts from an unsigned type to a signed type of the same size, or possibly smaller due to target-dependent integers. Performing such a cast is a no-op for the compiler (that is, nothing is changed at the bit level), and the binary representation of the value is reinterpreted. This can cause wrapping if the value is too big for the target signed type. However, the cast works as defined, so this lint is `Allow` by default.",
+      "default": "allow"
+    },
+    "cast_precision_loss": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Precision Loss",
+      "description": "Checks for casts from any numeric type to a float type where the receiving type cannot store all values from the original type without rounding errors. This possible rounding is to be expected, so this lint is `Allow` by default.",
+      "default": "allow"
+    },
+    "cast_ptr_alignment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Ptr Alignment",
+      "description": "Checks for casts, using `as` or `pointer::cast`, from a less strictly aligned pointer to a more strictly aligned pointer.",
+      "default": "allow"
+    },
+    "cast_sign_loss": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Sign Loss",
+      "description": "Checks for casts from a signed to an unsigned numeric type. In this case, negative values wrap around to large positive values, which can be quite surprising in practice. However, since the cast works as defined, this lint is `Allow` by default.",
+      "default": "allow"
+    },
+    "cast_slice_different_sizes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Slice Different Sizes",
+      "description": "Checks for `as` casts between raw pointers to slices with differently sized elements.",
+      "default": "deny"
+    },
+    "cast_slice_from_raw_parts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cast Slice From Raw Parts",
+      "description": "Checks for a raw slice being cast to a slice pointer",
+      "default": "warn"
+    },
+    "cfg_not_test": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cfg Not Test",
+      "description": "Checks for usage of `cfg` that excludes code from `test` builds. (i.e., `#[cfg(not(test))]`)",
+      "default": "allow"
+    },
+    "char_indices_as_byte_indices": {
+      "$ref": "#/definitions/Lint",
+      "title": "Char Indices As Byte Indices",
+      "description": "Checks for usage of a character position yielded by `.chars().enumerate()` in a context where a byte index is expected, such as an argument to a specific `str` method or indexing into a `str` or `String`.",
+      "default": "deny"
+    },
+    "char_lit_as_u8": {
+      "$ref": "#/definitions/Lint",
+      "title": "Char Lit As U8",
+      "description": "Checks for expressions where a character literal is cast to `u8` and suggests using a byte literal instead.",
+      "default": "warn"
+    },
+    "chars_last_cmp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Chars Last Cmp",
+      "description": "Checks for usage of `_.chars().last()` or `_.chars().next_back()` on a `str` to check if it ends with a given char.",
+      "default": "warn"
+    },
+    "chars_next_cmp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Chars Next Cmp",
+      "description": "Checks for usage of `.chars().next()` on a `str` to check if it starts with a given char.",
+      "default": "warn"
+    },
+    "checked_conversions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Checked Conversions",
+      "description": "Checks for explicit bounds checking when casting.",
+      "default": "allow"
+    },
+    "clear_with_drain": {
+      "$ref": "#/definitions/Lint",
+      "title": "Clear With Drain",
+      "description": "Checks for usage of `.drain(..)` for the sole purpose of clearing a container.",
+      "default": "allow"
+    },
+    "clone_on_copy": {
+      "$ref": "#/definitions/Lint",
+      "title": "Clone On Copy",
+      "description": "Checks for usage of `.clone()` on a `Copy` type.",
+      "default": "warn"
+    },
+    "clone_on_ref_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Clone On Ref Ptr",
+      "description": "Checks for usage of `.clone()` on a ref-counted pointer, (`Rc`, `Arc`, `rc::Weak`, or `sync::Weak`), and suggests calling Clone via unified function syntax instead (e.g., `Rc::clone(foo)`).",
+      "default": "allow"
+    },
+    "cloned_instead_of_copied": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cloned Instead Of Copied",
+      "description": "Checks for usage of `cloned()` on an `Iterator` or `Option` where `copied()` could be used instead.",
+      "default": "allow"
+    },
+    "cloned_ref_to_slice_refs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cloned Ref To Slice Refs",
+      "description": "Checks for slice references with cloned references such as `&[f.clone()]`.",
+      "default": "warn"
+    },
+    "cmp_null": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cmp Null",
+      "description": "This lint checks for equality comparisons with `ptr::null` or `ptr::null_mut`",
+      "default": "warn"
+    },
+    "cmp_owned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cmp Owned",
+      "description": "Checks for conversions to owned values just for the sake of a comparison.",
+      "default": "warn"
+    },
+    "coerce_container_to_any": {
+      "$ref": "#/definitions/Lint",
+      "title": "Coerce Container To Any",
+      "description": "Protects against unintended coercion of references to container types to `&dyn Any` when the container type dereferences to a `dyn Any` which could be directly referenced instead.",
+      "default": "allow"
+    },
+    "cognitive_complexity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Cognitive Complexity",
+      "description": "We used to think it measured how hard a method is to understand.",
+      "default": "allow"
+    },
+    "collapsible_else_if": {
+      "$ref": "#/definitions/Lint",
+      "title": "Collapsible Else If",
+      "description": "Checks for collapsible `else { if... }` expressions that can be collapsed to `else if...`.",
+      "default": "allow"
+    },
+    "collapsible_if": {
+      "$ref": "#/definitions/Lint",
+      "title": "Collapsible If",
+      "description": "Checks for nested `if` statements which can be collapsed by `&&`-combining their conditions.",
+      "default": "warn"
+    },
+    "collapsible_match": {
+      "$ref": "#/definitions/Lint",
+      "title": "Collapsible Match",
+      "description": "Finds nested `match` or `if let` expressions where the patterns may be \"collapsed\" together without adding any branches.",
+      "default": "warn"
+    },
+    "collapsible_str_replace": {
+      "$ref": "#/definitions/Lint",
+      "title": "Collapsible Str Replace",
+      "description": "Checks for consecutive calls to `str::replace` (2 or more) that can be collapsed into a single call.",
+      "default": "warn"
+    },
+    "collection_is_never_read": {
+      "$ref": "#/definitions/Lint",
+      "title": "Collection Is Never Read",
+      "description": "Checks for collections that are never queried.",
+      "default": "allow"
+    },
+    "comparison_chain": {
+      "$ref": "#/definitions/Lint",
+      "title": "Comparison Chain",
+      "description": "Checks comparison chains written with `if` that can be rewritten with `match` and `cmp`.",
+      "default": "allow"
+    },
+    "comparison_to_empty": {
+      "$ref": "#/definitions/Lint",
+      "title": "Comparison To Empty",
+      "description": "Checks for comparing to an empty slice such as `\"\"` or `[]`, and suggests using `.is_empty()` where applicable.",
+      "default": "warn"
+    },
+    "complexity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Complexity",
+      "description": "The `clippy::complexity` group offers lints that give you suggestions on how to simplify your code. It mostly focuses on code that can be written in a shorter and more readable way, while preserving the semantics.",
+      "default": "warn"
+    },
+    "confusing_method_to_numeric_cast": {
+      "$ref": "#/definitions/Lint",
+      "title": "Confusing Method To Numeric Cast",
+      "description": "Checks for casts of a primitive method pointer like `max`/`min` to any integer type.",
+      "default": "warn"
+    },
+    "const_is_empty": {
+      "$ref": "#/definitions/Lint",
+      "title": "Const Is Empty",
+      "description": "It identifies calls to `.is_empty()` on constant values.",
+      "default": "warn"
+    },
+    "copy_iterator": {
+      "$ref": "#/definitions/Lint",
+      "title": "Copy Iterator",
+      "description": "Checks for types that implement `Copy` as well as `Iterator`.",
+      "default": "allow"
+    },
+    "correctness": {
+      "$ref": "#/definitions/Lint",
+      "title": "Correctness",
+      "description": "The `clippy::correctness` group is the only lint group in Clippy which lints are deny-by-default and abort the compilation when triggered. This is for good reason: If you see a `correctness` lint, it means that your code is outright wrong or useless, and you should try to fix it.",
+      "default": "deny"
+    },
+    "crate_in_macro_def": {
+      "$ref": "#/definitions/Lint",
+      "title": "Crate In Macro Def",
+      "description": "Checks for usage of `crate` as opposed to `$crate` in a macro definition.",
+      "default": "warn"
+    },
+    "create_dir": {
+      "$ref": "#/definitions/Lint",
+      "title": "Create Dir",
+      "description": "Checks usage of `std::fs::create_dir` and suggest using `std::fs::create_dir_all` instead.",
+      "default": "allow"
+    },
+    "crosspointer_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Crosspointer Transmute",
+      "description": "Checks for transmutes between a type `T` and `*T`.",
+      "default": "warn"
+    },
+    "dbg_macro": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dbg Macro",
+      "description": "Checks for usage of the `dbg!` macro.",
+      "default": "allow"
+    },
+    "debug_assert_with_mut_call": {
+      "$ref": "#/definitions/Lint",
+      "title": "Debug Assert With Mut Call",
+      "description": "Checks for function/method calls with a mutable parameter in `debug_assert!`, `debug_assert_eq!` and `debug_assert_ne!` macros.",
+      "default": "allow"
+    },
+    "decimal_bitwise_operands": {
+      "$ref": "#/definitions/Lint",
+      "title": "Decimal Bitwise Operands",
+      "description": "Checks for decimal literals used as bit masks in bitwise operations.",
+      "default": "allow"
+    },
+    "decimal_literal_representation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Decimal Literal Representation",
+      "description": "Warns if there is a better representation for a numeric literal.",
+      "default": "allow"
+    },
+    "declare_interior_mutable_const": {
+      "$ref": "#/definitions/Lint",
+      "title": "Declare Interior Mutable Const",
+      "description": "Checks for the declaration of named constant which contain interior mutability.",
+      "default": "warn"
+    },
+    "default_constructed_unit_structs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Constructed Unit Structs",
+      "description": "Checks for construction on unit struct using `default`.",
+      "default": "warn"
+    },
+    "default_instead_of_iter_empty": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Instead Of Iter Empty",
+      "description": "It checks for `std::iter::Empty::default()` and suggests replacing it with `std::iter::empty()`.",
+      "default": "warn"
+    },
+    "default_numeric_fallback": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Numeric Fallback",
+      "description": "Checks for usage of unconstrained numeric literals which may cause default numeric fallback in type inference.",
+      "default": "allow"
+    },
+    "default_trait_access": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Trait Access",
+      "description": "Checks for literal calls to `Default::default()`.",
+      "default": "allow"
+    },
+    "default_union_representation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Union Representation",
+      "description": "Displays a warning when a union is declared with the default representation (without a `#[repr(C)]` attribute).",
+      "default": "allow"
+    },
+    "deprecated": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated",
+      "description": "The `clippy::deprecated` is empty lints that exist to ensure that `#[allow(lintname)]` still compiles after the lint was deprecated. Deprecation \"removes\" lints by removing their functionality and marking them as deprecated, which may cause further warnings but cannot cause a compiler error."
+    },
+    "deprecated_cfg_attr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Cfg Attr",
+      "description": "Checks for `#[cfg_attr(rustfmt, rustfmt_skip)]` and suggests to replace it with `#[rustfmt::skip]`.",
+      "default": "warn"
+    },
+    "deprecated_clippy_cfg_attr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Clippy Cfg Attr",
+      "description": "Checks for `#[cfg_attr(feature = \"cargo-clippy\",...)]` and for `#[cfg(feature = \"cargo-clippy\")]` and suggests to replace it with `#[cfg_attr(clippy,...)]` or `#[cfg(clippy)]`.",
+      "default": "warn"
+    },
+    "deprecated_semver": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Semver",
+      "description": "Checks for `#[deprecated]` annotations with a `since` field that is not a valid semantic version. Also allows \"TBD\" to signal future deprecation.",
+      "default": "deny"
+    },
+    "deref_addrof": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deref Addrof",
+      "description": "Checks for usage of `*&` and `*&mut` in expressions.",
+      "default": "warn"
+    },
+    "deref_by_slicing": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deref By Slicing",
+      "description": "Checks for slicing expressions which are equivalent to dereferencing the value.",
+      "default": "allow"
+    },
+    "derivable_impls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Derivable Impls",
+      "description": "Detects manual `std::default::Default` implementations that are identical to a derived implementation.",
+      "default": "warn"
+    },
+    "derive_ord_xor_partial_ord": {
+      "$ref": "#/definitions/Lint",
+      "title": "Derive Ord Xor Partial Ord",
+      "description": "Lints against manual `PartialOrd` and `Ord` implementations for types with a derived `Ord` or `PartialOrd` implementation.",
+      "default": "deny"
+    },
+    "derive_partial_eq_without_eq": {
+      "$ref": "#/definitions/Lint",
+      "title": "Derive Partial Eq Without Eq",
+      "description": "Checks for types that derive `PartialEq` and could implement `Eq`.",
+      "default": "allow"
+    },
+    "derived_hash_with_manual_eq": {
+      "$ref": "#/definitions/Lint",
+      "title": "Derived Hash With Manual Eq",
+      "description": "Lints against manual `PartialEq` implementations for types with a derived `Hash` implementation.",
+      "default": "deny"
+    },
+    "disallowed_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Fields",
+      "description": "Denies the configured fields in clippy.toml",
+      "default": "warn"
+    },
+    "disallowed_macros": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Macros",
+      "description": "Denies the configured macros in clippy.toml",
+      "default": "warn"
+    },
+    "disallowed_methods": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Methods",
+      "description": "Denies the configured methods and functions in clippy.toml",
+      "default": "warn"
+    },
+    "disallowed_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Names",
+      "description": "Checks for usage of disallowed names for variables, such as `foo`.",
+      "default": "warn"
+    },
+    "disallowed_script_idents": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Script Idents",
+      "description": "Checks for usage of unicode scripts other than those explicitly allowed by the lint config.",
+      "default": "allow"
+    },
+    "disallowed_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Disallowed Types",
+      "description": "Denies the configured types in clippy.toml.",
+      "default": "warn"
+    },
+    "diverging_sub_expression": {
+      "$ref": "#/definitions/Lint",
+      "title": "Diverging Sub Expression",
+      "description": "Checks for diverging calls that are not match arms or statements.",
+      "default": "warn"
+    },
+    "doc_broken_link": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Broken Link",
+      "description": "Checks the doc comments have unbroken links, mostly caused by bad formatted links such as broken across multiple lines.",
+      "default": "allow"
+    },
+    "doc_comment_double_space_linebreaks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Comment Double Space Linebreaks",
+      "description": "Detects doc comment linebreaks that use double spaces to separate lines, instead of back-slash (`\\`).",
+      "default": "allow"
+    },
+    "doc_include_without_cfg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Include Without Cfg",
+      "description": "Checks if included files in doc comments are included only for `cfg(doc)`.",
+      "default": "allow"
+    },
+    "doc_lazy_continuation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Lazy Continuation",
+      "description": "In CommonMark Markdown, the language used to write doc comments, a paragraph nested within a list or block quote does not need any line after the first one to be indented or marked. The specification calls this a \"lazy paragraph continuation.\"",
+      "default": "warn"
+    },
+    "doc_link_code": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Link Code",
+      "description": "Checks for links with code directly adjacent to code text: `[`MyItem`]` ``.",
+      "default": "allow"
+    },
+    "doc_link_with_quotes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Link With Quotes",
+      "description": "Detects the syntax `['foo']` in documentation comments (notice quotes instead of backticks) outside of code blocks",
+      "default": "allow"
+    },
+    "doc_markdown": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Markdown",
+      "description": "Checks for the presence of `_`, `::` or camel-case words outside ticks in documentation.",
+      "default": "allow"
+    },
+    "doc_nested_refdefs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Nested Refdefs",
+      "description": "Warns if a link reference definition appears at the start of a list item or quote.",
+      "default": "warn"
+    },
+    "doc_overindented_list_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Overindented List Items",
+      "description": "Detects overindented list items in doc comments where the continuation lines are indented more than necessary.",
+      "default": "warn"
+    },
+    "doc_paragraphs_missing_punctuation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Paragraphs Missing Punctuation",
+      "description": "Checks for doc comments whose paragraphs do not end with a period or another punctuation mark. Various Markdowns constructs are taken into account to avoid false positives.",
+      "default": "allow"
+    },
+    "doc_suspicious_footnotes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Doc Suspicious Footnotes",
+      "description": "Detects syntax that looks like a footnote reference.",
+      "default": "warn"
+    },
+    "double_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Double Comparisons",
+      "description": "Checks for double comparisons that could be simplified to a single expression.",
+      "default": "warn"
+    },
+    "double_ended_iterator_last": {
+      "$ref": "#/definitions/Lint",
+      "title": "Double Ended Iterator Last",
+      "description": "Checks for `Iterator::last` being called on a `DoubleEndedIterator`, which can be replaced with `DoubleEndedIterator::next_back`.",
+      "default": "warn"
+    },
+    "double_must_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Double Must Use",
+      "description": "Checks for a `#[must_use]` attribute without further information on functions and methods that return a type already marked as `#[must_use]`.",
+      "default": "warn"
+    },
+    "double_parens": {
+      "$ref": "#/definitions/Lint",
+      "title": "Double Parens",
+      "description": "Checks for unnecessary double parentheses.",
+      "default": "warn"
+    },
+    "drain_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Drain Collect",
+      "description": "Checks for calls to `.drain()` that clear the collection, immediately followed by a call to `.collect()`.",
+      "default": "warn"
+    },
+    "drop_non_drop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Drop Non Drop",
+      "description": "Checks for calls to `std::mem::drop` with a value that does not implement `Drop`.",
+      "default": "warn"
+    },
+    "duplicate_mod": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duplicate Mod",
+      "description": "Checks for files that are included as modules multiple times.",
+      "default": "warn"
+    },
+    "duplicate_underscore_argument": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duplicate Underscore Argument",
+      "description": "Checks for function arguments having the similar names differing by an underscore.",
+      "default": "warn"
+    },
+    "duplicated_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duplicated Attributes",
+      "description": "Checks for attributes that appear two or more times.",
+      "default": "warn"
+    },
+    "duration_suboptimal_units": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duration Suboptimal Units",
+      "description": "Checks for instances where a `std::time::Duration` is constructed using a smaller time unit when the value could be expressed more clearly using a larger unit.",
+      "default": "allow"
+    },
+    "duration_subsec": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duration Subsec",
+      "description": "Checks for calculation of subsecond microseconds or milliseconds from other `Duration` methods.",
+      "default": "warn"
+    },
+    "eager_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Eager Transmute",
+      "description": "Checks for integer validity checks, followed by a transmute that is (incorrectly) evaluated eagerly (e.g. using `bool::then_some`).",
+      "default": "deny"
+    },
+    "elidable_lifetime_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Elidable Lifetime Names",
+      "description": "Checks for lifetime annotations which can be replaced with anonymous lifetimes (`'_`).",
+      "default": "allow"
+    },
+    "else_if_without_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Else If Without Else",
+      "description": "Checks for usage of if expressions with an `else if` branch, but without a final `else` branch.",
+      "default": "allow"
+    },
+    "empty_docs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Docs",
+      "description": "Detects documentation that is empty.",
+      "default": "warn"
+    },
+    "empty_drop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Drop",
+      "description": "Checks for empty `Drop` implementations.",
+      "default": "allow"
+    },
+    "empty_enum_variants_with_brackets": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Enum Variants With Brackets",
+      "description": "Finds enum variants without fields that are declared with empty brackets.",
+      "default": "allow"
+    },
+    "empty_enums": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Enums",
+      "description": "Checks for `enum`s with no variants, which therefore are uninhabited types (cannot be instantiated).",
+      "default": "allow"
+    },
+    "empty_line_after_doc_comments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Line After Doc Comments",
+      "description": "Checks for empty lines after doc comments.",
+      "default": "warn"
+    },
+    "empty_line_after_outer_attr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Line After Outer Attr",
+      "description": "Checks for empty lines after outer attributes",
+      "default": "warn"
+    },
+    "empty_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Loop",
+      "description": "Checks for empty `loop` expressions.",
+      "default": "warn"
+    },
+    "empty_structs_with_brackets": {
+      "$ref": "#/definitions/Lint",
+      "title": "Empty Structs With Brackets",
+      "description": "Finds structs without fields (a so-called \"empty struct\") that are declared with brackets.",
+      "default": "allow"
+    },
+    "enum_clike_unportable_variant": {
+      "$ref": "#/definitions/Lint",
+      "title": "Enum Clike Unportable Variant",
+      "description": "Checks for C-like enumerations that are `repr(isize/usize)` and have values that don't fit into an `i32`.",
+      "default": "deny"
+    },
+    "enum_glob_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Enum Glob Use",
+      "description": "Checks for `use Enum::*`.",
+      "default": "allow"
+    },
+    "enum_variant_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Enum Variant Names",
+      "description": "Detects enumeration variants that are prefixed or suffixed by the same characters.",
+      "default": "warn"
+    },
+    "eq_op": {
+      "$ref": "#/definitions/Lint",
+      "title": "Eq Op",
+      "description": "Checks for equal operands to comparison, logical and bitwise, difference and division binary operators (`==`, `>`, etc., `&&`, `||`, `&`, `|`, `^`, `-` and `/`).",
+      "default": "deny"
+    },
+    "equatable_if_let": {
+      "$ref": "#/definitions/Lint",
+      "title": "Equatable If Let",
+      "description": "Checks for pattern matchings that can be expressed using equality.",
+      "default": "allow"
+    },
+    "erasing_op": {
+      "$ref": "#/definitions/Lint",
+      "title": "Erasing Op",
+      "description": "Checks for erasing operations, e.g., `x * 0`.",
+      "default": "deny"
+    },
+    "err_expect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Err Expect",
+      "description": "Checks for `.err().expect()` calls on the `Result` type.",
+      "default": "warn"
+    },
+    "error_impl_error": {
+      "$ref": "#/definitions/Lint",
+      "title": "Error Impl Error",
+      "description": "Checks for types named `Error` that implement `Error`.",
+      "default": "allow"
+    },
+    "excessive_nesting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Excessive Nesting",
+      "description": "Checks for blocks which are nested beyond a certain threshold.",
+      "default": "warn"
+    },
+    "excessive_precision": {
+      "$ref": "#/definitions/Lint",
+      "title": "Excessive Precision",
+      "description": "Checks for float literals with a precision greater than that supported by the underlying type.",
+      "default": "warn"
+    },
+    "exhaustive_enums": {
+      "$ref": "#/definitions/Lint",
+      "title": "Exhaustive Enums",
+      "description": "Warns on any exported `enum`s that are not tagged `#[non_exhaustive]`",
+      "default": "allow"
+    },
+    "exhaustive_structs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Exhaustive Structs",
+      "description": "Warns on any exported `struct`s that are not tagged `#[non_exhaustive]`",
+      "default": "allow"
+    },
+    "exit": {
+      "$ref": "#/definitions/Lint",
+      "title": "Exit",
+      "description": "Detects calls to the `exit()` function that are not in the `main` function. Calls to `exit()` immediately terminate the program.",
+      "default": "allow"
+    },
+    "expect_fun_call": {
+      "$ref": "#/definitions/Lint",
+      "title": "Expect Fun Call",
+      "description": "Checks for calls to `.expect(&format!(...))`, `.expect(foo(..))`, etc., and suggests to use `unwrap_or_else` instead",
+      "default": "warn"
+    },
+    "expect_used": {
+      "$ref": "#/definitions/Lint",
+      "title": "Expect Used",
+      "description": "Checks for `.expect()` or `.expect_err()` calls on `Result`s and `.expect()` call on `Option`s.",
+      "default": "allow"
+    },
+    "expl_impl_clone_on_copy": {
+      "$ref": "#/definitions/Lint",
+      "title": "Expl Impl Clone On Copy",
+      "description": "Checks for explicit `Clone` implementations for `Copy` types.",
+      "default": "allow"
+    },
+    "explicit_auto_deref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Auto Deref",
+      "description": "Checks for dereferencing expressions which would be covered by auto-deref.",
+      "default": "warn"
+    },
+    "explicit_counter_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Counter Loop",
+      "description": "Checks `for` loops over slices with an explicit counter and suggests the use of `.enumerate()`.",
+      "default": "warn"
+    },
+    "explicit_deref_methods": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Deref Methods",
+      "description": "Checks for explicit `deref()` or `deref_mut()` method calls.",
+      "default": "allow"
+    },
+    "explicit_into_iter_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Into Iter Loop",
+      "description": "Checks for loops on `y.into_iter()` where `y` will do, and suggests the latter.",
+      "default": "allow"
+    },
+    "explicit_iter_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Iter Loop",
+      "description": "Checks for loops on `x.iter()` where `&x` will do, and suggests the latter.",
+      "default": "allow"
+    },
+    "explicit_write": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Write",
+      "description": "Checks for usage of `write!()` / `writeln()!` which can be replaced with `(e)print!()` / `(e)println!()`",
+      "default": "warn"
+    },
+    "extend_from_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Extend From Slice",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "extend_with_drain": {
+      "$ref": "#/definitions/Lint",
+      "title": "Extend With Drain",
+      "description": "Checks for occurrences where one vector gets extended instead of append",
+      "default": "warn"
+    },
+    "extra_unused_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Extra Unused Lifetimes",
+      "description": "Checks for lifetimes in generics that are never used anywhere else.",
+      "default": "warn"
+    },
+    "extra_unused_type_parameters": {
+      "$ref": "#/definitions/Lint",
+      "title": "Extra Unused Type Parameters",
+      "description": "Checks for type parameters in generics that are never used anywhere else.",
+      "default": "warn"
+    },
+    "fallible_impl_from": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fallible Impl From",
+      "description": "Checks for impls of `From ` that contain `panic!()` or `unwrap()`",
+      "default": "allow"
+    },
+    "field_reassign_with_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Field Reassign With Default",
+      "description": "Checks for immediate reassignment of fields initialized with Default::default().",
+      "default": "warn"
+    },
+    "field_scoped_visibility_modifiers": {
+      "$ref": "#/definitions/Lint",
+      "title": "Field Scoped Visibility Modifiers",
+      "description": "Checks for usage of scoped visibility modifiers, like `pub(crate)`, on fields. These make a field visible within a scope between public and private.",
+      "default": "allow"
+    },
+    "filetype_is_file": {
+      "$ref": "#/definitions/Lint",
+      "title": "Filetype Is File",
+      "description": "Checks for `FileType::is_file()`.",
+      "default": "allow"
+    },
+    "filter_map_bool_then": {
+      "$ref": "#/definitions/Lint",
+      "title": "Filter Map Bool Then",
+      "description": "Checks for usage of `bool::then` in `Iterator::filter_map`.",
+      "default": "warn"
+    },
+    "filter_map_identity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Filter Map Identity",
+      "description": "Checks for usage of `filter_map(|x| x)`.",
+      "default": "warn"
+    },
+    "filter_map_next": {
+      "$ref": "#/definitions/Lint",
+      "title": "Filter Map Next",
+      "description": "Checks for usage of `_.filter_map(_).next()`.",
+      "default": "allow"
+    },
+    "filter_next": {
+      "$ref": "#/definitions/Lint",
+      "title": "Filter Next",
+      "description": "Checks for usage of `_.filter(_).next()`.",
+      "default": "warn"
+    },
+    "flat_map_identity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Flat Map Identity",
+      "description": "Checks for usage of `flat_map(|x| x)`.",
+      "default": "warn"
+    },
+    "flat_map_option": {
+      "$ref": "#/definitions/Lint",
+      "title": "Flat Map Option",
+      "description": "Checks for usage of `Iterator::flat_map()` where `filter_map()` could be used instead.",
+      "default": "allow"
+    },
+    "float_arithmetic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Float Arithmetic",
+      "description": "Checks for float arithmetic.",
+      "default": "allow"
+    },
+    "float_cmp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Float Cmp",
+      "description": "Checks for (in-)equality comparisons on floating-point values (apart from zero), except in functions called `*eq*` (which probably implement equality for a type involving floats).",
+      "default": "allow"
+    },
+    "float_cmp_const": {
+      "$ref": "#/definitions/Lint",
+      "title": "Float Cmp Const",
+      "description": "Checks for (in-)equality comparisons on constant floating-point values (apart from zero), except in functions called `*eq*` (which probably implement equality for a type involving floats).",
+      "default": "allow"
+    },
+    "float_equality_without_abs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Float Equality Without Abs",
+      "description": "Checks for statements of the form `(a - b)",
+      "default": "warn"
+    },
+    "fn_params_excessive_bools": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fn Params Excessive Bools",
+      "description": "Checks for excessive use of bools in function definitions.",
+      "default": "allow"
+    },
+    "fn_to_numeric_cast": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fn To Numeric Cast",
+      "description": "Checks for casts of function pointers to something other than `usize`.",
+      "default": "warn"
+    },
+    "fn_to_numeric_cast_any": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fn To Numeric Cast Any",
+      "description": "Checks for casts of a function pointer to any integer type.",
+      "default": "allow"
+    },
+    "fn_to_numeric_cast_with_truncation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fn To Numeric Cast With Truncation",
+      "description": "Checks for casts of a function pointer to a numeric type not wide enough to store an address.",
+      "default": "warn"
+    },
+    "for_kv_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "For Kv Map",
+      "description": "Checks for iterating a map (`HashMap` or `BTreeMap`) and ignoring either the keys or values.",
+      "default": "warn"
+    },
+    "forget_non_drop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Forget Non Drop",
+      "description": "Checks for calls to `std::mem::forget` with a value that does not implement `Drop`.",
+      "default": "warn"
+    },
+    "format_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Format Collect",
+      "description": "Checks for usage of `.map(|_| format!(..)).collect:: ()`.",
+      "default": "allow"
+    },
+    "format_in_format_args": {
+      "$ref": "#/definitions/Lint",
+      "title": "Format In Format Args",
+      "description": "Detects `format!` within the arguments of another macro that does formatting such as `format!` itself, `write!` or `println!`. Suggests inlining the `format!` call.",
+      "default": "warn"
+    },
+    "format_push_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Format Push String",
+      "description": "Detects cases where the result of a `format!` call is appended to an existing `String`.",
+      "default": "allow"
+    },
+    "four_forward_slashes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Four Forward Slashes",
+      "description": "Checks for outer doc comments written with 4 forward slashes (`////`).",
+      "default": "warn"
+    },
+    "from_iter_instead_of_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "From Iter Instead Of Collect",
+      "description": "Checks for `from_iter()` function calls on types that implement the `FromIterator` trait.",
+      "default": "allow"
+    },
+    "from_over_into": {
+      "$ref": "#/definitions/Lint",
+      "title": "From Over Into",
+      "description": "Searches for implementations of the `Into ` trait and suggests to implement `From ` instead.",
+      "default": "warn"
+    },
+    "from_raw_with_void_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "From Raw With Void Ptr",
+      "description": "Checks if we're passing a `c_void` raw pointer to `{Box,Rc,Arc,Weak}::from_raw(_)`",
+      "default": "warn"
+    },
+    "from_str_radix_10": {
+      "$ref": "#/definitions/Lint",
+      "title": "From Str Radix 10",
+      "description": "Checks for function invocations of the form `primitive::from_str_radix(s, 10)`",
+      "default": "warn"
+    },
+    "future_not_send": {
+      "$ref": "#/definitions/Lint",
+      "title": "Future Not Send",
+      "description": "This lint requires Future implementations returned from functions and methods to implement the `Send` marker trait, ignoring type parameters.",
+      "default": "allow"
+    },
+    "get_first": {
+      "$ref": "#/definitions/Lint",
+      "title": "Get First",
+      "description": "Checks for usage of `x.get(0)` instead of `x.first()` or `x.front()`.",
+      "default": "warn"
+    },
+    "get_last_with_len": {
+      "$ref": "#/definitions/Lint",
+      "title": "Get Last With Len",
+      "description": "Checks for usage of `x.get(x.len() - 1)` instead of `x.last()`.",
+      "default": "warn"
+    },
+    "get_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Get Unwrap",
+      "description": "Checks for usage of `.get().unwrap()` (or `.get_mut().unwrap`) on a standard library type which implements `Index`",
+      "default": "allow"
+    },
+    "host_endian_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Host Endian Bytes",
+      "description": "Checks for the usage of the `to_ne_bytes` method and/or the function `from_ne_bytes`.",
+      "default": "allow"
+    },
+    "identity_op": {
+      "$ref": "#/definitions/Lint",
+      "title": "Identity Op",
+      "description": "Checks for identity operations, e.g., `x + 0`.",
+      "default": "warn"
+    },
+    "if_let_mutex": {
+      "$ref": "#/definitions/Lint",
+      "title": "If Let Mutex",
+      "description": "Checks for `Mutex::lock` calls in `if let` expression with lock calls in any of the else blocks.",
+      "default": "deny"
+    },
+    "if_not_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "If Not Else",
+      "description": "Checks for usage of `!` or `!=` in an if condition with an else branch.",
+      "default": "allow"
+    },
+    "if_same_then_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "If Same Then Else",
+      "description": "Checks for `if/else` with the same body as the then part and the else part.",
+      "default": "warn"
+    },
+    "if_then_some_else_none": {
+      "$ref": "#/definitions/Lint",
+      "title": "If Then Some Else None",
+      "description": "Checks for if-else that could be written using either `bool::then` or `bool::then_some`.",
+      "default": "allow"
+    },
+    "ifs_same_cond": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ifs Same Cond",
+      "description": "Checks for consecutive `if`s with the same condition.",
+      "default": "deny"
+    },
+    "ignore_without_reason": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ignore Without Reason",
+      "description": "Checks for ignored tests without messages.",
+      "default": "allow"
+    },
+    "ignored_unit_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ignored Unit Patterns",
+      "description": "Checks for usage of `_` in patterns of type `()`.",
+      "default": "allow"
+    },
+    "impl_hash_borrow_with_str_and_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Impl Hash Borrow With Str And Bytes",
+      "description": "This lint is concerned with the semantics of `Borrow` and `Hash` for a type that implements all three of `Hash`, `Borrow ` and `Borrow ` as it is impossible to satisfy the semantics of Borrow and `Hash` for both `Borrow ` and `Borrow `.",
+      "default": "deny"
+    },
+    "impl_trait_in_params": {
+      "$ref": "#/definitions/Lint",
+      "title": "Impl Trait In Params",
+      "description": "Lints when `impl Trait` is being used in a function's parameters.",
+      "default": "allow"
+    },
+    "implicit_clone": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Clone",
+      "description": "Checks for the usage of `_.to_owned()`, `vec.to_vec()`, or similar when calling `_.clone()` would be clearer.",
+      "default": "allow"
+    },
+    "implicit_hasher": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Hasher",
+      "description": "Checks for public `impl` or `fn` missing generalization over different hashers and implicitly defaulting to the default hashing algorithm (`SipHash`).",
+      "default": "allow"
+    },
+    "implicit_return": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Return",
+      "description": "Checks for missing return statements at the end of a block.",
+      "default": "allow"
+    },
+    "implicit_saturating_add": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Saturating Add",
+      "description": "Checks for implicit saturating addition.",
+      "default": "warn"
+    },
+    "implicit_saturating_sub": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implicit Saturating Sub",
+      "description": "Checks for implicit saturating subtraction.",
+      "default": "warn"
+    },
+    "implied_bounds_in_impls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Implied Bounds In Impls",
+      "description": "Looks for bounds in `impl Trait` in return position that are implied by other bounds. This can happen when a trait is specified that another trait already has as a supertrait (e.g. `fn() -> impl Deref + DerefMut ` has an unnecessary `Deref` bound, because `Deref` is a supertrait of `DerefMut`)",
+      "default": "warn"
+    },
+    "impossible_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Impossible Comparisons",
+      "description": "Checks for double comparisons that can never succeed",
+      "default": "deny"
+    },
+    "imprecise_flops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Imprecise Flops",
+      "description": "Looks for floating-point expressions that can be expressed using built-in methods to improve accuracy at the cost of performance.",
+      "default": "allow"
+    },
+    "incompatible_msrv": {
+      "$ref": "#/definitions/Lint",
+      "title": "Incompatible Msrv",
+      "description": "This lint checks that no function newer than the defined MSRV (minimum supported rust version) is used in the crate.",
+      "default": "warn"
+    },
+    "inconsistent_digit_grouping": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inconsistent Digit Grouping",
+      "description": "Warns if an integral or floating-point constant is grouped inconsistently with underscores.",
+      "default": "warn"
+    },
+    "inconsistent_struct_constructor": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inconsistent Struct Constructor",
+      "description": "Checks for struct constructors where the order of the field init in the constructor is inconsistent with the order in the struct definition.",
+      "default": "allow"
+    },
+    "index_refutable_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Index Refutable Slice",
+      "description": "The lint checks for slice bindings in patterns that are only used to access individual slice values.",
+      "default": "allow"
+    },
+    "indexing_slicing": {
+      "$ref": "#/definitions/Lint",
+      "title": "Indexing Slicing",
+      "description": "Checks for usage of indexing or slicing that may panic at runtime.",
+      "default": "allow"
+    },
+    "ineffective_bit_mask": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ineffective Bit Mask",
+      "description": "Checks for bit masks in comparisons which can be removed without changing the outcome. The basic structure can be seen in the following table:",
+      "default": "deny"
+    },
+    "ineffective_open_options": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ineffective Open Options",
+      "description": "Checks if both `.write(true)` and `.append(true)` methods are called on a same `OpenOptions`.",
+      "default": "warn"
+    },
+    "inefficient_to_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inefficient To String",
+      "description": "Checks for usage of `.to_string()` on an `&&T` where `T` implements `ToString` directly (like `&&str` or `&&String`).",
+      "default": "allow"
+    },
+    "infallible_destructuring_match": {
+      "$ref": "#/definitions/Lint",
+      "title": "Infallible Destructuring Match",
+      "description": "Checks for matches being used to destructure a single-variant enum or tuple struct where a `let` will suffice.",
+      "default": "warn"
+    },
+    "infallible_try_from": {
+      "$ref": "#/definitions/Lint",
+      "title": "Infallible Try From",
+      "description": "Finds manual impls of `TryFrom` with infallible error types.",
+      "default": "warn"
+    },
+    "infinite_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Infinite Iter",
+      "description": "Checks for iteration that is guaranteed to be infinite.",
+      "default": "deny"
+    },
+    "infinite_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Infinite Loop",
+      "description": "Checks for infinite loops in a function where the return type is not `!` and lint accordingly.",
+      "default": "allow"
+    },
+    "inherent_to_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inherent To String",
+      "description": "Checks for the definition of inherent methods with a signature of `to_string(&self) -> String`.",
+      "default": "warn"
+    },
+    "inherent_to_string_shadow_display": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inherent To String Shadow Display",
+      "description": "Checks for the definition of inherent methods with a signature of `to_string(&self) -> String` and if the type implementing this method also implements the `Display` trait.",
+      "default": "deny"
+    },
+    "init_numbered_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Init Numbered Fields",
+      "description": "Checks for tuple structs initialized with field syntax. It will however not lint if a base initializer is present. The lint will also ignore code in macros.",
+      "default": "warn"
+    },
+    "inline_always": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inline Always",
+      "description": "Checks for items annotated with `#[inline(always)]`, unless the annotated function is empty or simply panics.",
+      "default": "allow"
+    },
+    "inline_asm_x86_att_syntax": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inline Asm X86 Att Syntax",
+      "description": "Checks for usage of AT&T x86 assembly syntax.",
+      "default": "allow"
+    },
+    "inline_asm_x86_intel_syntax": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inline Asm X86 Intel Syntax",
+      "description": "Checks for usage of Intel x86 assembly syntax.",
+      "default": "allow"
+    },
+    "inline_fn_without_body": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inline Fn Without Body",
+      "description": "Checks for `#[inline]` on trait methods without bodies",
+      "default": "deny"
+    },
+    "inspect_for_each": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inspect For Each",
+      "description": "Checks for usage of `inspect().for_each()`.",
+      "default": "warn"
+    },
+    "int_plus_one": {
+      "$ref": "#/definitions/Lint",
+      "title": "Int Plus One",
+      "description": "Checks for usage of `x >= y + 1` or `x - 1 >= y` (and `",
+      "default": "warn"
+    },
+    "integer_division": {
+      "$ref": "#/definitions/Lint",
+      "title": "Integer Division",
+      "description": "Checks for division of integers",
+      "default": "allow"
+    },
+    "integer_division_remainder_used": {
+      "$ref": "#/definitions/Lint",
+      "title": "Integer Division Remainder Used",
+      "description": "Checks for the usage of division (`/`) and remainder (`%`) operations when performed on any integer types using the default `Div` and `Rem` trait implementations.",
+      "default": "allow"
+    },
+    "into_iter_on_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Into Iter On Ref",
+      "description": "Checks for `into_iter` calls on references which should be replaced by `iter` or `iter_mut`.",
+      "default": "warn"
+    },
+    "into_iter_without_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Into Iter Without Iter",
+      "description": "This is the opposite of the `iter_without_into_iter` lint. It looks for `IntoIterator for (&|&mut) Type` implementations without an inherent `iter` or `iter_mut` method on the type or on any of the types in its `Deref` chain.",
+      "default": "allow"
+    },
+    "invalid_regex": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Regex",
+      "description": "Checks regex creation (with `Regex::new`, `RegexBuilder::new`, or `RegexSet::new`) for correct regex syntax.",
+      "default": "deny"
+    },
+    "invalid_upcast_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Upcast Comparisons",
+      "description": "Checks for comparisons where the relation is always either true or false, but where one side has been upcast so that the comparison is necessary. Only integer types are checked.",
+      "default": "allow"
+    },
+    "inverted_saturating_sub": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inverted Saturating Sub",
+      "description": "Checks for comparisons between integers, followed by subtracting the greater value from the lower one.",
+      "default": "deny"
+    },
+    "invisible_characters": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invisible Characters",
+      "description": "Checks for invisible Unicode characters in the code.",
+      "default": "deny"
+    },
+    "io_other_error": {
+      "$ref": "#/definitions/Lint",
+      "title": "Io Other Error",
+      "description": "This lint warns on calling `io::Error::new(..)` with a kind of `io::ErrorKind::Other`.",
+      "default": "warn"
+    },
+    "ip_constant": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ip Constant",
+      "description": "Checks for IP addresses that could be replaced with predefined constants such as `Ipv4Addr::new(127, 0, 0, 1)` instead of using the appropriate constants.",
+      "default": "allow"
+    },
+    "is_digit_ascii_radix": {
+      "$ref": "#/definitions/Lint",
+      "title": "Is Digit Ascii Radix",
+      "description": "Finds usages of `char::is_digit` that can be replaced with `is_ascii_digit` or `is_ascii_hexdigit`.",
+      "default": "warn"
+    },
+    "items_after_statements": {
+      "$ref": "#/definitions/Lint",
+      "title": "Items After Statements",
+      "description": "Checks for items declared after some statement in a block.",
+      "default": "allow"
+    },
+    "items_after_test_module": {
+      "$ref": "#/definitions/Lint",
+      "title": "Items After Test Module",
+      "description": "Triggers if an item is declared after the testing module marked with `#[cfg(test)]`.",
+      "default": "warn"
+    },
+    "iter_cloned_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Cloned Collect",
+      "description": "Checks for the use of `.cloned().collect()` on slice to create a `Vec`.",
+      "default": "warn"
+    },
+    "iter_count": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Count",
+      "description": "Checks for the use of `.iter().count()`.",
+      "default": "warn"
+    },
+    "iter_filter_is_ok": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Filter Is Ok",
+      "description": "Checks for usage of `.filter(Result::is_ok)` that may be replaced with a `.flatten()` call. This lint will require additional changes to the follow-up calls as it affects the type.",
+      "default": "allow"
+    },
+    "iter_filter_is_some": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Filter Is Some",
+      "description": "Checks for usage of `.filter(Option::is_some)` that may be replaced with a `.flatten()` call. This lint will require additional changes to the follow-up calls as it affects the type.",
+      "default": "allow"
+    },
+    "iter_kv_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Kv Map",
+      "description": "Checks for iterating a map (`HashMap` or `BTreeMap`) and ignoring either the keys or values.",
+      "default": "warn"
+    },
+    "iter_next_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Next Loop",
+      "description": "Checks for loops on `x.next()`.",
+      "default": "deny"
+    },
+    "iter_next_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Next Slice",
+      "description": "Checks for usage of `iter().next()` on a Slice or an Array",
+      "default": "warn"
+    },
+    "iter_not_returning_iterator": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Not Returning Iterator",
+      "description": "Detects methods named `iter` or `iter_mut` that do not have a return type that implements `Iterator`.",
+      "default": "allow"
+    },
+    "iter_nth": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Nth",
+      "description": "Checks for usage of `.iter().nth()`/`.iter_mut().nth()` on standard library types that have equivalent `.get()`/`.get_mut()` methods.",
+      "default": "warn"
+    },
+    "iter_nth_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Nth Zero",
+      "description": "Checks for the use of `iter.nth(0)`.",
+      "default": "warn"
+    },
+    "iter_on_empty_collections": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter On Empty Collections",
+      "description": "Checks for calls to `iter`, `iter_mut` or `into_iter` on empty collections",
+      "default": "allow"
+    },
+    "iter_on_single_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter On Single Items",
+      "description": "Checks for calls to `iter`, `iter_mut` or `into_iter` on collections containing a single item",
+      "default": "allow"
+    },
+    "iter_out_of_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Out Of Bounds",
+      "description": "Looks for iterator combinator calls such as `.take(x)` or `.skip(x)` where `x` is greater than the amount of items that an iterator will produce.",
+      "default": "warn"
+    },
+    "iter_over_hash_type": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Over Hash Type",
+      "description": "This is a restriction lint which prevents the use of hash types (i.e., `HashSet` and `HashMap`) in for loops.",
+      "default": "allow"
+    },
+    "iter_overeager_cloned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Overeager Cloned",
+      "description": "Checks for usage of `_.cloned(). ()` where call to `.cloned()` can be postponed.",
+      "default": "warn"
+    },
+    "iter_skip_next": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Skip Next",
+      "description": "Checks for usage of `.skip(x).next()` on iterators.",
+      "default": "warn"
+    },
+    "iter_skip_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Skip Zero",
+      "description": "Checks for usage of `.skip(0)` on iterators.",
+      "default": "deny"
+    },
+    "iter_with_drain": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter With Drain",
+      "description": "Checks for usage of `.drain(..)` on `Vec` and `VecDeque` for iteration.",
+      "default": "allow"
+    },
+    "iter_without_into_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iter Without Into Iter",
+      "description": "Looks for `iter` and `iter_mut` methods without an associated `IntoIterator for (&|&mut) Type` implementation.",
+      "default": "allow"
+    },
+    "iterator_step_by_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Iterator Step By Zero",
+      "description": "Checks for calling `.step_by(0)` on iterators which panics.",
+      "default": "deny"
+    },
+    "join_absolute_paths": {
+      "$ref": "#/definitions/Lint",
+      "title": "Join Absolute Paths",
+      "description": "Checks for calls to `Path::join` that start with a path separator (`\\\\` or `/`).",
+      "default": "warn"
+    },
+    "just_underscores_and_digits": {
+      "$ref": "#/definitions/Lint",
+      "title": "Just Underscores And Digits",
+      "description": "Checks if you have variables whose name consists of just underscores and digits.",
+      "default": "warn"
+    },
+    "large_const_arrays": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Const Arrays",
+      "description": "Checks for large `const` arrays that should be defined as `static` instead.",
+      "default": "warn"
+    },
+    "large_digit_groups": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Digit Groups",
+      "description": "Warns if the digits of an integral or floating-point constant are grouped into groups that are too large.",
+      "default": "allow"
+    },
+    "large_enum_variant": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Enum Variant",
+      "description": "Checks for large size differences between variants on `enum`s.",
+      "default": "warn"
+    },
+    "large_futures": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Futures",
+      "description": "It checks for the size of a `Future` created by `async fn` or `async {}`.",
+      "default": "allow"
+    },
+    "large_include_file": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Include File",
+      "description": "Checks for the inclusion of large files via `include_bytes!()` or `include_str!()`.",
+      "default": "allow"
+    },
+    "large_stack_arrays": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Stack Arrays",
+      "description": "Checks for local arrays that may be too large.",
+      "default": "allow"
+    },
+    "large_stack_frames": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Stack Frames",
+      "description": "Checks for functions that use a lot of stack space.",
+      "default": "allow"
+    },
+    "large_types_passed_by_value": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Types Passed By Value",
+      "description": "Checks for functions taking arguments by value, where the argument type is `Copy` and large enough to be worth considering passing by reference. Does not trigger if the function is being exported, because that might induce API breakage, if the parameter is declared as mutable, or if the argument is a `self`.",
+      "default": "allow"
+    },
+    "legacy_numeric_constants": {
+      "$ref": "#/definitions/Lint",
+      "title": "Legacy Numeric Constants",
+      "description": "Checks for usage of `::max_value()`, `std::::MAX`, `std::::EPSILON`, etc.",
+      "default": "warn"
+    },
+    "len_without_is_empty": {
+      "$ref": "#/definitions/Lint",
+      "title": "Len Without Is Empty",
+      "description": "Checks for items that implement `.len()` but not `.is_empty()`.",
+      "default": "warn"
+    },
+    "len_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Len Zero",
+      "description": "Checks for getting the length of something via `.len()` just to compare to zero, and suggests using `.is_empty()` where applicable.",
+      "default": "warn"
+    },
+    "let_and_return": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let And Return",
+      "description": "Checks for `let`-bindings, which are subsequently returned.",
+      "default": "warn"
+    },
+    "let_underscore_future": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Future",
+      "description": "Checks for `let _ = ` where the resulting type of expr implements `Future`",
+      "default": "warn"
+    },
+    "let_underscore_lock": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Lock",
+      "description": "Checks for `let _ = sync_lock`. This supports `mutex` and `rwlock` in `parking_lot`. For `std` locks see the `rustc` lint `let_underscore_lock`",
+      "default": "deny"
+    },
+    "let_underscore_must_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Must Use",
+      "description": "Checks for `let _ = ` where expr is `#[must_use]`",
+      "default": "allow"
+    },
+    "let_underscore_untyped": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Untyped",
+      "description": "Checks for `let _ = ` without a type annotation, and suggests to either provide one, or remove the `let` keyword altogether.",
+      "default": "allow"
+    },
+    "let_unit_value": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Unit Value",
+      "description": "Checks for binding a unit value.",
+      "default": "warn"
+    },
+    "let_with_type_underscore": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let With Type Underscore",
+      "description": "Detects when a variable is declared with an explicit type of `_`.",
+      "default": "warn"
+    },
+    "lines_filter_map_ok": {
+      "$ref": "#/definitions/Lint",
+      "title": "Lines Filter Map Ok",
+      "description": "Checks for usage of `lines.filter_map(Result::ok)` or `lines.flat_map(Result::ok)` when `lines` has type `std::io::Lines`.",
+      "default": "warn"
+    },
+    "linkedlist": {
+      "$ref": "#/definitions/Lint",
+      "title": "Linkedlist",
+      "description": "Checks for usage of any `LinkedList`, suggesting to use a `Vec` or a `VecDeque` (formerly called `RingBuf`).",
+      "default": "allow"
+    },
+    "lint_groups_priority": {
+      "$ref": "#/definitions/Lint",
+      "title": "Lint Groups Priority",
+      "description": "Checks for lint groups with the same priority as lints in the `Cargo.toml` `[lints]` table.",
+      "default": "deny"
+    },
+    "literal_string_with_formatting_args": {
+      "$ref": "#/definitions/Lint",
+      "title": "Literal String With Formatting Args",
+      "description": "Checks if string literals have formatting arguments outside of macros using them (like `format!`).",
+      "default": "allow"
+    },
+    "little_endian_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Little Endian Bytes",
+      "description": "Checks for the usage of the `to_le_bytes` method and/or the function `from_le_bytes`.",
+      "default": "allow"
+    },
+    "lossy_float_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Lossy Float Literal",
+      "description": "Checks for whole number float literals that cannot be represented as the underlying type without loss.",
+      "default": "allow"
+    },
+    "macro_metavars_in_unsafe": {
+      "$ref": "#/definitions/Lint",
+      "title": "Macro Metavars In Unsafe",
+      "description": "Looks for macros that expand metavariables in an unsafe block.",
+      "default": "warn"
+    },
+    "macro_use_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Macro Use Imports",
+      "description": "Checks for `#[macro_use] use...`.",
+      "default": "allow"
+    },
+    "main_recursion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Main Recursion",
+      "description": "Checks for recursion using the entrypoint.",
+      "default": "warn"
+    },
+    "manual_abs_diff": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Abs Diff",
+      "description": "Detects patterns like `if a > b { a - b } else { b - a }` and suggests using `a.abs_diff(b)`.",
+      "default": "warn"
+    },
+    "manual_assert": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Assert",
+      "description": "Detects `if`-then-`panic!` that can be replaced with `assert!`.",
+      "default": "allow"
+    },
+    "manual_async_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Async Fn",
+      "description": "It checks for manual implementations of `async` functions.",
+      "default": "warn"
+    },
+    "manual_bits": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Bits",
+      "description": "Checks for usage of `size_of:: () * 8` when `T::BITS` is available.",
+      "default": "warn"
+    },
+    "manual_c_str_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual C Str Literals",
+      "description": "Checks for the manual creation of C strings (a string with a `NUL` byte at the end), either through one of the `CStr` constructor functions, or more plainly by calling `.as_ptr()` on a (byte) string literal with a hardcoded `\\0` byte at the end.",
+      "default": "warn"
+    },
+    "manual_checked_ops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Checked Ops",
+      "description": "Detects manual zero checks before dividing integers, such as `if x!= 0 { y / x }`.",
+      "default": "warn"
+    },
+    "manual_clamp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Clamp",
+      "description": "Identifies good opportunities for a clamp function from std or core, and suggests using it.",
+      "default": "warn"
+    },
+    "manual_contains": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Contains",
+      "description": "Checks for usage of `iter().any()` on slices when it can be replaced with `contains()` and suggests doing so.",
+      "default": "warn"
+    },
+    "manual_dangling_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Dangling Ptr",
+      "description": "Checks for casts of small constant literals or `mem::align_of` results to raw pointers.",
+      "default": "warn"
+    },
+    "manual_div_ceil": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Div Ceil",
+      "description": "Checks for an expression like `(x + (y - 1)) / y` which is a common manual reimplementation of `x.div_ceil(y)`.",
+      "default": "warn"
+    },
+    "manual_filter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Filter",
+      "description": "Checks for usage of `match` which could be implemented using `filter`",
+      "default": "warn"
+    },
+    "manual_filter_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Filter Map",
+      "description": "Checks for usage of `_.filter(_).map(_)` that can be written more simply as `filter_map(_)`.",
+      "default": "warn"
+    },
+    "manual_find": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Find",
+      "description": "Checks for manual implementations of Iterator::find",
+      "default": "warn"
+    },
+    "manual_find_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Find Map",
+      "description": "Checks for usage of `_.find(_).map(_)` that can be written more simply as `find_map(_)`.",
+      "default": "warn"
+    },
+    "manual_flatten": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Flatten",
+      "description": "Checks for unnecessary `if let` usage in a for loop where only the `Some` or `Ok` variant of the iterator element is used.",
+      "default": "warn"
+    },
+    "manual_hash_one": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Hash One",
+      "description": "Checks for cases where `BuildHasher::hash_one` can be used.",
+      "default": "warn"
+    },
+    "manual_ignore_case_cmp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Ignore Case Cmp",
+      "description": "Checks for manual case-insensitive ASCII comparison.",
+      "default": "warn"
+    },
+    "manual_ilog2": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Ilog2",
+      "description": "Checks for expressions like `N - x.leading_zeros()` (where `N` is one less than bit width of `x`) or `x.ilog(2)`, which are manual reimplementations of `x.ilog2()`",
+      "default": "allow"
+    },
+    "manual_inspect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Inspect",
+      "description": "Checks for uses of `map` which return the original item.",
+      "default": "warn"
+    },
+    "manual_instant_elapsed": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Instant Elapsed",
+      "description": "Lints subtraction between `Instant::now()` and another `Instant`.",
+      "default": "allow"
+    },
+    "manual_is_ascii_check": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Ascii Check",
+      "description": "Suggests to use dedicated built-in methods, `is_ascii_(lowercase|uppercase|digit|hexdigit)` for checking on corresponding ascii range",
+      "default": "warn"
+    },
+    "manual_is_finite": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Finite",
+      "description": "Checks for manual `is_finite` reimplementations (i.e., `x!=::INFINITY && x!=::NEG_INFINITY`).",
+      "default": "warn"
+    },
+    "manual_is_infinite": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Infinite",
+      "description": "Checks for manual `is_infinite` reimplementations (i.e., `x ==::INFINITY || x ==::NEG_INFINITY`).",
+      "default": "warn"
+    },
+    "manual_is_multiple_of": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Multiple Of",
+      "description": "Checks for manual implementation of `.is_multiple_of()` on unsigned integer types.",
+      "default": "warn"
+    },
+    "manual_is_power_of_two": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Power Of Two",
+      "description": "Checks for expressions like `x.count_ones() == 1` or `x & (x - 1) == 0`, with x and unsigned integer, which may be manual reimplementations of `x.is_power_of_two()`.",
+      "default": "allow"
+    },
+    "manual_is_variant_and": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Is Variant And",
+      "description": "Checks for usage of `option.map(f).unwrap_or_default()` and `result.map(f).unwrap_or_default()` where `f` is a function or closure that returns the `bool` type.",
+      "default": "allow"
+    },
+    "manual_let_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Let Else",
+      "description": "Warn of cases where `let...else` could be used",
+      "default": "allow"
+    },
+    "manual_main_separator_str": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Main Separator Str",
+      "description": "Checks for references on `std::path::MAIN_SEPARATOR.to_string()` used to build a `&str`.",
+      "default": "warn"
+    },
+    "manual_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Map",
+      "description": "Checks for usage of `match` which could be implemented using `map`",
+      "default": "warn"
+    },
+    "manual_memcpy": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Memcpy",
+      "description": "Checks for for-loops that manually copy items between slices that could be optimized by having a memcpy.",
+      "default": "warn"
+    },
+    "manual_midpoint": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Midpoint",
+      "description": "Checks for manual implementation of `midpoint`.",
+      "default": "allow"
+    },
+    "manual_next_back": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Next Back",
+      "description": "Checks for `.rev().next()` on a `DoubleEndedIterator`",
+      "default": "warn"
+    },
+    "manual_non_exhaustive": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Non Exhaustive",
+      "description": "Checks for manual implementations of the non-exhaustive pattern.",
+      "default": "warn"
+    },
+    "manual_noop_waker": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Noop Waker",
+      "description": "Checks for manual implementations of `std::task::Wake` that are empty.",
+      "default": "warn"
+    },
+    "manual_ok_err": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Ok Err",
+      "description": "Checks for manual implementation of `.ok()` or `.err()` on `Result` values.",
+      "default": "warn"
+    },
+    "manual_ok_or": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Ok Or",
+      "description": "Finds patterns that reimplement `Option::ok_or`.",
+      "default": "warn"
+    },
+    "manual_option_as_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Option As Slice",
+      "description": "This detects various manual reimplementations of `Option::as_slice`.",
+      "default": "warn"
+    },
+    "manual_option_zip": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Option Zip",
+      "description": "Checks for usage of `a.and_then(|a| b.map(|b| (a, b)))` which can be more concisely expressed as `a.zip(b)`.",
+      "default": "warn"
+    },
+    "manual_pattern_char_comparison": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Pattern Char Comparison",
+      "description": "Checks for manual `char` comparison in string patterns",
+      "default": "warn"
+    },
+    "manual_pop_if": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Pop If",
+      "description": "Checks for code to be replaced by `pop_if` methods.",
+      "default": "warn"
+    },
+    "manual_range_contains": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Range Contains",
+      "description": "Checks for expressions like `x >= 3 && x",
+      "default": "warn"
+    },
+    "manual_range_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Range Patterns",
+      "description": "Looks for combined OR patterns that are all contained in a specific range, e.g. `6 | 4 | 5 | 9 | 7 | 8` can be rewritten as `4..=9`.",
+      "default": "warn"
+    },
+    "manual_rem_euclid": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Rem Euclid",
+      "description": "Checks for an expression like `((x % 4) + 4) % 4` which is a common manual reimplementation of `x.rem_euclid(4)`.",
+      "default": "warn"
+    },
+    "manual_repeat_n": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Repeat N",
+      "description": "Checks for `repeat().take()` that can be replaced with `repeat_n()`.",
+      "default": "warn"
+    },
+    "manual_retain": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Retain",
+      "description": "Checks for code to be replaced by `.retain()`.",
+      "default": "warn"
+    },
+    "manual_rotate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Rotate",
+      "description": "It detects manual bit rotations that could be rewritten using standard functions `rotate_left` or `rotate_right`.",
+      "default": "warn"
+    },
+    "manual_saturating_arithmetic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Saturating Arithmetic",
+      "description": "Checks for `.checked_add/sub(x).unwrap_or(MAX/MIN)`.",
+      "default": "warn"
+    },
+    "manual_slice_fill": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Slice Fill",
+      "description": "Checks for manually filling a slice with a value.",
+      "default": "warn"
+    },
+    "manual_slice_size_calculation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Slice Size Calculation",
+      "description": "When `a` is `&[T]`, detect `a.len() * size_of:: ()` and suggest `size_of_val(a)` instead.",
+      "default": "warn"
+    },
+    "manual_split_once": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Split Once",
+      "description": "Checks for usage of `str::splitn(2, _)`",
+      "default": "warn"
+    },
+    "manual_str_repeat": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Str Repeat",
+      "description": "Checks for manual implementations of `str::repeat`",
+      "default": "warn"
+    },
+    "manual_string_new": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual String New",
+      "description": "Checks for usage of `\"\"` to create a `String`, such as `\"\".to_string()`, `\"\".to_owned()`, `String::from(\"\")` and others.",
+      "default": "allow"
+    },
+    "manual_strip": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Strip",
+      "description": "Suggests using `strip_{prefix,suffix}` over `str::{starts,ends}_with` and slicing using the pattern's length.",
+      "default": "warn"
+    },
+    "manual_swap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Swap",
+      "description": "Checks for manual swapping.",
+      "default": "warn"
+    },
+    "manual_take": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Take",
+      "description": "Detects manual re-implementations of `std::mem::take`.",
+      "default": "warn"
+    },
+    "manual_try_fold": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Try Fold",
+      "description": "Checks for usage of `Iterator::fold` with a type that implements `Try`.",
+      "default": "warn"
+    },
+    "manual_unwrap_or": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Unwrap Or",
+      "description": "Finds patterns that reimplement `Option::unwrap_or` or `Result::unwrap_or`.",
+      "default": "warn"
+    },
+    "manual_unwrap_or_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual Unwrap Or Default",
+      "description": "Checks if a `match` or `if let` expression can be simplified using `.unwrap_or_default()`.",
+      "default": "warn"
+    },
+    "manual_while_let_some": {
+      "$ref": "#/definitions/Lint",
+      "title": "Manual While Let Some",
+      "description": "Looks for loops that check for emptiness of a `Vec` in the condition and pop an element in the body as a separate operation.",
+      "default": "warn"
+    },
+    "many_single_char_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Many Single Char Names",
+      "description": "Checks for too many variables whose name consists of a single character.",
+      "default": "allow"
+    },
+    "map_all_any_identity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map All Any Identity",
+      "description": "Checks for usage of `.map(…)`, followed by `.all(identity)` or `.any(identity)`.",
+      "default": "warn"
+    },
+    "map_clone": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Clone",
+      "description": "Checks for usage of `map(|x| x.clone())` or dereferencing closures for `Copy` types, on `Iterator` or `Option`, and suggests `cloned()` or `copied()` instead",
+      "default": "warn"
+    },
+    "map_collect_result_unit": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Collect Result Unit",
+      "description": "Checks for usage of `_.map(_).collect:: ()`.",
+      "default": "warn"
+    },
+    "map_entry": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Entry",
+      "description": "Checks for usage of `contains_key` + `insert` on `HashMap` or `BTreeMap`.",
+      "default": "warn"
+    },
+    "map_err_ignore": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Err Ignore",
+      "description": "Checks for instances of `map_err(|_| Some::Enum)`",
+      "default": "allow"
+    },
+    "map_flatten": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Flatten",
+      "description": "Checks for usage of `_.map(_).flatten(_)` on `Iterator` and `Option`",
+      "default": "warn"
+    },
+    "map_identity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Identity",
+      "description": "Checks for instances of `map(f)` where `f` is the identity function.",
+      "default": "warn"
+    },
+    "map_unwrap_or": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Unwrap Or",
+      "description": "Checks for usage of `option.map(_).unwrap_or(_)` or `option.map(_).unwrap_or_else(_)` or `result.map(_).unwrap_or_else(_)`.",
+      "default": "allow"
+    },
+    "map_with_unused_argument_over_ranges": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map With Unused Argument Over Ranges",
+      "description": "Checks for `Iterator::map` over ranges without using the parameter which could be more clearly expressed using `std::iter::repeat(...).take(...)` or `std::iter::repeat_n`.",
+      "default": "allow"
+    },
+    "match_as_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match As Ref",
+      "description": "Checks for match which is used to add a reference to an `Option` value.",
+      "default": "warn"
+    },
+    "match_bool": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Bool",
+      "description": "Checks for matches where match expression is a `bool`. It suggests to replace the expression with an `if...else` block.",
+      "default": "allow"
+    },
+    "match_like_matches_macro": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Like Matches Macro",
+      "description": "Checks for `match` or `if let` expressions producing a `bool` that could be written using `matches!`",
+      "default": "warn"
+    },
+    "match_on_vec_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match On Vec Items",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "match_overlapping_arm": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Overlapping Arm",
+      "description": "Checks for overlapping match arms.",
+      "default": "warn"
+    },
+    "match_ref_pats": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Ref Pats",
+      "description": "Checks for matches where all arms match a reference, suggesting to remove the reference and deref the matched expression instead. It also checks for `if let &foo = bar` blocks.",
+      "default": "warn"
+    },
+    "match_result_ok": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Result Ok",
+      "description": "Checks for unnecessary `ok()` in `while let`.",
+      "default": "warn"
+    },
+    "match_same_arms": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Same Arms",
+      "description": "Checks for `match` with identical arm bodies.",
+      "default": "allow"
+    },
+    "match_single_binding": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Single Binding",
+      "description": "Checks for useless match that binds to only one value.",
+      "default": "warn"
+    },
+    "match_str_case_mismatch": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Str Case Mismatch",
+      "description": "Checks for `match` expressions modifying the case of a string with non-compliant arms",
+      "default": "deny"
+    },
+    "match_wild_err_arm": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Wild Err Arm",
+      "description": "Checks for arm which matches all errors with `Err(_)` and take drastic actions like `panic!`.",
+      "default": "allow"
+    },
+    "match_wildcard_for_single_variants": {
+      "$ref": "#/definitions/Lint",
+      "title": "Match Wildcard For Single Variants",
+      "description": "Checks for wildcard enum matches for a single variant.",
+      "default": "allow"
+    },
+    "maybe_infinite_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Maybe Infinite Iter",
+      "description": "Checks for iteration that may be infinite.",
+      "default": "allow"
+    },
+    "mem_forget": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mem Forget",
+      "description": "Checks for usage of `std::mem::forget(t)` where `t` is `Drop` or has a field that implements `Drop`.",
+      "default": "allow"
+    },
+    "mem_replace_option_with_none": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mem Replace Option With None",
+      "description": "Checks for `mem::replace()` on an `Option` with `None`.",
+      "default": "warn"
+    },
+    "mem_replace_option_with_some": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mem Replace Option With Some",
+      "description": "Checks for `mem::replace()` on an `Option` with `Some(…)`.",
+      "default": "warn"
+    },
+    "mem_replace_with_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mem Replace With Default",
+      "description": "Checks for `std::mem::replace` on a value of type `T` with `T::default()`.",
+      "default": "warn"
+    },
+    "mem_replace_with_uninit": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mem Replace With Uninit",
+      "description": "Checks for `mem::replace(&mut _, mem::uninitialized())` and `mem::replace(&mut _, mem::zeroed())`.",
+      "default": "deny"
+    },
+    "min_ident_chars": {
+      "$ref": "#/definitions/Lint",
+      "title": "Min Ident Chars",
+      "description": "Checks for identifiers which consist of a single character (or fewer than the configured threshold).",
+      "default": "allow"
+    },
+    "min_max": {
+      "$ref": "#/definitions/Lint",
+      "title": "Min Max",
+      "description": "Checks for expressions where `std::cmp::min` and `max` are used to clamp values, but switched so that the result is constant.",
+      "default": "deny"
+    },
+    "misaligned_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Misaligned Transmute",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "mismatching_type_param_order": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mismatching Type Param Order",
+      "description": "Checks for type parameters which are positioned inconsistently between a type definition and impl block. Specifically, a parameter in an impl block which has the same name as a parameter in the type def, but is in a different place.",
+      "default": "allow"
+    },
+    "misnamed_getters": {
+      "$ref": "#/definitions/Lint",
+      "title": "Misnamed Getters",
+      "description": "Checks for getter methods that return a field that doesn't correspond to the name of the method, when there is a field's whose name matches that of the method.",
+      "default": "warn"
+    },
+    "misrefactored_assign_op": {
+      "$ref": "#/definitions/Lint",
+      "title": "Misrefactored Assign Op",
+      "description": "Checks for `a op= a op b` or `a op= b op a` patterns.",
+      "default": "warn"
+    },
+    "missing_assert_message": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Assert Message",
+      "description": "Checks assertions without a custom panic message.",
+      "default": "allow"
+    },
+    "missing_asserts_for_indexing": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Asserts For Indexing",
+      "description": "Checks for repeated slice indexing without asserting beforehand that the length is greater than the largest index used to index into the slice.",
+      "default": "allow"
+    },
+    "missing_const_for_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Const For Fn",
+      "description": "Suggests the use of `const` in functions and methods where possible.",
+      "default": "allow"
+    },
+    "missing_const_for_thread_local": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Const For Thread Local",
+      "description": "Suggests to use `const` in `thread_local!` macro if possible.",
+      "default": "warn"
+    },
+    "missing_docs_in_private_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Docs In Private Items",
+      "description": "Warns if there is missing documentation for any private documentable item.",
+      "default": "allow"
+    },
+    "missing_enforced_import_renames": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Enforced Import Renames",
+      "description": "Checks for imports that do not rename the item as specified in the `enforced-import-renames` config option.",
+      "default": "warn"
+    },
+    "missing_errors_doc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Errors Doc",
+      "description": "Checks the doc comments of publicly visible functions that return a `Result` type and warns if there is no `# Errors` section.",
+      "default": "allow"
+    },
+    "missing_fields_in_debug": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Fields In Debug",
+      "description": "Checks for manual `core::fmt::Debug` implementations that do not use all fields.",
+      "default": "allow"
+    },
+    "missing_inline_in_public_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Inline In Public Items",
+      "description": "It lints if an exported function, method, trait method with default impl, or trait method impl is not `#[inline]`.",
+      "default": "allow"
+    },
+    "missing_panics_doc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Panics Doc",
+      "description": "Checks the doc comments of publicly visible functions that may panic and warns if there is no `# Panics` section.",
+      "default": "allow"
+    },
+    "missing_safety_doc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Safety Doc",
+      "description": "Checks for the doc comments of publicly visible unsafe functions and warns if there is no `# Safety` section.",
+      "default": "warn"
+    },
+    "missing_spin_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Spin Loop",
+      "description": "Checks for empty spin loops",
+      "default": "warn"
+    },
+    "missing_trait_methods": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Trait Methods",
+      "description": "Checks if a provided method is used implicitly by a trait implementation.",
+      "default": "allow"
+    },
+    "missing_transmute_annotations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Transmute Annotations",
+      "description": "Checks if transmute calls have all generics specified.",
+      "default": "warn"
+    },
+    "mistyped_literal_suffixes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mistyped Literal Suffixes",
+      "description": "Warns for mistyped suffix in literals",
+      "default": "deny"
+    },
+    "mixed_attributes_style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mixed Attributes Style",
+      "description": "Checks for items that have the same kind of attributes with mixed styles (inner/outer).",
+      "default": "warn"
+    },
+    "mixed_case_hex_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mixed Case Hex Literals",
+      "description": "Warns on hexadecimal literals with mixed-case letter digits.",
+      "default": "warn"
+    },
+    "mixed_read_write_in_expression": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mixed Read Write In Expression",
+      "description": "Checks for a read and a write to the same variable where whether the read occurs before or after the write depends on the evaluation order of sub-expressions.",
+      "default": "allow"
+    },
+    "mod_module_files": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mod Module Files",
+      "description": "Checks that module layout uses only self named module files; bans `mod.rs` files.",
+      "default": "allow"
+    },
+    "module_inception": {
+      "$ref": "#/definitions/Lint",
+      "title": "Module Inception",
+      "description": "Checks for modules that have the same name as their parent module",
+      "default": "warn"
+    },
+    "module_name_repetitions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Module Name Repetitions",
+      "description": "Detects public item names that are prefixed or suffixed by the containing public module's name.",
+      "default": "allow"
+    },
+    "modulo_arithmetic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Modulo Arithmetic",
+      "description": "Checks for modulo arithmetic.",
+      "default": "allow"
+    },
+    "modulo_one": {
+      "$ref": "#/definitions/Lint",
+      "title": "Modulo One",
+      "description": "Checks for getting the remainder of integer division by one or minus one.",
+      "default": "deny"
+    },
+    "multi_assignments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multi Assignments",
+      "description": "Checks for nested assignments.",
+      "default": "warn"
+    },
+    "multiple_bound_locations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multiple Bound Locations",
+      "description": "Check if a generic is defined both in the bound predicate and in the `where` clause.",
+      "default": "warn"
+    },
+    "multiple_crate_versions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multiple Crate Versions",
+      "description": "Checks to see if multiple versions of a crate are being used.",
+      "default": "allow"
+    },
+    "multiple_inherent_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multiple Inherent Impl",
+      "description": "Checks for multiple inherent implementations of a struct",
+      "default": "allow"
+    },
+    "multiple_unsafe_ops_per_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multiple Unsafe Ops Per Block",
+      "description": "Checks for `unsafe` blocks that contain more than one unsafe operation.",
+      "default": "allow"
+    },
+    "must_use_candidate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Must Use Candidate",
+      "description": "Checks for public functions that have no `#[must_use]` attribute, but return something not already marked must-use, have no mutable arg and mutate no statics.",
+      "default": "allow"
+    },
+    "must_use_unit": {
+      "$ref": "#/definitions/Lint",
+      "title": "Must Use Unit",
+      "description": "Checks for a `#[must_use]` attribute on unit-returning functions and methods.",
+      "default": "warn"
+    },
+    "mut_from_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mut From Ref",
+      "description": "This lint checks for functions that take immutable references and return mutable ones. This will not trigger if no unsafe code exists as there are multiple safe functions which will do this transformation",
+      "default": "deny"
+    },
+    "mut_mut": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mut Mut",
+      "description": "Checks for instances of `mut mut` references.",
+      "default": "allow"
+    },
+    "mut_mutex_lock": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mut Mutex Lock",
+      "description": "Checks for `&mut Mutex::lock` calls",
+      "default": "warn"
+    },
+    "mut_range_bound": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mut Range Bound",
+      "description": "Checks for loops with a range bound that is a mutable variable.",
+      "default": "warn"
+    },
+    "mutable_key_type": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mutable Key Type",
+      "description": "Checks for sets/maps with mutable key types.",
+      "default": "warn"
+    },
+    "mutex_atomic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mutex Atomic",
+      "description": "Checks for usage of `Mutex ` where an atomic will do.",
+      "default": "allow"
+    },
+    "mutex_integer": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mutex Integer",
+      "description": "Checks for usage of `Mutex ` where `X` is an integral type.",
+      "default": "allow"
+    },
+    "naive_bytecount": {
+      "$ref": "#/definitions/Lint",
+      "title": "Naive Bytecount",
+      "description": "Checks for naive byte counts",
+      "default": "allow"
+    },
+    "needless_arbitrary_self_type": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Arbitrary Self Type",
+      "description": "The lint checks for `self` in fn parameters that specify the `Self`-type explicitly",
+      "default": "warn"
+    },
+    "needless_as_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless As Bytes",
+      "description": "It detects useless calls to `str::as_bytes()` before calling `len()` or `is_empty()`.",
+      "default": "warn"
+    },
+    "needless_bitwise_bool": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Bitwise Bool",
+      "description": "Checks for usage of bitwise and/or operators between booleans, where performance may be improved by using a lazy and.",
+      "default": "allow"
+    },
+    "needless_bool": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Bool",
+      "description": "Checks for expressions of the form `if c { true } else { false }` (or vice versa) and suggests using the condition directly.",
+      "default": "warn"
+    },
+    "needless_bool_assign": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Bool Assign",
+      "description": "Checks for expressions of the form `if c { x = true } else { x = false }` (or vice versa) and suggest assigning the variable directly from the condition.",
+      "default": "warn"
+    },
+    "needless_borrow": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Borrow",
+      "description": "Checks for address of operations (`&`) that are going to be dereferenced immediately by the compiler.",
+      "default": "warn"
+    },
+    "needless_borrowed_reference": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Borrowed Reference",
+      "description": "Checks for bindings that needlessly destructure a reference and borrow the inner value with `&ref`.",
+      "default": "warn"
+    },
+    "needless_borrows_for_generic_args": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Borrows For Generic Args",
+      "description": "Checks for borrow operations (`&`) that are used as a generic argument to a function when the borrowed value could be used.",
+      "default": "warn"
+    },
+    "needless_character_iteration": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Character Iteration",
+      "description": "Checks if an iterator is used to check if a string is ascii.",
+      "default": "warn"
+    },
+    "needless_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Collect",
+      "description": "Checks for functions collecting an iterator when collect is not needed.",
+      "default": "allow"
+    },
+    "needless_continue": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Continue",
+      "description": "The lint checks for `if`-statements appearing in loops that contain a `continue` statement in either their main blocks or their `else`-blocks, when omitting the `else`-block possibly with some rearrangement of code can make the code easier to understand. The lint also checks if the last statement in the loop is a `continue`",
+      "default": "allow"
+    },
+    "needless_doctest_main": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Doctest Main",
+      "description": "Checks for `fn main() {.. }` in doctests",
+      "default": "warn"
+    },
+    "needless_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Else",
+      "description": "Checks for empty `else` branches.",
+      "default": "warn"
+    },
+    "needless_for_each": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless For Each",
+      "description": "Checks for usage of `for_each` that would be more simply written as a `for` loop.",
+      "default": "allow"
+    },
+    "needless_ifs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Ifs",
+      "description": "Checks for empty `if` branches with no else branch.",
+      "default": "warn"
+    },
+    "needless_late_init": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Late Init",
+      "description": "Checks for late initializations that can be replaced by a `let` statement with an initializer.",
+      "default": "warn"
+    },
+    "needless_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Lifetimes",
+      "description": "Checks for lifetime annotations which can be removed by relying on lifetime elision.",
+      "default": "warn"
+    },
+    "needless_match": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Match",
+      "description": "Checks for unnecessary `match` or match-like `if let` returns for `Option` and `Result` when function signatures are the same.",
+      "default": "warn"
+    },
+    "needless_maybe_sized": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Maybe Sized",
+      "description": "Lints `?Sized` bounds applied to type parameters that cannot be unsized",
+      "default": "warn"
+    },
+    "needless_option_as_deref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Option As Deref",
+      "description": "Checks for no-op uses of `Option::{as_deref, as_deref_mut}`, for example, `Option::as_deref()` returns the same type.",
+      "default": "warn"
+    },
+    "needless_option_take": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Option Take",
+      "description": "Checks for calling `take` function after `as_ref`.",
+      "default": "warn"
+    },
+    "needless_parens_on_range_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Parens On Range Literals",
+      "description": "The lint checks for parenthesis on literals in range statements that are superfluous.",
+      "default": "warn"
+    },
+    "needless_pass_by_ref_mut": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Pass By Ref Mut",
+      "description": "Check if a `&mut` function argument is actually used mutably.",
+      "default": "allow"
+    },
+    "needless_pass_by_value": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Pass By Value",
+      "description": "Checks for functions taking arguments by value, but not consuming them in its body.",
+      "default": "allow"
+    },
+    "needless_pub_self": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Pub Self",
+      "description": "Checks for usage of `pub(self)` and `pub(in self)`.",
+      "default": "warn"
+    },
+    "needless_question_mark": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Question Mark",
+      "description": "Suggests replacing `Ok(x?)` or `Some(x?)` with `x` in return positions where the `?` operator is not needed to convert the type of `x`.",
+      "default": "warn"
+    },
+    "needless_range_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Range Loop",
+      "description": "Checks for looping over the range of `0..len` of some collection just to get the values by index.",
+      "default": "warn"
+    },
+    "needless_raw_string_hashes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Raw String Hashes",
+      "description": "Checks for raw string literals with an unnecessary amount of hashes around them.",
+      "default": "allow"
+    },
+    "needless_raw_strings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Raw Strings",
+      "description": "Checks for raw string literals where a string literal can be used instead.",
+      "default": "allow"
+    },
+    "needless_return": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Return",
+      "description": "Checks for return statements at the end of a block.",
+      "default": "warn"
+    },
+    "needless_return_with_question_mark": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Return With Question Mark",
+      "description": "Checks for return statements on `Err` paired with the `?` operator.",
+      "default": "warn"
+    },
+    "needless_splitn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Splitn",
+      "description": "Checks for usage of `str::splitn` (or `str::rsplitn`) where using `str::split` would be the same.",
+      "default": "warn"
+    },
+    "needless_type_cast": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Type Cast",
+      "description": "Checks for bindings (constants, statics, or let bindings) that are defined with one numeric type but are consistently cast to a different type in all usages.",
+      "default": "allow"
+    },
+    "needless_update": {
+      "$ref": "#/definitions/Lint",
+      "title": "Needless Update",
+      "description": "Checks for needlessly including a base struct on update when all fields are changed anyway.",
+      "default": "warn"
+    },
+    "neg_cmp_op_on_partial_ord": {
+      "$ref": "#/definitions/Lint",
+      "title": "Neg Cmp Op On Partial Ord",
+      "description": "Checks for the usage of negated comparison operators on types which only implement `PartialOrd` (e.g., `f64`).",
+      "default": "warn"
+    },
+    "neg_multiply": {
+      "$ref": "#/definitions/Lint",
+      "title": "Neg Multiply",
+      "description": "Checks for multiplication by -1 as a form of negation.",
+      "default": "warn"
+    },
+    "negative_feature_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Negative Feature Names",
+      "description": "Checks for negative feature names with prefix `no-` or `not-`",
+      "default": "allow"
+    },
+    "never_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Never Loop",
+      "description": "Checks for loops that will always `break`, `return` or `continue` an outer loop.",
+      "default": "deny"
+    },
+    "new_ret_no_self": {
+      "$ref": "#/definitions/Lint",
+      "title": "New Ret No Self",
+      "description": "Checks for `new` not returning a type that contains `Self`.",
+      "default": "warn"
+    },
+    "new_without_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "New Without Default",
+      "description": "Checks for public types with a `pub fn new() -> Self` method and no implementation of `Default`.",
+      "default": "warn"
+    },
+    "no_effect": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Effect",
+      "description": "Checks for statements which have no effect.",
+      "default": "warn"
+    },
+    "no_effect_replace": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Effect Replace",
+      "description": "Checks for `replace` statements which have no effect.",
+      "default": "warn"
+    },
+    "no_effect_underscore_binding": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Effect Underscore Binding",
+      "description": "Checks for binding to underscore prefixed variable without side-effects.",
+      "default": "allow"
+    },
+    "no_mangle_with_rust_abi": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Mangle With Rust Abi",
+      "description": "Checks for Rust ABI functions with the `#[no_mangle]` attribute.",
+      "default": "allow"
+    },
+    "non_ascii_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Ascii Literal",
+      "description": "Checks for non-ASCII characters in string and char literals.",
+      "default": "allow"
+    },
+    "non_canonical_clone_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Canonical Clone Impl",
+      "description": "Checks for non-canonical implementations of `Clone` when `Copy` is already implemented.",
+      "default": "warn"
+    },
+    "non_canonical_partial_ord_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Canonical Partial Ord Impl",
+      "description": "Checks for non-canonical implementations of `PartialOrd` when `Ord` is already implemented.",
+      "default": "warn"
+    },
+    "non_minimal_cfg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Minimal Cfg",
+      "description": "Checks for `any` and `all` combinators in `cfg` with only one condition.",
+      "default": "warn"
+    },
+    "non_octal_unix_permissions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Octal Unix Permissions",
+      "description": "Checks for non-octal values used to set Unix file permissions.",
+      "default": "deny"
+    },
+    "non_send_fields_in_send_ty": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Send Fields In Send Ty",
+      "description": "This lint warns about a `Send` implementation for a type that contains fields that are not safe to be sent across threads. It tries to detect fields that can cause a soundness issue when sent to another thread (e.g., `Rc`) while allowing `!Send` fields that are expected to exist in a `Send` type, such as raw pointers.",
+      "default": "allow"
+    },
+    "non_std_lazy_statics": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Std Lazy Statics",
+      "description": "Lints when `once_cell::sync::Lazy` or `lazy_static!` are used to define a static variable, and suggests replacing such cases with `std::sync::LazyLock` instead.",
+      "default": "allow"
+    },
+    "non_zero_suggestions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Zero Suggestions",
+      "description": "Checks for conversions from `NonZero` types to regular integer types, and suggests using `NonZero` types for the target as well.",
+      "default": "allow"
+    },
+    "nonminimal_bool": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nonminimal Bool",
+      "description": "Checks for boolean expressions that can be written more concisely.",
+      "default": "allow"
+    },
+    "nonsensical_open_options": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nonsensical Open Options",
+      "description": "Checks for duplicate open options as well as combinations that make no sense.",
+      "default": "deny"
+    },
+    "nonstandard_macro_braces": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nonstandard Macro Braces",
+      "description": "Checks that common macros are used with consistent bracing.",
+      "default": "allow"
+    },
+    "not_unsafe_ptr_arg_deref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Not Unsafe Ptr Arg Deref",
+      "description": "Checks for public functions that dereference raw pointer arguments but are not marked `unsafe`.",
+      "default": "deny"
+    },
+    "nursery": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nursery",
+      "description": "The `clippy::nursery` group contains lints which are buggy or need more work. It is not recommended to enable the whole group, but rather cherry-pick lints that are useful for your code base and your use case.",
+      "default": "allow"
+    },
+    "obfuscated_if_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Obfuscated If Else",
+      "description": "Checks for unnecessary method chains that can be simplified into `if.. else..`.",
+      "default": "warn"
+    },
+    "octal_escapes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Octal Escapes",
+      "description": "Checks for `\\0` escapes in string and byte literals that look like octal character escapes in C.",
+      "default": "warn"
+    },
+    "ok_expect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ok Expect",
+      "description": "Checks for usage of `ok().expect(..)`.",
+      "default": "warn"
+    },
+    "only_used_in_recursion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Only Used In Recursion",
+      "description": "Checks for arguments that are only used in recursion with no side-effects.",
+      "default": "warn"
+    },
+    "op_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Op Ref",
+      "description": "Checks for arguments to `==` which have their address taken to satisfy a bound and suggests to dereference the other argument instead",
+      "default": "warn"
+    },
+    "option_as_ref_cloned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option As Ref Cloned",
+      "description": "Checks for usage of `.as_ref().cloned()` and `.as_mut().cloned()` on `Option`s",
+      "default": "allow"
+    },
+    "option_as_ref_deref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option As Ref Deref",
+      "description": "Checks for usage of `_.as_ref().map(Deref::deref)` or its aliases (such as String::as_str).",
+      "default": "warn"
+    },
+    "option_env_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Env Unwrap",
+      "description": "Checks for usage of `option_env!(...).unwrap()` and suggests usage of the `env!` macro.",
+      "default": "deny"
+    },
+    "option_filter_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Filter Map",
+      "description": "Checks for iterators of `Option`s using `.filter(Option::is_some).map(Option::unwrap)` that may be replaced with a `.flatten()` call.",
+      "default": "warn"
+    },
+    "option_if_let_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option If Let Else",
+      "description": "Lints usage of `if let Some(v) =... { y } else { x }` and `match.. { Some(v) => y, None/_ => x }` which are more idiomatically done with `Option::map_or` (if the else bit is a pure expression) or `Option::map_or_else` (if the else bit is an impure expression).",
+      "default": "allow"
+    },
+    "option_map_or_err_ok": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Map Or Err Ok",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "option_map_or_none": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Map Or None",
+      "description": "Checks for usage of `_.map_or(None, _)`.",
+      "default": "warn"
+    },
+    "option_map_unit_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Map Unit Fn",
+      "description": "Checks for usage of `option.map(f)` where f is a function or closure that returns the unit type `()`.",
+      "default": "warn"
+    },
+    "option_option": {
+      "$ref": "#/definitions/Lint",
+      "title": "Option Option",
+      "description": "Checks for usage of `Option >` in function signatures and type definitions",
+      "default": "allow"
+    },
+    "or_fun_call": {
+      "$ref": "#/definitions/Lint",
+      "title": "Or Fun Call",
+      "description": "Checks for calls to `.or(foo(..))`, `.unwrap_or(foo(..))`, `.or_insert(foo(..))` etc., and suggests to use `.or_else(|| foo(..))`, `.unwrap_or_else(|| foo(..))`, `.unwrap_or_default()` or `.or_default()` etc. instead.",
+      "default": "allow"
+    },
+    "or_then_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Or Then Unwrap",
+      "description": "Checks for `.or(…).unwrap()` calls to Options and Results.",
+      "default": "warn"
+    },
+    "out_of_bounds_indexing": {
+      "$ref": "#/definitions/Lint",
+      "title": "Out Of Bounds Indexing",
+      "description": "Checks for out of bounds array indexing with a constant index.",
+      "default": "deny"
+    },
+    "overly_complex_bool_expr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Overly Complex Bool Expr",
+      "description": "Checks for boolean expressions that contain terminals that can be eliminated.",
+      "default": "allow"
+    },
+    "owned_cow": {
+      "$ref": "#/definitions/Lint",
+      "title": "Owned Cow",
+      "description": "Detects needlessly owned `Cow` types.",
+      "default": "warn"
+    },
+    "panic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Panic",
+      "description": "Checks for usage of `panic!`.",
+      "default": "allow"
+    },
+    "panic_in_result_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Panic In Result Fn",
+      "description": "Checks for usage of `panic!` or assertions in a function whose return type is `Result`.",
+      "default": "allow"
+    },
+    "panicking_overflow_checks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Panicking Overflow Checks",
+      "description": "Detects C-style underflow/overflow checks.",
+      "default": "deny"
+    },
+    "panicking_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Panicking Unwrap",
+      "description": "Checks for calls of `unwrap[_err]()` that will always fail.",
+      "default": "deny"
+    },
+    "partial_pub_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Partial Pub Fields",
+      "description": "Checks whether some but not all fields of a `struct` are public.",
+      "default": "allow"
+    },
+    "partialeq_ne_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Partialeq Ne Impl",
+      "description": "Checks for manual re-implementations of `PartialEq::ne`.",
+      "default": "warn"
+    },
+    "partialeq_to_none": {
+      "$ref": "#/definitions/Lint",
+      "title": "Partialeq To None",
+      "description": "Checks for binary comparisons to a literal `Option::None`.",
+      "default": "warn"
+    },
+    "path_buf_push_overwrite": {
+      "$ref": "#/definitions/Lint",
+      "title": "Path Buf Push Overwrite",
+      "description": "Checks for push calls on `PathBuf` that can cause overwrites.",
+      "default": "allow"
+    },
+    "path_ends_with_ext": {
+      "$ref": "#/definitions/Lint",
+      "title": "Path Ends With Ext",
+      "description": "Looks for calls to `Path::ends_with` calls where the argument looks like a file extension.",
+      "default": "warn"
+    },
+    "pathbuf_init_then_push": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pathbuf Init Then Push",
+      "description": "Checks for calls to `push` immediately after creating a new `PathBuf`.",
+      "default": "allow"
+    },
+    "pattern_type_mismatch": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pattern Type Mismatch",
+      "description": "Checks for patterns that aren't exact representations of the types they are applied to.",
+      "default": "allow"
+    },
+    "pedantic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pedantic",
+      "description": "The `clippy::pedantic` group makes Clippy even more pedantic. You can enable the whole group with `#![warn(clippy::pedantic)]` in the `lib.rs`/`main.rs` of your crate. This lint group is for Clippy power users that want an in depth check of their code.",
+      "default": "allow"
+    },
+    "perf": {
+      "$ref": "#/definitions/Lint",
+      "title": "Perf",
+      "description": "The `clippy::perf` group gives you suggestions on how you can increase the performance of your code. Those lints are mostly about code that the compiler can't trivially optimize, but has to be written in a slightly different way to make the optimizer job easier.",
+      "default": "warn"
+    },
+    "permissions_set_readonly_false": {
+      "$ref": "#/definitions/Lint",
+      "title": "Permissions Set Readonly False",
+      "description": "Checks for calls to `std::fs::Permissions.set_readonly` with argument `false`.",
+      "default": "warn"
+    },
+    "pointer_format": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pointer Format",
+      "description": "Detects pointer format as well as `Debug` formatting of raw pointers or function pointers or any types that have a derived `Debug` impl that recursively contains them.",
+      "default": "allow"
+    },
+    "pointers_in_nomem_asm_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pointers In Nomem Asm Block",
+      "description": "Checks if any pointer is being passed to an asm! block with `nomem` option.",
+      "default": "warn"
+    },
+    "possible_missing_comma": {
+      "$ref": "#/definitions/Lint",
+      "title": "Possible Missing Comma",
+      "description": "Checks for possible missing comma in an array. It lints if an array element is a binary operator expression and it lies on two lines.",
+      "default": "deny"
+    },
+    "possible_missing_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Possible Missing Else",
+      "description": "Checks for an `if` expression followed by either a block or another `if` that looks like it should have an `else` between them.",
+      "default": "warn"
+    },
+    "precedence": {
+      "$ref": "#/definitions/Lint",
+      "title": "Precedence",
+      "description": "Checks for operations where precedence may be unclear and suggests to add parentheses. It catches a mixed usage of arithmetic and bit shifting/combining operators, as well as method calls applied to closures.",
+      "default": "warn"
+    },
+    "precedence_bits": {
+      "$ref": "#/definitions/Lint",
+      "title": "Precedence Bits",
+      "description": "Checks for bit shifting operations combined with bit masking/combining operators and suggest using parentheses.",
+      "default": "allow"
+    },
+    "print_in_format_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Print In Format Impl",
+      "description": "Checks for usage of `println`, `print`, `eprintln` or `eprint` in an implementation of a formatting trait.",
+      "default": "warn"
+    },
+    "print_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Print Literal",
+      "description": "This lint warns about the use of literals as `print!`/`println!` args.",
+      "default": "warn"
+    },
+    "print_stderr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Print Stderr",
+      "description": "Checks for printing on stderr. The purpose of this lint is to catch debugging remnants.",
+      "default": "allow"
+    },
+    "print_stdout": {
+      "$ref": "#/definitions/Lint",
+      "title": "Print Stdout",
+      "description": "Checks for printing on stdout. The purpose of this lint is to catch debugging remnants.",
+      "default": "allow"
+    },
+    "print_with_newline": {
+      "$ref": "#/definitions/Lint",
+      "title": "Print With Newline",
+      "description": "This lint warns when you use `print!()` with a format string that ends in a newline.",
+      "default": "warn"
+    },
+    "println_empty_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Println Empty String",
+      "description": "This lint warns when you use `println!(\"\")` to print a newline.",
+      "default": "warn"
+    },
+    "ptr_arg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr Arg",
+      "description": "This lint checks for function arguments of type `&String`, `&Vec`, `&PathBuf`, and `Cow `. It will also suggest you replace `.clone()` calls with the appropriate `.to_owned()`/`to_string()` calls.",
+      "default": "warn"
+    },
+    "ptr_as_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr As Ptr",
+      "description": "Checks for `as` casts between raw pointers that don't change their constness, namely `*const T` to `*const U` and `*mut T` to `*mut U`.",
+      "default": "allow"
+    },
+    "ptr_cast_constness": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr Cast Constness",
+      "description": "Checks for `as` casts between raw pointers that change their constness, namely `*const T` to `*mut T` and `*mut T` to `*const T`.",
+      "default": "allow"
+    },
+    "ptr_eq": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr Eq",
+      "description": "Use `std::ptr::eq` when applicable",
+      "default": "warn"
+    },
+    "ptr_offset_by_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr Offset By Literal",
+      "description": "Checks for usage of the `offset` pointer method with an integer literal.",
+      "default": "allow"
+    },
+    "ptr_offset_with_cast": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr Offset With Cast",
+      "description": "Checks for usage of the `offset` pointer method with a `usize` casted to an `isize`.",
+      "default": "warn"
+    },
+    "pub_enum_variant_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub Enum Variant Names",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "pub_underscore_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub Underscore Fields",
+      "description": "Checks whether any field of the struct is prefixed with an `_` (underscore) and also marked `pub` (public)",
+      "default": "allow"
+    },
+    "pub_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub Use",
+      "description": "Restricts the usage of `pub use...`",
+      "default": "allow"
+    },
+    "pub_with_shorthand": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub With Shorthand",
+      "description": "Checks for usage of `pub()` with `in`.",
+      "default": "allow"
+    },
+    "pub_without_shorthand": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub Without Shorthand",
+      "description": "Checks for usage of `pub()` without `in`.",
+      "default": "allow"
+    },
+    "question_mark": {
+      "$ref": "#/definitions/Lint",
+      "title": "Question Mark",
+      "description": "Checks for expressions that could be replaced by the `?` operator.",
+      "default": "warn"
+    },
+    "question_mark_used": {
+      "$ref": "#/definitions/Lint",
+      "title": "Question Mark Used",
+      "description": "Checks for expressions that use the `?` operator and rejects them.",
+      "default": "allow"
+    },
+    "range_minus_one": {
+      "$ref": "#/definitions/Lint",
+      "title": "Range Minus One",
+      "description": "Checks for inclusive ranges where 1 is subtracted from the upper bound, e.g., `x..=(y-1)`.",
+      "default": "allow"
+    },
+    "range_plus_one": {
+      "$ref": "#/definitions/Lint",
+      "title": "Range Plus One",
+      "description": "Checks for exclusive ranges where 1 is added to the upper bound, e.g., `x..(y+1)`.",
+      "default": "allow"
+    },
+    "range_step_by_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Range Step By Zero",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "range_zip_with_len": {
+      "$ref": "#/definitions/Lint",
+      "title": "Range Zip With Len",
+      "description": "Checks for zipping a collection with the range of `0.._.len()`.",
+      "default": "warn"
+    },
+    "rc_buffer": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rc Buffer",
+      "description": "Checks for `Rc ` and `Arc ` when `T` is a mutable buffer type such as `String` or `Vec`.",
+      "default": "allow"
+    },
+    "rc_clone_in_vec_init": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rc Clone In Vec Init",
+      "description": "Checks for reference-counted pointers (`Arc`, `Rc`, `rc::Weak`, and `sync::Weak`) in `vec![elem; len]`",
+      "default": "warn"
+    },
+    "rc_mutex": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rc Mutex",
+      "description": "Checks for `Rc >`.",
+      "default": "allow"
+    },
+    "read_line_without_trim": {
+      "$ref": "#/definitions/Lint",
+      "title": "Read Line Without Trim",
+      "description": "Looks for calls to [`Stdin::read_line`] to read a line from the standard input into a string, then later attempting to use that string for an operation that will never work for strings with a trailing newline character in it (e.g. parsing into a `i32`).",
+      "default": "deny"
+    },
+    "read_zero_byte_vec": {
+      "$ref": "#/definitions/Lint",
+      "title": "Read Zero Byte Vec",
+      "description": "This lint catches reads into a zero-length `Vec`. Especially in the case of a call to `with_capacity`, this lint warns that read gets the number of bytes from the `Vec`'s length, not its capacity.",
+      "default": "allow"
+    },
+    "readonly_write_lock": {
+      "$ref": "#/definitions/Lint",
+      "title": "Readonly Write Lock",
+      "description": "Looks for calls to `RwLock::write` where the lock is only used for reading.",
+      "default": "warn"
+    },
+    "recursive_format_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Recursive Format Impl",
+      "description": "Checks for format trait implementations (e.g. `Display`) with a recursive call to itself which uses `self` as a parameter. This is typically done indirectly with the `write!` macro or with `to_string()`.",
+      "default": "deny"
+    },
+    "redundant_allocation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Allocation",
+      "description": "Checks for usage of redundant allocations anywhere in the code.",
+      "default": "warn"
+    },
+    "redundant_as_str": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant As Str",
+      "description": "Checks for usage of `as_str()` on a `String` chained with a method available on the `String` itself.",
+      "default": "warn"
+    },
+    "redundant_async_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Async Block",
+      "description": "Checks for `async` block that only returns `await` on a future.",
+      "default": "warn"
+    },
+    "redundant_at_rest_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant At Rest Pattern",
+      "description": "Checks for `[all @..]` patterns.",
+      "default": "warn"
+    },
+    "redundant_clone": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Clone",
+      "description": "Checks for a redundant `clone()` (and its relatives) which clones an owned value that is going to be dropped without further use.",
+      "default": "allow"
+    },
+    "redundant_closure": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Closure",
+      "description": "Checks for closures which just call another function where the function can be called directly. `unsafe` functions, calls where types get adjusted or where the callee is marked `#[track_caller]` are ignored.",
+      "default": "warn"
+    },
+    "redundant_closure_call": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Closure Call",
+      "description": "Detects closures called in the same expression where they are defined.",
+      "default": "warn"
+    },
+    "redundant_closure_for_method_calls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Closure For Method Calls",
+      "description": "Checks for closures which only invoke a method on the closure argument and can be replaced by referencing the method directly.",
+      "default": "allow"
+    },
+    "redundant_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Comparisons",
+      "description": "Checks for ineffective double comparisons against constants.",
+      "default": "deny"
+    },
+    "redundant_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Else",
+      "description": "Checks for `else` blocks that can be removed without changing semantics.",
+      "default": "allow"
+    },
+    "redundant_feature_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Feature Names",
+      "description": "Checks for feature names with prefix `use-`, `with-` or suffix `-support`",
+      "default": "allow"
+    },
+    "redundant_field_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Field Names",
+      "description": "Checks for fields in struct literals where shorthands could be used.",
+      "default": "warn"
+    },
+    "redundant_guards": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Guards",
+      "description": "Checks for unnecessary guards in match expressions.",
+      "default": "warn"
+    },
+    "redundant_iter_cloned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Iter Cloned",
+      "description": "Checks for calls to `Iterator::cloned` where the original value could be used instead.",
+      "default": "warn"
+    },
+    "redundant_locals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Locals",
+      "description": "Checks for redundant redefinitions of local bindings.",
+      "default": "warn"
+    },
+    "redundant_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Pattern",
+      "description": "Checks for patterns in the form `name @ _`.",
+      "default": "warn"
+    },
+    "redundant_pattern_matching": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Pattern Matching",
+      "description": "Lint for redundant pattern matching over `Result`, `Option`, `std::task::Poll`, `std::net::IpAddr` or `bool`s",
+      "default": "warn"
+    },
+    "redundant_pub_crate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Pub Crate",
+      "description": "Checks for items declared `pub(crate)` that are not crate visible because they are inside a private module.",
+      "default": "allow"
+    },
+    "redundant_slicing": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Slicing",
+      "description": "Checks for redundant slicing expressions which use the full range, and do not change the type.",
+      "default": "warn"
+    },
+    "redundant_static_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Static Lifetimes",
+      "description": "Checks for constants and statics with an explicit `'static` lifetime.",
+      "default": "warn"
+    },
+    "redundant_test_prefix": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Test Prefix",
+      "description": "Checks for test functions (functions annotated with `#[test]`) that are prefixed with `test_` which is redundant.",
+      "default": "allow"
+    },
+    "redundant_type_annotations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Type Annotations",
+      "description": "Warns about needless / redundant type annotations.",
+      "default": "allow"
+    },
+    "ref_as_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ref As Ptr",
+      "description": "Checks for casts of references to pointer using `as` and suggests `std::ptr::from_ref` and `std::ptr::from_mut` instead.",
+      "default": "allow"
+    },
+    "ref_binding_to_reference": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ref Binding To Reference",
+      "description": "Checks for `ref` bindings which create a reference to a reference.",
+      "default": "allow"
+    },
+    "ref_option": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ref Option",
+      "description": "Warns when a function signature uses `&Option ` instead of `Option `.",
+      "default": "allow"
+    },
+    "ref_option_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ref Option Ref",
+      "description": "Checks for usage of `&Option `.",
+      "default": "allow"
+    },
+    "ref_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ref Patterns",
+      "description": "Checks for usages of the `ref` keyword.",
+      "default": "allow"
+    },
+    "regex_creation_in_loops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Regex Creation In Loops",
+      "description": "Checks for regex compilation inside a loop with a literal.",
+      "default": "warn"
+    },
+    "regex_macro": {
+      "$ref": "#/definitions/Lint",
+      "title": "Regex Macro",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "renamed_function_params": {
+      "$ref": "#/definitions/Lint",
+      "title": "Renamed Function Params",
+      "description": "Lints when the name of function parameters from trait impl is different than its default implementation.",
+      "default": "allow"
+    },
+    "repeat_once": {
+      "$ref": "#/definitions/Lint",
+      "title": "Repeat Once",
+      "description": "Checks for usage of `.repeat(1)` and suggest the following method for each types.",
+      "default": "warn"
+    },
+    "repeat_vec_with_capacity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Repeat Vec With Capacity",
+      "description": "Looks for patterns such as `vec![Vec::with_capacity(x); n]` or `iter::repeat(Vec::with_capacity(x))`.",
+      "default": "warn"
+    },
+    "replace_box": {
+      "$ref": "#/definitions/Lint",
+      "title": "Replace Box",
+      "description": "Detects assignments of `Default::default()` or `Box::new(value)` to a place of type `Box `.",
+      "default": "warn"
+    },
+    "replace_consts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Replace Consts",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "repr_packed_without_abi": {
+      "$ref": "#/definitions/Lint",
+      "title": "Repr Packed Without Abi",
+      "description": "Checks for items with `#[repr(packed)]`-attribute without ABI qualification",
+      "default": "warn"
+    },
+    "reserve_after_initialization": {
+      "$ref": "#/definitions/Lint",
+      "title": "Reserve After Initialization",
+      "description": "Informs the user about a more concise way to create a vector with a known capacity.",
+      "default": "warn"
+    },
+    "rest_pat_in_fully_bound_structs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rest Pat In Fully Bound Structs",
+      "description": "Checks for unnecessary '..' pattern binding on struct when all fields are explicitly matched.",
+      "default": "allow"
+    },
+    "restriction": {
+      "$ref": "#/definitions/Lint",
+      "title": "Restriction",
+      "description": "The `clippy::restriction` group contains lints that will restrict you from using certain parts of the Rust language. It is not recommended to enable the whole group, but rather cherry-pick lints that are useful for your code base and your use case.",
+      "default": "allow"
+    },
+    "result_filter_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Result Filter Map",
+      "description": "Checks for iterators of `Result`s using `.filter(Result::is_ok).map(Result::unwrap)` that may be replaced with a `.flatten()` call.",
+      "default": "warn"
+    },
+    "result_large_err": {
+      "$ref": "#/definitions/Lint",
+      "title": "Result Large Err",
+      "description": "Checks for functions that return `Result` with an unusually large `Err`-variant.",
+      "default": "warn"
+    },
+    "result_map_or_into_option": {
+      "$ref": "#/definitions/Lint",
+      "title": "Result Map Or Into Option",
+      "description": "Checks for usage of `_.map_or(None, Some)`.",
+      "default": "warn"
+    },
+    "result_map_unit_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Result Map Unit Fn",
+      "description": "Checks for usage of `result.map(f)` where f is a function or closure that returns the unit type `()`.",
+      "default": "warn"
+    },
+    "result_unit_err": {
+      "$ref": "#/definitions/Lint",
+      "title": "Result Unit Err",
+      "description": "Checks for public functions that return a `Result` with an `Err` type of `()`. It suggests using a custom type that implements `std::error::Error`.",
+      "default": "warn"
+    },
+    "return_and_then": {
+      "$ref": "#/definitions/Lint",
+      "title": "Return And Then",
+      "description": "Detect functions that end with `Option::and_then` or `Result::and_then`, and suggest using the `?` operator instead.",
+      "default": "allow"
+    },
+    "return_self_not_must_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Return Self Not Must Use",
+      "description": "This lint warns when a method returning `Self` doesn't have the `#[must_use]` attribute.",
+      "default": "allow"
+    },
+    "reversed_empty_ranges": {
+      "$ref": "#/definitions/Lint",
+      "title": "Reversed Empty Ranges",
+      "description": "Checks for range expressions `x..y` where both `x` and `y` are constant and `x` is greater to `y`. Also triggers if `x` is equal to `y` when they are conditions to a `for` loop.",
+      "default": "deny"
+    },
+    "same_functions_in_if_condition": {
+      "$ref": "#/definitions/Lint",
+      "title": "Same Functions In If Condition",
+      "description": "Checks for consecutive `if`s with the same function call.",
+      "default": "allow"
+    },
+    "same_item_push": {
+      "$ref": "#/definitions/Lint",
+      "title": "Same Item Push",
+      "description": "Checks whether a for loop is being used to push a constant value into a Vec.",
+      "default": "warn"
+    },
+    "same_length_and_capacity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Same Length And Capacity",
+      "description": "Checks for usages of `Vec::from_raw_parts` and `String::from_raw_parts` where the same expression is used for the length and the capacity.",
+      "default": "allow"
+    },
+    "same_name_method": {
+      "$ref": "#/definitions/Lint",
+      "title": "Same Name Method",
+      "description": "It lints if a struct has two methods with the same name: one from a trait, another not from a trait.",
+      "default": "allow"
+    },
+    "search_is_some": {
+      "$ref": "#/definitions/Lint",
+      "title": "Search Is Some",
+      "description": "Checks for an iterator or string search (such as `find()`, `position()`, or `rposition()`) followed by a call to `is_some()` or `is_none()`.",
+      "default": "allow"
+    },
+    "seek_from_current": {
+      "$ref": "#/definitions/Lint",
+      "title": "Seek From Current",
+      "description": "Checks if the `seek` method of the `Seek` trait is called with `SeekFrom::Current(0)`, and if it is, suggests using `stream_position` instead.",
+      "default": "warn"
+    },
+    "seek_to_start_instead_of_rewind": {
+      "$ref": "#/definitions/Lint",
+      "title": "Seek To Start Instead Of Rewind",
+      "description": "Checks for jumps to the start of a stream that implements `Seek` and uses the `seek` method providing `Start` as parameter.",
+      "default": "warn"
+    },
+    "self_assignment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Self Assignment",
+      "description": "Checks for explicit self-assignments.",
+      "default": "deny"
+    },
+    "self_named_constructors": {
+      "$ref": "#/definitions/Lint",
+      "title": "Self Named Constructors",
+      "description": "Warns when constructors have the same name as their types.",
+      "default": "warn"
+    },
+    "self_named_module_files": {
+      "$ref": "#/definitions/Lint",
+      "title": "Self Named Module Files",
+      "description": "Checks that module layout uses only `mod.rs` files.",
+      "default": "allow"
+    },
+    "self_only_used_in_recursion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Self Only Used In Recursion",
+      "description": "Checks for `self` receiver that is only used in recursion with no side-effects.",
+      "default": "allow"
+    },
+    "semicolon_if_nothing_returned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Semicolon If Nothing Returned",
+      "description": "Looks for blocks of expressions and fires if the last expression returns `()` but is not followed by a semicolon.",
+      "default": "allow"
+    },
+    "semicolon_inside_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Semicolon Inside Block",
+      "description": "Suggests moving the semicolon after a block to the inside of the block, after its last expression.",
+      "default": "allow"
+    },
+    "semicolon_outside_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Semicolon Outside Block",
+      "description": "Suggests moving the semicolon from a block's final expression outside of the block.",
+      "default": "allow"
+    },
+    "separated_literal_suffix": {
+      "$ref": "#/definitions/Lint",
+      "title": "Separated Literal Suffix",
+      "description": "Warns if literal suffixes are separated by an underscore. To enforce separated literal suffix style, see the `unseparated_literal_suffix` lint.",
+      "default": "allow"
+    },
+    "serde_api_misuse": {
+      "$ref": "#/definitions/Lint",
+      "title": "Serde Api Misuse",
+      "description": "Checks for misuses of the serde API.",
+      "default": "deny"
+    },
+    "set_contains_or_insert": {
+      "$ref": "#/definitions/Lint",
+      "title": "Set Contains Or Insert",
+      "description": "Checks for usage of `contains` to see if a value is not present in a set like `HashSet` or `BTreeSet`, followed by an `insert`.",
+      "default": "allow"
+    },
+    "shadow_reuse": {
+      "$ref": "#/definitions/Lint",
+      "title": "Shadow Reuse",
+      "description": "Checks for bindings that shadow other bindings already in scope, while reusing the original value.",
+      "default": "allow"
+    },
+    "shadow_same": {
+      "$ref": "#/definitions/Lint",
+      "title": "Shadow Same",
+      "description": "Checks for bindings that shadow other bindings already in scope, while just changing reference level or mutability.",
+      "default": "allow"
+    },
+    "shadow_unrelated": {
+      "$ref": "#/definitions/Lint",
+      "title": "Shadow Unrelated",
+      "description": "Checks for bindings that shadow other bindings already in scope, either without an initialization or with one that does not even use the original value.",
+      "default": "allow"
+    },
+    "short_circuit_statement": {
+      "$ref": "#/definitions/Lint",
+      "title": "Short Circuit Statement",
+      "description": "Checks for the use of short circuit boolean conditions as a statement.",
+      "default": "warn"
+    },
+    "should_assert_eq": {
+      "$ref": "#/definitions/Lint",
+      "title": "Should Assert Eq",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "should_implement_trait": {
+      "$ref": "#/definitions/Lint",
+      "title": "Should Implement Trait",
+      "description": "Checks for methods that should live in a trait implementation of a `std` trait (see llogiq's blog post for further information) instead of an inherent implementation.",
+      "default": "warn"
+    },
+    "should_panic_without_expect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Should Panic Without Expect",
+      "description": "Checks for `#[should_panic]` attributes without specifying the expected panic message.",
+      "default": "allow"
+    },
+    "significant_drop_in_scrutinee": {
+      "$ref": "#/definitions/Lint",
+      "title": "Significant Drop In Scrutinee",
+      "description": "Checks for temporaries returned from function calls in a match scrutinee that have the `clippy::has_significant_drop` attribute.",
+      "default": "allow"
+    },
+    "significant_drop_tightening": {
+      "$ref": "#/definitions/Lint",
+      "title": "Significant Drop Tightening",
+      "description": "Searches for elements marked with `#[clippy::has_significant_drop]` that could be early dropped but are in fact dropped at the end of their scopes. In other words, enforces the \"tightening\" of their possible lifetimes.",
+      "default": "allow"
+    },
+    "similar_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Similar Names",
+      "description": "Checks for names that are very similar and thus confusing. In particular, the lint checks for names with a single character change.",
+      "default": "allow"
+    },
+    "single_call_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Call Fn",
+      "description": "Checks for functions that are only used once. Does not lint tests.",
+      "default": "allow"
+    },
+    "single_char_add_str": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Char Add Str",
+      "description": "Warns when using `push_str`/`insert_str` with a single-character string literal where `push`/`insert` with a `char` would work fine.",
+      "default": "warn"
+    },
+    "single_char_lifetime_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Char Lifetime Names",
+      "description": "Checks for lifetimes with names which are one character long.",
+      "default": "allow"
+    },
+    "single_char_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Char Pattern",
+      "description": "Checks for string methods that receive a single-character `str` as an argument, e.g., `_.split(\"x\")`.",
+      "default": "allow"
+    },
+    "single_component_path_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Component Path Imports",
+      "description": "Checking for imports with single component use path.",
+      "default": "warn"
+    },
+    "single_element_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Element Loop",
+      "description": "Checks whether a for loop has a single element.",
+      "default": "warn"
+    },
+    "single_match": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Match",
+      "description": "Checks for matches with a single arm where an `if let` will usually suffice.",
+      "default": "warn"
+    },
+    "single_match_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Match Else",
+      "description": "Checks for matches with two arms where an `if let else` will usually suffice.",
+      "default": "allow"
+    },
+    "single_option_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Option Map",
+      "description": "Checks for functions with method calls to `.map(_)` on an arg of type `Option` as the outermost expression.",
+      "default": "allow"
+    },
+    "single_range_in_vec_init": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Range In Vec Init",
+      "description": "Checks for `Vec` or array initializations that contain only one range.",
+      "default": "warn"
+    },
+    "size_of_in_element_count": {
+      "$ref": "#/definitions/Lint",
+      "title": "Size Of In Element Count",
+      "description": "Detects expressions where `size_of:: ` or `size_of_val:: ` is used as a count of elements of type `T`",
+      "default": "deny"
+    },
+    "size_of_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Size Of Ref",
+      "description": "Checks for calls to `size_of_val()` where the argument is a reference to a reference.",
+      "default": "warn"
+    },
+    "skip_while_next": {
+      "$ref": "#/definitions/Lint",
+      "title": "Skip While Next",
+      "description": "Checks for usage of `_.skip_while(condition).next()`.",
+      "default": "warn"
+    },
+    "sliced_string_as_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Sliced String As Bytes",
+      "description": "Checks for string slices immediately followed by `as_bytes`.",
+      "default": "warn"
+    },
+    "slow_vector_initialization": {
+      "$ref": "#/definitions/Lint",
+      "title": "Slow Vector Initialization",
+      "description": "Checks slow zero-filled vector initialization",
+      "default": "warn"
+    },
+    "stable_sort_primitive": {
+      "$ref": "#/definitions/Lint",
+      "title": "Stable Sort Primitive",
+      "description": "When sorting primitive values (integers, bools, chars, as well as arrays, slices, and tuples of such items), it is typically better to use an unstable sort than a stable sort.",
+      "default": "allow"
+    },
+    "std_instead_of_alloc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Std Instead Of Alloc",
+      "description": "Finds items imported through `std` when available through `alloc`.",
+      "default": "allow"
+    },
+    "std_instead_of_core": {
+      "$ref": "#/definitions/Lint",
+      "title": "Std Instead Of Core",
+      "description": "Finds items imported through `std` when available through `core`.",
+      "default": "allow"
+    },
+    "str_split_at_newline": {
+      "$ref": "#/definitions/Lint",
+      "title": "Str Split At Newline",
+      "description": "Checks for usages of `str.trim().split(\"\\n\")` and `str.trim().split(\"\\r\\n\")`.",
+      "default": "allow"
+    },
+    "str_to_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Str To String",
+      "description": "This lint checks for `.to_string()` method calls on values of type `&str`.",
+      "default": "allow"
+    },
+    "string_add": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Add",
+      "description": "Checks for all instances of `x + _` where `x` is of type `String`, but only if `string_add_assign` does not match.",
+      "default": "allow"
+    },
+    "string_add_assign": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Add Assign",
+      "description": "Checks for string appends of the form `x = x + y` (without `let`!).",
+      "default": "allow"
+    },
+    "string_extend_chars": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Extend Chars",
+      "description": "Checks for the use of `.extend(s.chars())` where s is a `&str` or `String`.",
+      "default": "warn"
+    },
+    "string_from_utf8_as_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "String From Utf8 As Bytes",
+      "description": "Check if the string is transformed to byte array and casted back to string.",
+      "default": "warn"
+    },
+    "string_lit_as_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Lit As Bytes",
+      "description": "Checks for the `as_bytes` method called on string literals that contain only ASCII characters.",
+      "default": "allow"
+    },
+    "string_lit_chars_any": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Lit Chars Any",
+      "description": "Checks for `.chars().any(|i| i == c)`.",
+      "default": "allow"
+    },
+    "string_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "String Slice",
+      "description": "Checks for slice operations on strings",
+      "default": "allow"
+    },
+    "string_to_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "String To String",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "strlen_on_c_strings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Strlen On C Strings",
+      "description": "Checks for usage of `libc::strlen` on a `CString` or `CStr` value, and suggest calling `count_bytes()` instead.",
+      "default": "warn"
+    },
+    "struct_excessive_bools": {
+      "$ref": "#/definitions/Lint",
+      "title": "Struct Excessive Bools",
+      "description": "Checks for excessive use of bools in structs.",
+      "default": "allow"
+    },
+    "struct_field_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Struct Field Names",
+      "description": "Detects struct fields that are prefixed or suffixed by the same characters or the name of the struct itself.",
+      "default": "allow"
+    },
+    "style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Style",
+      "description": "The `clippy::style` group is mostly about writing idiomatic code. Because style is subjective, this lint group is the most opinionated warn-by-default group in Clippy.",
+      "default": "warn"
+    },
+    "suboptimal_flops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suboptimal Flops",
+      "description": "Looks for floating-point expressions that can be expressed using built-in methods to improve both accuracy and performance.",
+      "default": "allow"
+    },
+    "suspicious": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious",
+      "description": "The `clippy::suspicious` group is similar to the correctness lints in that it contains lints that trigger on code that is really sus and should be fixed. As opposed to correctness lints, it might be possible that the linted code is intentionally written like it is.",
+      "default": "warn"
+    },
+    "suspicious_arithmetic_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Arithmetic Impl",
+      "description": "Lints for suspicious operations in impls of arithmetic operators, e.g. subtracting elements in an Add impl.",
+      "default": "warn"
+    },
+    "suspicious_assignment_formatting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Assignment Formatting",
+      "description": "Checks for usage of the non-existent `=*`, `=!` and `=-` operators.",
+      "default": "warn"
+    },
+    "suspicious_command_arg_space": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Command Arg Space",
+      "description": "Checks for `Command::arg()` invocations that look like they should be multiple arguments instead, such as `arg(\"-t ext2\")`.",
+      "default": "warn"
+    },
+    "suspicious_doc_comments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Doc Comments",
+      "description": "Detects the use of outer doc comments (`///`, `/**`) followed by a bang (`!`): `///!`",
+      "default": "warn"
+    },
+    "suspicious_else_formatting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Else Formatting",
+      "description": "Checks for formatting of `else`. It lints if the `else` is followed immediately by a newline or the `else` seems to be missing.",
+      "default": "warn"
+    },
+    "suspicious_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Map",
+      "description": "Checks for calls to `map` followed by a `count`.",
+      "default": "warn"
+    },
+    "suspicious_op_assign_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Op Assign Impl",
+      "description": "Lints for suspicious operations in impls of OpAssign, e.g. subtracting elements in an AddAssign impl.",
+      "default": "warn"
+    },
+    "suspicious_open_options": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Open Options",
+      "description": "Checks for the suspicious use of `OpenOptions::create()` without an explicit `OpenOptions::truncate()`.",
+      "default": "warn"
+    },
+    "suspicious_operation_groupings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Operation Groupings",
+      "description": "Checks for unlikely usages of binary operators that are almost certainly typos and/or copy/paste errors, given the other usages of binary operators nearby.",
+      "default": "allow"
+    },
+    "suspicious_splitn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Splitn",
+      "description": "Checks for calls to [`splitn`] (https://doc.rust-lang.org/std/primitive.str.html#method.splitn) and related functions with either zero or one splits.",
+      "default": "deny"
+    },
+    "suspicious_to_owned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious To Owned",
+      "description": "Checks for the usage of `_.to_owned()`, on a `Cow `.",
+      "default": "warn"
+    },
+    "suspicious_unary_op_formatting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Unary Op Formatting",
+      "description": "Checks the formatting of a unary operator on the right hand side of a binary operator. It lints if there is no space between the binary and unary operators, but there is a space between the unary and its operand.",
+      "default": "warn"
+    },
+    "suspicious_xor_used_as_pow": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Xor Used As Pow",
+      "description": "Warns for a Bitwise XOR (`^`) operator being probably confused as a powering. It will not trigger if any of the numbers are not in decimal.",
+      "default": "allow"
+    },
+    "swap_ptr_to_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Swap Ptr To Ref",
+      "description": "Checks for calls to `core::mem::swap` where either parameter is derived from a pointer",
+      "default": "warn"
+    },
+    "swap_with_temporary": {
+      "$ref": "#/definitions/Lint",
+      "title": "Swap With Temporary",
+      "description": "Checks for usage of `std::mem::swap` with temporary values.",
+      "default": "warn"
+    },
+    "tabs_in_doc_comments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Tabs In Doc Comments",
+      "description": "Checks doc comments for usage of tab characters.",
+      "default": "warn"
+    },
+    "temporary_assignment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Temporary Assignment",
+      "description": "Checks for construction of a structure or tuple just to assign a value in it.",
+      "default": "warn"
+    },
+    "test_attr_in_doctest": {
+      "$ref": "#/definitions/Lint",
+      "title": "Test Attr In Doctest",
+      "description": "Checks for `#[test]` in doctests unless they are marked with either `ignore`, `no_run` or `compile_fail`.",
+      "default": "warn"
+    },
+    "tests_outside_test_module": {
+      "$ref": "#/definitions/Lint",
+      "title": "Tests Outside Test Module",
+      "description": "Triggers when a testing function (marked with the `#[test]` attribute) isn't inside a testing module (marked with `#[cfg(test)]`).",
+      "default": "allow"
+    },
+    "to_digit_is_some": {
+      "$ref": "#/definitions/Lint",
+      "title": "To Digit Is Some",
+      "description": "Checks for `.to_digit(..).is_some()` on `char`s.",
+      "default": "warn"
+    },
+    "to_string_in_format_args": {
+      "$ref": "#/definitions/Lint",
+      "title": "To String In Format Args",
+      "description": "Checks for `ToString::to_string` applied to a type that implements `Display` in a macro that does formatting.",
+      "default": "warn"
+    },
+    "to_string_trait_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "To String Trait Impl",
+      "description": "Checks for direct implementations of `ToString`.",
+      "default": "warn"
+    },
+    "todo": {
+      "$ref": "#/definitions/Lint",
+      "title": "Todo",
+      "description": "Checks for usage of `todo!`.",
+      "default": "allow"
+    },
+    "too_long_first_doc_paragraph": {
+      "$ref": "#/definitions/Lint",
+      "title": "Too Long First Doc Paragraph",
+      "description": "Checks if the first paragraph in the documentation of items listed in the module page is too long.",
+      "default": "allow"
+    },
+    "too_many_arguments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Too Many Arguments",
+      "description": "Checks for functions with too many parameters.",
+      "default": "warn"
+    },
+    "too_many_lines": {
+      "$ref": "#/definitions/Lint",
+      "title": "Too Many Lines",
+      "description": "Checks for functions with a large amount of lines.",
+      "default": "allow"
+    },
+    "toplevel_ref_arg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Toplevel Ref Arg",
+      "description": "Checks for function arguments and let bindings denoted as `ref`.",
+      "default": "warn"
+    },
+    "trailing_empty_array": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trailing Empty Array",
+      "description": "Displays a warning when a struct with a trailing zero-sized array is declared without a `repr` attribute.",
+      "default": "allow"
+    },
+    "trait_duplication_in_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trait Duplication In Bounds",
+      "description": "Checks for cases where generics or trait objects are being used and multiple syntax specifications for trait bounds are used simultaneously.",
+      "default": "allow"
+    },
+    "transmute_bytes_to_str": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Bytes To Str",
+      "description": "Checks for transmutes from a `&[u8]` to a `&str`.",
+      "default": "warn"
+    },
+    "transmute_int_to_bool": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Int To Bool",
+      "description": "Checks for transmutes from an integer to a `bool`.",
+      "default": "warn"
+    },
+    "transmute_int_to_non_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Int To Non Zero",
+      "description": "Checks for transmutes from `T` to `NonZero `, and suggests the `new_unchecked` method instead.",
+      "default": "warn"
+    },
+    "transmute_null_to_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Null To Fn",
+      "description": "Checks for null function pointer creation through transmute.",
+      "default": "deny"
+    },
+    "transmute_ptr_to_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Ptr To Ptr",
+      "description": "Checks for transmutes from a pointer to a pointer, or from a reference to a reference.",
+      "default": "allow"
+    },
+    "transmute_ptr_to_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Ptr To Ref",
+      "description": "Checks for transmutes from a pointer to a reference.",
+      "default": "warn"
+    },
+    "transmute_undefined_repr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmute Undefined Repr",
+      "description": "Checks for transmutes between types which do not have a representation defined relative to each other.",
+      "default": "allow"
+    },
+    "transmutes_expressible_as_ptr_casts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmutes Expressible As Ptr Casts",
+      "description": "Checks for transmutes that could be a pointer cast.",
+      "default": "warn"
+    },
+    "transmuting_null": {
+      "$ref": "#/definitions/Lint",
+      "title": "Transmuting Null",
+      "description": "Checks for transmute calls which would receive a null pointer.",
+      "default": "deny"
+    },
+    "trim_split_whitespace": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trim Split Whitespace",
+      "description": "Warns about calling `str::trim` (or variants) before `str::split_whitespace`.",
+      "default": "warn"
+    },
+    "trivial_regex": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trivial Regex",
+      "description": "Checks for trivial regex creation (with `Regex::new`, `RegexBuilder::new`, or `RegexSet::new`).",
+      "default": "allow"
+    },
+    "trivially_copy_pass_by_ref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trivially Copy Pass By Ref",
+      "description": "Checks for functions taking arguments by reference, where the argument type is `Copy` and small enough to be more efficient to always pass by value.",
+      "default": "allow"
+    },
+    "try_err": {
+      "$ref": "#/definitions/Lint",
+      "title": "Try Err",
+      "description": "Checks for usage of `Err(x)?`.",
+      "default": "allow"
+    },
+    "tuple_array_conversions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Tuple Array Conversions",
+      "description": "Checks for tuple<=>array conversions that are not done with `.into()`.",
+      "default": "allow"
+    },
+    "type_complexity": {
+      "$ref": "#/definitions/Lint",
+      "title": "Type Complexity",
+      "description": "Checks for types used in structs, parameters and `let` declarations above a certain complexity threshold.",
+      "default": "warn"
+    },
+    "type_id_on_box": {
+      "$ref": "#/definitions/Lint",
+      "title": "Type Id On Box",
+      "description": "Looks for calls to `.type_id()` on a `Box `.",
+      "default": "warn"
+    },
+    "type_repetition_in_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Type Repetition In Bounds",
+      "description": "This lint warns about unnecessary type repetitions in trait bounds",
+      "default": "allow"
+    },
+    "unbuffered_bytes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unbuffered Bytes",
+      "description": "Checks for calls to `Read::bytes` on types which don't implement `BufRead`.",
+      "default": "warn"
+    },
+    "unchecked_time_subtraction": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unchecked Time Subtraction",
+      "description": "Lints subtraction between an `Instant` and a `Duration`, or between two `Duration` values.",
+      "default": "allow"
+    },
+    "unconditional_recursion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unconditional Recursion",
+      "description": "Checks that there isn't an infinite recursion in trait implementations.",
+      "default": "warn"
+    },
+    "undocumented_unsafe_blocks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Undocumented Unsafe Blocks",
+      "description": "Checks for `unsafe` blocks and impls without a `// SAFETY: ` comment explaining why the unsafe operations performed inside the block are safe.",
+      "default": "allow"
+    },
+    "unicode_not_nfc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unicode Not Nfc",
+      "description": "Checks for string literals that contain Unicode in a form that is not equal to its NFC-recomposition.",
+      "default": "allow"
+    },
+    "unimplemented": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unimplemented",
+      "description": "Checks for usage of `unimplemented!`.",
+      "default": "allow"
+    },
+    "uninhabited_references": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uninhabited References",
+      "description": "It detects references to uninhabited types, such as `!` and warns when those are either dereferenced or returned from a function.",
+      "default": "allow"
+    },
+    "uninit_assumed_init": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uninit Assumed Init",
+      "description": "Checks for `MaybeUninit::uninit().assume_init()`.",
+      "default": "deny"
+    },
+    "uninit_vec": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uninit Vec",
+      "description": "Checks for `set_len()` call that creates `Vec` with uninitialized elements. This is commonly caused by calling `set_len()` right after allocating or reserving a buffer with `new()`, `default()`, `with_capacity()`, or `reserve()`.",
+      "default": "deny"
+    },
+    "uninlined_format_args": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uninlined Format Args",
+      "description": "Detect when a variable is not inlined in a format string, and suggests to inline it.",
+      "default": "allow"
+    },
+    "unit_arg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unit Arg",
+      "description": "Checks for passing a unit value as an argument to a function without using a unit literal (`()`).",
+      "default": "warn"
+    },
+    "unit_cmp": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unit Cmp",
+      "description": "Checks for comparisons to unit. This includes all binary comparisons (like `==` and `",
+      "default": "deny"
+    },
+    "unit_hash": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unit Hash",
+      "description": "Detects `().hash(_)`.",
+      "default": "deny"
+    },
+    "unit_return_expecting_ord": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unit Return Expecting Ord",
+      "description": "Checks for functions that expect closures of type Fn(…) -> Ord where the implemented closure returns the unit type. The lint also suggests to remove the semi-colon at the end of the statement if present.",
+      "default": "deny"
+    },
+    "unnecessary_box_returns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Box Returns",
+      "description": "Checks for a return type containing a `Box ` where `T` implements `Sized`",
+      "default": "allow"
+    },
+    "unnecessary_cast": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Cast",
+      "description": "Checks for casts to the same type, casts of int literals to integer types, casts of float literals to float types, and casts between raw pointers that don't change type or constness.",
+      "default": "warn"
+    },
+    "unnecessary_clippy_cfg": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Clippy Cfg",
+      "description": "Checks for `#[cfg_attr(clippy, allow(clippy::lint))]` and suggests to replace it with `#[allow(clippy::lint)]`.",
+      "default": "warn"
+    },
+    "unnecessary_debug_formatting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Debug Formatting",
+      "description": "Checks for `Debug` formatting (`{:?}`) applied to an `OsStr` or `Path`.",
+      "default": "allow"
+    },
+    "unnecessary_fallible_conversions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Fallible Conversions",
+      "description": "Checks for calls to `TryInto::try_into` and `TryFrom::try_from` when their infallible counterparts could be used.",
+      "default": "warn"
+    },
+    "unnecessary_filter_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Filter Map",
+      "description": "Checks for `filter_map` calls that could be replaced by `filter` or `map`. More specifically it checks if the closure provided is only performing one of the filter or map operations and suggests the appropriate option.",
+      "default": "warn"
+    },
+    "unnecessary_find_map": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Find Map",
+      "description": "Checks for `find_map` calls that could be replaced by `find` or `map`. More specifically it checks if the closure provided is only performing one of the find or map operations and suggests the appropriate option.",
+      "default": "warn"
+    },
+    "unnecessary_first_then_check": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary First Then Check",
+      "description": "Checks the usage of `.first().is_some()` or `.first().is_none()` to check if a slice is empty.",
+      "default": "warn"
+    },
+    "unnecessary_fold": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Fold",
+      "description": "Checks for usage of `fold` when a more succinct alternative exists. Specifically, this checks for `fold`s which could be replaced by `any`, `all`, `sum` or `product`.",
+      "default": "warn"
+    },
+    "unnecessary_get_then_check": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Get Then Check",
+      "description": "Checks the usage of `.get().is_some()` or `.get().is_none()` on std map types.",
+      "default": "warn"
+    },
+    "unnecessary_join": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Join",
+      "description": "Checks for usage of `.collect:: >().join(\"\")` on iterators.",
+      "default": "allow"
+    },
+    "unnecessary_lazy_evaluations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Lazy Evaluations",
+      "description": "As the counterpart to `or_fun_call`, this lint looks for unnecessary lazily evaluated closures on `Option` and `Result`.",
+      "default": "warn"
+    },
+    "unnecessary_literal_bound": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Literal Bound",
+      "description": "Detects functions that are written to return `&str` that could return `&'static str` but instead return a `&'a str`.",
+      "default": "allow"
+    },
+    "unnecessary_literal_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Literal Unwrap",
+      "description": "Checks for `.unwrap()` related calls on `Result`s and `Option`s that are constructed.",
+      "default": "warn"
+    },
+    "unnecessary_map_on_constructor": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Map On Constructor",
+      "description": "Suggests removing the use of a `map()` (or `map_err()`) method when an `Option` or `Result` is being constructed.",
+      "default": "warn"
+    },
+    "unnecessary_map_or": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Map Or",
+      "description": "Converts some constructs mapping an Enum value for equality comparison.",
+      "default": "warn"
+    },
+    "unnecessary_min_or_max": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Min Or Max",
+      "description": "Checks for unnecessary calls to `min()` or `max()` in the following cases",
+      "default": "warn"
+    },
+    "unnecessary_mut_passed": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Mut Passed",
+      "description": "Detects passing a mutable reference to a function that only requires an immutable reference.",
+      "default": "warn"
+    },
+    "unnecessary_operation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Operation",
+      "description": "Checks for expression statements that can be reduced to a sub-expression.",
+      "default": "warn"
+    },
+    "unnecessary_option_map_or_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Option Map Or Else",
+      "description": "Checks for usage of `.map_or_else()` \"map closure\" for `Option` type.",
+      "default": "warn"
+    },
+    "unnecessary_owned_empty_strings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Owned Empty Strings",
+      "description": "Detects cases of owned empty strings being passed as an argument to a function expecting `&str`",
+      "default": "warn"
+    },
+    "unnecessary_result_map_or_else": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Result Map Or Else",
+      "description": "Checks for usage of `.map_or_else()` \"map closure\" for `Result` type.",
+      "default": "warn"
+    },
+    "unnecessary_safety_comment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Safety Comment",
+      "description": "Checks for `// SAFETY: ` comments on safe code.",
+      "default": "allow"
+    },
+    "unnecessary_safety_doc": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Safety Doc",
+      "description": "Checks for the doc comments of publicly visible safe functions and traits and warns if there is a `# Safety` section.",
+      "default": "allow"
+    },
+    "unnecessary_self_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Self Imports",
+      "description": "Checks for imports ending in `::{self}`.",
+      "default": "allow"
+    },
+    "unnecessary_semicolon": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Semicolon",
+      "description": "Checks for the presence of a semicolon at the end of a `match` or `if` statement evaluating to `()`.",
+      "default": "allow"
+    },
+    "unnecessary_sort_by": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Sort By",
+      "description": "Checks for usage of `Vec::sort_by` passing in a closure which compares the two arguments, either directly or indirectly.",
+      "default": "warn"
+    },
+    "unnecessary_struct_initialization": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Struct Initialization",
+      "description": "Checks for initialization of an identical `struct` from another instance of the type, either by copying a base without setting any field or by moving all fields individually.",
+      "default": "allow"
+    },
+    "unnecessary_to_owned": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary To Owned",
+      "description": "Checks for unnecessary calls to `ToOwned::to_owned` and other `to_owned`-like functions.",
+      "default": "warn"
+    },
+    "unnecessary_trailing_comma": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Trailing Comma",
+      "description": "Suggests removing an unnecessary trailing comma before the closing parenthesis in single-line macro invocations.",
+      "default": "allow"
+    },
+    "unnecessary_unwrap": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Unwrap",
+      "description": "Checks for calls of `unwrap[_err]()` that cannot fail.",
+      "default": "warn"
+    },
+    "unnecessary_wraps": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Wraps",
+      "description": "Checks for private functions that only return `Ok` or `Some`.",
+      "default": "allow"
+    },
+    "unneeded_field_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unneeded Field Pattern",
+      "description": "Checks for structure field patterns bound to wildcards.",
+      "default": "allow"
+    },
+    "unneeded_struct_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unneeded Struct Pattern",
+      "description": "Checks for struct patterns that match against unit variant.",
+      "default": "warn"
+    },
+    "unneeded_wildcard_pattern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unneeded Wildcard Pattern",
+      "description": "Checks for tuple and struct patterns with a wildcard pattern (`_`) is next to a rest pattern (`..`).",
+      "default": "warn"
+    },
+    "unnested_or_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnested Or Patterns",
+      "description": "Checks for unnested or-patterns, e.g., `Some(0) | Some(2)` and suggests replacing the pattern with a nested one, `Some(0 | 2)`.",
+      "default": "allow"
+    },
+    "unreachable": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unreachable",
+      "description": "Checks for usage of `unreachable!`.",
+      "default": "allow"
+    },
+    "unreadable_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unreadable Literal",
+      "description": "Warns if a long integral or floating-point constant does not contain underscores.",
+      "default": "allow"
+    },
+    "unsafe_derive_deserialize": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Derive Deserialize",
+      "description": "Checks for deriving `serde::Deserialize` on a type that has methods using `unsafe`.",
+      "default": "allow"
+    },
+    "unsafe_removed_from_name": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Removed From Name",
+      "description": "Checks for imports that remove \"unsafe\" from an item's name.",
+      "default": "warn"
+    },
+    "unsafe_vector_initialization": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Vector Initialization",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "unseparated_literal_suffix": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unseparated Literal Suffix",
+      "description": "Warns if literal suffixes are not separated by an underscore. To enforce unseparated literal suffix style, see the `separated_literal_suffix` lint.",
+      "default": "allow"
+    },
+    "unsound_collection_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsound Collection Transmute",
+      "description": "Checks for transmutes between collections whose types have different ABI, size or alignment.",
+      "default": "deny"
+    },
+    "unstable_as_mut_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unstable As Mut Slice",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "unstable_as_slice": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unstable As Slice",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "unused_async": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Async",
+      "description": "Checks for functions that are declared `async` but have no `.await`s inside of them.",
+      "default": "allow"
+    },
+    "unused_collect": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Collect",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "unused_enumerate_index": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Enumerate Index",
+      "description": "Checks for uses of the `enumerate` method where the index is unused (`_`)",
+      "default": "warn"
+    },
+    "unused_format_specs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Format Specs",
+      "description": "Detects formatting parameters that have no effect on the output of `format!()`, `println!()` or similar macros.",
+      "default": "warn"
+    },
+    "unused_io_amount": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Io Amount",
+      "description": "Checks for unused written/read amount.",
+      "default": "deny"
+    },
+    "unused_peekable": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Peekable",
+      "description": "Checks for the creation of a `peekable` iterator that is never `.peek()`ed",
+      "default": "allow"
+    },
+    "unused_result_ok": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Result Ok",
+      "description": "Checks for calls to `Result::ok()` without using the returned `Option`.",
+      "default": "allow"
+    },
+    "unused_rounding": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Rounding",
+      "description": "Detects cases where a whole-number literal float is being rounded, using the `floor`, `ceil`, or `round` methods.",
+      "default": "allow"
+    },
+    "unused_self": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Self",
+      "description": "Checks methods that contain a `self` argument but don't use it",
+      "default": "allow"
+    },
+    "unused_trait_names": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Trait Names",
+      "description": "Checks for `use Trait` where the Trait is only used for its methods and not referenced by a path directly.",
+      "default": "allow"
+    },
+    "unused_unit": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Unit",
+      "description": "Checks for unit (`()`) expressions that can be removed.",
+      "default": "warn"
+    },
+    "unusual_byte_groupings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unusual Byte Groupings",
+      "description": "Warns if hexadecimal or binary literals are not grouped by nibble or byte.",
+      "default": "warn"
+    },
+    "unwrap_in_result": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unwrap In Result",
+      "description": "Checks for functions of type `Result` that contain `expect()` or `unwrap()`",
+      "default": "allow"
+    },
+    "unwrap_or_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unwrap Or Default",
+      "description": "Checks for usages of the following functions with an argument that constructs a default value (e.g., `Default::default` or `String::new`):",
+      "default": "warn"
+    },
+    "unwrap_used": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unwrap Used",
+      "description": "Checks for `.unwrap()` or `.unwrap_err()` calls on `Result`s and `.unwrap()` call on `Option`s.",
+      "default": "allow"
+    },
+    "upper_case_acronyms": {
+      "$ref": "#/definitions/Lint",
+      "title": "Upper Case Acronyms",
+      "description": "Checks for fully capitalized names and optionally names containing a capitalized acronym.",
+      "default": "warn"
+    },
+    "use_debug": {
+      "$ref": "#/definitions/Lint",
+      "title": "Use Debug",
+      "description": "Checks for usage of `Debug` formatting. The purpose of this lint is to catch debugging remnants.",
+      "default": "allow"
+    },
+    "use_self": {
+      "$ref": "#/definitions/Lint",
+      "title": "Use Self",
+      "description": "Checks for unnecessary repetition of structure name when a replacement with `Self` is applicable.",
+      "default": "allow"
+    },
+    "used_underscore_binding": {
+      "$ref": "#/definitions/Lint",
+      "title": "Used Underscore Binding",
+      "description": "Checks for the use of bindings with a single leading underscore.",
+      "default": "allow"
+    },
+    "used_underscore_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Used Underscore Items",
+      "description": "Checks for the use of item with a single leading underscore.",
+      "default": "allow"
+    },
+    "useless_asref": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Asref",
+      "description": "Checks for usage of `.as_ref()` or `.as_mut()` where the types before and after the call are the same.",
+      "default": "warn"
+    },
+    "useless_attribute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Attribute",
+      "description": "Checks for `extern crate` and `use` items annotated with lint attributes.",
+      "default": "deny"
+    },
+    "useless_concat": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Concat",
+      "description": "Checks that the `concat!` macro has at least two arguments.",
+      "default": "warn"
+    },
+    "useless_conversion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Conversion",
+      "description": "Checks for `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` calls which uselessly convert to the same type.",
+      "default": "warn"
+    },
+    "useless_format": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Format",
+      "description": "Checks for the use of `format!(\"string literal with no argument\")` and `format!(\"{}\", foo)` where `foo` is a string.",
+      "default": "warn"
+    },
+    "useless_let_if_seq": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Let If Seq",
+      "description": "Checks for variable declarations immediately followed by a conditional affectation.",
+      "default": "allow"
+    },
+    "useless_nonzero_new_unchecked": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Nonzero New Unchecked",
+      "description": "Checks for `NonZero*::new_unchecked()` being used in a `const` context.",
+      "default": "warn"
+    },
+    "useless_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Transmute",
+      "description": "Checks for transmutes to the original type of the object and transmutes that could be a cast.",
+      "default": "warn"
+    },
+    "useless_vec": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Vec",
+      "description": "Checks for usage of `vec![..]` when using `[..]` would be possible.",
+      "default": "warn"
+    },
+    "vec_box": {
+      "$ref": "#/definitions/Lint",
+      "title": "Vec Box",
+      "description": "Checks for usage of `Vec >` where T: Sized anywhere in the code. Check the Box documentation for more information.",
+      "default": "warn"
+    },
+    "vec_init_then_push": {
+      "$ref": "#/definitions/Lint",
+      "title": "Vec Init Then Push",
+      "description": "Checks for calls to `push` immediately after creating a new `Vec`.",
+      "default": "warn"
+    },
+    "vec_resize_to_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Vec Resize To Zero",
+      "description": "Finds occurrences of `Vec::resize(0, an_int)`",
+      "default": "deny"
+    },
+    "verbose_bit_mask": {
+      "$ref": "#/definitions/Lint",
+      "title": "Verbose Bit Mask",
+      "description": "Checks for bit masks that can be replaced by a call to `trailing_zeros`",
+      "default": "allow"
+    },
+    "verbose_file_reads": {
+      "$ref": "#/definitions/Lint",
+      "title": "Verbose File Reads",
+      "description": "Checks for usage of File::read_to_end and File::read_to_string.",
+      "default": "allow"
+    },
+    "volatile_composites": {
+      "$ref": "#/definitions/Lint",
+      "title": "Volatile Composites",
+      "description": "This lint warns when volatile load/store operations (`write_volatile`/`read_volatile`) are applied to composite types.",
+      "default": "allow"
+    },
+    "waker_clone_wake": {
+      "$ref": "#/definitions/Lint",
+      "title": "Waker Clone Wake",
+      "description": "Checks for usage of `waker.clone().wake()`",
+      "default": "warn"
+    },
+    "while_float": {
+      "$ref": "#/definitions/Lint",
+      "title": "While Float",
+      "description": "Checks for while loops comparing floating point values.",
+      "default": "allow"
+    },
+    "while_immutable_condition": {
+      "$ref": "#/definitions/Lint",
+      "title": "While Immutable Condition",
+      "description": "Checks whether variables used within while loop condition can be (and are) mutated in the body.",
+      "default": "deny"
+    },
+    "while_let_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "While Let Loop",
+      "description": "Detects `loop + match` combinations that are easier written as a `while let` loop.",
+      "default": "warn"
+    },
+    "while_let_on_iterator": {
+      "$ref": "#/definitions/Lint",
+      "title": "While Let On Iterator",
+      "description": "Checks for `while let` expressions on iterators.",
+      "default": "warn"
+    },
+    "wildcard_dependencies": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wildcard Dependencies",
+      "description": "Checks for wildcard dependencies in the `Cargo.toml`.",
+      "default": "allow"
+    },
+    "wildcard_enum_match_arm": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wildcard Enum Match Arm",
+      "description": "Checks for wildcard enum matches using `_`.",
+      "default": "allow"
+    },
+    "wildcard_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wildcard Imports",
+      "description": "Checks for wildcard imports `use _::*`.",
+      "default": "allow"
+    },
+    "wildcard_in_or_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wildcard In Or Patterns",
+      "description": "Checks for wildcard pattern used with others patterns in same match arm.",
+      "default": "warn"
+    },
+    "write_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Write Literal",
+      "description": "This lint warns about the use of literals as `write!`/`writeln!` args.",
+      "default": "warn"
+    },
+    "write_with_newline": {
+      "$ref": "#/definitions/Lint",
+      "title": "Write With Newline",
+      "description": "This lint warns when you use `write!()` with a format string that ends in a newline.",
+      "default": "warn"
+    },
+    "writeln_empty_string": {
+      "$ref": "#/definitions/Lint",
+      "title": "Writeln Empty String",
+      "description": "This lint warns when you use `writeln!(buf, \"\")` to print a newline.",
+      "default": "warn"
+    },
+    "wrong_pub_self_convention": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wrong Pub Self Convention",
+      "description": "Nothing. This lint has been deprecated",
+      "deprecated": true
+    },
+    "wrong_self_convention": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wrong Self Convention",
+      "description": "Checks for methods with certain name prefixes or suffixes, and which do not adhere to standard conventions regarding how `self` is taken. The actual rules are:",
+      "default": "warn"
+    },
+    "wrong_transmute": {
+      "$ref": "#/definitions/Lint",
+      "title": "Wrong Transmute",
+      "description": "Checks for transmutes that can't ever be correct on any architecture.",
+      "default": "deny"
+    },
+    "zero_divided_by_zero": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zero Divided By Zero",
+      "description": "Checks for `0.0 / 0.0`.",
+      "default": "warn"
+    },
+    "zero_prefixed_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zero Prefixed Literal",
+      "description": "Warns if an integral constant literal starts with `0`.",
+      "default": "warn"
+    },
+    "zero_ptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zero Ptr",
+      "description": "Catch casts from `0` to some pointer type",
+      "default": "warn"
+    },
+    "zero_repeat_side_effects": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zero Repeat Side Effects",
+      "description": "Checks for array or vec initializations which contain an expression with side effects, but which have a repeat count of zero.",
+      "default": "warn"
+    },
+    "zero_sized_map_values": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zero Sized Map Values",
+      "description": "Checks for maps with zero-sized value types anywhere in the code.",
+      "default": "allow"
+    },
+    "zombie_processes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zombie Processes",
+      "description": "Looks for code that spawns a process but never calls `wait()` on the child.",
+      "default": "warn"
+    },
+    "zst_offset": {
+      "$ref": "#/definitions/Lint",
+      "title": "Zst Offset",
+      "description": "Checks for `offset(_)`, `wrapping_`{`add`, `sub`}, etc. on raw pointers to zero-sized types",
+      "default": "deny"
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/Lint"
+  },
+  "x-tombi-table-keys-order": "version-sort",
+  "x-tombi-additional-key-label": "lint_name",
+  "definitions": {
+    "DetailedLint": {
+      "title": "Detailed Lint",
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/LintLevel"
+        },
+        "priority": {
+          "description": "The priority that controls which lints or [lint groups](https://doc.rust-lang.org/rustc/lints/groups.html) override other lint groups. Lower (particularly negative) numbers have lower priority, being overridden by higher numbers, and show up first on the command-line to tools like rustc.",
+          "type": "integer"
+        },
+        "check-cfg": {
+          "description": "A list of `cfg` expressions that this lint should check for.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": ["cfg(foo)"]
+        }
+      },
+      "x-tombi-table-keys-order": "schema"
+    },
+    "Lint": {
+      "title": "Lint",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LintLevel"
+        },
+        {
+          "$ref": "#/definitions/DetailedLint"
+        }
+      ]
+    },
+    "LintLevel": {
+      "title": "Lint Level",
+      "description": "Specify the [lint level](https://doc.rust-lang.org/rustc/lints/levels.html) for a lint or lint group.",
+      "type": "string",
+      "enum": ["forbid", "deny", "warn", "allow"]
+    }
+  }
+}

--- a/src/schemas/json/cargo-lints-rust.json
+++ b/src/schemas/json/cargo-lints-rust.json
@@ -1,0 +1,1457 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/cargo-lints-rust.json",
+  "title": "Rust Compiler Lints",
+  "description": "Lint settings for Rust compiler individual lints and lint groups.",
+  "type": "object",
+  "properties": {
+    "aarch64_softfloat_neon": {
+      "$ref": "#/definitions/Lint",
+      "title": "Aarch64 Softfloat Neon",
+      "description": "The `aarch64_softfloat_neon` lint detects usage of `#[target_feature(enable = \"neon\")]` on softfloat aarch64 targets. Enabling this target feature causes LLVM to alter the ABI of function calls, making this attribute unsound to use.",
+      "default": "warn"
+    },
+    "absolute_paths_not_starting_with_crate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Absolute Paths Not Starting With Crate",
+      "description": "The `absolute_paths_not_starting_with_crate` lint detects fully qualified paths that start with a module name instead of `crate`, `self`, or an extern crate name",
+      "default": "allow"
+    },
+    "ambiguous_associated_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ambiguous Associated Items",
+      "description": "The `ambiguous_associated_items` lint detects ambiguity between associated items and enum variants.",
+      "default": "deny"
+    },
+    "ambiguous_glob_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ambiguous Glob Imports",
+      "description": "The `ambiguous_glob_imports` lint detects glob imports that should report ambiguity errors, but previously didn\u2019t do that due to rustc bugs.",
+      "default": "deny"
+    },
+    "ambiguous_glob_reexports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ambiguous Glob Reexports",
+      "description": "The `ambiguous_glob_reexports` lint detects cases where names re-exported via globs collide. Downstream users trying to use the same name re-exported from multiple globs will receive a warning pointing out redefinition of the same name.",
+      "default": "warn"
+    },
+    "ambiguous_negative_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ambiguous Negative Literals",
+      "description": "The `ambiguous_negative_literals` lint checks for cases that are confusing between a negative literal and a negation that\u2019s not part of the literal.",
+      "default": "allow"
+    },
+    "ambiguous_wide_pointer_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ambiguous Wide Pointer Comparisons",
+      "description": "The `ambiguous_wide_pointer_comparisons` lint checks comparison of `*const/*mut ?Sized` as the operands.",
+      "default": "warn"
+    },
+    "anonymous_parameters": {
+      "$ref": "#/definitions/Lint",
+      "title": "Anonymous Parameters",
+      "description": "The `anonymous_parameters` lint detects anonymous parameters in trait definitions.",
+      "default": "warn"
+    },
+    "arithmetic_overflow": {
+      "$ref": "#/definitions/Lint",
+      "title": "Arithmetic Overflow",
+      "description": "The `arithmetic_overflow` lint detects that an arithmetic operation will overflow.",
+      "default": "deny"
+    },
+    "array_into_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Array Into Iter",
+      "description": "The `array_into_iter` lint detects calling `into_iter` on arrays.",
+      "default": "warn"
+    },
+    "asm_sub_register": {
+      "$ref": "#/definitions/Lint",
+      "title": "Asm Sub Register",
+      "description": "The `asm_sub_register` lint detects using only a subset of a register for inline asm inputs.",
+      "default": "warn"
+    },
+    "async_fn_in_trait": {
+      "$ref": "#/definitions/Lint",
+      "title": "Async Fn In Trait",
+      "description": "The `async_fn_in_trait` lint detects use of `async fn` in the definition of a publicly-reachable trait.",
+      "default": "warn"
+    },
+    "bad_asm_style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bad Asm Style",
+      "description": "The `bad_asm_style` lint detects the use of the `.intel_syntax` and `.att_syntax` directives.",
+      "default": "warn"
+    },
+    "bare_trait_objects": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bare Trait Objects",
+      "description": "The `bare_trait_objects` lint suggests using `dyn Trait` for trait objects.",
+      "default": "warn"
+    },
+    "binary_asm_labels": {
+      "$ref": "#/definitions/Lint",
+      "title": "Binary Asm Labels",
+      "description": "The `binary_asm_labels` lint detects the use of numeric labels containing only binary digits in the inline `asm!` macro.",
+      "default": "deny"
+    },
+    "bindings_with_variant_name": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bindings With Variant Name",
+      "description": "The `bindings_with_variant_name` lint detects pattern bindings with the same name as one of the matched variants.",
+      "default": "deny"
+    },
+    "boxed_slice_into_iter": {
+      "$ref": "#/definitions/Lint",
+      "title": "Boxed Slice Into Iter",
+      "description": "The `boxed_slice_into_iter` lint detects calling `into_iter` on boxed slices.",
+      "default": "warn"
+    },
+    "break_with_label_and_loop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Break With Label And Loop",
+      "description": "The `break_with_label_and_loop` lint detects labeled `break` expressions with an unlabeled loop as their value expression.",
+      "default": "warn"
+    },
+    "clashing_extern_declarations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Clashing Extern Declarations",
+      "description": "The `clashing_extern_declarations` lint detects when an `extern fn` has been declared with the same name but different types.",
+      "default": "warn"
+    },
+    "closure_returning_async_block": {
+      "$ref": "#/definitions/Lint",
+      "title": "Closure Returning Async Block",
+      "description": "The `closure_returning_async_block` lint detects cases where users write a closure that returns an async block.",
+      "default": "allow"
+    },
+    "coherence_leak_check": {
+      "$ref": "#/definitions/Lint",
+      "title": "Coherence Leak Check",
+      "description": "The `coherence_leak_check` lint detects conflicting implementations of a trait that are only distinguished by the old leak-check code.",
+      "default": "warn"
+    },
+    "conflicting_repr_hints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Conflicting Repr Hints",
+      "description": "The `conflicting_repr_hints` lint detects `repr` attributes with conflicting hints.",
+      "default": "deny"
+    },
+    "confusable_idents": {
+      "$ref": "#/definitions/Lint",
+      "title": "Confusable Idents",
+      "description": "The `confusable_idents` lint detects visually confusable pairs between identifiers.",
+      "default": "warn"
+    },
+    "const_evaluatable_unchecked": {
+      "$ref": "#/definitions/Lint",
+      "title": "Const Evaluatable Unchecked",
+      "description": "The `const_evaluatable_unchecked` lint detects a generic constant used in a type.",
+      "default": "warn"
+    },
+    "const_item_mutation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Const Item Mutation",
+      "description": "The `const_item_mutation` lint detects attempts to mutate a `const` item.",
+      "default": "warn"
+    },
+    "dangerous_implicit_autorefs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dangerous Implicit Autorefs",
+      "description": "The `dangerous_implicit_autorefs` lint checks for implicitly taken references to dereferences of raw pointers.",
+      "default": "deny"
+    },
+    "dangling_pointers_from_temporaries": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dangling Pointers From Temporaries",
+      "description": "The `dangling_pointers_from_temporaries` lint detects getting a pointer to data of a temporary that will immediately get dropped.",
+      "default": "warn"
+    },
+    "dead_code": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dead Code",
+      "description": "The `dead_code` lint detects unused, unexported items.",
+      "default": "warn"
+    },
+    "default_overrides_default_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Default Overrides Default Fields",
+      "description": "The `default_overrides_default_fields` lint checks for manual `impl` blocks of the `Default` trait of types with default field values.",
+      "default": "deny"
+    },
+    "dependency_on_unit_never_type_fallback": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dependency On Unit Never Type Fallback",
+      "description": "The `dependency_on_unit_never_type_fallback` lint detects cases where code compiles with never type fallback being `()`, but will stop compiling with fallback being `!`.",
+      "default": "warn"
+    },
+    "deprecated": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated",
+      "description": "The `deprecated` lint detects use of deprecated items.",
+      "default": "warn"
+    },
+    "deprecated_in_future": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated In Future",
+      "description": "detects use of items that will be deprecated in a future version.",
+      "default": "allow"
+    },
+    "deprecated_safe_2024": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Safe 2024",
+      "description": "The `deprecated_safe_2024` lint detects unsafe functions being used as safe functions.",
+      "default": "allow"
+    },
+    "deprecated_where_clause_location": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Where Clause Location",
+      "description": "The `deprecated_where_clause_location` lint detects when a where clause in front of the equals in an associated type.",
+      "default": "warn"
+    },
+    "deref_into_dyn_supertrait": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deref Into Dyn Supertrait",
+      "description": "The `deref_into_dyn_supertrait` lint is emitted whenever there is a `Deref` implementation for `dyn SubTrait` with a `dyn SuperTrait` type as the `Output` type.",
+      "default": "allow"
+    },
+    "deref_nullptr": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deref Nullptr",
+      "description": "The `deref_nullptr` lint detects when a null pointer is dereferenced, which causes undefined behavior.",
+      "default": "warn"
+    },
+    "double_negations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Double Negations",
+      "description": "The `double_negations` lint detects expressions of the form `--x`.",
+      "default": "warn"
+    },
+    "drop_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Drop Bounds",
+      "description": "The `drop_bounds` lint checks for generics with `std::ops::Drop` as bounds.",
+      "default": "warn"
+    },
+    "dropping_copy_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dropping Copy Types",
+      "description": "The `dropping_copy_types` lint checks for calls to `std::mem::drop` with a value that derives the Copy trait.",
+      "default": "warn"
+    },
+    "dropping_references": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dropping References",
+      "description": "The `dropping_references` lint checks for calls to `std::mem::drop` with a reference instead of an owned value.",
+      "default": "warn"
+    },
+    "duplicate_macro_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Duplicate Macro Attributes",
+      "description": "The `duplicate_macro_attributes` lint detects when a `#[test]`-like built-in macro attribute is duplicated on an item. This lint may trigger on `bench`, `cfg_eval`, `test` and `test_case`.",
+      "default": "warn"
+    },
+    "dyn_drop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Dyn Drop",
+      "description": "The `dyn_drop` lint checks for trait objects with `std::ops::Drop`.",
+      "default": "warn"
+    },
+    "edition_2024_expr_fragment_specifier": {
+      "$ref": "#/definitions/Lint",
+      "title": "Edition 2024 Expr Fragment Specifier",
+      "description": "The `edition_2024_expr_fragment_specifier` lint detects the use of `expr` fragments in macros during migration to the 2024 edition.",
+      "default": "allow"
+    },
+    "elided_lifetimes_in_associated_constant": {
+      "$ref": "#/definitions/Lint",
+      "title": "Elided Lifetimes In Associated Constant",
+      "description": "The `elided_lifetimes_in_associated_constant` lint detects elided lifetimes in associated constants when there are other lifetimes in scope. This was accidentally supported, and this lint was later relaxed to allow eliding lifetimes to `'static` when there are no lifetimes in scope.",
+      "default": "deny"
+    },
+    "elided_lifetimes_in_paths": {
+      "$ref": "#/definitions/Lint",
+      "title": "Elided Lifetimes In Paths",
+      "description": "The `elided_lifetimes_in_paths` lint detects the use of hidden lifetime parameters.",
+      "default": "allow"
+    },
+    "ellipsis_inclusive_range_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ellipsis Inclusive Range Patterns",
+      "description": "The `ellipsis_inclusive_range_patterns` lint detects the `...` range pattern, which is deprecated.",
+      "default": "warn"
+    },
+    "enum_intrinsics_non_enums": {
+      "$ref": "#/definitions/Lint",
+      "title": "Enum Intrinsics Non Enums",
+      "description": "The `enum_intrinsics_non_enums` lint detects calls to intrinsic functions that require an enum (`core::mem::discriminant`, `core::mem::variant_count`), but are called with a non-enum type.",
+      "default": "deny"
+    },
+    "explicit_builtin_cfgs_in_flags": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Builtin Cfgs In Flags",
+      "description": "The `explicit_builtin_cfgs_in_flags` lint detects builtin cfgs set via the `--cfg` flag.",
+      "default": "deny"
+    },
+    "explicit_outlives_requirements": {
+      "$ref": "#/definitions/Lint",
+      "title": "Explicit Outlives Requirements",
+      "description": "The `explicit_outlives_requirements` lint detects unnecessary lifetime bounds that can be inferred.",
+      "default": "allow"
+    },
+    "exported_private_dependencies": {
+      "$ref": "#/definitions/Lint",
+      "title": "Exported Private Dependencies",
+      "description": "The `exported_private_dependencies` lint detects private dependencies that are exposed in a public interface.",
+      "default": "warn"
+    },
+    "ffi_unwind_calls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ffi Unwind Calls",
+      "description": "The `ffi_unwind_calls` lint detects calls to foreign functions or function pointers with `C-unwind` or other FFI-unwind ABIs.",
+      "default": "allow"
+    },
+    "for_loops_over_fallibles": {
+      "$ref": "#/definitions/Lint",
+      "title": "For Loops Over Fallibles",
+      "description": "The `for_loops_over_fallibles` lint checks for `for` loops over `Option` or `Result` values.",
+      "default": "warn"
+    },
+    "forbidden_lint_groups": {
+      "$ref": "#/definitions/Lint",
+      "title": "Forbidden Lint Groups",
+      "description": "The `forbidden_lint_groups` lint detects violations of `forbid` applied to a lint group. Due to a bug in the compiler, these used to be overlooked entirely. They now generate a warning.",
+      "default": "warn"
+    },
+    "forgetting_copy_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Forgetting Copy Types",
+      "description": "The `forgetting_copy_types` lint checks for calls to `std::mem::forget` with a value that derives the Copy trait.",
+      "default": "warn"
+    },
+    "forgetting_references": {
+      "$ref": "#/definitions/Lint",
+      "title": "Forgetting References",
+      "description": "The `forgetting_references` lint checks for calls to `std::mem::forget` with a reference instead of an owned value.",
+      "default": "warn"
+    },
+    "function_item_references": {
+      "$ref": "#/definitions/Lint",
+      "title": "Function Item References",
+      "description": "The `function_item_references` lint detects function references that are formatted with `fmt::Pointer` or transmuted.",
+      "default": "warn"
+    },
+    "fuzzy_provenance_casts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Fuzzy Provenance Casts",
+      "description": "The `fuzzy_provenance_casts` lint detects an `as` cast between an integer and a pointer.",
+      "default": "allow"
+    },
+    "hidden_glob_reexports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Hidden Glob Reexports",
+      "description": "The `hidden_glob_reexports` lint detects cases where glob re-export items are shadowed by private items.",
+      "default": "warn"
+    },
+    "if_let_rescope": {
+      "$ref": "#/definitions/Lint",
+      "title": "If Let Rescope",
+      "description": "The `if_let_rescope` lint detects cases where a temporary value with significant drop is generated on the right hand side of `if let` and suggests a rewrite into `match` when possible.",
+      "default": "allow"
+    },
+    "ill_formed_attribute_input": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ill Formed Attribute Input",
+      "description": "The `ill_formed_attribute_input` lint detects ill-formed attribute inputs that were previously accepted and used in practice.",
+      "default": "deny"
+    },
+    "impl_trait_overcaptures": {
+      "$ref": "#/definitions/Lint",
+      "title": "Impl Trait Overcaptures",
+      "description": "The `impl_trait_overcaptures` lint warns against cases where lifetime capture behavior will differ in edition 2024.",
+      "default": "allow"
+    },
+    "impl_trait_redundant_captures": {
+      "$ref": "#/definitions/Lint",
+      "title": "Impl Trait Redundant Captures",
+      "description": "The `impl_trait_redundant_captures` lint warns against cases where use of the precise capturing `use ` syntax is not needed.",
+      "default": "allow"
+    },
+    "improper_ctypes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Improper Ctypes",
+      "description": "The `improper_ctypes` lint detects incorrect use of types in foreign modules.",
+      "default": "warn"
+    },
+    "improper_ctypes_definitions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Improper Ctypes Definitions",
+      "description": "The `improper_ctypes_definitions` lint detects incorrect use of `extern` function definitions.",
+      "default": "warn"
+    },
+    "incomplete_features": {
+      "$ref": "#/definitions/Lint",
+      "title": "Incomplete Features",
+      "description": "The `incomplete_features` lint detects unstable features enabled with the `feature` attribute that may function improperly in some or all cases.",
+      "default": "warn"
+    },
+    "incomplete_include": {
+      "$ref": "#/definitions/Lint",
+      "title": "Incomplete Include",
+      "description": "The `incomplete_include` lint detects the use of the `include!` macro with a file that contains more than one expression.",
+      "default": "deny"
+    },
+    "ineffective_unstable_trait_impl": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ineffective Unstable Trait Impl",
+      "description": "The `ineffective_unstable_trait_impl` lint detects `#[unstable]` attributes which are not used.",
+      "default": "deny"
+    },
+    "inline_no_sanitize": {
+      "$ref": "#/definitions/Lint",
+      "title": "Inline No Sanitize",
+      "description": "The `inline_no_sanitize` lint detects incompatible use of `#[inline(always)]` and `#[sanitize(xyz = \"off\")]`.",
+      "default": "warn"
+    },
+    "internal_features": {
+      "$ref": "#/definitions/Lint",
+      "title": "Internal Features",
+      "description": "The `internal_features` lint detects unstable features enabled with the `feature` attribute that are internal to the compiler or standard library.",
+      "default": "warn"
+    },
+    "invalid_atomic_ordering": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Atomic Ordering",
+      "description": "The `invalid_atomic_ordering` lint detects passing an `Ordering` to an atomic operation that does not support that ordering.",
+      "default": "deny"
+    },
+    "invalid_doc_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Doc Attributes",
+      "description": "The `invalid_doc_attributes` lint detects when the `#[doc(...)]` is misused.",
+      "default": "deny"
+    },
+    "invalid_from_utf8": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid From Utf8",
+      "description": "The `invalid_from_utf8` lint checks for calls to `std::str::from_utf8` and `std::str::from_utf8_mut` with a known invalid UTF-8 value.",
+      "default": "warn"
+    },
+    "invalid_from_utf8_unchecked": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid From Utf8 Unchecked",
+      "description": "The `invalid_from_utf8_unchecked` lint checks for calls to `std::str::from_utf8_unchecked` and `std::str::from_utf8_unchecked_mut` with a known invalid UTF-8 value.",
+      "default": "deny"
+    },
+    "invalid_macro_export_arguments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Macro Export Arguments",
+      "description": "The `invalid_macro_export_arguments` lint detects cases where `#[macro_export]` is being used with invalid arguments.",
+      "default": "warn"
+    },
+    "invalid_nan_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Nan Comparisons",
+      "description": "The `invalid_nan_comparisons` lint checks comparison with `f32::NAN` or `f64::NAN` as one of the operand.",
+      "default": "warn"
+    },
+    "invalid_null_arguments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Null Arguments",
+      "description": "The `invalid_null_arguments` lint checks for invalid usage of null pointers in arguments.",
+      "default": "deny"
+    },
+    "invalid_reference_casting": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Reference Casting",
+      "description": "The `invalid_reference_casting` lint checks for casts of `&T` to `&mut T` without using interior mutability.",
+      "default": "deny"
+    },
+    "invalid_type_param_default": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Type Param Default",
+      "description": "The `invalid_type_param_default` lint detects type parameter defaults erroneously allowed in an invalid location.",
+      "default": "deny"
+    },
+    "invalid_value": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Value",
+      "description": "The `invalid_value` lint detects creating a value that is not valid, such as a null reference.",
+      "default": "warn"
+    },
+    "irrefutable_let_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Irrefutable Let Patterns",
+      "description": "The `irrefutable_let_patterns` lint detects irrefutable patterns in `if let`s, `while let`s, and `if let` guards.",
+      "default": "warn"
+    },
+    "keyword_idents_2018": {
+      "$ref": "#/definitions/Lint",
+      "title": "Keyword Idents 2018",
+      "description": "The `keyword_idents_2018` lint detects edition keywords being used as an identifier.",
+      "default": "allow"
+    },
+    "keyword_idents_2024": {
+      "$ref": "#/definitions/Lint",
+      "title": "Keyword Idents 2024",
+      "description": "The `keyword_idents_2024` lint detects edition keywords being used as an identifier.",
+      "default": "allow"
+    },
+    "large_assignments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Large Assignments",
+      "description": "The `large_assignments` lint detects when objects of large types are being moved around.",
+      "default": "warn"
+    },
+    "late_bound_lifetime_arguments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Late Bound Lifetime Arguments",
+      "description": "The `late_bound_lifetime_arguments` lint detects generic lifetime arguments in path segments with late bound lifetime parameters.",
+      "default": "warn"
+    },
+    "legacy_derive_helpers": {
+      "$ref": "#/definitions/Lint",
+      "title": "Legacy Derive Helpers",
+      "description": "The `legacy_derive_helpers` lint detects derive helper attributes that are used before they are introduced.",
+      "default": "warn"
+    },
+    "let_underscore_drop": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Drop",
+      "description": "The `let_underscore_drop` lint checks for statements which don\u2019t bind an expression which has a non-trivial Drop implementation to anything, causing the expression to be dropped immediately instead of at end of scope.",
+      "default": "allow"
+    },
+    "let_underscore_lock": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore Lock",
+      "description": "The `let_underscore_lock` lint checks for statements which don\u2019t bind a mutex to anything, causing the lock to be released immediately instead of at end of scope, which is typically incorrect.",
+      "default": "deny"
+    },
+    "linker_messages": {
+      "$ref": "#/definitions/Lint",
+      "title": "Linker Messages",
+      "description": "The `linker_messages` lint forwards warnings from the linker.",
+      "default": "allow"
+    },
+    "long_running_const_eval": {
+      "$ref": "#/definitions/Lint",
+      "title": "Long Running Const Eval",
+      "description": "The `long_running_const_eval` lint is emitted when const eval is running for a long time to ensure rustc terminates even if you accidentally wrote an infinite loop.",
+      "default": "deny"
+    },
+    "lossy_provenance_casts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Lossy Provenance Casts",
+      "description": "The `lossy_provenance_casts` lint detects an `as` cast between a pointer and an integer.",
+      "default": "allow"
+    },
+    "macro_expanded_macro_exports_accessed_by_absolute_paths": {
+      "$ref": "#/definitions/Lint",
+      "title": "Macro Expanded Macro Exports Accessed By Absolute Paths",
+      "description": "The `macro_expanded_macro_exports_accessed_by_absolute_paths` lint detects macro-expanded `macro_export` macros from the current crate that cannot be referred to by absolute paths.",
+      "default": "deny"
+    },
+    "macro_use_extern_crate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Macro Use Extern Crate",
+      "description": "The `macro_use_extern_crate` lint detects the use of the `macro_use` attribute.",
+      "default": "allow"
+    },
+    "malformed_diagnostic_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Malformed Diagnostic Attributes",
+      "description": "The `malformed_diagnostic_attributes` lint detects malformed diagnostic attributes.",
+      "default": "warn"
+    },
+    "malformed_diagnostic_format_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Malformed Diagnostic Format Literals",
+      "description": "The `malformed_diagnostic_format_literals` lint detects malformed diagnostic format literals.",
+      "default": "warn"
+    },
+    "map_unit_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Map Unit Fn",
+      "description": "The `map_unit_fn` lint checks for `Iterator::map` receive a callable that returns `()`.",
+      "default": "warn"
+    },
+    "meta_variable_misuse": {
+      "$ref": "#/definitions/Lint",
+      "title": "Meta Variable Misuse",
+      "description": "The `meta_variable_misuse` lint detects possible meta-variable misuse in macro definitions.",
+      "default": "allow"
+    },
+    "mismatched_lifetime_syntaxes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mismatched Lifetime Syntaxes",
+      "description": "The `mismatched_lifetime_syntaxes` lint detects when the same lifetime is referred to by different syntaxes between function arguments and return values.",
+      "default": "warn"
+    },
+    "misplaced_diagnostic_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Misplaced Diagnostic Attributes",
+      "description": "The `misplaced_diagnostic_attributes` lint detects wrongly placed diagnostic attributes.",
+      "default": "warn"
+    },
+    "missing_abi": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Abi",
+      "description": "The `missing_abi` lint detects cases where the ABI is omitted from `extern` declarations.",
+      "default": "warn"
+    },
+    "missing_copy_implementations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Copy Implementations",
+      "description": "The `missing_copy_implementations` lint detects potentially-forgotten implementations of `Copy` for public types.",
+      "default": "allow"
+    },
+    "missing_debug_implementations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Debug Implementations",
+      "description": "The `missing_debug_implementations` lint detects missing implementations of `fmt::Debug` for public types.",
+      "default": "allow"
+    },
+    "missing_docs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Docs",
+      "description": "The `missing_docs` lint detects missing documentation for public items.",
+      "default": "allow"
+    },
+    "missing_unsafe_on_extern": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Unsafe On Extern",
+      "description": "The `missing_unsafe_on_extern` lint detects missing unsafe keyword on extern declarations.",
+      "default": "allow"
+    },
+    "mixed_script_confusables": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mixed Script Confusables",
+      "description": "The `mixed_script_confusables` lint detects visually confusable characters in identifiers between different scripts.",
+      "default": "warn"
+    },
+    "multiple_supertrait_upcastable": {
+      "$ref": "#/definitions/Lint",
+      "title": "Multiple Supertrait Upcastable",
+      "description": "The `multiple_supertrait_upcastable` lint detects when a dyn-compatible trait has multiple supertraits.",
+      "default": "allow"
+    },
+    "must_not_suspend": {
+      "$ref": "#/definitions/Lint",
+      "title": "Must Not Suspend",
+      "description": "The `must_not_suspend` lint guards against values that shouldn\u2019t be held across suspend points (`.await`)",
+      "default": "allow"
+    },
+    "mutable_transmutes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Mutable Transmutes",
+      "description": "The `mutable_transmutes` lint catches transmuting from `&T` to `&mut T` because it is undefined behavior.",
+      "default": "deny"
+    },
+    "named_arguments_used_positionally": {
+      "$ref": "#/definitions/Lint",
+      "title": "Named Arguments Used Positionally",
+      "description": "The `named_arguments_used_positionally` lint detects cases where named arguments are only used positionally in format strings. This usage is valid but potentially very confusing.",
+      "default": "warn"
+    },
+    "named_asm_labels": {
+      "$ref": "#/definitions/Lint",
+      "title": "Named Asm Labels",
+      "description": "The `named_asm_labels` lint detects the use of named labels in the inline `asm!` macro.",
+      "default": "deny"
+    },
+    "never_type_fallback_flowing_into_unsafe": {
+      "$ref": "#/definitions/Lint",
+      "title": "Never Type Fallback Flowing Into Unsafe",
+      "description": "The `never_type_fallback_flowing_into_unsafe` lint detects cases where never type fallback affects unsafe function calls.",
+      "default": "warn"
+    },
+    "no_mangle_const_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Mangle Const Items",
+      "description": "The `no_mangle_const_items` lint detects any `const` items with the `no_mangle` attribute.",
+      "default": "deny"
+    },
+    "no_mangle_generic_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "No Mangle Generic Items",
+      "description": "The `no_mangle_generic_items` lint detects generic items that must be mangled.",
+      "default": "warn"
+    },
+    "non_ascii_idents": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Ascii Idents",
+      "description": "The `non_ascii_idents` lint detects non-ASCII identifiers.",
+      "default": "allow"
+    },
+    "non_camel_case_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Camel Case Types",
+      "description": "The `non_camel_case_types` lint detects types, variants, traits and type parameters that don\u2019t have camel case names.",
+      "default": "warn"
+    },
+    "non_contiguous_range_endpoints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Contiguous Range Endpoints",
+      "description": "The `non_contiguous_range_endpoints` lint detects likely off-by-one errors when using exclusive range patterns.",
+      "default": "warn"
+    },
+    "non_exhaustive_omitted_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Exhaustive Omitted Patterns",
+      "description": "The `non_exhaustive_omitted_patterns` lint aims to help consumers of a `#[non_exhaustive]` struct or enum who want to match all of its fields/variants explicitly.",
+      "default": "allow"
+    },
+    "non_fmt_panics": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Fmt Panics",
+      "description": "The `non_fmt_panics` lint detects `panic!(..)` invocations where the first argument is not a formatting string.",
+      "default": "warn"
+    },
+    "non_local_definitions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Local Definitions",
+      "description": "The `non_local_definitions` lint checks for `impl` blocks and `#[macro_export]` macro inside bodies (functions, enum discriminant, \u2026).",
+      "default": "warn"
+    },
+    "non_shorthand_field_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Shorthand Field Patterns",
+      "description": "The `non_shorthand_field_patterns` lint detects using `Struct { x: x }` instead of `Struct { x }` in a pattern.",
+      "default": "warn"
+    },
+    "non_snake_case": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Snake Case",
+      "description": "The `non_snake_case` lint detects variables, methods, functions, lifetime parameters and modules that don\u2019t have snake case names.",
+      "default": "warn"
+    },
+    "non_upper_case_globals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Non Upper Case Globals",
+      "description": "The `non_upper_case_globals` lint detects static items that don\u2019t have uppercase identifiers.",
+      "default": "warn"
+    },
+    "noop_method_call": {
+      "$ref": "#/definitions/Lint",
+      "title": "Noop Method Call",
+      "description": "The `noop_method_call` lint detects specific calls to noop methods such as a calling ` ::clone` where `T: !Clone`.",
+      "default": "warn"
+    },
+    "opaque_hidden_inferred_bound": {
+      "$ref": "#/definitions/Lint",
+      "title": "Opaque Hidden Inferred Bound",
+      "description": "The `opaque_hidden_inferred_bound` lint detects cases in which nested `impl Trait` in associated type bounds are not written generally enough to satisfy the bounds of the associated type.",
+      "default": "warn"
+    },
+    "out_of_scope_macro_calls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Out Of Scope Macro Calls",
+      "description": "The `out_of_scope_macro_calls` lint detects `macro_rules` called when they are not in scope, above their definition, which may happen in key-value attributes.",
+      "default": "warn"
+    },
+    "overflowing_literals": {
+      "$ref": "#/definitions/Lint",
+      "title": "Overflowing Literals",
+      "description": "The `overflowing_literals` lint detects literals out of range for their type.",
+      "default": "deny"
+    },
+    "overlapping_range_endpoints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Overlapping Range Endpoints",
+      "description": "The `overlapping_range_endpoints` lint detects `match` arms that have range patterns that overlap on their endpoints.",
+      "default": "warn"
+    },
+    "path_statements": {
+      "$ref": "#/definitions/Lint",
+      "title": "Path Statements",
+      "description": "The `path_statements` lint detects path statements with no effect.",
+      "default": "warn"
+    },
+    "patterns_in_fns_without_body": {
+      "$ref": "#/definitions/Lint",
+      "title": "Patterns In Fns Without Body",
+      "description": "The `patterns_in_fns_without_body` lint detects `mut` identifier patterns as a parameter in functions without a body.",
+      "default": "deny"
+    },
+    "private_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Private Bounds",
+      "description": "The `private_bounds` lint detects types in a secondary interface of an item, that are more private than the item itself. Secondary interface of an item consists of bounds on generic parameters and where clauses, including supertraits for trait items.",
+      "default": "warn"
+    },
+    "private_interfaces": {
+      "$ref": "#/definitions/Lint",
+      "title": "Private Interfaces",
+      "description": "The `private_interfaces` lint detects types in a primary interface of an item, that are more private than the item itself. Primary interface of an item is all its interface except for bounds on generic parameters and where clauses.",
+      "default": "warn"
+    },
+    "proc_macro_derive_resolution_fallback": {
+      "$ref": "#/definitions/Lint",
+      "title": "Proc Macro Derive Resolution Fallback",
+      "description": "The `proc_macro_derive_resolution_fallback` lint detects proc macro derives using inaccessible names from parent modules.",
+      "default": "deny"
+    },
+    "ptr_to_integer_transmute_in_consts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ptr To Integer Transmute In Consts",
+      "description": "The `ptr_to_integer_transmute_in_consts` lint detects pointer to integer transmute in const functions and associated constants.",
+      "default": "warn"
+    },
+    "pub_use_of_private_extern_crate": {
+      "$ref": "#/definitions/Lint",
+      "title": "Pub Use Of Private Extern Crate",
+      "description": "The `pub_use_of_private_extern_crate` lint detects a specific situation of re-exporting a private `extern crate`.",
+      "default": "deny"
+    },
+    "redundant_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Imports",
+      "description": "The `redundant_imports` lint detects imports that are redundant due to being imported already; either through a previous import, or being present in the prelude.",
+      "default": "allow"
+    },
+    "redundant_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Lifetimes",
+      "description": "The `redundant_lifetimes` lint detects lifetime parameters that are redundant because they are equal to another named lifetime.",
+      "default": "allow"
+    },
+    "redundant_semicolons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Semicolons",
+      "description": "The `redundant_semicolons` lint detects unnecessary trailing semicolons.",
+      "default": "warn"
+    },
+    "refining_impl_trait_internal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Refining Impl Trait Internal",
+      "description": "The `refining_impl_trait_internal` lint detects `impl Trait` return types in method signatures that are refined by a trait implementation, meaning the implementation adds information about the return type that is not present in the trait.",
+      "default": "warn"
+    },
+    "refining_impl_trait_reachable": {
+      "$ref": "#/definitions/Lint",
+      "title": "Refining Impl Trait Reachable",
+      "description": "The `refining_impl_trait_reachable` lint detects `impl Trait` return types in method signatures that are refined by a publicly reachable trait implementation, meaning the implementation adds information about the return type that is not present in the trait.",
+      "default": "warn"
+    },
+    "renamed_and_removed_lints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Renamed And Removed Lints",
+      "description": "The `renamed_and_removed_lints` lint detects lints that have been renamed or removed.",
+      "default": "warn"
+    },
+    "repr_transparent_external_private_fields": {
+      "$ref": "#/definitions/Lint",
+      "title": "Repr Transparent External Private Fields",
+      "description": "transparent type contains an external ZST that is marked #[non_exhaustive] or contains private fields.",
+      "default": "warn"
+    },
+    "rust_2021_incompatible_closure_captures": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2021 Incompatible Closure Captures",
+      "description": "The `rust_2021_incompatible_closure_captures` lint detects variables that aren\u2019t completely captured in Rust 2021, such that the `Drop` order of their fields may differ between Rust 2018 and 2021.",
+      "default": "allow"
+    },
+    "rust_2021_incompatible_or_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2021 Incompatible Or Patterns",
+      "description": "The `rust_2021_incompatible_or_patterns` lint detects usage of old versions of or-patterns.",
+      "default": "allow"
+    },
+    "rust_2021_prefixes_incompatible_syntax": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2021 Prefixes Incompatible Syntax",
+      "description": "The `rust_2021_prefixes_incompatible_syntax` lint detects identifiers that will be parsed as a prefix instead in Rust 2021.",
+      "default": "allow"
+    },
+    "rust_2021_prelude_collisions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2021 Prelude Collisions",
+      "description": "The `rust_2021_prelude_collisions` lint detects the usage of trait methods which are ambiguous with traits added to the prelude in future editions.",
+      "default": "allow"
+    },
+    "rust_2024_guarded_string_incompatible_syntax": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2024 Guarded String Incompatible Syntax",
+      "description": "The `rust_2024_guarded_string_incompatible_syntax` lint detects `#` tokens that will be parsed as part of a guarded string literal in Rust 2024.",
+      "default": "allow"
+    },
+    "rust_2024_incompatible_pat": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2024 Incompatible Pat",
+      "description": "The `rust_2024_incompatible_pat` lint detects patterns whose meaning will change in the Rust 2024 edition.",
+      "default": "allow"
+    },
+    "rust_2024_prelude_collisions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2024 Prelude Collisions",
+      "description": "The `rust_2024_prelude_collisions` lint detects the usage of trait methods which are ambiguous with traits added to the prelude in future editions.",
+      "default": "allow"
+    },
+    "self_constructor_from_outer_item": {
+      "$ref": "#/definitions/Lint",
+      "title": "Self Constructor From Outer Item",
+      "description": "The `self_constructor_from_outer_item` lint detects cases where the `Self` constructor was silently allowed due to a bug in the resolver, and which may produce surprising and unintended behavior.",
+      "default": "warn"
+    },
+    "semicolon_in_expressions_from_macros": {
+      "$ref": "#/definitions/Lint",
+      "title": "Semicolon In Expressions From Macros",
+      "description": "The `semicolon_in_expressions_from_macros` lint detects trailing semicolons in macro bodies when the macro is invoked in expression position. This was previous accepted, but is being phased out.",
+      "default": "warn"
+    },
+    "single_use_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Single Use Lifetimes",
+      "description": "The `single_use_lifetimes` lint detects lifetimes that are only used once.",
+      "default": "allow"
+    },
+    "soft_unstable": {
+      "$ref": "#/definitions/Lint",
+      "title": "Soft Unstable",
+      "description": "The `soft_unstable` lint detects unstable features that were unintentionally allowed on stable. This is a future-incompatible lint to transition this to a hard error in the future. See issue #64266 for more details.",
+      "default": "deny"
+    },
+    "special_module_name": {
+      "$ref": "#/definitions/Lint",
+      "title": "Special Module Name",
+      "description": "The `special_module_name` lint detects module declarations for files that have a special meaning.",
+      "default": "warn"
+    },
+    "stable_features": {
+      "$ref": "#/definitions/Lint",
+      "title": "Stable Features",
+      "description": "The `stable_features` lint detects a `feature` attribute that has since been made stable.",
+      "default": "warn"
+    },
+    "static_mut_refs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Static Mut Refs",
+      "description": "The `static_mut_refs` lint checks for shared or mutable references of mutable static inside `unsafe` blocks and `unsafe` functions.",
+      "default": "warn"
+    },
+    "supertrait_item_shadowing_definition": {
+      "$ref": "#/definitions/Lint",
+      "title": "Supertrait Item Shadowing Definition",
+      "description": "detects when a supertrait item is shadowed by a subtrait item.",
+      "default": "allow"
+    },
+    "supertrait_item_shadowing_usage": {
+      "$ref": "#/definitions/Lint",
+      "title": "Supertrait Item Shadowing Usage",
+      "description": "detects when a supertrait item is shadowed by a subtrait item.",
+      "default": "allow"
+    },
+    "suspicious_double_ref_op": {
+      "$ref": "#/definitions/Lint",
+      "title": "Suspicious Double Ref Op",
+      "description": "The `suspicious_double_ref_op` lint checks for usage of `.clone()`/`.borrow()`/`.deref()` on an `&&T` when `T: !Deref/Borrow/Clone`, which means the call will return the inner `&T`, instead of performing the operation on the underlying `T` and can be confusing.",
+      "default": "warn"
+    },
+    "tail_expr_drop_order": {
+      "$ref": "#/definitions/Lint",
+      "title": "Tail Expr Drop Order",
+      "description": "The `tail_expr_drop_order` lint looks for those values generated at the tail expression location, that runs a custom `Drop` destructor. Some of them may be dropped earlier in Edition 2024 that they used to in Edition 2021 and prior. This lint detects those cases and provides you information on those values and their custom destructor implementations. Your discretion on this information is required.",
+      "default": "allow"
+    },
+    "test_unstable_lint": {
+      "$ref": "#/definitions/Lint",
+      "title": "Test Unstable Lint",
+      "description": "The `test_unstable_lint` lint tests unstable lints and is perma-unstable.",
+      "default": "deny"
+    },
+    "text_direction_codepoint_in_comment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Text Direction Codepoint In Comment",
+      "description": "The `text_direction_codepoint_in_comment` lint detects Unicode codepoints in comments that change the visual representation of text on screen in a way that does not correspond to their on memory representation.",
+      "default": "deny"
+    },
+    "text_direction_codepoint_in_literal": {
+      "$ref": "#/definitions/Lint",
+      "title": "Text Direction Codepoint In Literal",
+      "description": "The `text_direction_codepoint_in_literal` lint detects Unicode codepoints that change the visual representation of text on screen in a way that does not correspond to their on memory representation.",
+      "default": "deny"
+    },
+    "trivial_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trivial Bounds",
+      "description": "The `trivial_bounds` lint detects trait bounds that don\u2019t depend on any type parameters.",
+      "default": "warn"
+    },
+    "trivial_casts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trivial Casts",
+      "description": "The `trivial_casts` lint detects trivial casts which could be replaced with coercion, which may require a temporary variable.",
+      "default": "allow"
+    },
+    "trivial_numeric_casts": {
+      "$ref": "#/definitions/Lint",
+      "title": "Trivial Numeric Casts",
+      "description": "The `trivial_numeric_casts` lint detects trivial numeric casts of types which could be removed.",
+      "default": "allow"
+    },
+    "type_alias_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Type Alias Bounds",
+      "description": "The `type_alias_bounds` lint detects bounds in type aliases.",
+      "default": "warn"
+    },
+    "tyvar_behind_raw_pointer": {
+      "$ref": "#/definitions/Lint",
+      "title": "Tyvar Behind Raw Pointer",
+      "description": "The `tyvar_behind_raw_pointer` lint detects raw pointer to an inference variable.",
+      "default": "warn"
+    },
+    "uncommon_codepoints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uncommon Codepoints",
+      "description": "The `uncommon_codepoints` lint detects uncommon Unicode codepoints in identifiers.",
+      "default": "warn"
+    },
+    "unconditional_panic": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unconditional Panic",
+      "description": "The `unconditional_panic` lint detects an operation that will cause a panic at runtime.",
+      "default": "deny"
+    },
+    "unconditional_recursion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unconditional Recursion",
+      "description": "The `unconditional_recursion` lint detects functions that cannot return without calling themselves.",
+      "default": "warn"
+    },
+    "uncovered_param_in_projection": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uncovered Param In Projection",
+      "description": "The `uncovered_param_in_projection` lint detects a violation of one of Rust\u2019s orphan rules for foreign trait implementations that concerns the use of type parameters inside trait associated type paths (\u201cprojections\u201d) whose output may not be a local type that is mistakenly considered to \u201ccover\u201d said parameters which is unsound and which may be rejected by a future version of the compiler.",
+      "default": "warn"
+    },
+    "undropped_manually_drops": {
+      "$ref": "#/definitions/Lint",
+      "title": "Undropped Manually Drops",
+      "description": "The `undropped_manually_drops` lint check for calls to `std::mem::drop` with a value of `std::mem::ManuallyDrop` which doesn\u2019t drop.",
+      "default": "deny"
+    },
+    "unexpected_cfgs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unexpected Cfgs",
+      "description": "The `unexpected_cfgs` lint detects unexpected conditional compilation conditions.",
+      "default": "warn"
+    },
+    "unfulfilled_lint_expectations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unfulfilled Lint Expectations",
+      "description": "The `unfulfilled_lint_expectations` lint detects when a lint expectation is unfulfilled.",
+      "default": "warn"
+    },
+    "ungated_async_fn_track_caller": {
+      "$ref": "#/definitions/Lint",
+      "title": "Ungated Async Fn Track Caller",
+      "description": "The `ungated_async_fn_track_caller` lint warns when the `#[track_caller]` attribute is used on an async function without enabling the corresponding unstable feature flag.",
+      "default": "warn"
+    },
+    "uninhabited_static": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uninhabited Static",
+      "description": "The `uninhabited_static` lint detects uninhabited statics.",
+      "default": "warn"
+    },
+    "unit_bindings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unit Bindings",
+      "description": "The `unit_bindings` lint detects cases where bindings are useless because they have the unit type `()` as their inferred type. The lint is suppressed if the user explicitly annotates the let binding with the unit type `()`, or if the let binding uses an underscore wildcard pattern, i.e. `let _ = expr`, or if the binding is produced from macro expansions.",
+      "default": "allow"
+    },
+    "unknown_crate_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unknown Crate Types",
+      "description": "The `unknown_crate_types` lint detects an unknown crate type found in a `crate_type` attribute.",
+      "default": "deny"
+    },
+    "unknown_diagnostic_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unknown Diagnostic Attributes",
+      "description": "The `unknown_diagnostic_attributes` lint detects unknown diagnostic attributes.",
+      "default": "warn"
+    },
+    "unknown_lints": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unknown Lints",
+      "description": "The `unknown_lints` lint detects unrecognized lint attributes.",
+      "default": "warn"
+    },
+    "unnameable_test_items": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnameable Test Items",
+      "description": "The `unnameable_test_items` lint detects `#[test]` functions that are not able to be run by the test harness because they are in a position where they are not nameable.",
+      "default": "warn"
+    },
+    "unnameable_types": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnameable Types",
+      "description": "The `unnameable_types` lint detects types for which you can get objects of that type, but cannot name the type itself.",
+      "default": "allow"
+    },
+    "unnecessary_transmutes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unnecessary Transmutes",
+      "description": "The `unnecessary_transmutes` lint detects transmutations that have safer alternatives.",
+      "default": "warn"
+    },
+    "unpredictable_function_pointer_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unpredictable Function Pointer Comparisons",
+      "description": "The `unpredictable_function_pointer_comparisons` lint checks comparison of function pointer as the operands.",
+      "default": "warn"
+    },
+    "unqualified_local_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unqualified Local Imports",
+      "description": "The `unqualified_local_imports` lint checks for `use` items that import a local item using a path that does not start with `self::`, `super::`, or `crate::`.",
+      "default": "allow"
+    },
+    "unreachable_code": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unreachable Code",
+      "description": "The `unreachable_code` lint detects unreachable code paths.",
+      "default": "warn"
+    },
+    "unreachable_patterns": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unreachable Patterns",
+      "description": "The `unreachable_patterns` lint detects unreachable patterns.",
+      "default": "warn"
+    },
+    "unreachable_pub": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unreachable Pub",
+      "description": "The `unreachable_pub` lint triggers for `pub` items not reachable from other crates - that means neither directly accessible, nor reexported (with `pub use`), nor leaked through things like return types (which the `unnameable_types` lint can detect if desired).",
+      "default": "allow"
+    },
+    "unsafe_attr_outside_unsafe": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Attr Outside Unsafe",
+      "description": "The `unsafe_attr_outside_unsafe` lint detects a missing unsafe keyword on attributes considered unsafe.",
+      "default": "allow"
+    },
+    "unsafe_code": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Code",
+      "description": "The `unsafe_code` lint catches usage of `unsafe` code and other potentially unsound constructs like `no_mangle`, `export_name`, and `link_section`.",
+      "default": "allow"
+    },
+    "unsafe_op_in_unsafe_fn": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsafe Op In Unsafe Fn",
+      "description": "The `unsafe_op_in_unsafe_fn` lint detects unsafe operations in unsafe functions without an explicit unsafe block.",
+      "default": "allow"
+    },
+    "unstable_features": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unstable Features",
+      "description": "The `unstable_features` lint detects uses of `#![feature]`.",
+      "default": "allow"
+    },
+    "unstable_name_collisions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unstable Name Collisions",
+      "description": "The `unstable_name_collisions` lint detects that you have used a name that the standard library plans to add in the future.",
+      "default": "warn"
+    },
+    "unstable_syntax_pre_expansion": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unstable Syntax Pre Expansion",
+      "description": "The `unstable_syntax_pre_expansion` lint detects the use of unstable syntax that is discarded during attribute expansion.",
+      "default": "warn"
+    },
+    "unsupported_calling_conventions": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unsupported Calling Conventions",
+      "description": "The `unsupported_calling_conventions` lint is output whenever there is a use of the `stdcall`, `fastcall`, and `cdecl` calling conventions (or their unwind variants) on targets that cannot meaningfully be supported for the requested target.",
+      "default": "warn"
+    },
+    "unused_allocation": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Allocation",
+      "description": "The `unused_allocation` lint detects unnecessary allocations that can be eliminated.",
+      "default": "warn"
+    },
+    "unused_assignments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Assignments",
+      "description": "The `unused_assignments` lint detects assignments that will never be read.",
+      "default": "warn"
+    },
+    "unused_associated_type_bounds": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Associated Type Bounds",
+      "description": "The `unused_associated_type_bounds` lint is emitted when an associated type bound is added to a trait object, but the associated type has a `where Self: Sized` bound, and is thus unavailable on the trait object anyway.",
+      "default": "warn"
+    },
+    "unused_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Attributes",
+      "description": "The `unused_attributes` lint detects attributes that were not used by the compiler.",
+      "default": "warn"
+    },
+    "unused_braces": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Braces",
+      "description": "The `unused_braces` lint detects unnecessary braces around an expression.",
+      "default": "warn"
+    },
+    "unused_comparisons": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Comparisons",
+      "description": "The `unused_comparisons` lint detects comparisons made useless by limits of the types involved.",
+      "default": "warn"
+    },
+    "unused_crate_dependencies": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Crate Dependencies",
+      "description": "The `unused_crate_dependencies` lint detects crate dependencies that are never used.",
+      "default": "allow"
+    },
+    "unused_doc_comments": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Doc Comments",
+      "description": "The `unused_doc_comments` lint detects doc comments that aren\u2019t used by `rustdoc`.",
+      "default": "warn"
+    },
+    "unused_extern_crates": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Extern Crates",
+      "description": "The `unused_extern_crates` lint guards against `extern crate` items that are never used.",
+      "default": "allow"
+    },
+    "unused_features": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Features",
+      "description": "The `unused_features` lint detects unused or unknown features found in crate-level `feature` attributes.",
+      "default": "warn"
+    },
+    "unused_import_braces": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Import Braces",
+      "description": "The `unused_import_braces` lint catches unnecessary braces around an imported item.",
+      "default": "allow"
+    },
+    "unused_imports": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Imports",
+      "description": "The `unused_imports` lint detects imports that are never used.",
+      "default": "warn"
+    },
+    "unused_labels": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Labels",
+      "description": "The `unused_labels` lint detects labels that are never used.",
+      "default": "warn"
+    },
+    "unused_lifetimes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Lifetimes",
+      "description": "The `unused_lifetimes` lint detects lifetime parameters that are never used.",
+      "default": "allow"
+    },
+    "unused_macro_rules": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Macro Rules",
+      "description": "The `unused_macro_rules` lint detects macro rules that were not used.",
+      "default": "allow"
+    },
+    "unused_macros": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Macros",
+      "description": "The `unused_macros` lint detects macros that were not used.",
+      "default": "warn"
+    },
+    "unused_must_use": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Must Use",
+      "description": "The `unused_must_use` lint detects unused result of a type flagged as `#[must_use]`.",
+      "default": "warn"
+    },
+    "unused_mut": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Mut",
+      "description": "The `unused_mut` lint detects mut variables which don\u2019t need to be mutable.",
+      "default": "warn"
+    },
+    "unused_parens": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Parens",
+      "description": "The `unused_parens` lint detects `if`, `match`, `while` and `return` with parentheses; they do not need them.",
+      "default": "warn"
+    },
+    "unused_qualifications": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Qualifications",
+      "description": "The `unused_qualifications` lint detects unnecessarily qualified names.",
+      "default": "allow"
+    },
+    "unused_results": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Results",
+      "description": "The `unused_results` lint checks for the unused result of an expression in a statement.",
+      "default": "allow"
+    },
+    "unused_unsafe": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Unsafe",
+      "description": "The `unused_unsafe` lint detects unnecessary use of an `unsafe` block.",
+      "default": "warn"
+    },
+    "unused_variables": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Variables",
+      "description": "The `unused_variables` lint detects variables which are not used in any way.",
+      "default": "warn"
+    },
+    "useless_deprecated": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Deprecated",
+      "description": "The `useless_deprecated` lint detects deprecation attributes with no effect.",
+      "default": "deny"
+    },
+    "useless_ptr_null_checks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Useless Ptr Null Checks",
+      "description": "The `useless_ptr_null_checks` lint checks for useless null checks against pointers obtained from non-null types.",
+      "default": "warn"
+    },
+    "uses_power_alignment": {
+      "$ref": "#/definitions/Lint",
+      "title": "Uses Power Alignment",
+      "description": "The `uses_power_alignment` lint detects specific `repr(C)` aggregates on AIX. In its platform C ABI, AIX uses the \u201cpower\u201d (as in PowerPC) alignment rule (detailed in https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=data-using-alignment-modes#alignment), which can also be set for XLC by `#pragma align(power)` or `-qalign=power`. Aggregates with a floating-point type as the recursively first field (as in \u201cat offset 0\u201d) modify the layout of subsequent fields of the associated structs to use an alignment value where the floating-point type is aligned on a 4-byte boundary.",
+      "default": "warn"
+    },
+    "variant_size_differences": {
+      "$ref": "#/definitions/Lint",
+      "title": "Variant Size Differences",
+      "description": "The `variant_size_differences` lint detects enums with widely varying variant sizes.",
+      "default": "allow"
+    },
+    "warnings": {
+      "$ref": "#/definitions/Lint",
+      "title": "Warnings",
+      "description": "All lints that are set to issue warnings"
+    },
+    "while_true": {
+      "$ref": "#/definitions/Lint",
+      "title": "While True",
+      "description": "The `while_true` lint detects `while true { }`.",
+      "default": "warn"
+    },
+    "bad-style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bad Style",
+      "description": "Deprecated alias for `nonstandard-style`."
+    },
+    "deprecated-safe": {
+      "$ref": "#/definitions/Lint",
+      "title": "Deprecated Safe",
+      "description": "Lints for functions which were erroneously marked as safe in the past"
+    },
+    "future-incompatible": {
+      "$ref": "#/definitions/Lint",
+      "title": "Future Incompatible",
+      "description": "Lints that detect code that has future-compatibility problems"
+    },
+    "keyword-idents": {
+      "$ref": "#/definitions/Lint",
+      "title": "Keyword Idents",
+      "description": "Lints that detect identifiers which will be come keywords in later editions"
+    },
+    "let-underscore": {
+      "$ref": "#/definitions/Lint",
+      "title": "Let Underscore",
+      "description": "Lints that detect wildcard let bindings that are likely to be invalid"
+    },
+    "nonstandard-style": {
+      "$ref": "#/definitions/Lint",
+      "title": "Nonstandard Style",
+      "description": "Violation of standard naming conventions"
+    },
+    "refining-impl-trait": {
+      "$ref": "#/definitions/Lint",
+      "title": "Refining Impl Trait",
+      "description": "Detects refinement of `impl Trait` return types by trait implementations"
+    },
+    "rust-2018-compatibility": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2018 Compatibility",
+      "description": "Lints used to transition code from the 2015 edition to 2018"
+    },
+    "rust-2018-idioms": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2018 Idioms",
+      "description": "Lints to nudge you toward idiomatic features of Rust 2018"
+    },
+    "rust-2021-compatibility": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2021 Compatibility",
+      "description": "Lints used to transition code from the 2018 edition to 2021"
+    },
+    "rust-2024-compatibility": {
+      "$ref": "#/definitions/Lint",
+      "title": "Rust 2024 Compatibility",
+      "description": "Lints used to transition code from the 2021 edition to 2024"
+    },
+    "unknown-or-malformed-diagnostic-attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unknown Or Malformed Diagnostic Attributes",
+      "description": "detects unknown or malformed diagnostic attributes"
+    },
+    "unused": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused",
+      "description": "Lints that detect things being declared but not used, or excess syntax"
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/Lint"
+  },
+  "x-tombi-table-keys-order": "version-sort",
+  "x-tombi-additional-key-label": "lint_name",
+  "definitions": {
+    "DetailedLint": {
+      "title": "Detailed Lint",
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/LintLevel"
+        },
+        "priority": {
+          "description": "The priority that controls which lints or [lint groups](https://doc.rust-lang.org/rustc/lints/groups.html) override other lint groups. Lower (particularly negative) numbers have lower priority, being overridden by higher numbers, and show up first on the command-line to tools like rustc.",
+          "type": "integer"
+        },
+        "check-cfg": {
+          "description": "A list of `cfg` expressions that this lint should check for.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "examples": ["cfg(foo)"]
+        }
+      },
+      "x-tombi-table-keys-order": "schema"
+    },
+    "Lint": {
+      "title": "Lint",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LintLevel"
+        },
+        {
+          "$ref": "#/definitions/DetailedLint"
+        }
+      ]
+    },
+    "LintLevel": {
+      "title": "Lint Level",
+      "description": "Specify the [lint level](https://doc.rust-lang.org/rustc/lints/levels.html) for a lint or lint group.",
+      "type": "string",
+      "enum": ["forbid", "deny", "warn", "allow"]
+    }
+  }
+}

--- a/src/schemas/json/cargo-lints-rustdoc.json
+++ b/src/schemas/json/cargo-lints-rustdoc.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/cargo-lints-rustdoc.json",
+  "title": "Rustdoc Lints",
+  "description": "Lint settings for rustdoc individual lints and the `all` lint.",
+  "type": "object",
+  "properties": {
+    "bare_urls": {
+      "$ref": "#/definitions/Lint",
+      "title": "Bare URLs",
+      "description": "detects URLs that are not hyperlinks.",
+      "default": "warn"
+    },
+    "broken_intra_doc_links": {
+      "$ref": "#/definitions/Lint",
+      "title": "Broken Intra Doc Links",
+      "description": "failures in resolving intra-doc link targets.",
+      "default": "warn"
+    },
+    "invalid_codeblock_attributes": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Codeblock Attributes",
+      "description": "codeblock attribute looks a lot like a known one.",
+      "default": "warn"
+    },
+    "invalid_html_tags": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid HTML Tags",
+      "description": "detects invalid HTML tags in doc comments.",
+      "default": "warn"
+    },
+    "invalid_rust_codeblocks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Invalid Rust Codeblocks",
+      "description": "codeblock could not be parsed as valid Rust or is empty.",
+      "default": "warn"
+    },
+    "missing_crate_level_docs": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Crate Level Docs",
+      "description": "detects crates with no crate-level documentation.",
+      "default": "allow"
+    },
+    "missing_doc_code_examples": {
+      "$ref": "#/definitions/Lint",
+      "title": "Missing Doc Code Examples",
+      "description": "detects publicly-exported items without code samples in their documentation.",
+      "default": "allow"
+    },
+    "private_doc_tests": {
+      "$ref": "#/definitions/Lint",
+      "title": "Private Doc Tests",
+      "description": "detects code samples in docs of private items not documented by rustdoc.",
+      "default": "allow"
+    },
+    "private_intra_doc_links": {
+      "$ref": "#/definitions/Lint",
+      "title": "Private Intra Doc Links",
+      "description": "linking from a public item to a private one.",
+      "default": "warn"
+    },
+    "redundant_explicit_links": {
+      "$ref": "#/definitions/Lint",
+      "title": "Redundant Explicit Links",
+      "description": "detects redundant explicit links in doc comments.",
+      "default": "warn"
+    },
+    "unescaped_backticks": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unescaped Backticks",
+      "description": "detects unescaped backticks in doc comments.",
+      "default": "allow"
+    },
+    "all": {
+      "$ref": "#/definitions/Lint",
+      "title": "All",
+      "description": "The group of all rustdoc lints (`#![allow(rustdoc::all)]`)."
+    }
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/Lint"
+  },
+  "x-tombi-table-keys-order": "version-sort",
+  "x-tombi-additional-key-label": "lint_name",
+  "definitions": {
+    "DetailedLint": {
+      "title": "Detailed Lint",
+      "type": "object",
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/LintLevel"
+        },
+        "priority": {
+          "description": "The priority that controls which lints or [lint groups](https://doc.rust-lang.org/rustc/lints/groups.html) override other lint groups. Lower (particularly negative) numbers have lower priority, being overridden by higher numbers, and show up first on the command-line to tools like rustc.",
+          "type": "integer"
+        }
+      },
+      "x-tombi-table-keys-order": "schema"
+    },
+    "Lint": {
+      "title": "Lint",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LintLevel"
+        },
+        {
+          "$ref": "#/definitions/DetailedLint"
+        }
+      ]
+    },
+    "LintLevel": {
+      "title": "Lint Level",
+      "description": "Specify the [lint level](https://doc.rust-lang.org/rustc/lints/levels.html) for a lint or lint group.",
+      "type": "string",
+      "enum": ["forbid", "deny", "warn", "allow"]
+    }
+  }
+}

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -326,40 +326,20 @@
       "type": "object",
       "properties": {
         "rust": {
-          "description": "Lint settings for the Rust compiler. See the Rust compiler's [individual lints](https://doc.rust-lang.org/rustc/lints/listing/index.html) or [lint groups](https://doc.rust-lang.org/rustc/lints/groups.html).",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Lint"
-          },
-          "x-tombi-additional-key-label": "lint_name",
-          "x-tombi-table-keys-order": "version-sort"
+          "$ref": "https://www.schemastore.org/cargo-lints-rust.json",
+          "description": "Lint settings for the Rust compiler. See the Rust compiler's [individual lints](https://doc.rust-lang.org/rustc/lints/listing/index.html) or [lint groups](https://doc.rust-lang.org/rustc/lints/groups.html)."
         },
         "rustdoc": {
-          "description": "Lint settings for [Rustdoc](https://doc.rust-lang.org/rustdoc/). See Rustdoc's [individual lints](https://doc.rust-lang.org/rustdoc/lints.html) (rustdoc does not have lint groups)",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Lint"
-          },
-          "x-tombi-additional-key-label": "lint_name",
-          "x-tombi-table-keys-order": "version-sort"
+          "$ref": "https://www.schemastore.org/cargo-lints-rustdoc.json",
+          "description": "Lint settings for [Rustdoc](https://doc.rust-lang.org/rustdoc/). See Rustdoc's [individual lints](https://doc.rust-lang.org/rustdoc/lints.html)."
         },
         "clippy": {
-          "description": "Lint settings for [Clippy](https://doc.rust-lang.org/clippy/). See Clippy's [individual lints](https://rust-lang.github.io/rust-clippy/master/index.html) or [lint groups](https://doc.rust-lang.org/clippy/lints.html) documentation.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Lint"
-          },
-          "x-tombi-additional-key-label": "lint_name",
-          "x-tombi-table-keys-order": "version-sort"
+          "$ref": "https://www.schemastore.org/cargo-lints-clippy.json",
+          "description": "Lint settings for [Clippy](https://doc.rust-lang.org/clippy/). See Clippy's [individual lints](https://rust-lang.github.io/rust-clippy/master/index.html) or [lint groups](https://doc.rust-lang.org/clippy/lints.html) documentation."
         },
         "cargo": {
-          "description": "Lint settings for [Cargo](https://doc.rust-lang.org/cargo/). See Cargo's [individual lints](https://doc.rust-lang.org/cargo/reference/lints.html) documentation.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Lint"
-          },
-          "x-tombi-additional-key-label": "lint_name",
-          "x-tombi-table-keys-order": "version-sort"
+          "$ref": "https://www.schemastore.org/cargo-lints-cargo.json",
+          "description": "Lint settings for [Cargo](https://doc.rust-lang.org/cargo/). See Cargo's [individual lints](https://doc.rust-lang.org/cargo/reference/lints.html) documentation."
         }
       },
       "additionalProperties": {


### PR DESCRIPTION
- Introduced a new JSON schema file for Rustdoc lints (`cargo-lints-rustdoc.json`) defining various lint settings.
- Updated the existing Cargo schema (`cargo.json`) to reference the new Rustdoc lints schema.
- Ensured all lint-related properties in the Cargo schema point to their respective schemas for better validation.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
