### PR TITLE
update vhwdebugger-binding-schema to 1.0.100

### DIFF
--- a/src/negative_test/vhwdebugger-binding-schema/isystem_with_tasking_key.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/isystem_with_tasking_key.vhwdebugger-binding.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  MyDebugger1:
+    type: isystem
+    node: localhost
+    port: 1234
+    tasking:
+      disable-winidea-polling: true

--- a/src/negative_test/vhwdebugger-binding-schema/segger_just_port.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/segger_just_port.vhwdebugger-binding.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  debugger1:
+    type: segger-jlink
+    port: 1234
+    segger-jlink:
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD

--- a/src/negative_test/vhwdebugger-binding-schema/segger_node_and_serial.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/segger_node_and_serial.vhwdebugger-binding.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  debugger1:
+    type: segger-jlink
+    node: localhost
+    segger-jlink:
+      serial-number: '852012345'
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD

--- a/src/negative_test/vhwdebugger-binding-schema/segger_node_port_and_serial.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/segger_node_port_and_serial.vhwdebugger-binding.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  debugger1:
+    type: segger-jlink
+    node: localhost
+    port: 1234
+    segger-jlink:
+      serial-number: '852012345'
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD

--- a/src/negative_test/vhwdebugger-binding-schema/segger_port_and_serial.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/segger_port_and_serial.vhwdebugger-binding.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  debugger1:
+    type: segger-jlink
+    port: 1234
+    segger-jlink:
+      serial-number: '852012345'
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD

--- a/src/negative_test/vhwdebugger-binding-schema/tasking_with_isystem_key.vhwdebugger-binding.yaml
+++ b/src/negative_test/vhwdebugger-binding-schema/tasking_with_isystem_key.vhwdebugger-binding.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+debuggers:
+  MyDebugger1:
+    type: tasking
+    node: localhost
+    port: 1234
+    isystem:
+      disable-winidea-polling: true

--- a/src/schemas/json/vhwdebugger-binding-schema.json
+++ b/src/schemas/json/vhwdebugger-binding-schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/vhwdebugger-binding-schema.json",
-  "$ref": "#/definitions/7d459/full",
-  "title": "Vector CANoe Hardware Debugger Binding Configuration Schema",
+  "$ref": "#/definitions/20a6a/full",
   "type": "object",
+  "title": "Vector CANoe Hardware Debugger Binding Configuration Schema",
   "definitions": {
     "b06cc": {
       "full": {
@@ -490,7 +490,7 @@
         }
       }
     },
