### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.112

### DIFF
--- a/src/helpers/coverage.js
+++ b/src/helpers/coverage.js
@@ -60,6 +60,33 @@ function collectPropertyValues(data, propName) {
 // matching is deferred to v2.
 function collectValuesByPath(data, path) {
   const values = []
+
+  // For $defs paths (e.g. "#$defs/hookCommand.shell"), path-based traversal
+  // cannot work because the path references the schema definition, not the
+  // test data structure.  Fall back to a deep name-based search for the
+  // terminal property name so that test files exercising the property via
+  // $ref usage are still matched.
+  if (path.startsWith('#')) {
+    const propName = path.split('.').pop()
+    function deepCollect(current) {
+      if (!current || typeof current !== 'object') return
+      if (Array.isArray(current)) {
+        for (const item of current) deepCollect(item)
+        return
+      }
+      for (const [key, val] of Object.entries(current)) {
+        if (key === propName && val !== undefined && val !== null) {
+          values.push(val)
+        }
+        if (typeof val === 'object' && val !== null) {
+          deepCollect(val)
+        }
+      }
+    }
+    deepCollect(data)
+    return values
+  }
+
   const segments = path.split('.')
 
   function traverse(current, remaining) {

--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -1,14 +1,19 @@
 {
   "autoUpdatesChannel": "beta",
+  "defaultShell": "zsh",
+  "disableDeepLinkRegistration": "enabled",
   "effortLevel": "extreme",
   "forceLoginMethod": "github",
   "permissions": {
     "defaultMode": "invalid-mode",
+    "disableAutoMode": "enabled",
     "disableBypassPermissionsMode": "enabled"
   },
   "spinnerVerbs": {
     "mode": "merge",
     "verbs": ["Analyzing"]
   },
-  "teammateMode": "split"
+  "teammateMode": "split",
+  "tui": "mini",
+  "viewMode": "list"
 }

--- a/src/negative_test/claude-code-settings/invalid-hook-shell.json
+++ b/src/negative_test/claude-code-settings/invalid-hook-shell.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "echo test",
+            "shell": "fish",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  }
+}

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4,8 +4,8 @@
   "$defs": {
     "permissionRule": {
       "type": "string",
-      "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|NotebookEdit|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -53,6 +53,19 @@
               "type": "boolean",
               "description": "Run this hook asynchronously without blocking Claude Code"
             },
+            "asyncRewake": {
+              "type": "boolean",
+              "description": "When true, the hook runs in the background and wakes the model when it exits with code 2. Implies async."
+            },
+            "shell": {
+              "type": "string",
+              "enum": ["bash", "powershell"],
+              "description": "Shell interpreter for the command. \"bash\" uses the login shell (bash/zsh/sh); \"powershell\" uses pwsh. Defaults to bash."
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter (e.g., \"Bash(git *)\"). Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
+            },
             "statusMessage": {
               "type": "string",
               "description": "Custom spinner message displayed while the hook runs"
@@ -83,6 +96,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
             },
             "statusMessage": {
               "type": "string",
@@ -115,6 +132,10 @@
               "description": "Optional timeout in seconds (default: 60)",
               "exclusiveMinimum": 0
             },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
+            },
             "statusMessage": {
               "type": "string",
               "description": "Custom spinner message displayed while the hook runs"
@@ -123,7 +144,7 @@
         },
         {
           "type": "object",
-          "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hooks",
+          "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hook-fields",
           "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
@@ -156,6 +177,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
             },
             "statusMessage": {
               "type": "string",
@@ -229,7 +254,7 @@
         "type": "string",
         "minLength": 1
       },
-      "description": "Glob patterns for CLAUDE.md files to exclude from loading. Useful in monorepos to skip irrelevant instructions from other teams. Patterns match against absolute file paths. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded. See https://code.claude.com/docs/en/memory#exclude-specific-claudemd-files",
+      "description": "Glob patterns for CLAUDE.md files to exclude from loading. Useful in monorepos to skip irrelevant instructions from other teams. Patterns match against absolute file paths. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded. See https://code.claude.com/docs/en/memory#exclude-specific-claude-md-files",
       "examples": [
         [
           "**/monorepo/CLAUDE.md",
@@ -239,8 +264,8 @@
     },
     "cleanupPeriodDays": {
       "type": "integer",
-      "minimum": 0,
-      "description": "Number of days to retain chat transcripts (0 to disable cleanup)",
+      "minimum": 1,
+      "description": "Number of days to retain sessions and orphaned subagent worktrees. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings",
       "examples": [20, 30, 60],
       "default": 30
     },
@@ -343,6 +368,11 @@
           "enum": ["disable"],
           "description": "Disable the ability to bypass permission prompts"
         },
+        "disableAutoMode": {
+          "type": "string",
+          "enum": ["disable"],
+          "description": "Set to \"disable\" to prevent auto mode from being activated. Removes `auto` from the Shift+Tab cycle and rejects `--permission-mode auto` at startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/permissions"
+        },
         "additionalDirectories": {
           "type": "array",
           "items": {
@@ -355,7 +385,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
+      "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
       "examples": [
         {
           "allow": ["Bash(git add:*)"],
@@ -396,8 +426,8 @@
     },
     "effortLevel": {
       "type": "string",
-      "enum": ["low", "medium", "high"],
-      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Defaults vary by model and plan (Opus 4.6 defaults to medium for Max and Team subscribers). Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
+      "enum": ["low", "medium", "high", "xhigh", "max"],
+      "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high, or medium on Pro and Max plans; Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
       "type": "boolean",
@@ -608,6 +638,13 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "StopFailure": {
+          "type": "array",
+          "description": "Hooks that run when a turn ends due to an API error (e.g., rate_limit, authentication_failed, billing_error, invalid_request, server_error, max_output_tokens, unknown). Matcher can scope to specific error types. Hook output and exit code are ignored. See https://code.claude.com/docs/en/hooks",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "SubagentStart": {
           "type": "array",
           "description": "Hooks that run when a subagent is spawned",
@@ -733,6 +770,14 @@
       "type": "boolean",
       "description": "Disable all hooks and statusLine execution. When true in managed settings, user and project-level disableAllHooks cannot override it. See https://code.claude.com/docs/en/hooks#disable-or-remove-hooks"
     },
+    "allowedChannelPlugins": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "(Managed settings only) Allowlist of plugin IDs whose MCP servers may advertise channel notifications when channelsEnabled is true. When set, only the listed plugins can push inbound messages. See https://code.claude.com/docs/en/mcp"
+    },
     "allowedHttpHookUrls": {
       "type": "array",
       "items": {
@@ -765,6 +810,11 @@
         "padding": {
           "type": "number",
           "description": "Optional number of extra horizontal spacing characters added to the status line content; defaults to 0."
+        },
+        "refreshInterval": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Re-run the status line command every N seconds in addition to event-driven updates. Leave unset to run only on events. Useful for time-based data like clocks, or when background subagents change git state while the main session is idle. See https://code.claude.com/docs/en/statusline"
         }
       },
       "required": ["type", "command"],
@@ -1225,6 +1275,15 @@
             "allowManagedDomainsOnly": {
               "type": "boolean",
               "description": "(Managed settings only) Only allowedDomains and WebFetch(domain:...) allow rules from managed settings are respected. User, project, local, and flag settings domains are ignored. Denied domains are still respected from all sources. Non-allowed domains are automatically blocked without user prompts."
+            },
+            "allowMachLookup": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "macOS only. Additional XPC/Mach service names the sandbox may look up. Supports a single trailing * for prefix matching. Needed for tools that communicate via XPC such as the iOS Simulator or Playwright. See https://code.claude.com/docs/en/settings",
+              "examples": [["com.apple.coresimulator.*"]]
             }
           },
           "additionalProperties": false
@@ -1311,6 +1370,26 @@
             }
           },
           "additionalProperties": false
+        },
+        "ripgrep": {
+          "type": "object",
+          "description": "Custom ripgrep configuration for Claude Code's bundled ripgrep support. Overrides the bundled binary and arguments.",
+          "additionalProperties": false,
+          "required": ["command"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Path to the ripgrep binary to use",
+              "minLength": 1
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Additional arguments to pass to the ripgrep binary"
+            }
+          }
         }
       },
       "additionalProperties": false
