### PR TITLE
Update paper-plugin.json schema for 26.1+

### DIFF
--- a/src/schemas/json/paper-plugin.json
+++ b/src/schemas/json/paper-plugin.json
@@ -160,8 +160,8 @@
     "api-version": {
       "description": "The API version of the plugin",
       "type": "string",
-      "pattern": "^1\\.\\d{2}(\\.\\d{1,2})?$",
-      "examples": ["1.19", "1.20", "1.20.6"]
+      "pattern": "^\\d{1,2}\\.\\d{1,2}(\\.\\d{1,2})?$",
+      "examples": ["1.19", "1.20", "1.20.6", "26.1.1"]
     },
     "dependencies": {
       "description": "Plugin dependencies.",


### PR DESCRIPTION
Minecraft recently updated their versioning scheme to calver. Following this change, Paper adjusted their `api-version` field requirement to fit the new versioning scheme.

This PR adjusts the JSON schema to now also permit values in the format of `X(X?).X(X?)(.X(X?))?` instead of the previously forced `1.XX(.X(X?))?`. This now permits the following values (examples):

- `26.1`, `26.1.1`, `26.2`
- `1.21.1`, `1.20.5`.
