### PR TITLE
feat(ryl): add schema for v0.7.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5828,6 +5828,12 @@
       "url": "https://www.schemastore.org/rustfmt.json"
     },
     {
+      "name": "ryl",
+      "description": "ryl, a fast YAML linter written in Rust",
+      "fileMatch": ["ryl.toml", ".ryl.toml"],
+      "url": "https://www.schemastore.org/ryl.json"
+    },
+    {
       "name": "Rust toolchain",
       "description": "A declarative managing the Rust toolchain",
       "fileMatch": ["rust-toolchain.toml"],

--- a/src/negative_test/ryl/01-invalid.toml
+++ b/src/negative_test/ryl/01-invalid.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/ryl.json
+[rules.comments]
+require-starting-space = "yes"

--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -1,0 +1,1623 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/ryl.json",
+  "definitions": {
+    "FixRuleName": {
+      "description": "A fixable rule name accepted by `fix.unfixable`.",
+      "enum": [
+        "braces",
+        "brackets",
+        "commas",
+        "comments",
+        "comments-indentation",
+        "new-line-at-end-of-file",
+        "new-lines"
+      ],
+      "type": "string"
+    },
+    "FixTable": {
+      "additionalProperties": false,
+      "description": "TOML `[fix]` table.",
+      "properties": {
+        "fixable": {
+          "items": {
+            "$ref": "#/definitions/FixableRuleSelector"
+          },
+          "type": ["array", "null"]
+        },
+        "unfixable": {
+          "items": {
+            "$ref": "#/definitions/FixRuleName"
+          },
+          "type": ["array", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "FixableRuleSelector": {
+      "description": "A rule selector accepted by `fix.fixable`.",
+      "enum": [
+        "ALL",
+        "braces",
+        "brackets",
+        "commas",
+        "comments",
+        "comments-indentation",
+        "new-line-at-end-of-file",
+        "new-lines"
+      ],
+      "type": "string"
+    },
+    "ForbidMode": {
+      "enum": ["non-empty"],
+      "type": "string"
+    },
+    "ForbidSetting": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/ForbidMode"
+        }
+      ]
+    },
+    "IndentSequencesMode": {
+      "enum": ["whatever", "consistent"],
+      "type": "string"
+    },
+    "IndentSequencesSetting": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/IndentSequencesMode"
+        }
+      ]
+    },
+    "NewLinesType": {
+      "enum": ["unix", "dos", "platform"],
+      "type": "string"
+    },
+    "QuoteType": {
+      "enum": ["any", "single", "double"],
+      "type": "string"
+    },
+    "QuotedStringsRequired": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/QuotedStringsRequiredMode"
+        }
+      ]
+    },
+    "QuotedStringsRequiredMode": {
+      "enum": ["only-when-needed"],
+      "type": "string"
+    },
+    "RuleEntryForAnchorsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForAnchorsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForBraceLikeOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForBraceLikeOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForColonsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForColonsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForCommasOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForCommasOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForCommentsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForCommentsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForDocumentPresenceOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForDocumentPresenceOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForEmptyLinesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForEmptyLinesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForEmptyValuesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForEmptyValuesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForFloatValuesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForFloatValuesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForHyphensOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForHyphensOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForIndentationOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForIndentationOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForKeyDuplicatesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForKeyDuplicatesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForKeyOrderingOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForKeyOrderingOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForLineLengthOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForLineLengthOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForNewLinesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForNewLinesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForNoOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForNoOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForOctalValuesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForOctalValuesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForQuotedStringsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForQuotedStringsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForTruthyOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForTruthyOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleLevel": {
+      "description": "Rule severity override.",
+      "enum": ["error", "warning"],
+      "type": "string"
+    },
+    "RuleOptionsForAnchorsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-duplicated-anchors": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-undeclared-aliases": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-unused-anchors": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForBraceLikeOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ForbidSetting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-spaces-inside": {
+          "type": ["integer", "null"]
+        },
+        "max-spaces-inside-empty": {
+          "type": ["integer", "null"]
+        },
+        "min-spaces-inside": {
+          "type": ["integer", "null"]
+        },
+        "min-spaces-inside-empty": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForColonsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-spaces-after": {
+          "type": ["integer", "null"]
+        },
+        "max-spaces-before": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForCommasOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-spaces-after": {
+          "type": ["integer", "null"]
+        },
+        "max-spaces-before": {
+          "type": ["integer", "null"]
+        },
+        "min-spaces-after": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForCommentsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-shebangs": {
+          "type": ["boolean", "null"]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "min-spaces-from-content": {
+          "type": ["integer", "null"]
+        },
+        "require-starting-space": {
+          "type": ["boolean", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForDocumentPresenceOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "present": {
+          "type": ["boolean", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForEmptyLinesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": ["integer", "null"]
+        },
+        "max-end": {
+          "type": ["integer", "null"]
+        },
+        "max-start": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForEmptyValuesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-in-block-mappings": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-in-block-sequences": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-in-flow-mappings": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForFloatValuesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-inf": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-nan": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-scientific-notation": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require-numeral-before-decimal": {
+          "type": ["boolean", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForHyphensOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max-spaces-after": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForIndentationOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "check-multi-line-strings": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "indent-sequences": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IndentSequencesSetting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "spaces": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SpacesSetting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForKeyDuplicatesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-duplicated-merge-keys": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForKeyOrderingOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignored-keys": {
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForLineLengthOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allow-non-breakable-inline-mappings": {
+          "type": ["boolean", "null"]
+        },
+        "allow-non-breakable-words": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": ["integer", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForNewLinesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NewLinesType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForNoOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForOctalValuesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-explicit-octal": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-implicit-octal": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForQuotedStringsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allow-quoted-quotes": {
+          "type": ["boolean", "null"]
+        },
+        "check-keys": {
+          "type": ["boolean", "null"]
+        },
+        "extra-allowed": {
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        },
+        "extra-required": {
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "quote-type": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/QuoteType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "required": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/QuotedStringsRequired"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForTruthyOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allowed-values": {
+          "items": {
+            "$ref": "#/definitions/TruthyAllowedValue"
+          },
+          "type": ["array", "null"]
+        },
+        "check-keys": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleSwitch": {
+      "description": "Shorthand rule enable/disable syntax.",
+      "enum": ["enable", "disable"],
+      "type": "string"
+    },
+    "RulesTable": {
+      "description": "Built-in rule table for TOML config.",
+      "properties": {
+        "anchors": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForAnchorsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "braces": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForBraceLikeOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "brackets": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForBraceLikeOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "colons": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForColonsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commas": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForCommasOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "comments": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForCommentsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "comments-indentation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "document-end": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForDocumentPresenceOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "document-start": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForDocumentPresenceOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty-lines": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForEmptyLinesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "empty-values": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForEmptyValuesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "float-values": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForFloatValuesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hyphens": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForHyphensOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "indentation": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForIndentationOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key-duplicates": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForKeyDuplicatesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key-ordering": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForKeyOrderingOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "line-length": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForLineLengthOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "new-line-at-end-of-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "new-lines": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNewLinesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "octal-values": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForOctalValuesOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "quoted-strings": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForQuotedStringsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "trailing-spaces": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "truthy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForTruthyOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SpacesMode": {
+      "enum": ["consistent"],
+      "type": "string"
+    },
+    "SpacesSetting": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "$ref": "#/definitions/SpacesMode"
+        }
+      ]
+    },
+    "StringOrVec": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "A TOML field that accepts either one string or a list of strings."
+    },
+    "TruthyAllowedValue": {
+      "enum": [
+        "YES",
+        "Yes",
+        "yes",
+        "NO",
+        "No",
+        "no",
+        "TRUE",
+        "True",
+        "true",
+        "FALSE",
+        "False",
+        "false",
+        "ON",
+        "On",
+        "on",
+        "OFF",
+        "Off",
+        "off"
+      ],
+      "type": "string"
+    }
+  },
+  "description": "JSON Schema root for `ryl` TOML configuration.",
+  "properties": {
+    "fix": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FixTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Native fix policy, available only in TOML config."
+    },
+    "ignore": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StringOrVec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Ignore patterns, either as one multi-line string or a list of patterns."
+    },
+    "ignore-from-file": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StringOrVec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Paths to files that contain ignore patterns."
+    },
+    "locale": {
+      "description": "Locale identifier used by diagnostics.",
+      "type": ["string", "null"]
+    },
+    "rules": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RulesTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Rule configuration table."
+    },
+    "yaml-files": {
+      "description": "Glob patterns used to identify YAML files while scanning directories.",
+      "items": {
+        "type": "string"
+      },
+      "type": ["array", "null"]
+    }
+  },
+  "title": "ryl TOML config",
+  "type": "object"
+}

--- a/src/test/ryl/01-valid.toml
+++ b/src/test/ryl/01-valid.toml
@@ -1,0 +1,9 @@
+#:schema ../../schemas/json/ryl.json
+yaml-files = ["*.yaml", "*.yml"]
+ignore = ["vendor/**"]
+
+[rules]
+document-start = "disable"
+
+[rules.comments]
+require-starting-space = true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Changes

- Adds `src/schemas/json/ryl.json`
- Adds the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/da35ac843bdbf5bb28b5c7cfdfece830caa5a142/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/da35ac843bdbf5bb28b5c7cfdfece830caa5a142/.github/workflows/sync-schemastore.yml