### PR TITLE
add schema for fence (github.com/Use-Tusk/fence)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -957,6 +957,12 @@
       "url": "https://fasterci.com/config.schema.json"
     },
     {
+      "name": "Fence configuration",
+      "description": "Configuration file for fence, a lightweight, container-free sandbox for running commands with network and filesystem restrictions",
+      "fileMatch": ["fence.json"],
+      "url": "https://raw.githubusercontent.com/Use-Tusk/fence/refs/heads/main/docs/schema/fence.schema.json"
+    },
+    {
       "name": "Foxx Manifest",
       "description": "ArangoDB Foxx service manifest file",
       "fileMatch": ["manifest.json"],


### PR DESCRIPTION
Add a schema for validating config files for [fence](https://github.com/Use-Tusk/fence), a lightweight, container-free sandbox for running commands with network and filesystem restrictions. This is a very important tool in the age of AI agents.