### PR TITLE
Revert "Add Podman Desktop Extension schema (self-hosted)"

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5162,12 +5162,6 @@
       "url": "https://raw.githubusercontent.com/Songmu/podbard/main/schema.yaml"
     },
     {
-      "name": "Podman Desktop Extension",
-      "description": "Podman Desktop extension package.json manifest",
-      "fileMatch": [],
-      "url": "https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/schemas/extension-schema.json"
-    },
-    {
       "name": "POPxf",
       "description": "Polynomial Observable Predictions in High-Energy Physics",
       "fileMatch": ["*.popxf", "*.popxf.json"],


### PR DESCRIPTION
Reverts #5605.

The self-hosted catalog entry does not work for our use case. We expected the schema to be served from `https://json.schemastore.org/podman-desktop-extension.json`, but that URL returns 404 — self-hosted entries only appear in the catalog for IDE `fileMatch` auto-detection and are not served from `schemastore.org`.

We can't rely on `fileMatch` either because our schema targets `package.json`, which is too generic for auto-matching.

We plan to re-submit with the schema hosted directly in `src/schemas/json/`, with versioned schema files updated on each Podman Desktop release (similar to the [agripparc approach](https://github.com/SchemaStore/schemastore/pull/1950)). We would also add a CODEOWNERS entry so our bot can self-merge schema update PRs without requiring SchemaStore maintainer review.

Made with [Cursor](https://cursor.com)