### PR TITLE
feat(reposets): add catalog entries for reposets cli config and credentials schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5656,6 +5656,18 @@
       "url": "https://www.schemastore.org/replit.json"
     },
     {
+      "name": "reposets Configuration",
+      "description": "Configuration for the reposets CLI tool for syncing GitHub repository settings",
+      "fileMatch": ["reposets.config.toml", "reposets.config.json"],
+      "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json"
+    },
+    {
+      "name": "reposets Credentials",
+      "description": "Authentication profiles for the reposets CLI tool",
+      "fileMatch": ["reposets.credentials.toml", "reposets.credentials.json"],
+      "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json"
+    },
+    {
       "name": "*.resjson",
       "description": "Windows App localization file",
       "fileMatch": ["*.resjson"],


### PR DESCRIPTION
## Summary

- Register two externally-hosted JSON Schemas for the [reposets](https://github.com/spencerbeggs/reposets) CLI tool
- `reposets.config.schema.json` — configuration for syncing GitHub repository settings, secrets, variables, rulesets, and environments
- `reposets.credentials.schema.json` — authentication profiles for the reposets CLI

Both schemas are draft-07, hosted in the reposets repo, and use `x-tombi-*` / `x-taplo` extensions for TOML language server support.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>