### PR TITLE
Add OpenDecree schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9707,6 +9707,34 @@
       "description": "Definition for a single repository",
       "fileMatch": ["raid.yaml", "raid.yml", "raid.json"],
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-repo.schema.json"
+    },
+    {
+      "name": "OpenDecree Schema",
+      "description": "OpenDecree schema definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications.",
+      "fileMatch": [
+        "decree.schema.yaml",
+        "decree.schema.yml",
+        "*.decree.schema.yaml",
+        "*.decree.schema.yml"
+      ],
+      "url": "https://schemas.opendecree.dev/schema/v0.1.0/decree-schema.json",
+      "versions": {
+        "v0.1.0": "https://schemas.opendecree.dev/schema/v0.1.0/decree-schema.json"
+      }
+    },
+    {
+      "name": "OpenDecree Configuration",
+      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired decree.schema.yaml.",
+      "fileMatch": [
+        "decree.config.yaml",
+        "decree.config.yml",
+        "*.decree.config.yaml",
+        "*.decree.config.yml"
+      ],
+      "url": "https://schemas.opendecree.dev/schema/v0.1.0/decree-config.json",
+      "versions": {
+        "v0.1.0": "https://schemas.opendecree.dev/schema/v0.1.0/decree-config.json"
+      }
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9710,7 +9710,7 @@
     },
     {
       "name": "OpenDecree Schema",
-      "description": "OpenDecree schema definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications.",
+      "description": "OpenDecree schema definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications",
       "fileMatch": [
         "decree.schema.yaml",
         "decree.schema.yml",
@@ -9724,7 +9724,7 @@
     },
     {
       "name": "OpenDecree Configuration",
-      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired decree.schema.yaml.",
+      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired decree.schema.yaml",
       "fileMatch": [
         "decree.config.yaml",
         "decree.config.yml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9709,8 +9709,8 @@
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-repo.schema.json"
     },
     {
-      "name": "OpenDecree Schema",
-      "description": "OpenDecree schema definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications",
+      "name": "OpenDecree",
+      "description": "OpenDecree definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications",
       "fileMatch": [
         "decree.schema.yaml",
         "decree.schema.yml",
@@ -9724,7 +9724,7 @@
     },
     {
       "name": "OpenDecree Configuration",
-      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired decree.schema.yaml",
+      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired main decree yaml",
       "fileMatch": [
         "decree.config.yaml",
         "decree.config.yml",


### PR DESCRIPTION
Adds two catalog entries for [OpenDecree](https://opendecree.dev), an alpha-stage schema-driven business configuration management service:

- **OpenDecree Schema** — for `*.decree.schema.yaml` files (schema definitions).
- **OpenDecree Configuration** — for `*.decree.config.yaml` files (config values).

Both meta-schemas are JSON Schema 2020-12, hosted on GitHub Pages with a stable HTTPS URL on `schemas.opendecree.dev`.

- Source repository: [opendecree/decree](https://github.com/opendecree/decree) (Apache 2.0)
- Meta-schema sources: [`schemas/v0.1.0/`](https://github.com/opendecree/decree/tree/main/schemas/v0.1.0)
- Hosting runbook: [`docs/development/schemas-hosting-runbook.md`](https://github.com/opendecree/decree/blob/main/docs/development/schemas-hosting-runbook.md)
- Tracking issue: [opendecree/decree#126](https://github.com/opendecree/decree/issues/126)

The `fileMatch` patterns are project-specific (`decree.schema.*`, `*.decree.schema.*`, etc.) — no risk of generic false positives.