@@ -1448,11 +1527,26 @@
               }
             },
             "description": "User configuration values for MCP servers keyed by server name"
+          },
+          "options": {
+            "type": "object",
+            "description": "Non-sensitive option values from the plugin manifest's userConfig, keyed by option name. Sensitive values go to secure storage instead. See https://code.claude.com/docs/en/plugins-reference",
+            "additionalProperties": {
+              "anyOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
       },
-      "description": "Per-plugin configuration including MCP server user configs, keyed by plugin ID (plugin@marketplace format). See https://code.claude.com/docs/en/plugins"
+      "description": "Per-plugin configuration including MCP server user configs and plugin options, keyed by plugin ID (plugin@marketplace format). See https://code.claude.com/docs/en/plugins"
     },
     "allowManagedMcpServersOnly": {
       "type": "boolean",
@@ -1616,6 +1710,113 @@
           }
         ]
       }
+    },
+    "agent": {
+      "type": "string",
+      "description": "Name of an agent (built-in or custom) to use for the main thread. Applies the agent's system prompt, tool restrictions, and model. See https://code.claude.com/docs/en/sub-agents",
+      "minLength": 1
+    },
+    "autoMemoryDirectory": {
+      "type": "string",
+      "description": "Custom directory path for auto-memory storage. Supports ~/ prefix for home-directory expansion. Ignored if set in checked-in project settings (.claude/settings.json) for security. Defaults to ~/.claude/projects/<sanitized-cwd>/memory/ when unset. See https://code.claude.com/docs/en/memory",
+      "minLength": 1
+    },
+    "autoMode": {
+      "type": "object",
+      "description": "Customization for the auto mode classifier prompt. Typically configured in managed settings to tune the allow/deny rules used when permissions.defaultMode is \"auto\". Note: allow and soft_deny REPLACE the default classifier rules entirely — review carefully. See https://code.claude.com/docs/en/permissions",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional rules appended to the auto mode classifier allow section"
+        },
+        "soft_deny": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional rules appended to the auto mode classifier soft-deny section"
+        },
+        "environment": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Environment entries appended to the auto mode classifier environment section"
+        }
+      }
+    },
+    "channelsEnabled": {
+      "type": "boolean",
+      "description": "(Teams/Enterprise) Opt-in for channel notifications — MCP servers with the claude/channel capability pushing inbound messages. Default off. When true, users can select servers via --channels. See https://code.claude.com/docs/en/mcp",
+      "default": false
+    },
+    "defaultShell": {
+      "type": "string",
+      "enum": ["bash", "powershell"],
+      "description": "Default shell for input-box ! commands. Default: bash. Using \"powershell\" routes ! commands through PowerShell on Windows and requires CLAUDE_CODE_USE_POWERSHELL_TOOL=1 with pwsh on PATH. See https://code.claude.com/docs/en/settings"
+    },
+    "disableDeepLinkRegistration": {
+      "type": "string",
+      "enum": ["disable"],
+      "description": "Set to \"disable\" to prevent Claude Code from registering the `claude://` deep-link protocol handler on startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings"
+    },
+    "disableSkillShellExecution": {
+      "type": "boolean",
+      "description": "Disable inline shell execution for `` !`...` `` and ` ```! ` blocks in skills and custom slash commands from user, project, plugin, or additional-directory sources. Commands are replaced with [shell command execution disabled by policy] instead of being run. Bundled and managed skills are not affected. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings"
+    },
+    "forceRemoteSettingsRefresh": {
+      "type": "boolean",
+      "description": "(Managed settings only) Block CLI startup until remote managed settings are freshly fetched from the server. If the fetch fails, the CLI exits (fail-closed) rather than continuing with cached settings. When not set, startup continues without waiting for remote settings. See https://code.claude.com/docs/en/server-managed-settings"
+    },
+    "minimumVersion": {
+      "type": "string",
+      "description": "Minimum Claude Code version to stay on. Prevents downgrades when switching release channels. See https://code.claude.com/docs/en/settings",
+      "examples": ["2.1.0"],
+      "minLength": 1
+    },
+    "showClearContextOnPlanAccept": {
+      "type": "boolean",
+      "description": "When true, the plan-approval dialog offers a \"clear context\" option. Defaults to false.",
+      "default": false
+    },
+    "showThinkingSummaries": {
+      "type": "boolean",
+      "description": "Show thinking summaries in the transcript view (Ctrl+O). Thinking summaries are not generated by default in interactive sessions; set to true to restore. See https://code.claude.com/docs/en/settings",
+      "default": false
+    },
+    "skipDangerousModePermissionPrompt": {
+      "type": "boolean",
+      "description": "Whether the user has accepted the bypass permissions mode dialog. Typically managed by the CLI rather than set by hand."
+    },
+    "strictPluginOnlyCustomization": {
+      "description": "(Managed settings) Block non-plugin customization sources for the listed surfaces. Array form locks specific surfaces (e.g., [\"skills\", \"hooks\"]); true locks all four; false is an explicit no-op. See https://code.claude.com/docs/en/plugins-reference",
+      "anyOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["skills", "agents", "hooks", "mcp"]
+          }
+        }
+      ]
+    },
+    "tui": {
+      "type": "string",
+      "enum": ["fullscreen", "default"],
+      "description": "TUI rendering mode. Use \"fullscreen\" for the flicker-free alt-screen renderer with virtualized scrollback; \"default\" for the classic main-screen renderer. Corresponds to the /tui command. See https://code.claude.com/docs/en/settings"
+    },
+    "viewMode": {
+      "type": "string",
+      "enum": ["default", "verbose", "focus"],
+      "description": "Transcript view mode. \"default\" shows standard interactive view; \"verbose\" shows expanded tool details; \"focus\" shows prompt, one-line tool summaries, and final response only (Ctrl+O toggle). See https://code.claude.com/docs/en/settings"
+    },
+    "useAutoModeDuringPlan": {
+      "type": "boolean",
+      "description": "When true, apply the auto mode classifier during plan mode to auto-approve safe read-only tool calls while planning. Has no effect unless permissions.defaultMode allows auto. See https://code.claude.com/docs/en/permissions"
+    },
+    "voiceEnabled": {
+      "type": "boolean",
+      "description": "Enable push-to-talk voice dictation. Typically written automatically when /voice is used. Requires a Claude.ai account. See https://code.claude.com/docs/en/settings"
     }
   },
   "title": "Claude Code Settings"