-    "7d459": {
+    "20a6a": {
       "full": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Vector CANoe Hardware Debugger Binding Configuration Schema",
@@ -498,12 +498,701 @@
         "type": "object",
         "oneOf": [
           {
+            "$ref": "#/definitions/0cfa1/full"
+          },
+          {
             "$ref": "#/definitions/b06cc/full"
           },
           {
             "$ref": "#/definitions/a8e9a/full"
           }
         ]
+      }
+    },
+    "0cfa1": {
+      "full": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "title": "Debugger Configuration Version 1.2",
+        "description": "Debugger configuration for the Vector CANoe hardware debugger binding (version 1.2)",
+        "additionalProperties": false,
+        "required": ["version", "debuggers"],
+        "properties": {
+          "version": {
+            "title": "Version",
+            "description": "The version of the configuration. Controls what features are available",
+            "type": "string",
+            "const": "1.2"
+          },
+          "default-debugger": {
+            "title": "Default Debugger",
+            "description": "The default debugger if a distributed object is not assigned explicitly. Must reference an element from the `debuggers` list",
+            "type": "string",
+            "pattern": "^[-_a-zA-Z0-9]+$"
+          },
+          "debuggers": {
+            "title": "Debugger Configurations",
+            "description": "List of all configured debuggers. The elements' key determines the name of the debugger",
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "patternProperties": {
+              "^[-_a-zA-Z0-9]+$": {
+                "oneOf": [
+                  {
+                    "title": "Debugger Configuration (Lauterbach)",
+                    "description": "Debugger Configuration for TRACE32 (Lauterbach)",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "node", "port"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "lauterbach"
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the TRACE32 instance on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "node": {
+                        "title": "Node Address",
+                        "description": "The IP address of the node where the TRACE32 instance is running",
+                        "type": "string",
+                        "examples": ["localhost", "192.168.0.1"]
+                      },
+                      "port": {
+                        "title": "Node Port",
+                        "description": "The port on which the TRACE32 instance is listening.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "examples": [5315, 20000]
+                      },
+                      "lauterbach": {
+                        "title": "Lauterbach TRACE32 Settings",
+                        "description": "Debugger specific settings for TRACE32 (Lauterbach)",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "pack-len": {
+                            "title": "TRACE32 Package Length",
+                            "description": "The UDP package length. Must match the package length configured for the TRACE32 instance",
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1024,
+                            "default": 1024
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "lauterbach",
+                        "node": "localhost",
+                        "port": 20000
+                      },
+                      {
+                        "type": "lauterbach",
+                        "node": "localhost",
+                        "port": 20000,
+                        "run": true,
+                        "reset": true,
+                        "lauterbach": {
+                          "pack-len": 512
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "$comment": "DO NOT ADD NEW FIELDS TO, OR EXTEND EXISTING FIELDS OF THIS ENTRY. This entry is deprecated.",
+                    "title": "DEPRECATED Debugger Configuration (iSYSTEM)",
+                    "description": "DEPRECATED Debugger Configuration for winIDEA (iSYSTEM). Replaced by the 'Debugger Configuration (TASKING winIDEA)''.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "node", "port"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "isystem"
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the winIDEA instance on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "node": {
+                        "title": "Node Address",
+                        "description": "The IP address of the node where the winIDEA instance is running",
+                        "type": "string",
+                        "examples": ["localhost", "192.168.0.1"]
+                      },
+                      "port": {
+                        "title": "Node Port",
+                        "description": "The port on which the winIDEA instance is listening.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "examples": [5315, 20000]
+                      },
+                      "isystem": {
+                        "title": "iSYSTEM winIDEA Settings",
+                        "description": "Debugger specific settings for winIDEA (iSYSTEM)",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "disable-winidea-polling": {
+                            "title": "Disable winIDEA GUI Polling",
+                            "description": "Disables the polling of the winIDEA GUI. When set to `true`, it can reduce jitter when communicating with the SIL Adapter on the target. Makes interactive work with the GUI not possible",
+                            "type": "boolean",
+                            "default": false
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "isystem",
+                        "node": "localhost",
+                        "port": 5315
+                      },
+                      {
+                        "type": "isystem",
+                        "node": "localhost",
+                        "port": 5315,
+                        "run": true,
+                        "reset": true,
+                        "isystem": {
+                          "disable-winidea-polling": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Debugger Configuration (TASKING winIDEA)",
+                    "description": "Debugger Configuration for TASKING winIDEA",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "node", "port"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "tasking"
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the winIDEA instance on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "node": {
+                        "title": "Node Address",
+                        "description": "The IP address of the node where the winIDEA instance is running",
+                        "type": "string",
+                        "examples": ["localhost", "192.168.0.1"]
+                      },
+                      "port": {
+                        "title": "Node Port",
+                        "description": "The port on which the winIDEA instance is listening.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "examples": [5315, 20000]
+                      },
+                      "tasking": {
+                        "title": "TASKING winIDEA Settings",
+                        "description": "Debugger specific settings for TASKING winIDEA",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "disable-winidea-polling": {
+                            "title": "Disable winIDEA GUI Polling",
+                            "description": "Disables the polling of the winIDEA GUI. When set to `true`, it can reduce jitter when communicating with the SIL Adapter on the target. Makes interactive work with the GUI not possible",
+                            "type": "boolean",
+                            "default": false
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "tasking",
+                        "node": "localhost",
+                        "port": 5315
+                      },
+                      {
+                        "type": "tasking",
+                        "node": "localhost",
+                        "port": 5315,
+                        "run": true,
+                        "reset": true,
+                        "tasking": {
+                          "disable-winidea-polling": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Debugger Configuration (GDB)",
+                    "description": "Debugger Configuration for GDB",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "node", "port", "run", "gdb"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "gdb"
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must always be true for GDB",
+                        "type": "boolean",
+                        "const": true
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the GDB server on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "node": {
+                        "title": "Node Address",
+                        "description": "The IP address of the node where the GDB server is running",
+                        "type": "string",
+                        "examples": ["localhost", "192.168.0.1"]
+                      },
+                      "port": {
+                        "title": "Node Port",
+                        "description": "The port on which the GDB server is listening.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "examples": [5315, 20000]
+                      },
+                      "gdb": {
+                        "title": "GDB Settings",
+                        "description": "Debugger specific settings for GDB",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "path-to-gdb-client",
+                          "path-to-symbol-file"
+                        ],
+                        "properties": {
+                          "path-to-gdb-client": {
+                            "title": "GDB Client",
+                            "description": "Absolute or relative path to the GDB client, which shall be used by CANoe. Path is relative to this configuration file. This is usually supplied with the compiler toolset",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": [
+                              "gdb.exe",
+                              "C:/Program Files (x86)/Arm GNU Toolchain arm-none-eabi/bin/arm-none-eabi-gdb.exe"
+                            ]
+                          },
+                          "path-to-symbol-file": {
+                            "title": "GDB Symbol File",
+                            "description": "Absolute or relative path to the symbol file, which shall be used by GDB. Path is relative to this configuration file. Symbol file must match to the binary running on the target",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": ["MyBinary.elf", "MyBinarySymbols.elf"]
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "gdb",
+                        "node": "localhost",
+                        "port": 1234,
+                        "run": true,
+                        "gdb": {
+                          "path-to-gdb-client": "path/to/gdb.exe",
+                          "path-to-symbol-file": "path/to/Symbols.elf"
+                        }
+                      },
+                      {
+                        "type": "gdb",
+                        "node": "localhost",
+                        "port": 1234,
+                        "run": true,
+                        "reset": true,
+                        "gdb": {
+                          "path-to-gdb-client": "path/to/gdb.exe",
+                          "path-to-symbol-file": "path/to/Symbols.elf"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Debugger Configuration (SEGGER J-Link over TCP/IP)",
+                    "description": "Debugger Configuration for SEGGER J-Link over TCP/IP",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "node", "segger-jlink"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "segger-jlink"
+                      },
+                      "node": {
+                        "title": "Debugger Address",
+                        "description": "The hostname or IP address of the SEGGER J-Link debugger.",
+                        "type": "string",
+                        "examples": [
+                          "jlink-pro.debuggers.example.com",
+                          "192.168.0.1",
+                          "852012345"
+                        ]
+                      },
+                      "port": {
+                        "title": "Debugger Port",
+                        "description": "The port on which the SEGGER J-Link is listening. Using value 0 will use the default port.",
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "default": 0,
+                        "examples": [19020]
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the SEGGER J-Link instance on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "segger-jlink": {
+                        "title": "SEGGER J-Link Settings",
+                        "description": "Debugger specific settings for SEGGER J-Link",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "path-to-symbol-file",
+                          "device",
+                          "target-interface"
+                        ],
+                        "properties": {
+                          "path-to-symbol-file": {
+                            "title": "Symbol File",
+                            "description": "Absolute or relative path to the symbol file. Path is relative to this configuration file. Symbol file must match to the binary running on the target.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": ["MyBinary.elf", "MyBinarySymbols.elf"]
+                          },
+                          "device": {
+                            "title": "Device",
+                            "description": "The device name of the target as specified by the list of supported devices on the SEGGER website. The device will be selected by executing the `device = ...` Command String. See [Supported Devices](https://www.segger.com/supported-devices) for more.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": ["RP2040_M0_0", "STM32H723VE"]
+                          },
+                          "target-interface": {
+                            "title": "Target Interface",
+                            "description": "The target interface the SEGGER J-Link will use to connect to the device.",
+                            "type": "string",
+                            "oneOf": [
+                              {
+                                "const": "SWD",
+                                "title": "SWD Target Interface",
+                                "description": "Instructs the debugger to use the Serial Wire Debug (SWD) interface to connect to the device."
+                              },
+                              {
+                                "const": "JTAG",
+                                "title": "JTAG Target Interface",
+                                "description": "Instructs the debugger to use the Joint Test Action Group (JTAG) interface to connect to the device."
+                              }
+                            ]
+                          },
+                          "speed": {
+                            "title": "Target Interface Speed",
+                            "description": "The speed at which the SEGGER J-Link will connect to the device over the target interface in kHz. The value 0 will instruct the SEGGER J-Link to autodetect the speed. The value 65535 will instruct the SEGGER J-Link to use adaptive clocking.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "default": 0,
+                            "examples": [2000, 4000]
+                          },
+                          "jlink-dll-path": {
+                            "title": "Path to the JLinkARM.dll or JLink_x64.dll",
+                            "description": "Absolute or relative path to the DLL file. Path is relative to this configuration file. If not present, an attempt to automatically find an installed JLink DLL is made. The bitness (32 / 64) of the selected DLL must match the runtime kernel bitness, otherwise loading the DLL will fail.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": [
+                              "D:\\Debugger\\SEGGER\\JLink_V884\\JLink_x64.dll",
+                              "JLinkARM-One.dll"
+                            ]
+                          },
+                          "jlink-commands": {
+                            "title": "Additional SEGGER J-Link Command Strings",
+                            "description": "List of additional SEGGER J-Link command strings that are executed directly after the device is selected, but before the target interface and speed are selected. See [J-Link Command Strings](https://kb.segger.com/J-Link_Command_Strings) for the full list of supported command strings.",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "examples": [
+                                "AppendToLogFile",
+                                "EnableRemarks",
+                                "SupplyPower"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "segger-jlink",
+                        "node": "localhost",
+                        "port": 5315,
+                        "segger-jlink": {
+                          "path-to-symbol-file": "build/my-firmware.elf",
+                          "device": "RP2040_M0_0",
+                          "target-interface": "SWD"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "$comment": "IMPORTANT: Keep all fields except 'serial-number' / 'node' + 'port' in sync. with the TCP/IP variant.",
+                    "title": "Debugger Configuration (SEGGER J-Link over USB)",
+                    "description": "Debugger Configuration for SEGGER J-Link over USB",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["type", "segger-jlink"],
+                    "properties": {
+                      "type": {
+                        "title": "Debugger Connection Type",
+                        "type": "string",
+                        "const": "segger-jlink"
+                      },
+                      "reset": {
+                        "title": "Target Reset",
+                        "description": "Connecting to the target on measurement start will cause a target reset. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "run": {
+                        "title": "Start Execution",
+                        "description": "Connecting to the target on measurement start will start execution of the program. Must be supported by the target",
+                        "type": "boolean",
+                        "default": false,
+                        "examples": [true, false]
+                      },
+                      "auto-connect": {
+                        "title": "Auto Connect",
+                        "description": "Automatically connects to the SEGGER J-Link instance on measurement start.",
+                        "type": "boolean",
+                        "default": true,
+                        "examples": [true, false]
+                      },
+                      "segger-jlink": {
+                        "title": "SEGGER J-Link Settings",
+                        "description": "Debugger specific settings for SEGGER J-Link",
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "serial-number",
+                          "path-to-symbol-file",
+                          "device",
+                          "target-interface"
+                        ],
+                        "properties": {
+                          "serial-number": {
+                            "oneOf": [
+                              {
+                                "title": "Serial Number of the Debugger",
+                                "description": "The serial number of the SEGGER J-Link debugger.",
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 999999999,
+                                "examples": [852012345]
+                              },
+                              {
+                                "allOf": [
+                                  {
+                                    "title": "Serial Number of the Debugger",
+                                    "description": "The serial number of the SEGGER J-Link debugger.",
+                                    "type": "string",
+                                    "examples": ["852012345"]
+                                  },
+                                  {
+                                    "not": {
+                                      "const": "auto"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "title": "Serial Number of the Debugger",
+                                "description": "Using the value 'auto' will automatically select a debugger connected via USB. Automatic selection will fail if more than one debugger is connected.",
+                                "const": "auto"
+                              }
+                            ]
+                          },
+                          "path-to-symbol-file": {
+                            "title": "Symbol File",
+                            "description": "Absolute or relative path to the symbol file. Path is relative to this configuration file. Symbol file must match to the binary running on the target.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": ["MyBinary.elf", "MyBinarySymbols.elf"]
+                          },
+                          "device": {
+                            "title": "Device",
+                            "description": "The device name of the target as specified by the list of supported devices on the SEGGER website. The device will be selected by executing the `device = ...` Command String. See [Supported Devices](https://www.segger.com/supported-devices) for more.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": ["RP2040_M0_0", "STM32H723VE"]
+                          },
+                          "target-interface": {
+                            "title": "Target Interface",
+                            "description": "The target interface the SEGGER J-Link will use to connect to the device.",
+                            "type": "string",
+                            "oneOf": [
+                              {
+                                "const": "SWD",
+                                "title": "SWD Target Interface",
+                                "description": "Instructs the debugger to use the Serial Wire Debug (SWD) interface to connect to the device."
+                              },
+                              {
+                                "const": "JTAG",
+                                "title": "JTAG Target Interface",
+                                "description": "Instructs the debugger to use the Joint Test Action Group (JTAG) interface to connect to the device."
+                              }
+                            ]
+                          },
+                          "speed": {
+                            "title": "Target Interface Speed",
+                            "description": "The speed at which the SEGGER J-Link will connect to the device over the target interface in kHz. The value 0 will instruct the SEGGER J-Link to autodetect the speed. The value 65535 will instruct the SEGGER J-Link to use adaptive clocking.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 65535,
+                            "examples": [2000, 4000]
+                          },
+                          "jlink-dll-path": {
+                            "title": "Path to the JLinkARM.dll or JLink_x64.dll",
+                            "description": "Absolute or relative path to the DLL file. Path is relative to this configuration file. If not present, an attempt to automatically find an installed JLink DLL is made. The bitness (32 / 64) of the selected DLL must match the runtime kernel bitness, otherwise loading the DLL will fail.",
+                            "type": "string",
+                            "minLength": 1,
+                            "examples": [
+                              "D:\\Debugger\\SEGGER\\JLink_V884\\JLink_x64.dll",
+                              "JLinkARM-One.dll"
+                            ]
+                          },
+                          "jlink-commands": {
+                            "title": "Additional SEGGER J-Link Command Strings",
+                            "description": "List of additional SEGGER J-Link command strings that are executed directly after the device is selected, but before the target interface and speed are selected. See [J-Link Command Strings](https://kb.segger.com/J-Link_Command_Strings) for the full list of supported command strings.",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "examples": [
+                                "AppendToLogFile",
+                                "EnableRemarks",
+                                "SupplyPower"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "examples": [
+                      {
+                        "type": "segger-jlink",
+                        "segger-jlink": {
+                          "serial-number": "852012345",
+                          "path-to-symbol-file": "build/my-firmware.elf",
+                          "device": "RP2040_M0_0",
+                          "target-interface": "SWD"
+                        }
+                      },
+                      {
+                        "type": "segger-jlink",
+                        "segger-jlink": {
+                          "serial-number": "auto",
+                          "path-to-symbol-file": "build/my-other-firmware.elf",
+                          "device": "RP2040_M0_0",
+                          "target-interface": "SWD"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/test/vhwdebugger-binding-schema/success.1.2.vhwdebugger-binding.yaml
+++ b/src/test/vhwdebugger-binding-schema/success.1.2.vhwdebugger-binding.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=../../schemas/json/vhwdebugger-binding-schema.json
+version: '1.2'
+
+default-debugger: DefaultValues
+
+debuggers:
+  DefaultValues:
+    type: lauterbach
+    node: localhost
+    port: 30000
+
+  iSYSTEM:
+    type: isystem
+    reset: true
+    run: true
+    node: localhost
+    port: 5315
+    isystem:
+      disable-winidea-polling: true
+
+  TASKING:
+    type: tasking
+    reset: true
+    run: true
+    node: localhost
+    port: 5315
+    tasking:
+      disable-winidea-polling: true
+
+  Lauterbach:
+    type: lauterbach
+    reset: false
+    run: true
+    node: localhost
+    port: 30000
+    auto-connect: true
+    lauterbach:
+      pack-len: 123
+
+  GDB:
+    type: gdb
+    node: localhost
+    port: 1234
+    run: true
+    auto-connect: false
+    gdb:
+      path-to-gdb-client: 'dummy/gdb.exe'
+      path-to-symbol-file: 'dummy/app.elf'
+
+  SEGGER-IP:
+    type: segger-jlink
+    node: localhost
+    port: 1234
+    run: true
+    auto-connect: false
+    segger-jlink:
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD
+      speed: 4000
+      jlink-dll-path: 'dummy/jlink.dll'
+      jlink-commands:
+        - 'command number one'
+        - 'the second command'
+
+  SEGGER-USB:
+    type: segger-jlink
+    run: true
+    auto-connect: false
+    segger-jlink:
+      serial-number: '852012345'
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD
+      speed: 4000
+      jlink-dll-path: 'dummy/jlink.dll'
+      jlink-commands:
+        - 'command number one'
+        - 'the second command'
+
+  SEGGER-USB-2:
+    type: segger-jlink
+    run: true
+    auto-connect: false
+    segger-jlink:
+      serial-number: 852012345
+      path-to-symbol-file: 'dummy/app.elf'
+      device: RP2040_M0_0
+      target-interface: SWD
+      speed: 4000
+      jlink-dll-path: 'dummy/jlink.dll'
+      jlink-commands:
+        - 'command number one'
+        - 'the second command'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Updates the JSON schema for the Hardware Debugger Binding YAML configuration of the tool CANoe created by Vector Informatik GmbH to version `1.2` of the schema (from version 1.0.100 of the Hardware Debugger Binding).