### PR TITLE
Update claude-code-settings.json: add CwdChanged and FileChanged hook events

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -678,6 +678,20 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "CwdChanged": {
+          "type": "array",
+          "description": "Hooks that run when the working directory changes. Provides cwd (new directory) and previous_cwd. Matchers are ignored; fires on every directory change. See https://code.claude.com/docs/en/hooks#cwdchanged",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
+        "FileChanged": {
+          "type": "array",
+          "description": "Hooks that run when a watched file is created, modified, or deleted. Supports filename matchers. Provides file_path and file_event_type (created, modified, deleted). See https://code.claude.com/docs/en/hooks#filechanged",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "ConfigChange": {
           "type": "array",
           "description": "Hooks that run when settings, managed settings, or skill files change during a session. Supports matchers: user_settings, project_settings, local_settings, policy_settings, skills. Command handlers only. Exit code 2 blocks the change (except policy_settings which is audit-only). See https://code.claude.com/docs/en/hooks#configchange",


### PR DESCRIPTION
## Summary

Add two new hook event definitions to the Claude Code settings schema that are already supported by Claude Code:

- **CwdChanged**: Hooks that run when the working directory changes. Provides `cwd` (new directory) and `previous_cwd`. Matchers are ignored; fires on every directory change.
- **FileChanged**: Hooks that run when a watched file is created, modified, or deleted. Supports filename matchers. Provides `file_path` and `file_event_type` (created, modified, deleted).

## Reference

- Claude Code hooks documentation: https://code.claude.com/docs/en/hooks