### PR TITLE
fix(github-action): correct `if` description — remove trailing period, add `${{ }}`-required-with-`!` exception

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -123,7 +123,7 @@
               },
               "if": {
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsif",
-                "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions.",
+                "description": "You can use the if conditional to prevent a step from running unless a condition is met. You can use any supported context and expression to create a conditional.\nExpressions in an if conditional do not require the ${{ }} syntax. However, you must always use the ${{ }} expression syntax or escape with '', \"\", or () when the expression starts with !, since ! is reserved notation in YAML format. For more information, see https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions",
                 "type": "string"
               },
               "env": {


### PR DESCRIPTION
Fixes #5215.

## Scope
One-line description edit to the `if` property in `src/schemas/json/github-action.json` (line 126). No schema semantics change; no validator behavior delta. Existing test fixtures under `src/test/github-action/` and `src/negative_test/github-action/` continue to exercise the validator unchanged.

## Two changes
1. **Remove trailing period** from the `help.github.com` citation URL so tools that auto-detect links do not capture the period as part of the URL (the rendering bug #5215 flagged with a screenshot).
2. **Add the `${{ }}`-required-with-`!` exception.** The current description says "Expressions in an `if` conditional do not require the `${{ }}` syntax" but omits the documented exception. This PR adds a single sentence stating that `${{ }}` (or escaping with `''`, `""`, or `()`) is required when the expression starts with `!`, since `!` is YAML-reserved.

## Truth-anchor
Source: [github/docs — `data/reusables/actions/expression-syntax-if.md`](https://github.com/github/docs/blob/main/data/reusables/actions/expression-syntax-if.md), the canonical reusable fragment rendered at [docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif). The added sentence preserves GitHub's wording verbatim, with a leading "However," added to preserve the logical contrast against the preceding "do not require" sentence.

## Verification
- `node ./cli.js check --schema-name=github-action.json` → green (Ajv validation passed, no pre-check failures).
- `npm run prettier:fix` → only `src/schemas/json/github-action.json` modified; diff is a single line.

## AI disclosure
This PR was authored with Claude Code assistance (Anthropic) as part of a structured methodology called Helix. Human reviewer approved the spec and the diff before this PR was opened. SchemaStore has no AI contribution policy as of 2026-04-24; this disclosure is offered as default courtesy.