### PR TITLE
✨ Add JSON Schema for FastAPI in `pyproject.toml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,9 @@ src/schemas/json/cargo.json @ya7010
 src/schemas/json/tombi.json @ya7010
 src/schemas/json/pyproject.json @ya7010
 
+# Managed by FastAPI Team:
+src/schemas/json/partial-fastapi.json @tiangolo
+
 # Managed by Contextive Team:
 src/schemas/json/contextive-glossary.json @chrissimon-au
 src/test/contextive-glossary/ @chrissimon-au

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1196,6 +1196,12 @@
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-black.json"
     },
     {
+      "name": "partial-fastapi.json",
+      "description": "FastAPI web framework configuration for pyproject.toml",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-fastapi.json"
+    },
+    {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
       "fileMatch": [".suite.json", ".xsuite.json"],

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -331,6 +331,7 @@
     "partial-setuptools-scm.json", // pyproject.json[tool.setuptools-scm]
     "partial-scikit-build.json", // pyproject.json[tool.scikit-build]
     "partial-cibuildwheel.json", // pyproject.json[tool.cibuildwheel]
+    "partial-fastapi.json", // pyproject.json[tool.fastapi]
     "partial-mypy.json", // pyproject.json[tool.mypy]
     "partial-pdm.json", // pyproject.json[tool.pdm]
     "partial-pdm-dockerize.json", // pyproject.json[tool.pdm.dockerize]
@@ -1269,6 +1270,7 @@
         "maturin.json",
         "partial-black.json",
         "partial-cibuildwheel.json",
+        "partial-fastapi.json",
         "partial-mypy.json",
         "partial-pdm.json",
         "partial-pdm-dockerize.json",

--- a/src/schemas/json/partial-fastapi.json
+++ b/src/schemas/json/partial-fastapi.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-fastapi.json",
+  "type": "object",
+  "properties": {
+    "entrypoint": {
+      "type": "string",
+      "title": "Application Entrypoint",
+      "description": "Import string entrypoint for the **FastAPI** application, in the format: \n```\nimportable.module:attribute\n```\n\nFor example, for an app like:\n\n ```python\nfrom fastapi import FastAPI\n\napp = FastAPI()\n```\n\nin a file at `backend/main.py`\n the config could look like:\n\n```toml\n[tool.fastapi]\nentrypoint = \"backend.main:app\"\n```\n\nDocs: https://fastapi.tiangolo.com/fastapi-cli/",
+      "examples": ["main:app", "backend.main:app"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -972,6 +972,11 @@
           "title": "Wheel Builder",
           "description": "Build Python wheels for all platforms."
         },
+        "fastapi": {
+          "$ref": "https://json.schemastore.org/partial-fastapi.json",
+          "title": "Web Framework",
+          "description": "FastAPI web framework configuration."
+        },
         "mypy": {
           "$ref": "https://json.schemastore.org/partial-mypy.json",
           "title": "Static Type Checker",

--- a/src/test/pyproject/fastapi.toml
+++ b/src/test/pyproject/fastapi.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.fastapi]
+entrypoint = "backend.main:app"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

✨ Add JSON Schema for FastAPI in `pyproject.toml`

I created, own, and maintain FastAPI (https://github.com/fastapi/fastapi). Recently we added support for configurations in `pyproject.toml`, this adds support for it.

I based it on the patterns I see for other Python libraries with pyproject.toml.

I wanted to have the JSON Schema in the fastapi repo, but I understand that's not supported for partials (https://github.com/SchemaStore/schemastore/issues/2731), so I'm adding it in full here to the repo. Also adding the `CODEOWNERS` config to allow me to edit it in the future if we add extra configs.

I tested it by temporarily copying the contents of the partial manually to the JSON Schema for `pyproject.toml` and triggering autocompletion on VS Code with Tombi installed. That's also how I tweaked the description format.

### AI Disclaimer

I used Claude Opus 4.6 in several iterative prompts, plus some manual tweaks written by hand.