--- a/src/test/claude-code-settings/complete-config.json
+++ b/src/test/claude-code-settings/complete-config.json
@@ -1,6 +1,7 @@
 {
   "apiKeyHelper": "/usr/local/bin/claude-auth",
   "cleanupPeriodDays": 30,
+  "effortLevel": "medium",
   "env": {
     "DEBUG_MODE": "true",
     "EDITOR": "vim"
@@ -22,5 +23,6 @@
       "Bash(wget:*)",
       "WebFetch(domain:bad.actor.com)"
     ]
-  }
+  },
+  "viewMode": "default"
 }

--- a/src/test/claude-code-settings/edge-cases.json
+++ b/src/test/claude-code-settings/edge-cases.json
@@ -1,6 +1,6 @@
 {
   "autoUpdatesChannel": "stable",
-  "cleanupPeriodDays": 0,
+  "cleanupPeriodDays": 1,
   "effortLevel": "low",
   "env": {},
   "fastMode": false,

--- a/src/test/claude-code-settings/enum-coverage.json
+++ b/src/test/claude-code-settings/enum-coverage.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "channelsEnabled": false,
+  "defaultShell": "bash",
+  "effortLevel": "xhigh",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "echo bash",
+            "shell": "bash",
+            "type": "command"
+          },
+          {
+            "command": "Get-Content",
+            "shell": "powershell",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  },
+  "terminalTitleFromRename": true,
+  "tui": "fullscreen",
+  "viewMode": "verbose"
+}

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "agent": "code-reviewer",
   "allowManagedHooksOnly": false,
   "allowManagedPermissionRulesOnly": false,
