### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.119

### DIFF
--- a/src/helpers/coverage.js
+++ b/src/helpers/coverage.js
@@ -60,6 +60,33 @@ function collectPropertyValues(data, propName) {
 // matching is deferred to v2.
 function collectValuesByPath(data, path) {
   const values = []
+
+  // For $defs paths (e.g. "#$defs/hookCommand.shell"), path-based traversal
+  // cannot work because the path references the schema definition, not the
+  // test data structure.  Fall back to a deep name-based search for the
+  // terminal property name so that test files exercising the property via
+  // $ref usage are still matched.
+  if (path.startsWith('#')) {
+    const propName = path.split('.').pop()
+    function deepCollect(current) {
+      if (!current || typeof current !== 'object') return
+      if (Array.isArray(current)) {
+        for (const item of current) deepCollect(item)
+        return
+      }
+      for (const [key, val] of Object.entries(current)) {
+        if (key === propName && val !== undefined && val !== null) {
+          values.push(val)
+        }
+        if (typeof val === 'object' && val !== null) {
+          deepCollect(val)
+        }
+      }
+    }
+    deepCollect(data)
+    return values
+  }
+
   const segments = path.split('.')
 
   function traverse(current, remaining) {

--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -1,14 +1,19 @@
 {
   "autoUpdatesChannel": "beta",
+  "defaultShell": "zsh",
+  "disableDeepLinkRegistration": "enabled",
   "effortLevel": "extreme",
   "forceLoginMethod": "github",
   "permissions": {
     "defaultMode": "invalid-mode",
+    "disableAutoMode": "enabled",
     "disableBypassPermissionsMode": "enabled"
   },
   "spinnerVerbs": {
     "mode": "merge",
     "verbs": ["Analyzing"]
   },
-  "teammateMode": "split"
+  "teammateMode": "split",
+  "tui": "mini",
+  "viewMode": "list"
 }

--- a/src/negative_test/claude-code-settings/invalid-hook-shell.json
+++ b/src/negative_test/claude-code-settings/invalid-hook-shell.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "echo test",
+            "shell": "fish",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  }
+}

--- a/src/negative_test/claude-code-settings/missing-required-hook-fields.json
+++ b/src/negative_test/claude-code-settings/missing-required-hook-fields.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command"
+          },
+          {
+            "tool": "lint_file",
+            "type": "mcp_tool"
           }
         ]
       }

