### PR TITLE
Allow bare bun in `packageManager`

### DIFF
--- a/src/negative_test/package/package-manager-bun-substring.json
+++ b/src/negative_test/package/package-manager-bun-substring.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "bunny"
+}

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -797,7 +797,7 @@
     "packageManager": {
       "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
       "type": "string",
-      "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
+      "pattern": "^((npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?|bun)$"
     },
     "engines": {
       "type": "object",

--- a/src/test/package/package-manager-bun.json
+++ b/src/test/package/package-manager-bun.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../schemas/json/package.json",
+  "packageManager": "bun"
+}


### PR DESCRIPTION
I've changed the pattern for `package.json`'s `packageManager` field to make Bun's version optional.

Bun is the runtime; forcing version here is not a good choice. And Corepack does not support Bun, so whether or not there is a version of Bun doesn't really matter for Corepack users.