### PR TITLE
Allow autoinstall.yaml for Ubuntu Autoinstall

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6779,7 +6779,7 @@
     {
       "name": "Ubuntu Server Autoinstall",
       "description": "Settings file for Ubuntu Autoinstall",
-      "fileMatch": ["user-data"],
+      "fileMatch": ["user-data", "autoinstall.yaml"],
       "url": "https://www.schemastore.org/ubuntu-server-autoinstall.json"
     },
     {


### PR DESCRIPTION
Add `autoinstall.yaml` to `fileMatch` patterns for Ubuntu Autoinstall configuration.

## References

https://canonical-subiquity.readthedocs-hosted.com/en/latest/tutorial/providing-autoinstall.html#autoinstall-on-the-installation-media

> Another option for supplying autoinstall to the Ubuntu installer is to place a file named `autoinstall.yaml` on the installation media itself.

https://github.com/canonical/subiquity/blob/b021eac5541487ebf304e85cf1991c83aa97a964/subiquity/cmd/server.py#L79-L87

> Path to autoinstall file. Empty value disables autoinstall.  By default tries to load /autoinstall.yaml, or autoinstall data from cloud-init.

## Real-world usage

[`path:autoinstall.yaml "autoinstall:" "version: 1" language:YAML NOT is:fork`](https://github.com/search?q=path%3Aautoinstall.yaml+%22autoinstall%3A%22+%22version%3A+1%22+language%3AYAML+NOT+is%3Afork&type=code): 102 files