### PR TITLE
treefmt: Add no-positional-arg-support

### DIFF
--- a/src/schemas/json/treefmt.json
+++ b/src/schemas/json/treefmt.json
@@ -78,6 +78,10 @@
             "priority": {
               "type": "integer",
               "default": 0
+            },
+            "no-positional-arg-support": {
+              "type": "boolean",
+              "default": false
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
`no-positional-arg-support` added in [v2.5.0](https://github.com/numtide/treefmt/releases/tag/v2.5.0)

https://github.com/numtide/treefmt/blob/main/docs/site/getting-started/configure.md#no-positional-arg-support