+  "allowedChannelPlugins": ["internal-notifier@corp"],
   "allowedHttpHookUrls": ["https://hooks.example.com/*", "http://localhost:*"],
   "alwaysThinkingEnabled": false,
   "apiKeyHelper": "/usr/local/bin/claude-auth-helper",
@@ -9,7 +11,13 @@
     "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
     "pr": ""
   },
+  "autoMemoryDirectory": "~/.claude/custom-memory",
   "autoMemoryEnabled": false,
+  "autoMode": {
+    "allow": ["All read-only operations"],
+    "environment": ["WSL2 on Windows"],
+    "soft_deny": ["Deleting files"]
+  },
   "autoUpdatesChannel": "latest",
   "availableModels": ["sonnet", "haiku"],
   "awsAuthRefresh": "aws sso login --profile myprofile",
@@ -20,15 +28,19 @@
       "source": "pathPattern"
     }
   ],
+  "channelsEnabled": true,
   "claudeMdExcludes": [
     "**/other-team/CLAUDE.md",
     "/home/user/monorepo/.claude/rules/**"
   ],
   "cleanupPeriodDays": 60,
   "companyAnnouncements": ["Welcome to the team!"],
+  "defaultShell": "powershell",
   "disableAllHooks": false,
+  "disableDeepLinkRegistration": "disable",
+  "disableSkillShellExecution": false,
   "disabledMcpjsonServers": ["untrusted-server"],
-  "effortLevel": "medium",
+  "effortLevel": "max",
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {
     "formatter@anthropic-tools": true
@@ -56,6 +68,7 @@
   },
   "forceLoginMethod": "console",
   "forceLoginOrgUUID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "forceRemoteSettingsRefresh": false,
   "hooks": {
     "ConfigChange": [
       {
@@ -103,7 +116,10 @@
       {
         "hooks": [
           {
+            "asyncRewake": true,
             "command": "echo 'File write detected' >> ~/.claude-code/activity.log",
+            "if": "Write(**/*.py)",
+            "shell": "bash",
             "type": "command"
           }
         ],
@@ -127,6 +143,16 @@
             "timeout": 10,
             "type": "http",
             "url": "https://hooks.example.com/session-end"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Stop failed' >> ~/.claude-code/errors.log",
+            "type": "command"
           }
         ]
       }
@@ -156,6 +182,7 @@
   "includeCoAuthoredBy": true,
   "includeGitInstructions": false,
   "language": "english",
+  "minimumVersion": "2.1.0",
   "model": "opus",
   "modelOverrides": {
     "claude-opus-4-6": "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/opus-prod"
@@ -186,7 +213,8 @@
       "Bash(rm -rf:*)",
       "Write(/etc/**)",
       "Write(/System/**)"
-    ]
+    ],
+    "disableAutoMode": "disable"
   },
   "plansDirectory": "./plans",
   "pluginConfigs": {
@@ -195,6 +223,10 @@
         "formatter": {
           "autoFormat": "true"
         }
+      },
+      "options": {
+        "lineWidth": 80,
+        "useTabs": false
       }
     }
   },
@@ -209,6 +241,8 @@
     "enabled": true,
     "excludedCommands": ["docker", "git"],
     "filesystem": {
+      "allowManagedReadPathsOnly": false,
+      "allowRead": ["~/.ssh/known_hosts"],
       "allowWrite": ["~/.kube", "//tmp/build"],
       "denyRead": ["~/.ssh/id_rsa"],
       "denyWrite": ["//etc", "//usr"]
@@ -216,14 +250,22 @@
     "network": {
       "allowAllUnixSockets": false,
       "allowLocalBinding": true,
+      "allowMachLookup": ["com.apple.coresimulator.*"],
       "allowManagedDomainsOnly": true,
       "allowUnixSockets": ["/var/run/docker.sock"],
       "allowedDomains": ["github.com", "*.npmjs.org", "registry.yarnpkg.com"],
       "httpProxyPort": 8080,
       "socksProxyPort": 8081
+    },
+    "ripgrep": {
+      "args": ["--hidden"],
+      "command": "/usr/bin/rg"
     }
   },
