### PR TITLE
Add Podman Desktop Extension schema (self-hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5150,6 +5150,12 @@
       "url": "https://raw.githubusercontent.com/Songmu/podbard/main/schema.yaml"
     },
     {
+      "name": "Podman Desktop Extension",
+      "description": "Podman Desktop extension package.json manifest",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/schemas/extension-schema.json"
+    },
+    {
       "name": "POPxf",
       "description": "Polynomial Observable Predictions in High-Energy Physics",
       "fileMatch": ["*.popxf", "*.popxf.json"],


### PR DESCRIPTION
## What

Register [Podman Desktop](https://podman-desktop.io)'s extension manifest schema as a **self-hosted** entry in the catalog.

The schema validates `package.json` files for Podman Desktop extensions. It is generated from a Zod schema and maintained in the upstream repository.

## Schema URL

```
https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/schemas/extension-schema.json
```

## `fileMatch`

Empty — `package.json` is too generic for auto-matching. Extension authors reference the schema explicitly via `$schema`.

## Upstream references

- Repository: https://github.com/podman-desktop/podman-desktop
- Schema file: [`schemas/extension-schema.json`](https://github.com/podman-desktop/podman-desktop/blob/main/schemas/extension-schema.json)
- Tracking issue: https://github.com/podman-desktop/podman-desktop/issues/16051


Made with [Cursor](https://cursor.com)