--- a/src/negative_test/claude-code-settings/wrong-property-types.json
+++ b/src/negative_test/claude-code-settings/wrong-property-types.json
@@ -24,7 +24,8 @@
   "sandbox": {
     "network": {
       "allowAllUnixSockets": "yes",
-      "allowedDomains": "api.anthropic.com"
+      "allowedDomains": "api.anthropic.com",
+      "deniedDomains": "should-be-array"
     }
   },
   "strictKnownMarketplaces": [

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4,8 +4,8 @@
   "$defs": {
     "permissionRule": {
       "type": "string",
-      "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|NotebookEdit|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -53,6 +53,19 @@
               "type": "boolean",
               "description": "Run this hook asynchronously without blocking Claude Code"
             },
+            "asyncRewake": {
+              "type": "boolean",
+              "description": "When true, the hook runs in the background and wakes the model when it exits with code 2. Implies async."
+            },
+            "shell": {
+              "type": "string",
+              "enum": ["bash", "powershell"],
+              "description": "Shell interpreter for the command. \"bash\" uses the login shell (bash/zsh/sh); \"powershell\" uses pwsh. Defaults to bash."
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter (e.g., \"Bash(git *)\"). Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
+            },
             "statusMessage": {
               "type": "string",
               "description": "Custom spinner message displayed while the hook runs"
@@ -83,6 +96,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
             },
             "statusMessage": {
               "type": "string",
@@ -115,6 +132,10 @@
               "description": "Optional timeout in seconds (default: 60)",
               "exclusiveMinimum": 0
             },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
+            },
             "statusMessage": {
               "type": "string",
               "description": "Custom spinner message displayed while the hook runs"
@@ -123,7 +144,7 @@
         },
         {
           "type": "object",
-          "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hooks",
+          "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hook-fields",
           "additionalProperties": false,
           "required": ["type", "url"],
           "properties": {
@@ -156,6 +177,10 @@
               "type": "number",
               "description": "Optional timeout in seconds (default: 30)",
               "exclusiveMinimum": 0
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
             },
             "statusMessage": {
               "type": "string",
@@ -229,7 +254,7 @@
         "type": "string",
         "minLength": 1
       },
-      "description": "Glob patterns for CLAUDE.md files to exclude from loading. Useful in monorepos to skip irrelevant instructions from other teams. Patterns match against absolute file paths. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded. See https://code.claude.com/docs/en/memory#exclude-specific-claudemd-files",
+      "description": "Glob patterns for CLAUDE.md files to exclude from loading. Useful in monorepos to skip irrelevant instructions from other teams. Patterns match against absolute file paths. Arrays merge across settings layers. Managed policy CLAUDE.md files cannot be excluded. See https://code.claude.com/docs/en/memory#exclude-specific-claude-md-files",
       "examples": [
         [
           "**/monorepo/CLAUDE.md",
@@ -239,8 +264,8 @@
     },
     "cleanupPeriodDays": {
       "type": "integer",
-      "minimum": 0,
-      "description": "Number of days to retain chat transcripts (0 to disable cleanup)",
+      "minimum": 1,
+      "description": "Number of days to retain sessions and orphaned subagent worktrees. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings",
       "examples": [20, 30, 60],
       "default": 30
     },
@@ -343,6 +368,11 @@
           "enum": ["disable"],
           "description": "Disable the ability to bypass permission prompts"
         },
+        "disableAutoMode": {
+          "type": "string",
+          "enum": ["disable"],
+          "description": "Set to \"disable\" to prevent auto mode from being activated. Removes `auto` from the Shift+Tab cycle and rejects `--permission-mode auto` at startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/permissions"
+        },
         "additionalDirectories": {
           "type": "array",
           "items": {
@@ -355,7 +385,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/settings#tools-available-to-claude for full list of tools available to Claude.",
+      "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
       "examples": [
         {
           "allow": ["Bash(git add:*)"],
@@ -396,8 +426,8 @@
     },
     "effortLevel": {
       "type": "string",
-      "enum": ["low", "medium", "high"],
-      "description": "Control Opus 4.6 adaptive reasoning effort. Lower effort is faster and cheaper for straightforward tasks, higher effort provides deeper reasoning. Defaults vary by model and plan (Opus 4.6 defaults to medium for Max and Team subscribers). Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
+      "enum": ["low", "medium", "high", "xhigh", "max"],
+      "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high, or medium on Pro and Max plans; Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
       "type": "boolean",
@@ -608,6 +638,13 @@
             "$ref": "#/$defs/hookMatcher"
           }
         },
+        "StopFailure": {
+          "type": "array",
+          "description": "Hooks that run when a turn ends due to an API error (e.g., rate_limit, authentication_failed, billing_error, invalid_request, server_error, max_output_tokens, unknown). Matcher can scope to specific error types. Hook output and exit code are ignored. See https://code.claude.com/docs/en/hooks",
+          "items": {
+            "$ref": "#/$defs/hookMatcher"
+          }
+        },
         "SubagentStart": {
           "type": "array",
           "description": "Hooks that run when a subagent is spawned",
@@ -733,6 +770,14 @@
       "type": "boolean",
       "description": "Disable all hooks and statusLine execution. When true in managed settings, user and project-level disableAllHooks cannot override it. See https://code.claude.com/docs/en/hooks#disable-or-remove-hooks"
     },
+    "allowedChannelPlugins": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "(Managed settings only) Allowlist of plugin IDs whose MCP servers may advertise channel notifications when channelsEnabled is true. When set, only the listed plugins can push inbound messages. See https://code.claude.com/docs/en/mcp"
+    },
     "allowedHttpHookUrls": {
       "type": "array",
       "items": {
@@ -765,6 +810,11 @@
         "padding": {
           "type": "number",
           "description": "Optional number of extra horizontal spacing characters added to the status line content; defaults to 0."
+        },
+        "refreshInterval": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Re-run the status line command every N seconds in addition to event-driven updates. Leave unset to run only on events. Useful for time-based data like clocks, or when background subagents change git state while the main session is idle. See https://code.claude.com/docs/en/statusline"
         }
       },
       "required": ["type", "command"],
@@ -1225,6 +1275,15 @@
             "allowManagedDomainsOnly": {
               "type": "boolean",
               "description": "(Managed settings only) Only allowedDomains and WebFetch(domain:...) allow rules from managed settings are respected. User, project, local, and flag settings domains are ignored. Denied domains are still respected from all sources. Non-allowed domains are automatically blocked without user prompts."
+            },
+            "allowMachLookup": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "macOS only. Additional XPC/Mach service names the sandbox may look up. Supports a single trailing * for prefix matching. Needed for tools that communicate via XPC such as the iOS Simulator or Playwright. See https://code.claude.com/docs/en/settings",
+              "examples": [["com.apple.coresimulator.*"]]
             }
           },
           "additionalProperties": false
@@ -1311,6 +1370,26 @@
             }
           },
           "additionalProperties": false
