### PR TITLE
fix(tsconfig,jsconfig): update paths items description to remove baseUrl reference

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -742,7 +742,7 @@
                 "uniqueItems": true,
                 "items": {
                   "type": "string",
-                  "description": "Path mapping to be computed relative to baseUrl option."
+                  "description": "An array of paths to use as alternatives when resolving this module import."
                 }
               },
               "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -833,7 +833,7 @@
                 "uniqueItems": true,
                 "items": {
                   "type": "string",
-                  "description": "Path mapping to be computed relative to baseUrl option."
+                  "description": "An array of paths to use as alternatives when resolving this module import."
                 }
               },
               "markdownDescription": "A series of entries which re-map imports to lookup locations relative to the [`baseUrl`](https://typescriptlang.org/tsconfig/#baseUrl) if set, or to the tsconfig file itself otherwise. There is a larger coverage of `paths` in [the `moduleResolution` reference page](https://typescriptlang.org/docs/handbook/modules/reference.html#paths).\n\n`paths` lets you declare how TypeScript should resolve an import in your `require`/`import`s.\n\n```json tsconfig\n{\n  \"compilerOptions\": {\n    \"paths\": {\n      \"jquery\": [\"./vendor/jquery/dist/jquery\"]\n    }\n  }\n}\n```\n\nThis would allow you to be able to write `import \"jquery\"`, and get all of the correct typing locally.\n\n```json tsconfig\n{\n  \"compilerOptions\": {\n    \"paths\": {\n        \"app/*\": [\"./src/app/*\"],\n        \"config/*\": [\"./src/app/_config/*\"],\n        \"environment/*\": [\"./src/environments/*\"],\n        \"shared/*\": [\"./src/app/_shared/*\"],\n        \"helpers/*\": [\"./src/helpers/*\"],\n        \"tests/*\": [\"./src/tests/*\"]\n    }\n  }\n}\n```\n\nIn this case, you can tell the TypeScript file resolver to support a number of custom prefixes to find code.\n\nNote that this feature does not change how import paths are emitted by `tsc`, so `paths` should only be used to inform TypeScript that another tool has this mapping and will use it at runtime or when bundling.",


### PR DESCRIPTION
The `items` description for the `paths` map value in both `tsconfig.json` and `jsconfig.json` schemas currently reads:

> Path mapping to be computed relative to baseUrl option.

This is stale. `baseUrl` was removed in TypeScript 7 and the paths option now resolves relative to the tsconfig file location itself. The old description is confusing for users on newer versions of TypeScript.

Updated to neutral language that is accurate across all TypeScript versions:

> An array of paths to use as alternatives when resolving this module import.

Related: https://github.com/microsoft/typescript-go/issues/2443