### PR TITLE
add Bpod Finite-State Machine

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -703,6 +703,19 @@
       }
     },
     {
+      "name": "Bpod Finite-State Machine",
+      "description": "Definition of a Bpod Finite-State Machine",
+      "fileMatch": [
+        "*.bpod-fsm.json",
+        "*.bpod-fsm.yaml",
+        "*.bpod-fsm.yml",
+        "bpod-fsm.json",
+        "bpod-fsm.yaml",
+        "bpod-fsm.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/int-brain-lab/bpod-core/main/.schema/statemachine.json"
+    },
+    {
       "name": "buf.yaml",
       "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration",
       "fileMatch": ["buf.yaml"],


### PR DESCRIPTION
This PR adds support for Bpod Finite-State Machine definitions, as used by bpod-core - see [int-brain-lab/bpod-core](https://github.com/int-brain-lab/bpod-core). I hope I did things correctly ...