+        },
+        "ripgrep": {
+          "type": "object",
+          "description": "Custom ripgrep configuration for Claude Code's bundled ripgrep support. Overrides the bundled binary and arguments.",
+          "additionalProperties": false,
+          "required": ["command"],
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Path to the ripgrep binary to use",
+              "minLength": 1
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Additional arguments to pass to the ripgrep binary"
+            }
+          }
         }
       },
       "additionalProperties": false
@@ -1448,11 +1527,26 @@
               }
             },
             "description": "User configuration values for MCP servers keyed by server name"
+          },
+          "options": {
+            "type": "object",
+            "description": "Non-sensitive option values from the plugin manifest's userConfig, keyed by option name. Sensitive values go to secure storage instead. See https://code.claude.com/docs/en/plugins-reference",
+            "additionalProperties": {
+              "anyOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
       },
-      "description": "Per-plugin configuration including MCP server user configs, keyed by plugin ID (plugin@marketplace format). See https://code.claude.com/docs/en/plugins"
+      "description": "Per-plugin configuration including MCP server user configs and plugin options, keyed by plugin ID (plugin@marketplace format). See https://code.claude.com/docs/en/plugins"
     },
     "allowManagedMcpServersOnly": {
       "type": "boolean",
@@ -1616,6 +1710,113 @@
           }
         ]
       }
+    },
+    "agent": {
+      "type": "string",
+      "description": "Name of an agent (built-in or custom) to use for the main thread. Applies the agent's system prompt, tool restrictions, and model. See https://code.claude.com/docs/en/sub-agents",
+      "minLength": 1
+    },
+    "autoMemoryDirectory": {
+      "type": "string",
+      "description": "Custom directory path for auto-memory storage. Supports ~/ prefix for home-directory expansion. Ignored if set in checked-in project settings (.claude/settings.json) for security. Defaults to ~/.claude/projects/<sanitized-cwd>/memory/ when unset. See https://code.claude.com/docs/en/memory",
+      "minLength": 1
+    },
+    "autoMode": {
+      "type": "object",
+      "description": "Customization for the auto mode classifier prompt. Typically configured in managed settings to tune the allow/deny rules used when permissions.defaultMode is \"auto\". Note: allow and soft_deny REPLACE the default classifier rules entirely — review carefully. See https://code.claude.com/docs/en/permissions",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional rules appended to the auto mode classifier allow section"
+        },
+        "soft_deny": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional rules appended to the auto mode classifier soft-deny section"
+        },
+        "environment": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Environment entries appended to the auto mode classifier environment section"
+        }
+      }
+    },
+    "channelsEnabled": {
+      "type": "boolean",
+      "description": "(Teams/Enterprise) Opt-in for channel notifications — MCP servers with the claude/channel capability pushing inbound messages. Default off. When true, users can select servers via --channels. See https://code.claude.com/docs/en/mcp",
+      "default": false
+    },
+    "defaultShell": {
+      "type": "string",
+      "enum": ["bash", "powershell"],
+      "description": "Default shell for input-box ! commands. Default: bash. Using \"powershell\" routes ! commands through PowerShell on Windows and requires CLAUDE_CODE_USE_POWERSHELL_TOOL=1 with pwsh on PATH. See https://code.claude.com/docs/en/settings"
+    },
+    "disableDeepLinkRegistration": {
+      "type": "string",
+      "enum": ["disable"],
+      "description": "Set to \"disable\" to prevent Claude Code from registering the `claude://` deep-link protocol handler on startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings"
+    },
+    "disableSkillShellExecution": {
+      "type": "boolean",
+      "description": "Disable inline shell execution for `` !`...` `` and ` ```! ` blocks in skills and custom slash commands from user, project, plugin, or additional-directory sources. Commands are replaced with [shell command execution disabled by policy] instead of being run. Bundled and managed skills are not affected. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings"
+    },
+    "forceRemoteSettingsRefresh": {
+      "type": "boolean",
+      "description": "(Managed settings only) Block CLI startup until remote managed settings are freshly fetched from the server. If the fetch fails, the CLI exits (fail-closed) rather than continuing with cached settings. When not set, startup continues without waiting for remote settings. See https://code.claude.com/docs/en/server-managed-settings"
+    },
+    "minimumVersion": {
+      "type": "string",
+      "description": "Minimum Claude Code version to stay on. Prevents downgrades when switching release channels. See https://code.claude.com/docs/en/settings",
+      "examples": ["2.1.0"],
+      "minLength": 1
+    },
+    "showClearContextOnPlanAccept": {
+      "type": "boolean",
+      "description": "When true, the plan-approval dialog offers a \"clear context\" option. Defaults to false.",
+      "default": false
+    },
+    "showThinkingSummaries": {
+      "type": "boolean",
+      "description": "Show thinking summaries in the transcript view (Ctrl+O). Thinking summaries are not generated by default in interactive sessions; set to true to restore. See https://code.claude.com/docs/en/settings",
+      "default": false
+    },
+    "skipDangerousModePermissionPrompt": {
+      "type": "boolean",
+      "description": "Whether the user has accepted the bypass permissions mode dialog. Typically managed by the CLI rather than set by hand."
+    },
+    "strictPluginOnlyCustomization": {
+      "description": "(Managed settings) Block non-plugin customization sources for the listed surfaces. Array form locks specific surfaces (e.g., [\"skills\", \"hooks\"]); true locks all four; false is an explicit no-op. See https://code.claude.com/docs/en/plugins-reference",
+      "anyOf": [
+        { "type": "boolean" },
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["skills", "agents", "hooks", "mcp"]
+          }
+        }
+      ]
+    },
+    "tui": {
+      "type": "string",
+      "enum": ["fullscreen", "default"],
+      "description": "TUI rendering mode. Use \"fullscreen\" for the flicker-free alt-screen renderer with virtualized scrollback; \"default\" for the classic main-screen renderer. Corresponds to the /tui command. See https://code.claude.com/docs/en/settings"
+    },
+    "viewMode": {
+      "type": "string",
+      "enum": ["default", "verbose", "focus"],
+      "description": "Transcript view mode. \"default\" shows standard interactive view; \"verbose\" shows expanded tool details; \"focus\" shows prompt, one-line tool summaries, and final response only (Ctrl+O toggle). See https://code.claude.com/docs/en/settings"
+    },
+    "useAutoModeDuringPlan": {
+      "type": "boolean",
+      "description": "When true, apply the auto mode classifier during plan mode to auto-approve safe read-only tool calls while planning. Has no effect unless permissions.defaultMode allows auto. See https://code.claude.com/docs/en/permissions"
+    },
+    "voiceEnabled": {
+      "type": "boolean",
+      "description": "Enable push-to-talk voice dictation. Typically written automatically when /voice is used. Requires a Claude.ai account. See https://code.claude.com/docs/en/settings"
     }
   },
   "title": "Claude Code Settings"

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -1280,6 +1280,14 @@
               },
               "description": "Allowlist of network domains for sandboxed commands. Supports wildcard patterns like *.example.com"
             },
