### PR TITLE
Update description and URL for Expoot app config

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2803,9 +2803,9 @@
     },
     {
       "name": "Expoot app config",
-      "description": "The config for creating a React Native Desktop app with best-effort Expo support, used by the create-expoot CLI",
+      "description": "The config for creating a React Native Desktop app with best-effort Expo support, used by the expoot CLI",
       "fileMatch": ["expoot-app.json"],
-      "url": "https://raw.githubusercontent.com/shirakaba/expoot/main/packages/create-expoot/schemas/app-config.json"
+      "url": "https://raw.githubusercontent.com/shirakaba/expoot/main/packages/expoot/schemas/expoot-app.schema.json"
     },
     {
       "name": "EasyVCR .NET",


### PR DESCRIPTION
A follow-up to #5615 (thank you for merging!).

This PR updates the `description` and `url` fields for **Expoot app config**, as I've changed the CLI from being about creating apps/modules (`create-expoot app|module`) to being more all-purpose (`expoot create-app`).

Sorry for the inconvenience.