### PR TITLE
Fix catalog to unmap `app.json` to Expo

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2745,7 +2745,7 @@
     {
       "name": "Expo SDK",
       "description": "Expo SDK app manifest",
-      "fileMatch": ["app.json"],
+      "fileMatch": [],
       "url": "https://www.schemastore.org/expo-53.0.0.json",
       "versions": {
         "37.0.0": "https://www.schemastore.org/expo-37.0.0.json",


### PR DESCRIPTION
Closes #1121, a popular issue, to remove a mapping that conflicted with a generic filename.