### PR TITLE
fix(tsconfig,jsconfig): add missing ES2022.Regexp and ES2023.Intl lib entries

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -742,7 +742,7 @@
                 "uniqueItems": true,
                 "items": {
                   "type": "string",
-                  "description": "Path mapping to be computed relative to baseUrl option."
+                  "description": "An array of paths to use as alternatives when resolving this module import."
                 }
               },
               "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"
@@ -912,6 +912,7 @@
                       "ES2022.Error",
                       "ES2022.Intl",
                       "ES2022.Object",
+                      "ES2022.Regexp",
                       "ES2022.String",
                       "ES2022.SharedMemory",
                       "ES2022.RegExp",
@@ -936,6 +937,7 @@
                       "Decorators.Legacy",
                       "ES2017.Date",
                       "ES2023.Collection",
+                      "ES2023.Intl",
                       "ESNext.Decorators",
                       "ESNext.Disposable",
                       "ESNext.Error",

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -833,7 +833,7 @@
                 "uniqueItems": true,
                 "items": {
                   "type": "string",
-                  "description": "Path mapping to be computed relative to baseUrl option."
+                  "description": "An array of paths to use as alternatives when resolving this module import."
                 }
               },
               "markdownDescription": "A series of entries which re-map imports to lookup locations relative to the [`baseUrl`](https://typescriptlang.org/tsconfig/#baseUrl) if set, or to the tsconfig file itself otherwise. There is a larger coverage of `paths` in [the `moduleResolution` reference page](https://typescriptlang.org/docs/handbook/modules/reference.html#paths).\n\n`paths` lets you declare how TypeScript should resolve an import in your `require`/`import`s.\n\n```json tsconfig\n{\n  \"compilerOptions\": {\n    \"paths\": {\n      \"jquery\": [\"./vendor/jquery/dist/jquery\"]\n    }\n  }\n}\n```\n\nThis would allow you to be able to write `import \"jquery\"`, and get all of the correct typing locally.\n\n```json tsconfig\n{\n  \"compilerOptions\": {\n    \"paths\": {\n        \"app/*\": [\"./src/app/*\"],\n        \"config/*\": [\"./src/app/_config/*\"],\n        \"environment/*\": [\"./src/environments/*\"],\n        \"shared/*\": [\"./src/app/_shared/*\"],\n        \"helpers/*\": [\"./src/helpers/*\"],\n        \"tests/*\": [\"./src/tests/*\"]\n    }\n  }\n}\n```\n\nIn this case, you can tell the TypeScript file resolver to support a number of custom prefixes to find code.\n\nNote that this feature does not change how import paths are emitted by `tsc`, so `paths` should only be used to inform TypeScript that another tool has this mapping and will use it at runtime or when bundling.",
@@ -1013,6 +1013,7 @@
                       "ES2022.Error",
                       "ES2022.Intl",
                       "ES2022.Object",
+                      "ES2022.Regexp",
                       "ES2022.String",
                       "ES2022.SharedMemory",
                       "ES2022.RegExp",
@@ -1037,6 +1038,7 @@
                       "Decorators.Legacy",
                       "ES2017.Date",
                       "ES2023.Collection",
+                      "ES2023.Intl",
                       "ESNext.Decorators",
                       "ESNext.Disposable",
                       "ESNext.Error",


### PR DESCRIPTION
Fixes #5152

## What

TypeScript ships `es2022.regexp.d.ts` and `es2023.intl.d.ts` as separate lib files, but neither is listed in the `compilerOptions.lib` enum in the tsconfig.json or jsconfig.json schemas. This causes false validation errors when users set `"lib": ["ES2022.Regexp"]` or `"lib": ["ES2023.Intl"]` in their tsconfig/jsconfig.

## Changes

Both `src/schemas/json/tsconfig.json` and `src/schemas/json/jsconfig.json`:

- Added `"ES2022.Regexp"` after `"ES2022.Object"` (alphabetical order)
- Added `"ES2023.Intl"` after `"ES2023.Collection"` (alphabetical order)

## Verification

TypeScript lib source confirms both files exist:
- https://github.com/microsoft/TypeScript/blob/main/src/lib/es2022.regexp.d.ts
- https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.intl.d.ts

The maintainer also noted in issue #5152 that jsconfig.json would need the same fix.