### PR TITLE
Revert "Allow bare bun in `packageManager` (#5589)"

### DIFF
--- a/src/negative_test/package/package-manager-bun-substring.json
+++ b/src/negative_test/package/package-manager-bun-substring.json
@@ -1,3 +1,0 @@
-{
-  "packageManager": "bunny"
-}

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -797,7 +797,7 @@
     "packageManager": {
       "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
       "type": "string",
-      "pattern": "^((npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?|bun)$"
+      "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
     },
     "engines": {
       "type": "object",

--- a/src/test/package/package-manager-bun.json
+++ b/src/test/package/package-manager-bun.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "../../schemas/json/package.json",
-  "packageManager": "bun"
-}


### PR DESCRIPTION
Fixes #5594

Fixing bugs in existing more popular package managers supersedes Bun support.

cc @LitoMore - If make another PR, please add a test case that prevents this regression. There is a suggested regex in the connected issue.