### PR TITLE
Add estampo.toml schema (self-hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2650,6 +2650,12 @@
       "url": "https://www.schemastore.org/esquio.json"
     },
     {
+      "name": "estampo.toml",
+      "description": "Configuration for estampo, the build system for reproducible 3D prints",
+      "fileMatch": ["estampo.toml", "estampo.*.toml"],
+      "url": "https://raw.githubusercontent.com/estampo/estampo/main/docs/estampo.schema.json"
+    },
+    {
       "name": "epr-manifest.json",
       "description": "Entry Point Regulation manifest file",
       "fileMatch": ["epr-manifest.json"],


### PR DESCRIPTION
Adds a catalog entry for [estampo](https://github.com/estampo/estampo), a build system for reproducible 3D prints.

**Schema URL:** https://raw.githubusercontent.com/estampo/estampo/main/docs/estampo.schema.json

**fileMatch:** `estampo.toml`, `estampo.*.toml`

The schema is self-hosted in the estampo repository. It covers the full TOML config structure including pipeline stages, slicer engine settings (OrcaSlicer and CuraEngine), parts, and command stages.

JSON Schema draft: 2020-12