### PR TITLE
Fix #5574 - claude code settings schema trailing commas

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -186,7 +186,7 @@
     }
   },
   "description": "Configuration settings for Claude Code. Learn more: https://code.claude.com/docs/en/settings",
-  "allowTrailingCommas": true,
+  "allowTrailingCommas": false,
   "additionalProperties": true,
   "type": "object",
   "properties": {


### PR DESCRIPTION
See issue #5574 