### PR TITLE
Add support for "allowLayoutOverrides" in Drupal recipes

### DIFF
--- a/src/schemas/json/drupal-recipe.json
+++ b/src/schemas/json/drupal-recipe.json
@@ -48,6 +48,73 @@
     },
     "actionsList": {
       "generic": {
+        "hideComponent": {
+          "type": "string",
+          "title": "Hides a component from an entity view display or entity form display.",
+          "description": "Value: The component id",
+          "default": "uid"
+        },
+        "hideComponents": {
+          "type": "array",
+          "description": "Value: The list of component ids",
+          "items": [
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "setComponent": {
+          "type": "object",
+          "description": "Allows adding a field to an entity's view or form displays.",
+          "properties": {
+            "name": {
+              "description": "The field id. i.e. field_tags",
+              "type": "string"
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "description": "The field type. i.e. entity_reference_label",
+                  "type": "string"
+                },
+                "label": {
+                  "description": "Label position. i.e. above",
+                  "type": "string",
+                  "enum": ["above", "below", "hidden", "inline"]
+                },
+                "settings": {
+                  "type": "object",
+                  "properties": {
+                    "link": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "third_party_settings": {
+                  "type": "object"
+                },
+                "weight": {
+                  "type": "number"
+                },
+                "region": {
+                  "$ref": "#/$defs/theme/defaultRegions",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "setComponents": {
+          "type": "array",
+          "description": "Allows adding adding the configuration for multiple fields.",
+          "items": [
+            {
+              "$ref": "#/$defs/actionsList/generic/setComponent"
+            }
+          ]
+        },
         "cloneAs": {
           "description": "Creates a clone of any config entity with a new ID.",
           "type": "string"
@@ -222,75 +289,20 @@
         "core.entity_form_display.*.*.*": {
           "$comment": "",
           "type": "object",
-          "title": "Form/View display",
+          "title": "Form display",
           "description": "",
           "properties": {
             "hideComponent": {
-              "type": "string",
-              "title": "Hides a component from an entity view display or entity form display.",
-              "description": "Value: The component id",
-              "default": "uid"
+              "$ref": "#/$defs/actionsList/generic/hideComponent"
             },
             "hideComponents": {
-              "type": "array",
-              "description": "Value: The list of component ids",
-              "items": [
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/$defs/actionsList/generic/hideComponents"
             },
             "setComponent": {
-              "type": "object",
-              "description": "Allows adding a field to an entity's view or form displays.",
-              "properties": {
-                "name": {
-                  "description": "The field id. i.e. field_tags",
-                  "type": "string"
-                },
-                "options": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "description": "The field type. i.e. entity_reference_label",
-                      "type": "string"
-                    },
-                    "label": {
-                      "description": "Label position. i.e. above",
-                      "type": "string",
-                      "enum": ["above", "below", "hidden", "inline"]
-                    },
-                    "settings": {
-                      "type": "object",
-                      "properties": {
-                        "link": {
-                          "type": "boolean"
-                        }
-                      }
-                    },
-                    "third_party_settings": {
-                      "type": "object"
-                    },
-                    "weight": {
-                      "type": "number"
-                    },
-                    "region": {
-                      "$ref": "#/$defs/theme/defaultRegions",
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
+              "$ref": "#/$defs/actionsList/generic/setComponent"
             },
             "setComponents": {
-              "type": "array",
-              "description": "Allows adding adding the configuration for multiple fields.",
-              "items": [
-                {
-                  "$ref": "#/$defs/actionsList/specific/core.entity_form_display.*.*.*/properties/setComponent"
-                }
-              ]
+              "$ref": "#/$defs/actionsList/generic/setComponents"
             },
             "cloneAs": {
               "$ref": "#/$defs/actionsList/generic/cloneAs"
@@ -326,7 +338,59 @@
           "additionalProperties": false
         },
         "core.entity_view_display.*.*.*": {
-          "$ref": "#/$defs/actionsList/specific/core.entity_form_display.*.*.*"
+          "$comment": "",
+          "type": "object",
+          "title": "Form display",
+          "description": "",
+          "properties": {
+            "allowLayoutOverrides": {
+              "type": "boolean",
+              "title": "Sets whether layout builder overrides are allowed."
+            },
+            "hideComponent": {
+              "$ref": "#/$defs/actionsList/generic/hideComponent"
+            },
+            "hideComponents": {
+              "$ref": "#/$defs/actionsList/generic/hideComponents"
+            },
+            "setComponent": {
+              "$ref": "#/$defs/actionsList/generic/setComponent"
+            },
+            "setComponents": {
+              "$ref": "#/$defs/actionsList/generic/setComponents"
+            },
+            "cloneAs": {
+              "$ref": "#/$defs/actionsList/generic/cloneAs"
+            },
+            "create": {
+              "$ref": "#/$defs/actionsList/generic/create"
+            },
+            "createIfNotExists": {
+              "$ref": "#/$defs/actionsList/generic/createIfNotExists"
+            },
+            "createForEach": {
+              "$ref": "#/$defs/actionsList/generic/createForEach"
+            },
+            "createForEachIfNotExists": {
+              "$ref": "#/$defs/actionsList/generic/createForEachIfNotExists"
+            },
+            "set": {
+              "$ref": "#/$defs/actionsList/generic/set"
+            },
+            "setMultiple": {
+              "$ref": "#/$defs/actionsList/generic/setMultiple"
+            },
+            "setThirdPartySetting": {
+              "$ref": "#/$defs/actionsList/generic/setThirdPartySetting"
+            },
+            "setThirdPartySettings": {
+              "$ref": "#/$defs/actionsList/generic/setThirdPartySettings"
+            },
+            "simpleConfigUpdate": {
+              "$ref": "#/$defs/actionsList/generic/simpleConfigUpdate"
+            }
+          },
+          "additionalProperties": false
         },
         "contact.form.*": {
           "type": "object",

--- a/src/test/drupal-recipe/drupal-recipe.yml
+++ b/src/test/drupal-recipe/drupal-recipe.yml
@@ -263,6 +263,7 @@ config:
         - module: layout_builder
           key: enabled
           value: false
+      allowLayoutOverrides: true
     contact.form.feedback:
       createIfNotExists:
         langcode: es


### PR DESCRIPTION
This change introduces a schema definition for the "allowLayoutOverrides" config action for "core.entity_view_display.\*.\*.\*" entities. It accepts a boolean value (`true` to allow overrides, `false` to disallow).

This change may seem more narrowly-scoped than appropriate since the upstream change[^1] also introduced new "enableLayoutBuilder" and "disableLayoutBuilder" actions; however, there is no precedent for how to define schema for parameter-less actions, and I would prefer to let the project's upstream maintainers establish that precedent.

[^1]: [Issue #3486981 by phenaproxima, thejimbirch: Allow recipes to enable Layout Builder via config actions](https://git.drupalcode.org/project/drupal/-/commit/524cf737ec1284471552fb632bb833b2d25b5fd1)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
