### PR TITLE
Fix Codeowners Merge workflow to run on more events

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -1,6 +1,6 @@
 name: 'Maintenance: Codeowners Detection and Mention'
 on:
-  pull_request_target: { types: [opened] }
+  pull_request_target: { types: [opened, reopened, ready_for_review] }
   issue_comment: { types: [created] }
   pull_request_review: { types: [submitted] }
 


### PR DESCRIPTION
This closes #5567.

In PRs like #5566, if a pull request is submitted as a draft, The codeowners workflow isn't ran (expected behavior) since draft's aren't ready. It's defined like so:

```yaml
jobs:
  codeowners-merge:
    if: "github.repository == 'SchemaStore/schemastore' && github.event.pull_request.draft == false"
```


However, if the pull request is then marked as ready for review, the codeowners merge workflow still isn't ran. This updates the event hooks so that it is ran afterwards. It now is also ran after the pull request is re-opened, which fixes a similar bug.

Verified the fix in #5573.