### PR TITLE
Allow bare bun in `packageManager`

### DIFF
--- a/src/negative_test/package/package-manager-bare-npm.json
+++ b/src/negative_test/package/package-manager-bare-npm.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "npm"
+}

--- a/src/negative_test/package/package-manager-bun-substring.json
+++ b/src/negative_test/package/package-manager-bun-substring.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "bunny"
+}

--- a/src/negative_test/package/package-manager-missing-patch-version.json
+++ b/src/negative_test/package/package-manager-missing-patch-version.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "npm@10.9"
+}

--- a/src/negative_test/package/package-manager-unknown-manager.json
+++ b/src/negative_test/package/package-manager-unknown-manager.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "corepack@1.0.0"
+}

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -797,7 +797,14 @@
     "packageManager": {
       "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
       "type": "string",
-      "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
+      "oneOf": [
+        {
+          "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
+        },
+        {
+          "const": "bun"
+        }
+      ]
     },
     "engines": {
       "type": "object",

--- a/src/test/package/package-manager-bare-bun.json
+++ b/src/test/package/package-manager-bare-bun.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "bun"
+}

--- a/src/test/package/package-manager-bun-version.json
+++ b/src/test/package/package-manager-bun-version.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "bun@1.2.3"
+}

--- a/src/test/package/package-manager-prerelease-integrity.json
+++ b/src/test/package/package-manager-prerelease-integrity.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "yarn@4.0.0-rc.1+sha224.953c8233f7a92884"
+}

--- a/src/test/package/package-manager-prerelease.json
+++ b/src/test/package/package-manager-prerelease.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "npm@10.9.0-beta.1"
+}


### PR DESCRIPTION
This is another run of https://github.com/SchemaStore/schemastore/pull/5599.

Here, I used the `oneOf` to extend the definition for the best compatibility.