### PR TITLE
Document update-types feature within the `allow` block

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -744,6 +744,10 @@
               },
               "dependency-type": {
                 "$ref": "#/definitions/dependency-type"
+              },
+              "update-types": {
+                "$ref": "#/definitions/update-types",
+                "description": "Use to ignore types of updates. You can combine this with 'dependency-name: \"*\"' to allow particular update-types for all dependencies."
               }
             },
             "anyOf": [

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -747,7 +747,7 @@
               },
               "update-types": {
                 "$ref": "#/definitions/update-types",
-                "description": "Use to ignore types of updates. You can combine this with 'dependency-name: \"*\"' to allow particular update-types for all dependencies."
+                "description": "Use to allow specific types of updates. You can combine this with 'dependency-name: \"*\"' to allow particular update-types for all dependencies."
               }
             },
             "anyOf": [


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/issues/12668

Example usage

```yml
allow:
  - dependency-name: "activesupport"
    update-types: ["version-update:semver-minor", "version-update:semver-patch"]
  - dependency-name: "rack"
    update-types: ["version-update:semver-patch"]
  - dependency-name: "zeitwerk"    # no update-types = allow all
  - dependency-type: "production"
    update-types: ["version-update:semver-patch"]
```