+            "deniedDomains": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": "Blocklist of network domains for sandboxed commands. Blocks specific domains even when a broader allowedDomains wildcard would otherwise permit them. Supports wildcard patterns like *.example.com. See https://code.claude.com/docs/en/sandboxing"
+            },
             "allowManagedDomainsOnly": {
               "type": "boolean",
               "description": "(Managed settings only) Only allowedDomains and WebFetch(domain:...) allow rules from managed settings are respected. User, project, local, and flag settings domains are ignored. Denied domains are still respected from all sources. Non-allowed domains are automatically blocked without user prompts."

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -187,6 +187,47 @@
               "description": "Custom spinner message displayed while the hook runs"
             }
           }
+        },
+        {
+          "type": "object",
+          "description": "MCP tool hook. Call a tool on an already-connected MCP server. See https://code.claude.com/docs/en/hooks#mcp-tool-hook-fields",
+          "additionalProperties": false,
+          "required": ["type", "server", "tool"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Hook type",
+              "const": "mcp_tool"
+            },
+            "server": {
+              "type": "string",
+              "description": "Name of a configured MCP server (must already be connected)",
+              "minLength": 1
+            },
+            "tool": {
+              "type": "string",
+              "description": "Name of the tool to call on that server",
+              "minLength": 1
+            },
+            "input": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Arguments passed to the tool. String values support ${path} substitution from hook JSON input (e.g., ${tool_input.file_path}, ${cwd})"
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Optional timeout in seconds (default: 60)",
+              "exclusiveMinimum": 0
+            },
+            "if": {
+              "type": "string",
+              "description": "Optional permission-rule-syntax filter. Evaluated only on tool-related events (PreToolUse, PostToolUse, PostToolUseFailure, PermissionRequest, PermissionDenied); on other events a hook with `if` set never runs. See https://code.claude.com/docs/en/hooks-guide#filter-hooks-with-matchers"
+            },
+            "statusMessage": {
+              "type": "string",
+              "description": "Custom spinner message displayed while the hook runs"
+            }
+          }
         }
       ]
     },