+  "showClearContextOnPlanAccept": true,
+  "showThinkingSummaries": true,
   "showTurnDuration": false,
+  "skipDangerousModePermissionPrompt": true,
   "skipWebFetchPreflight": false,
   "skippedMarketplaces": ["untrusted-marketplace"],
   "skippedPlugins": ["risky-plugin@unknown-marketplace"],
@@ -239,10 +281,16 @@
   "statusLine": {
     "command": "~/.claude/statusline.sh",
     "padding": 1,
+    "refreshInterval": 5,
     "type": "command"
   },
+  "strictPluginOnlyCustomization": ["skills", "hooks"],
   "teammateMode": "tmux",
   "terminalProgressBarEnabled": false,
+  "tui": "default",
+  "useAutoModeDuringPlan": true,
+  "viewMode": "focus",
+  "voiceEnabled": true,
   "worktree": {
     "sparsePaths": ["packages/my-app", "shared/utils"]
   }


### PR DESCRIPTION
Syncs `claude-code-settings.json` from v2.1.76 ([previous sync](https://github.com/SchemaStore/schemastore/pull/5467)) to [v2.1.112](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md). **Subsumes the contributions in open PRs #5483 (large v2.1.81 sync) and #5583 (hookCommand fields).** Resulting diff reflects a deep review of live docs at https://code.claude.com/docs/en with multi-pass verification and matching with docs and Changelog.

## Schema

### New hookCommand fields
- Add `asyncRewake` (command-only) — background hook that wakes the model on exit code 2 ([v2.1.79](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2179))
- Add `shell` (command-only, enum `bash`|`powershell`) — shell interpreter selector, per [hooks documentation](https://code.claude.com/docs/en/hooks) ([v2.1.85](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2185))
- Add `if` (command/prompt/agent/http) — permission-rule-syntax filter, per [hooks-guide#filter-hooks-with-matchers](https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers). Evaluated only on tool-related events; description notes the scope.
- **Excluded: `once`** — proposed in #5583, but current [hooks docs](https://code.claude.com/docs/en/hooks) scope this field to skill frontmatter YAML, not settings.json `hookCommand`.

### New hook event
- Add `StopFailure` — runs when a turn ends due to an API error (matcher values: `rate_limit`, `authentication_failed`, `billing_error`, `invalid_request`, `server_error`, `max_output_tokens`, `unknown`), per [hooks documentation](https://code.claude.com/docs/en/hooks) ([v2.1.84](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2184))

### Top-level properties (17)
- `agent` — run the main thread as a named [subagent](https://code.claude.com/docs/en/sub-agents), per [settings documentation](https://code.claude.com/docs/en/settings)
- `allowedChannelPlugins` — managed-only allowlist of plugins that may push channel notifications when `channelsEnabled` is true
- `autoMemoryDirectory` — custom auto-memory storage path, per [memory documentation](https://code.claude.com/docs/en/memory)
- `autoMode` — auto-mode classifier prompt customization (`allow`/`soft_deny`/`environment`), per [permissions documentation](https://code.claude.com/docs/en/permissions). Description warns that `allow`/`soft_deny` entirely replace classifier defaults.
- `channelsEnabled` — Teams/Enterprise opt-in for channel notifications
- `defaultShell` (enum `bash`|`powershell`) — default shell for input-box `!` commands; notes that `powershell` requires `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` with `pwsh` on `PATH`
- `disableDeepLinkRegistration` (`"disable"`) — prevents `claude://` protocol handler registration (managed-only)
- `disableSkillShellExecution` — disable inline shell execution in skills and custom slash commands ([v2.1.91](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2191))
- `forceRemoteSettingsRefresh` — fail-closed managed-only bootstrap policy ([v2.1.92](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2192))
- `minimumVersion` — prevents downgrades when switching release channels
- `showClearContextOnPlanAccept` — adds clear-context option on plan approval dialog
- `showThinkingSummaries` — restore thinking summaries in transcript view (off by default, [v2.1.89](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2189))
- `skipDangerousModePermissionPrompt` — tracks bypass-permissions opt-in dialog acceptance
- `strictPluginOnlyCustomization` — managed-only; locks customization surfaces (`skills`/`agents`/`hooks`/`mcp`) to plugin sources
- `tui` (enum `fullscreen`|`default`) — flicker-free alt-screen vs classic renderer ([v2.1.110](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21110))
- `useAutoModeDuringPlan` — apply auto-mode classifier during plan mode
- `viewMode` (enum `default`|`verbose`|`focus`) — transcript view mode (`focus` is the Ctrl+O toggle)
- `voiceEnabled` — push-to-talk dictation (see [voice-dictation docs](https://code.claude.com/docs/en/voice-dictation))

### Nested additions
- `permissions.disableAutoMode` (`"disable"`) — mirror of `disableBypassPermissionsMode`, per [permissions documentation](https://code.claude.com/docs/en/permissions). Note: #5483 placed this at both top-level and under `permissions`; only the nested form is correct per docs.
- `sandbox.network.allowMachLookup` — macOS-only XPC/Mach service allowlist, per [settings documentation](https://code.claude.com/docs/en/settings) ([v2.1.97](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2197))
- `sandbox.ripgrep` — custom ripgrep binary/args
- `statusLine.refreshInterval` (min 1) — re-run status line every N seconds, per [statusline documentation](https://code.claude.com/docs/en/statusline) ([v2.1.97](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2197))
- `pluginConfigs.*.options` — non-sensitive plugin `userConfig` values, per [plugins-reference](https://code.claude.com/docs/en/plugins-reference)

### Enum extensions
- `effortLevel`: add `xhigh` (Opus 4.7, [v2.1.111](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21111)) and `max`; description rewritten to match [model-config documentation](https://code.claude.com/docs/en/model-config#adjust-effort-level) for per-model/plan defaults and `max` session-only behavior
- `permissionRule` pattern: add `Monitor` and `PowerShell` tools

### Tightenings
- `cleanupPeriodDays` minimum: `0` → `1` — v2.1.89 validator [explicitly rejects `0`](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2189) (previously silently disabled cleanup)

### Doc-anchor fixes
- `hooks-guide#filter-hooks-with-if` → `hooks-guide#filter-hooks-with-matchers`
- `hooks#http-hooks` → `hooks#http-hook-fields`
- `memory#exclude-specific-claudemd-files` → `memory#exclude-specific-claude-md-files`
- `settings#tools-available-to-claude` → [`/docs/en/tools-reference`](https://code.claude.com/docs/en/tools-reference) (canonical tool list page)

## Tests

- `modern-complete-config.json` — exercises every new property for full coverage
- `complete-config.json` — adds `effortLevel: medium` and `viewMode: default` for enum-value spread
- `edge-cases.json` — updates `cleanupPeriodDays: 0` → `1` (forced by tightened minimum)
- New `enum-coverage.json` — filename/concept taken from #5483 by @r-johnv; content adapted to our schema to cover alternate enum values (`bash`, `fullscreen`, `xhigh`, `verbose`) and fill positive-coverage gaps across the new enums

## Negative tests

- `invalid-enum-values.json` — adds invalid values for `defaultShell`, `disableDeepLinkRegistration`, `permissions.disableAutoMode`, `tui`, `viewMode`
- New `invalid-hook-shell.json` — identical to the file proposed in #5583 by @sarahdeaton; exercises the `hookCommand.shell` invalid-enum path

## Coverage helper

- `src/helpers/coverage.js` — adds a deep name-based fallback for `$defs`-path resolution in `collectValuesByPath` so enum/required checks match values exercised via `$ref`. **Included from #5483 by @r-johnv** to extend the coverage gate so the `#$defs/hookCommand.shell` check passes in this sync (would otherwise fail the gate). Committed separately to preserve authorship.

## Skipped

- `once` hookCommand field (alike #5583) — Had added, but removed after validation. Per [hooks documentation](https://code.claude.com/docs/en/hooks), the `once` field belongs to skill **frontmatter** YAML (hooks declared inside skills), not to `hookCommand` entries declared in `settings.json`.
- Top-level `disableAutoMode` duplicate from #5483 — kept only under `permissions` per docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)