### PR TITLE
Add @sarahdeaton to Anthropic Team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # the repo, unless a later match takes precedence.
 * @madskristensen @hyperupcall
 
-src/schema-validation.jsonc @ssbarnea @webknjaz @CircleCI-Public/developer-experience @meeech @gordonsyme @skoch13 @andrey-skl @zmaks @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj @VCecileKefelian @pandatix @NicoFgrx @ya7010 @chrissimon-au @danielbayley @btea @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi @domdomegg @bogini @ianmacartney @thomasballinger @Nicolapps
+src/schema-validation.jsonc @ssbarnea @webknjaz @CircleCI-Public/developer-experience @meeech @gordonsyme @skoch13 @andrey-skl @zmaks @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj @VCecileKefelian @pandatix @NicoFgrx @ya7010 @chrissimon-au @danielbayley @btea @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi @domdomegg @bogini @sarahdeaton @ianmacartney @thomasballinger @Nicolapps
 
 # Managed by Ansible DevTools Team members:
 src/schemas/json/ansible-* @ssbarnea @webknjaz
@@ -62,13 +62,13 @@ src/test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyag
 src/negative_test/powerpages.config/ @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi
 
 # Managed by Anthropic Team:
-src/schemas/json/claude-code-settings.json @domdomegg @bogini @ant-kurt
-src/test/claude-code-settings/ @domdomegg @bogini @ant-kurt
-src/negative_test/claude-code-settings/ @domdomegg @bogini @ant-kurt
-src/schemas/json/claude-code-keybindings.json @domdomegg @bogini @antrewmorrison
-src/test/claude-code-keybindings/ @domdomegg @bogini @antrewmorrison
-src/negative_test/claude-code-keybindings/ @domdomegg @bogini @antrewmorrison
-src/helpers/coverage.js @domdomegg @bogini @antrewmorrison
+src/schemas/json/claude-code-settings.json @domdomegg @bogini @sarahdeaton @ant-kurt
+src/test/claude-code-settings/ @domdomegg @bogini @sarahdeaton @ant-kurt
+src/negative_test/claude-code-settings/ @domdomegg @bogini @sarahdeaton @ant-kurt
+src/schemas/json/claude-code-keybindings.json @domdomegg @bogini @sarahdeaton @antrewmorrison
+src/test/claude-code-keybindings/ @domdomegg @bogini @sarahdeaton @antrewmorrison
+src/negative_test/claude-code-keybindings/ @domdomegg @bogini @sarahdeaton @antrewmorrison
+src/helpers/coverage.js @domdomegg @bogini @sarahdeaton @antrewmorrison
 
 # Managed by Convex Team:
 src/schemas/json/convex.json @ianmacartney @thomasballinger @Nicolapps


### PR DESCRIPTION
Adds @sarahdeaton from the Anthropic team as a code owner for the claude-code-settings and claude-code-keybindings schemas (alongside existing Anthropic owners), plus the shared `src/schema-validation.jsonc` and `src/helpers/coverage.js` entries.