@@ -233,7 +274,7 @@
     "autoUpdatesChannel": {
       "type": "string",
       "enum": ["stable", "latest"],
-      "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release. Set DISABLE_AUTOUPDATER=1 to disable updates entirely.",
+      "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release. Set DISABLE_AUTOUPDATER=1 to disable background auto-updates, or DISABLE_UPDATES=1 (added in v2.1.118) to block all update paths including manual `claude update`.",
       "default": "latest"
     },
     "awsCredentialExport": {
@@ -265,7 +306,7 @@
     "cleanupPeriodDays": {
       "type": "integer",
       "minimum": 1,
-      "description": "Number of days to retain sessions and orphaned subagent worktrees. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings",
+      "description": "Number of days to retain sessions, orphaned subagent worktrees, tasks, shell snapshots, and backups. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings",
       "examples": [20, 30, 60],
       "default": 30
     },
@@ -427,7 +468,7 @@
     "effortLevel": {
       "type": "string",
       "enum": ["low", "medium", "high", "xhigh", "max"],
-      "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high, or medium on Pro and Max plans; Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
+      "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high on all plans (Pro/Max raised from medium to high in v2.1.117); Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
       "type": "boolean",
@@ -1474,6 +1515,11 @@
       "description": "Reduce or disable UI animations (spinners, shimmer, flash effects) for accessibility",
       "default": false
     },
+    "prUrlTemplate": {
+      "type": "string",
+      "description": "URL template for the PR badge shown in the footer and in tool-result summaries. Substitutes placeholders {host}, {owner}, {repo}, {number}, {url} from the gh-reported PR URL. Use this to point PR links at an internal code-review tool instead of github.com. Does not affect #123 autolinks in Claude's prose. See https://code.claude.com/docs/en/settings",
+      "examples": ["https://reviews.example.com/{owner}/{repo}/pull/{number}"]
+    },
     "alwaysThinkingEnabled": {
       "type": "boolean",
       "description": "Enable extended thinking by default for all sessions. Typically configured via the /config command rather than editing directly. See https://code.claude.com/docs/en/common-workflows#use-extended-thinking-thinking-mode"
@@ -1739,23 +1785,23 @@
     },
     "autoMode": {
       "type": "object",
-      "description": "Customization for the auto mode classifier prompt. Typically configured in managed settings to tune the allow/deny rules used when permissions.defaultMode is \"auto\". Note: allow and soft_deny REPLACE the default classifier rules entirely — review carefully. See https://code.claude.com/docs/en/permissions",
+      "description": "Customization for the auto mode classifier prompt. Typically configured in managed settings to tune the allow/deny rules used when permissions.defaultMode is \"auto\". By default, allow, soft_deny, and environment REPLACE the corresponding built-in classifier section entirely. Include the literal string \"$defaults\" as an array entry (added in v2.1.118) to splice the built-in defaults in at that position alongside your custom rules. See https://code.claude.com/docs/en/permissions",
       "additionalProperties": false,
       "properties": {
         "allow": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Additional rules appended to the auto mode classifier allow section"
+          "description": "Rules for the auto mode classifier allow section. Replaces the built-in allow rules entirely unless the literal string \"$defaults\" is included as an entry, which splices the built-in defaults in at that position."
         },
         "soft_deny": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Additional rules appended to the auto mode classifier soft-deny section"
+          "description": "Rules for the auto mode classifier soft-deny section. Replaces the built-in soft-deny rules entirely unless the literal string \"$defaults\" is included as an entry, which splices the built-in defaults in at that position."
         },
         "environment": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Environment entries appended to the auto mode classifier environment section"
+          "description": "Entries for the auto mode classifier environment section. Replaces the built-in environment context entirely unless the literal string \"$defaults\" is included as an entry, which splices the built-in defaults in at that position."
         }
       }
     },
@@ -1833,6 +1879,10 @@
     "voiceEnabled": {
       "type": "boolean",
       "description": "Enable push-to-talk voice dictation. Typically written automatically when /voice is used. Requires a Claude.ai account. See https://code.claude.com/docs/en/settings"
+    },
+    "wslInheritsWindowsSettings": {
+      "type": "boolean",
+      "description": "(Windows managed settings only) When true, Claude Code on WSL reads managed settings from the Windows policy chain in addition to /etc/claude-code, with Windows sources taking priority. Only honored when set in the HKLM registry key or C:\\Program Files\\ClaudeCode\\managed-settings.json, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows. See https://code.claude.com/docs/en/settings"
     }
   },
   "title": "Claude Code Settings"

