### PR TITLE
Add Expoot app config to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2791,6 +2791,12 @@
       "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
     },
     {
+      "name": "Expoot app config",
+      "description": "The config for creating a React Native Desktop app with best-effort Expo support, used by the create-expoot CLI",
+      "fileMatch": ["expoot-app.json"],
+      "url": "https://raw.githubusercontent.com/shirakaba/expoot/main/packages/create-expoot/schemas/app-config.json"
+    },
+    {
       "name": "EasyVCR .NET",
       "description": "EasyVCR .NET recording file",
       "fileMatch": ["*.easyvcr", "**/cassettes/*.json"],


### PR DESCRIPTION
This PR adds the schema for the `expoot-app.json` file, used by the (work in progress) [Expoot](https://github.com/shirakaba/expoot) `create-expoot` CLI, a tool for creating React Native Desktop apps with best-effort support for Expo.

- The schema itself: [expoot-app.schema.json](https://github.com/shirakaba/expoot/blob/ce113873b00502c57d8abe6d1258df29a94a6901/packages/create-expoot/schemas/expoot-app.schema.json)
- The ArkType definition: [app-config.ts](https://github.com/shirakaba/expoot/blob/8991f404c3059bb25d974f7d43bc508eb229e1f4/packages/create-expoot/src/app-config.ts)
- The script to generate the schema from that ArkType definition via [toJsonSchema()](https://arktype.io/docs/configuration#tojsonschema): [update-schema.ts](https://github.com/shirakaba/expoot/blob/8991f404c3059bb25d974f7d43bc508eb229e1f4/packages/create-expoot/scripts/update-schema.ts)

Thanks!