### PR TITLE
Replace default with examples on the directory field

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -865,7 +865,7 @@
         "directory": {
           "description": "Location of package manifests",
           "type": "string",
-          "default": "/"
+          "examples": ["/", "/ecosystem"]
         },
         "exclude-paths": {
           "description": "List of file paths to exclude from dependency updates",


### PR DESCRIPTION
## Problem

The `directory` field includes `"default": "/"`, which in JSON Schema semantics suggests that `"/"` is assumed when the field is absent. This is misleading for two reasons:

* The schema's own `allOf` constraint requires exactly one of `directory` or `directories` to be present, meaning the field can never actually be omitted.
* The [Dependabot documentation ](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--) makes no mention of `"/"` as a default. Dependabot expects `directory` to be explicitly provided and does not fall back to any value if it is missing.

## Tradeoff 

This change is a correctness improvement to be spec-compliant and accurate that tools like code generators will respect, but comes with an IDE intellisense regression for editors that do not yet recognize examples as a source of completion hints. See this [issue for IDEA](https://youtrack.jetbrains.com/issue/IJPL-243009/Support-examples-keyword-as-completion-hints-for-string-fields-in-JSON-Schema). 

That said, using `default` as an intellisense workaround is misleading, as noted in the issue, and breaks many other tools that rely on the `default` field.