--- a/src/test/claude-code-settings/complete-config.json
+++ b/src/test/claude-code-settings/complete-config.json
@@ -1,6 +1,7 @@
 {
   "apiKeyHelper": "/usr/local/bin/claude-auth",
   "cleanupPeriodDays": 30,
+  "effortLevel": "medium",
   "env": {
     "DEBUG_MODE": "true",
     "EDITOR": "vim"
@@ -22,5 +23,6 @@
       "Bash(wget:*)",
       "WebFetch(domain:bad.actor.com)"
     ]
-  }
+  },
+  "viewMode": "default"
 }

--- a/src/test/claude-code-settings/edge-cases.json
+++ b/src/test/claude-code-settings/edge-cases.json
@@ -1,6 +1,6 @@
 {
   "autoUpdatesChannel": "stable",
-  "cleanupPeriodDays": 0,
+  "cleanupPeriodDays": 1,
   "effortLevel": "low",
   "env": {},
   "fastMode": false,

--- a/src/test/claude-code-settings/enum-coverage.json
+++ b/src/test/claude-code-settings/enum-coverage.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "channelsEnabled": false,
+  "defaultShell": "bash",
+  "effortLevel": "xhigh",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "echo bash",
+            "shell": "bash",
+            "type": "command"
+          },
+          {
+            "command": "Get-Content",
+            "shell": "powershell",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ]
+  },
+  "terminalTitleFromRename": true,
+  "tui": "fullscreen",
+  "viewMode": "verbose"
+}

--- a/src/test/claude-code-settings/hooks-complete.json
+++ b/src/test/claude-code-settings/hooks-complete.json
@@ -90,6 +90,16 @@
             "command": "git diff",
             "statusMessage": "Reviewing changes",
             "type": "command"
+          },
+          {
+            "input": {
+              "file": "${tool_input.file_path}"
+            },
+            "server": "linter",
+            "statusMessage": "Linting edited file",
+            "timeout": 30,
+            "tool": "lint_file",
+            "type": "mcp_tool"
           }
         ],
         "matcher": "Edit"

--- a/src/test/claude-code-settings/managed-settings.json
+++ b/src/test/claude-code-settings/managed-settings.json
@@ -50,5 +50,6 @@
       "allowedDomains": ["*.company.com", "registry.npmjs.org"],
       "deniedDomains": ["blocked.example.com"]
     }
-  }
+  },
+  "wslInheritsWindowsSettings": true
 }

--- a/src/test/claude-code-settings/managed-settings.json
+++ b/src/test/claude-code-settings/managed-settings.json
@@ -47,7 +47,8 @@
     "enabled": true,
     "network": {
       "allowManagedDomainsOnly": true,
-      "allowedDomains": ["*.company.com", "registry.npmjs.org"]
+      "allowedDomains": ["*.company.com", "registry.npmjs.org"],
+      "deniedDomains": ["blocked.example.com"]
     }
   }
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -14,9 +14,9 @@
   "autoMemoryDirectory": "~/.claude/custom-memory",
   "autoMemoryEnabled": false,
   "autoMode": {
-    "allow": ["All read-only operations"],
-    "environment": ["WSL2 on Windows"],
-    "soft_deny": ["Deleting files"]
+    "allow": ["$defaults", "All read-only operations"],
+    "environment": ["$defaults", "WSL2 on Windows"],
+    "soft_deny": ["$defaults", "Deleting files"]
   },
   "autoUpdatesChannel": "latest",
   "availableModels": ["sonnet", "haiku"],
@@ -121,6 +121,14 @@
             "if": "Write(**/*.py)",
             "shell": "bash",
             "type": "command"
+          },
+          {
+            "input": {
+              "file": "${tool_input.file_path}"
+            },
+            "server": "linter",
+            "tool": "lint_file",
+            "type": "mcp_tool"
           }
         ],
         "matcher": "Write"
@@ -231,6 +239,7 @@
     }
   },
   "pluginTrustMessage": "All plugins from our internal marketplace are pre-approved by the security team.",
+  "prUrlTemplate": "https://reviews.example.com/{owner}/{repo}/pull/{number}",
   "prefersReducedMotion": true,
   "respectGitignore": false,
   "sandbox": {
@@ -294,5 +303,6 @@
   "voiceEnabled": true,
   "worktree": {
     "sparsePaths": ["packages/my-app", "shared/utils"]
-  }
+  },
+  "wslInheritsWindowsSettings": false
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "agent": "code-reviewer",
   "allowManagedHooksOnly": false,
   "allowManagedPermissionRulesOnly": false,
+  "allowedChannelPlugins": ["internal-notifier@corp"],
   "allowedHttpHookUrls": ["https://hooks.example.com/*", "http://localhost:*"],
   "alwaysThinkingEnabled": false,
   "apiKeyHelper": "/usr/local/bin/claude-auth-helper",
