### PR TITLE
claude-code-settings: effortLevel xhigh + marketplace autoUpdate/lastUpdated

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -396,7 +396,7 @@
     },
     "effortLevel": {
       "type": "string",
-      "enum": ["low", "medium", "high"],
+      "enum": ["low", "medium", "high", "xhigh"],
       "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Defaults vary by model and plan (Opus 4.6 defaults to medium for Max and Team subscribers). Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
@@ -963,6 +963,14 @@
           "installLocation": {
             "type": "string",
             "description": "Local cache path where marketplace manifest is stored (auto-generated if not provided)"
+          },
+          "autoUpdate": {
+            "type": "boolean",
+            "description": "Whether to automatically update this marketplace on Claude Code startup. Written automatically by Claude Code when you toggle auto-update for a marketplace"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of the last marketplace refresh. Written automatically by Claude Code"
           }
         },
         "required": ["source"],

--- a/src/test/claude-code-settings/effort-level-xhigh.json
+++ b/src/test/claude-code-settings/effort-level-xhigh.json
@@ -1,0 +1,4 @@
+{
+  "effortLevel": "xhigh",
+  "model": "opus"
+}

--- a/src/test/claude-code-settings/marketplace-host-pattern.json
+++ b/src/test/claude-code-settings/marketplace-host-pattern.json
@@ -7,6 +7,8 @@
       }
     },
     "internal-git": {
+      "autoUpdate": true,
+      "lastUpdated": "2026-04-20T10:00:00Z",
       "source": {
         "hostPattern": "git.internal.example.com",
         "source": "hostPattern"


### PR DESCRIPTION
## Summary

Fixes valid Claude Code settings being flagged as invalid by the schema. Two gaps:

### 1. `effortLevel` missing `"xhigh"`

Per the [official docs](https://code.claude.com/docs/en/settings):

> `effortLevel` — Persist the effort level across sessions. Accepts `"low"`, `"medium"`, `"high"`, or `"xhigh"`. Written automatically when you run `/effort` with one of those values.

### 2. `extraKnownMarketplaces` entries missing `autoUpdate` and `lastUpdated`

Claude Code writes these automatically on marketplace entries. Verified in the Claude Code 2.1.114 binary, which validates each marketplace entry with a Zod schema that includes:

```
autoUpdate: boolean().optional().describe("Whether to automatically update this marketplace...")
lastUpdated: string().describe("ISO 8601 timestamp of last marketplace refresh")
```

Because the `extraKnownMarketplaces` entry object uses `additionalProperties: false`, these unknown-to-the-schema but valid-at-runtime fields raise false-positive errors in editors.

## Changes

- `src/schemas/json/claude-code-settings.json`
  - Add `"xhigh"` to `effortLevel` enum
  - Add `autoUpdate` (boolean) and `lastUpdated` (string) to the `extraKnownMarketplaces` entry schema
- Test fixtures
  - `edge-cases.json`: use `effortLevel: "xhigh"` to cover the new enum value (existing fixtures already cover the other three)
  - `marketplace-host-pattern.json`: add `autoUpdate` and `lastUpdated` on one entry to cover the new properties

## Test plan

- [ ] CI schema validation passes
- [ ] Fixtures with `"xhigh"`, `autoUpdate`, and `lastUpdated` validate against the updated schema