### PR TITLE
Fix overly broad Ansible `defaults/*` pattern.

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3190,8 +3190,6 @@
       "fileMatch": [
         "**/vars/*.yml",
         "**/vars/*.yaml",
-        "**/defaults/*.yml",
-        "**/defaults/*.yaml",
         "**/host_vars/*.yml",
         "**/host_vars/*.yaml",
         "**/group_vars/*.yml",


### PR DESCRIPTION
Fixes #2919.

Although users of Ansible will no longer have the schema of YAML files in `default` inferred, note that RedHat's YAML server does not have a way to disable false positives, as mentioned in the linked issue. So priority is given to disable the offending pattern.