@@ -9,7 +11,13 @@
     "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
     "pr": ""
   },
+  "autoMemoryDirectory": "~/.claude/custom-memory",
   "autoMemoryEnabled": false,
+  "autoMode": {
+    "allow": ["All read-only operations"],
+    "environment": ["WSL2 on Windows"],
+    "soft_deny": ["Deleting files"]
+  },
   "autoUpdatesChannel": "latest",
   "availableModels": ["sonnet", "haiku"],
   "awsAuthRefresh": "aws sso login --profile myprofile",
@@ -20,15 +28,19 @@
       "source": "pathPattern"
     }
   ],
+  "channelsEnabled": true,
   "claudeMdExcludes": [
     "**/other-team/CLAUDE.md",
     "/home/user/monorepo/.claude/rules/**"
   ],
   "cleanupPeriodDays": 60,
   "companyAnnouncements": ["Welcome to the team!"],
+  "defaultShell": "powershell",
   "disableAllHooks": false,
+  "disableDeepLinkRegistration": "disable",
+  "disableSkillShellExecution": false,
   "disabledMcpjsonServers": ["untrusted-server"],
-  "effortLevel": "medium",
+  "effortLevel": "max",
   "enableAllProjectMcpServers": true,
   "enabledPlugins": {
     "formatter@anthropic-tools": true
@@ -56,6 +68,7 @@
   },
   "forceLoginMethod": "console",
   "forceLoginOrgUUID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "forceRemoteSettingsRefresh": false,
   "hooks": {
     "ConfigChange": [
       {
@@ -103,7 +116,10 @@
       {
         "hooks": [
           {
+            "asyncRewake": true,
             "command": "echo 'File write detected' >> ~/.claude-code/activity.log",
+            "if": "Write(**/*.py)",
+            "shell": "bash",
             "type": "command"
           }
         ],
@@ -127,6 +143,16 @@
             "timeout": 10,
             "type": "http",
             "url": "https://hooks.example.com/session-end"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "command": "echo 'Stop failed' >> ~/.claude-code/errors.log",
+            "type": "command"
           }
         ]
       }
@@ -156,6 +182,7 @@
   "includeCoAuthoredBy": true,
   "includeGitInstructions": false,
   "language": "english",
+  "minimumVersion": "2.1.0",
   "model": "opus",
   "modelOverrides": {
     "claude-opus-4-6": "arn:aws:bedrock:us-east-2:123456789012:application-inference-profile/opus-prod"
@@ -186,7 +213,8 @@
       "Bash(rm -rf:*)",
       "Write(/etc/**)",
       "Write(/System/**)"
-    ]
+    ],
+    "disableAutoMode": "disable"
   },
   "plansDirectory": "./plans",
   "pluginConfigs": {
@@ -195,6 +223,10 @@
         "formatter": {
           "autoFormat": "true"
         }
+      },
+      "options": {
+        "lineWidth": 80,
+        "useTabs": false
       }
     }
   },
@@ -209,6 +241,8 @@
     "enabled": true,
     "excludedCommands": ["docker", "git"],
     "filesystem": {
+      "allowManagedReadPathsOnly": false,
+      "allowRead": ["~/.ssh/known_hosts"],
       "allowWrite": ["~/.kube", "//tmp/build"],
       "denyRead": ["~/.ssh/id_rsa"],
       "denyWrite": ["//etc", "//usr"]
@@ -216,14 +250,22 @@
     "network": {
       "allowAllUnixSockets": false,
       "allowLocalBinding": true,
+      "allowMachLookup": ["com.apple.coresimulator.*"],
       "allowManagedDomainsOnly": true,
       "allowUnixSockets": ["/var/run/docker.sock"],
       "allowedDomains": ["github.com", "*.npmjs.org", "registry.yarnpkg.com"],
       "httpProxyPort": 8080,
       "socksProxyPort": 8081
+    },
+    "ripgrep": {
+      "args": ["--hidden"],
+      "command": "/usr/bin/rg"
     }
   },
+  "showClearContextOnPlanAccept": true,
+  "showThinkingSummaries": true,
   "showTurnDuration": false,
+  "skipDangerousModePermissionPrompt": true,
   "skipWebFetchPreflight": false,
   "skippedMarketplaces": ["untrusted-marketplace"],
   "skippedPlugins": ["risky-plugin@unknown-marketplace"],
@@ -239,10 +281,16 @@
   "statusLine": {
     "command": "~/.claude/statusline.sh",
     "padding": 1,
+    "refreshInterval": 5,
     "type": "command"
   },
+  "strictPluginOnlyCustomization": ["skills", "hooks"],
   "teammateMode": "tmux",
   "terminalProgressBarEnabled": false,
