### PR TITLE
feat(dependabot-2.0): add missing reviewers field to update and multi-ecosystem-group

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -771,6 +771,16 @@
           "minItems": 1,
           "uniqueItems": true
         },
+        "reviewers": {
+          "description": "Reviewers to request on pull requests",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
         "commit-message": {
           "description": "Dependabot attempts to detect your commit message preferences and use similar patterns. Use this option to specify your preferences explicitly.",
           "type": "object",
@@ -1361,6 +1371,16 @@
         },
         "assignees": {
           "description": "Assignees to set on pull requests (additive - merges with ecosystem-level assignees)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "reviewers": {
+          "description": "Reviewers to request on pull requests (additive - merges with ecosystem-level reviewers)",
           "type": "array",
           "items": {
             "type": "string",

--- a/src/test/dependabot-2.0/multi-ecosystem-groups.full-featured.yaml
+++ b/src/test/dependabot-2.0/multi-ecosystem-groups.full-featured.yaml
@@ -10,6 +10,8 @@ multi-ecosystem-groups:
       timezone: America/New_York
     assignees:
       - platform-team
+    reviewers:
+      - platform-reviewer
     labels:
       - infrastructure
       - dependencies
@@ -38,6 +40,8 @@ updates:
       - '*'
     assignees:
       - docker-admin
+    reviewers:
+      - docker-reviewer
     labels:
       - docker
     multi-ecosystem-group: infrastructure

--- a/src/test/dependabot-2.0/reviewers.json
+++ b/src/test/dependabot-2.0/reviewers.json
@@ -1,0 +1,13 @@
+{
+  "updates": [
+    {
+      "reviewers": ["rose", "tulip", "daffodil", "daisy"],
+      "directory": "/",
+      "package-ecosystem": "npm",
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/test/dependabot-2.0/reviewers.json
+++ b/src/test/dependabot-2.0/reviewers.json
@@ -1,9 +1,9 @@
 {
   "updates": [
     {
-      "reviewers": ["rose", "tulip", "daffodil", "daisy"],
       "directory": "/",
       "package-ecosystem": "npm",
+      "reviewers": ["rose", "tulip", "daffodil", "daisy"],
       "schedule": {
         "interval": "daily"
       }


### PR DESCRIPTION
## What

Adds the `reviewers` field to the Dependabot 2.0 schema in two places:

- `definitions.update.properties` — per-ecosystem update blocks
- `definitions.multi-ecosystem-group.properties` — group-level defaults

## Why

`reviewers` is a [documented Dependabot option](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers) but is absent from the current schema. Because `additionalProperties: false` is set on update entries, any `dependabot.yml` that uses `reviewers` currently fails schema validation despite being valid configuration accepted by GitHub's backend.

`assignees` is structurally identical and already present in both locations — `reviewers` follows the same shape (array of GitHub username strings, `minItems: 1`, `uniqueItems: true`). The group-level description mirrors the existing `assignees` wording with "additive - merges with ecosystem-level reviewers" to be consistent.

## Changes

- `src/schemas/json/dependabot-2.0.json` — adds `reviewers` property after `assignees` in both definitions
- `src/test/dependabot-2.0/reviewers.json` — new test fixture (mirrors `assignees.json`)
- `src/test/dependabot-2.0/multi-ecosystem-groups.full-featured.yaml` — extends existing fixture with `reviewers` at both the group level and update level

## References

- GitHub Dependabot options reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers