### PR TITLE
Update prek's schema to 0.3.11

### DIFF
--- a/src/schemas/json/prek.json
+++ b/src/schemas/json/prek.json
@@ -276,6 +276,10 @@
           "description": "Write the output of the hook to a file when the hook fails or verbose is enabled.",
           "type": "string"
         },
+        "shell": {
+          "$ref": "#/definitions/Shell",
+          "description": "Run the hook entry through a predefined shell adapter."
+        },
         "require_serial": {
           "description": "This hook will execute using a single process instead of in parallel.\nDefault is false.",
           "type": "boolean"
@@ -369,6 +373,11 @@
           "exclusiveMinimum": 0
         }
       ]
+    },
+    "Shell": {
+      "description": "A predefined shell adapter used to run hook entries as shell source.",
+      "type": "string",
+      "enum": ["sh", "bash", "pwsh", "powershell", "cmd"]
     },
     "Stage": {
       "type": "string",
@@ -510,6 +519,10 @@
         "log_file": {
           "description": "Write the output of the hook to a file when the hook fails or verbose is enabled.",
           "type": "string"
+        },
+        "shell": {
+          "$ref": "#/definitions/Shell",
+          "description": "Run the hook entry through a predefined shell adapter."
         },
         "require_serial": {
           "description": "This hook will execute using a single process instead of in parallel.\nDefault is false.",
@@ -659,6 +672,10 @@
         "log_file": {
           "description": "Write the output of the hook to a file when the hook fails or verbose is enabled.",
           "type": "string"
+        },
+        "shell": {
+          "$ref": "#/definitions/Shell",
+          "description": "Run the hook entry through a predefined shell adapter."
         },
         "require_serial": {
           "description": "This hook will execute using a single process instead of in parallel.\nDefault is false.",
@@ -812,6 +829,10 @@
         "log_file": {
           "description": "Write the output of the hook to a file when the hook fails or verbose is enabled.",
           "type": "string"
+        },
+        "shell": {
+          "$ref": "#/definitions/Shell",
+          "description": "Run the hook entry through a predefined shell adapter."
         },
         "require_serial": {
           "description": "This hook will execute using a single process instead of in parallel.\nDefault is false.",


### PR DESCRIPTION
Update prek's schema to 0.3.11 to include the new `shell` hook options.