+  "tui": "default",
+  "useAutoModeDuringPlan": true,
+  "viewMode": "focus",
+  "voiceEnabled": true,
   "worktree": {
     "sparsePaths": ["packages/my-app", "shared/utils"]
   }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -254,6 +254,7 @@
       "allowManagedDomainsOnly": true,
       "allowUnixSockets": ["/var/run/docker.sock"],
       "allowedDomains": ["github.com", "*.npmjs.org", "registry.yarnpkg.com"],
+      "deniedDomains": ["ads.example.com", "*.tracker.com"],
       "httpProxyPort": 8080,
       "socksProxyPort": 8081
     },


### PR DESCRIPTION
Supersedes #5585. Bundles v2.1.112 baseline plus subsequent v2.1.113–v2.1.119 changes into a single PR.

## Schema

- Bring `claude-code-settings.json` to Claude Code [v2.1.112](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21112) baseline (subsumes #5585).
- Add `sandbox.network.deniedDomains` array property; blocks specific domains even when broader `allowedDomains` wildcard would permit them ([v2.1.113](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21113), [sandboxing docs](https://code.claude.com/docs/en/sandboxing)).
- Update `effortLevel` description: Pro/Max default on Opus 4.6 and Sonnet 4.6 raised from `medium` to `high` ([v2.1.117](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21117), [model-config docs](https://code.claude.com/docs/en/model-config#adjust-effort-level)).
- Update `cleanupPeriodDays` description: scope expanded to cover `~/.claude/tasks/`, `~/.claude/shell-snapshots/`, and `~/.claude/backups/` ([v2.1.117](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21117)).
- Update `autoUpdatesChannel` description: reference `DISABLE_UPDATES=1` env var for blocking all update paths including manual `claude update` ([v2.1.118](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21118)).
- Update `autoMode` (and child `allow`/`soft_deny`/`environment`) descriptions: document the literal `"$defaults"` sentinel for splicing built-in classifier rules in at that array position alongside custom rules ([v2.1.118](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21118), [permissions docs](https://code.claude.com/docs/en/permissions)).
- Add `mcp_tool` hook handler variant in `\$defs.hookCommand` for direct MCP-tool invocation from hooks ([v2.1.118](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21118), [hooks docs](https://code.claude.com/docs/en/hooks#mcp-tool-hook-fields)).
- Add `prUrlTemplate` top-level string for routing the footer PR badge to a custom code-review URL with placeholders `{host}/{owner}/{repo}/{number}/{url}` ([v2.1.119](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21119), [settings docs](https://code.claude.com/docs/en/settings)).
- Add `wslInheritsWindowsSettings` managed-only boolean for WSL inheriting Windows-side managed settings ([v2.1.118](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21118), [settings docs](https://code.claude.com/docs/en/settings)).

## Tests

- `modern-complete-config.json`: add `sandbox.network.deniedDomains`, `prUrlTemplate`, `wslInheritsWindowsSettings`; demonstrate `\"\$defaults\"` token in `autoMode.allow`/`soft_deny`/`environment`; add `mcp_tool` hook example under `PreToolUse`.
- `managed-settings.json`: add `sandbox.network.deniedDomains` and `wslInheritsWindowsSettings: true` to reflect managed-only context.
- `hooks-complete.json`: add `mcp_tool` hook example with `input`/`server`/`tool`/`timeout`/`statusMessage` under `PostToolUse`.

## Negative tests

- `wrong-property-types.json`: add `deniedDomains: \"should-be-array\"` (array type violation).
- `missing-required-hook-fields.json`: add `mcp_tool` entry missing required `server` field.

## Skipped

- v2.1.117 env vars `CLAUDE_CODE_FORK_SUBAGENT` and `OTEL_LOG_TOOL_DETAILS` — env-only with no corresponding settings.json property; verified via documentation. Schema does not enumerate every env var, only those mapping to settings properties.
- v2.1.119 env vars `CLAUDE_CODE_HIDE_CWD` and `ENABLE_TOOL_SEARCH` — same reasoning.
- v2.1.117 `/model` selection persistence to `.claude/settings.local.json` — runtime auto-write behavior, not a schema contract change.
- v2.1.117 native `bfs`/`ugrep` replacements for Glob/Grep on macOS/Linux — implementation detail; tool names and invocation surface unchanged.
- v2.1.119 hook input field `duration_ms` for PostToolUse / PostToolUseFailure — runtime hook *input* JSON, not a settings.json field.
- v2.1.119 status-line stdin additions (`effort.level`, `thinking.enabled`) — runtime input passed to status-line script, not a schema field.