### PR TITLE
fix: update schema to match maturin v1.13.1

### DIFF
--- a/src/schemas/json/maturin.json
+++ b/src/schemas/json/maturin.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/maturin.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ToolMaturin",
   "description": "The `[tool.maturin]` section of a pyproject.toml",
   "type": "object",
@@ -8,13 +7,16 @@
   "properties": {
     "all-features": {
       "description": "Activate all available features",
-      "type": ["boolean", "null"]
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "auditwheel": {
       "description": "Audit wheel mode",
       "anyOf": [
         {
-          "$ref": "#/definitions/AuditWheelMode"
+          "$ref": "#/$defs/AuditWheelMode"
         },
         {
           "type": "null"
@@ -23,13 +25,16 @@
     },
     "bindings": {
       "description": "Bindings type",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "compatibility": {
       "description": "Platform compatibility",
       "anyOf": [
         {
-          "$ref": "#/definitions/PlatformTag"
+          "$ref": "#/$defs/PlatformTag"
         },
         {
           "type": "null"
@@ -38,138 +43,226 @@
     },
     "config": {
       "description": "Override a configuration value (unstable)",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       }
     },
     "data": {
       "description": "Path to the wheel directory, defaults to `<module_name>.data`",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "editable-profile": {
+      "description": "Same as `profile` but for \"editable\" builds",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "exclude": {
-      "description": "Exclude files matching the given glob pattern(s)",
-      "type": ["array", "null"],
+      "description": "Exclude files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.",
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
-        "$ref": "#/definitions/GlobPattern"
+        "$ref": "#/$defs/GlobPattern"
       }
     },
     "features": {
       "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and `python-version` keys.",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
-        "$ref": "#/definitions/FeatureSpec"
+        "$ref": "#/$defs/FeatureSpec"
       }
     },
     "frozen": {
       "description": "Require Cargo.lock and cache are up to date",
-      "type": ["boolean", "null"]
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "generate-ci": {
+      "description": "CI generation configuration",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GenerateCIConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "include": {
-      "description": "Include files matching the given glob pattern(s)",
-      "type": ["array", "null"],
+      "description": "Include files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.\nWhen `python-source` is configured, patterns are also tried relative to\nthat directory if no matches are found.",
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
-        "$ref": "#/definitions/GlobPattern"
+        "$ref": "#/$defs/GlobPattern"
       }
+    },
+    "include-import-lib": {
+      "description": "Include the import library (.dll.lib) in the wheel on Windows",
+      "type": "boolean",
+      "default": false
     },
     "locked": {
       "description": "Require Cargo.lock is up to date",
-      "type": ["boolean", "null"]
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "manifest-path": {
       "description": "Path to Cargo.toml",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "module-name": {
       "description": "Module name, accepts setuptools style import name like `foo.bar`",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "no-default-features": {
       "description": "Do not activate the `default` feature",
-      "type": ["boolean", "null"]
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "profile": {
       "description": "Build artifacts with the specified Cargo profile",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "python-packages": {
       "description": "Python packages to include",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       }
     },
     "python-source": {
       "description": "The directory with python module, contains `<module_name>/__init__.py`",
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "rustc-args": {
       "description": "Additional rustc arguments",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       }
     },
-    "sdist-generator": {
-      "description": "Source distribution generator",
-      "default": "cargo",
-      "allOf": [
+    "sbom": {
+      "description": "SBOM configuration",
+      "anyOf": [
         {
-          "$ref": "#/definitions/SdistGenerator"
+          "$ref": "#/$defs/SbomConfig"
+        },
+        {
+          "type": "null"
         }
       ]
     },
+    "sdist-generator": {
+      "description": "Source distribution generator",
+      "$ref": "#/$defs/SdistGenerator",
+      "default": "cargo"
+    },
     "skip-auditwheel": {
       "description": "Skip audit wheel",
-      "default": false,
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "strip": {
       "description": "Strip the final binary",
-      "default": false,
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "target": {
       "description": "Target configuration",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/TargetConfig"
-      }
+        "$ref": "#/$defs/TargetConfig"
+      },
+      "default": {}
     },
     "targets": {
       "description": "Cargo compile targets",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
-        "$ref": "#/definitions/CargoTarget"
+        "$ref": "#/$defs/CargoTarget"
       }
     },
     "unstable-flags": {
       "description": "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "type": "string"
       }
+    },
+    "use-base-python": {
+      "description": "Use base Python executable instead of venv Python executable in PEP 517 build.",
+      "type": "boolean",
+      "default": false
     }
   },
-  "definitions": {
+  "$defs": {
     "AuditWheelMode": {
       "description": "Auditwheel mode",
       "oneOf": [
         {
           "description": "Audit and repair wheel for manylinux compliance",
           "type": "string",
-          "enum": ["repair"]
+          "const": "repair"
         },
         {
           "description": "Check wheel for manylinux compliance, but do not repair",
           "type": "string",
-          "enum": ["check"]
+          "const": "check"
+        },
+        {
+          "description": "Audit wheel and warn about external libraries, but do not fail or repair",
+          "type": "string",
+          "const": "warn"
         },
         {
           "description": "Don't check for manylinux compliance",
           "type": "string",
-          "enum": ["skip"]
+          "const": "skip"
         }
       ]
     },
@@ -179,46 +272,44 @@
         {
           "description": "Binary executable target",
           "type": "string",
-          "enum": ["bin"]
+          "const": "bin"
         },
         {
           "description": "Dynamic system library target",
           "type": "string",
-          "enum": ["cdylib"]
+          "const": "cdylib"
         },
         {
           "description": "Dynamic Rust library target",
           "type": "string",
-          "enum": ["dylib"]
+          "const": "dylib"
         },
         {
           "description": "Rust library",
           "type": "string",
-          "enum": ["lib"]
+          "const": "lib"
         },
         {
           "description": "Rust library for use as an intermediate target",
           "type": "string",
-          "enum": ["rlib"]
+          "const": "rlib"
         },
         {
           "description": "Static library",
           "type": "string",
-          "enum": ["staticlib"]
+          "const": "staticlib"
         }
       ]
     },
     "CargoTarget": {
       "description": "Cargo compile target",
       "type": "object",
-      "required": ["name"],
-      "x-tombi-table-keys-order": "schema",
       "properties": {
         "kind": {
           "description": "Kind of target (\"bin\", \"cdylib\")",
           "anyOf": [
             {
-              "$ref": "#/definitions/CargoCrateType"
+              "$ref": "#/$defs/CargoCrateType"
             },
             {
               "type": "null"
@@ -229,29 +320,44 @@
           "description": "Name as given in the `Cargo.toml` or generated from the file name",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "name"
+      ]
     },
     "FeatureSpec": {
-      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n]\n```",
+      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\", python-implementation = \"cpython\" },\n  { feature = \"pypy-compat\", python-implementation = \"pypy\" },\n]\n```",
       "anyOf": [
         {
           "description": "A plain feature name, always enabled",
           "type": "string"
         },
         {
-          "description": "A feature enabled only when the target Python version matches",
+          "description": "A feature enabled only when the conditions match",
           "type": "object",
           "properties": {
             "feature": {
               "description": "The cargo feature to enable",
               "type": "string"
             },
+            "python-implementation": {
+              "description": "Python implementation name, e.g. \"cpython\", \"pypy\", \"graalpy\"",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "python-version": {
               "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["feature", "python-version"]
+          "required": [
+            "feature"
+          ]
         }
       ]
     },
@@ -261,12 +367,12 @@
         {
           "description": "Source distribution",
           "type": "string",
-          "enum": ["sdist"]
+          "const": "sdist"
         },
         {
           "description": "Wheel",
           "type": "string",
-          "enum": ["wheel"]
+          "const": "wheel"
         }
       ]
     },
@@ -275,20 +381,133 @@
       "anyOf": [
         {
           "description": "A single [Format] value",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Format"
-            }
-          ]
+          "$ref": "#/$defs/Format"
         },
         {
           "description": "Multiple [Format] values",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Format"
+            "$ref": "#/$defs/Format"
           }
         }
       ]
+    },
+    "GenerateCIConfig": {
+      "description": "The `[tool.maturin.generate-ci]` section",
+      "type": "object",
+      "properties": {
+        "github": {
+          "description": "GitHub Actions configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GitHubCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "GitHubCIConfig": {
+      "description": "The `[tool.maturin.generate-ci.github]` section",
+      "type": "object",
+      "properties": {
+        "android": {
+          "description": "Android platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "args": {
+          "description": "Extra arguments to pass to maturin (applies to all platforms)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "emscripten": {
+          "description": "Emscripten platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "linux": {
+          "description": "Linux (manylinux) platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "macos": {
+          "description": "macOS platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "musllinux": {
+          "description": "Musllinux platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pytest": {
+          "description": "Enable pytest",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "skip-attestation": {
+          "description": "Skip artifact attestation",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "windows": {
+          "description": "Windows platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "zig": {
+          "description": "Use zig for cross compilation",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     },
     "GlobPattern": {
       "description": "A glob pattern for the include and exclude configuration.\n\nSee [PyProjectToml::include] and [PyProject::exclude].\n\nBased on <https://python-poetry.org/docs/pyproject/#include-and-exclude>.",
@@ -300,90 +519,256 @@
         {
           "description": "A glob `path` with a `format` key to specify one or more [Format] values",
           "type": "object",
-          "required": ["format", "path"],
-          "x-tombi-table-keys-order": "schema",
           "properties": {
             "format": {
               "description": "One or more [Format] values",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Formats"
-                }
-              ]
+              "$ref": "#/$defs/Formats"
             },
             "path": {
               "description": "A glob",
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "path",
+            "format"
+          ]
+        },
+        {
+          "description": "A glob `path` relative to a crate's OUT_DIR",
+          "type": "object",
+          "properties": {
+            "crate_name": {
+              "description": "Optional crate name (defaults to the root crate)",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "description": "Source: must be \"out-dir\"",
+              "$ref": "#/$defs/IncludeFrom"
+            },
+            "path": {
+              "description": "A glob pattern relative to OUT_DIR",
+              "type": "string"
+            },
+            "to": {
+              "description": "Target path in wheel (e.g. \"my_package/\")",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "from",
+            "to"
+          ]
         }
       ]
+    },
+    "IncludeFrom": {
+      "description": "Supported values for the `from` field in include patterns.",
+      "oneOf": [
+        {
+          "description": "Include files from the crate's OUT_DIR",
+          "type": "string",
+          "const": "out-dir"
+        }
+      ]
+    },
+    "PlatformCIConfig": {
+      "description": "Per-platform CI configuration",
+      "type": "object",
+      "properties": {
+        "args": {
+          "description": "Extra arguments to pass to maturin",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "before-script-linux": {
+          "description": "Script to run before build on Linux",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "container": {
+          "description": "Container image to use",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docker-options": {
+          "description": "Docker options",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manylinux": {
+          "description": "Manylinux version (e.g. \"auto\", \"2_28\", \"musllinux_1_2\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runner": {
+          "description": "Default runner for this platform",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rust-toolchain": {
+          "description": "Rust toolchain (e.g. \"nightly\", \"stable\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rustup-components": {
+          "description": "Rustup components to install",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "description": "Detailed per-target configuration (mutually exclusive with `targets`)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TargetCIConfig"
+          }
+        },
+        "targets": {
+          "description": "Simple list of target architectures (mutually exclusive with `target`)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "PlatformTag": {
       "description": "Decides how to handle manylinux and musllinux compliance",
       "oneOf": [
         {
-          "description": "Use the manylinux_x_y tag",
+          "description": "Use the `manylinux_<major>_<minor>` tag",
           "type": "object",
-          "required": ["Manylinux"],
-          "x-tombi-table-keys-order": "schema",
           "properties": {
             "Manylinux": {
               "type": "object",
-              "required": ["x", "y"],
-              "x-tombi-table-keys-order": "schema",
               "properties": {
-                "x": {
+                "major": {
                   "description": "GLIBC version major",
                   "type": "integer",
                   "format": "uint16",
-                  "minimum": 0.0
+                  "maximum": 65535,
+                  "minimum": 0
                 },
-                "y": {
+                "minor": {
                   "description": "GLIBC version minor",
                   "type": "integer",
                   "format": "uint16",
-                  "minimum": 0.0
+                  "maximum": 65535,
+                  "minimum": 0
                 }
-              }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": [
+            "Manylinux"
+          ]
         },
         {
-          "description": "Use the musllinux_x_y tag",
+          "description": "Use the `musllinux_<major>_<minor>` tag",
           "type": "object",
-          "required": ["Musllinux"],
-          "x-tombi-table-keys-order": "schema",
           "properties": {
             "Musllinux": {
               "type": "object",
-              "required": ["x", "y"],
-              "x-tombi-table-keys-order": "schema",
               "properties": {
-                "x": {
+                "major": {
                   "description": "musl libc version major",
                   "type": "integer",
                   "format": "uint16",
-                  "minimum": 0.0
+                  "maximum": 65535,
+                  "minimum": 0
                 },
-                "y": {
+                "minor": {
                   "description": "musl libc version minor",
                   "type": "integer",
                   "format": "uint16",
-                  "minimum": 0.0
+                  "maximum": 65535,
+                  "minimum": 0
                 }
-              }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": [
+            "Musllinux"
+          ]
         },
         {
           "description": "Use the native linux tag",
           "type": "string",
-          "enum": ["Linux"]
+          "const": "Linux"
+        },
+        {
+          "description": "Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.",
+          "type": "string",
+          "const": "Pypi"
         }
       ]
+    },
+    "SbomConfig": {
+      "description": "SBOM configuration",
+      "type": "object",
+      "properties": {
+        "auditwheel": {
+          "description": "Generate a CycloneDX SBOM for external shared libraries grafted during\nauditwheel repair. Defaults to `true` when repair copies libraries.\n\nThe SBOM is written to `<dist-info>/sboms/auditwheel.cdx.json` and\nrecords which OS packages (deb, rpm, apk) provided the grafted\nlibraries, following the same convention as Python's auditwheel.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "include": {
+          "description": "Additional SBOM files to include in the `.dist-info/sboms` directory.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "rust": {
+          "description": "Generate an SBOM for Rust crates. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
     },
     "SdistGenerator": {
       "description": "Source distribution generator",
@@ -391,23 +776,94 @@
         {
           "description": "Use `cargo package --list`",
           "type": "string",
-          "enum": ["cargo"]
+          "const": "cargo"
         },
         {
           "description": "Use `git ls-files`",
           "type": "string",
-          "enum": ["git"]
+          "const": "git"
         }
+      ]
+    },
+    "TargetCIConfig": {
+      "description": "Per-target CI configuration within a platform",
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "Target architecture (e.g. \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "args": {
+          "description": "Extra arguments to pass to maturin",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "before-script-linux": {
+          "description": "Before-script-linux override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "container": {
+          "description": "Container image override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docker-options": {
+          "description": "Docker options override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manylinux": {
+          "description": "Manylinux version override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runner": {
+          "description": "Runner override for this target",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rust-toolchain": {
+          "description": "Rust toolchain override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rustup-components": {
+          "description": "Rustup components override",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "arch"
       ]
     },
     "TargetConfig": {
       "description": "Target configuration",
       "type": "object",
-      "x-tombi-table-keys-order": "schema",
       "properties": {
         "macos-deployment-target": {
           "description": "macOS deployment target version",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/src/schemas/json/maturin.json
+++ b/src/schemas/json/maturin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/maturin.json",
   "$defs": {
     "AuditWheelMode": {

--- a/src/schemas/json/maturin.json
+++ b/src/schemas/json/maturin.json
@@ -1,245 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "ToolMaturin",
-  "description": "The `[tool.maturin]` section of a pyproject.toml",
-  "type": "object",
-  "x-tombi-table-keys-order": "schema",
-  "properties": {
-    "all-features": {
-      "description": "Activate all available features",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "auditwheel": {
-      "description": "Audit wheel mode",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/AuditWheelMode"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "bindings": {
-      "description": "Bindings type",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "compatibility": {
-      "description": "Platform compatibility",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/PlatformTag"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "config": {
-      "description": "Override a configuration value (unstable)",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "data": {
-      "description": "Path to the wheel directory, defaults to `<module_name>.data`",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "editable-profile": {
-      "description": "Same as `profile` but for \"editable\" builds",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "exclude": {
-      "description": "Exclude files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/$defs/GlobPattern"
-      }
-    },
-    "features": {
-      "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and `python-version` keys.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/$defs/FeatureSpec"
-      }
-    },
-    "frozen": {
-      "description": "Require Cargo.lock and cache are up to date",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "generate-ci": {
-      "description": "CI generation configuration",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/GenerateCIConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "include": {
-      "description": "Include files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.\nWhen `python-source` is configured, patterns are also tried relative to\nthat directory if no matches are found.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/$defs/GlobPattern"
-      }
-    },
-    "include-import-lib": {
-      "description": "Include the import library (.dll.lib) in the wheel on Windows",
-      "type": "boolean",
-      "default": false
-    },
-    "locked": {
-      "description": "Require Cargo.lock is up to date",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "manifest-path": {
-      "description": "Path to Cargo.toml",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "module-name": {
-      "description": "Module name, accepts setuptools style import name like `foo.bar`",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "no-default-features": {
-      "description": "Do not activate the `default` feature",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "profile": {
-      "description": "Build artifacts with the specified Cargo profile",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "python-packages": {
-      "description": "Python packages to include",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "python-source": {
-      "description": "The directory with python module, contains `<module_name>/__init__.py`",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "rustc-args": {
-      "description": "Additional rustc arguments",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "sbom": {
-      "description": "SBOM configuration",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/SbomConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "sdist-generator": {
-      "description": "Source distribution generator",
-      "$ref": "#/$defs/SdistGenerator",
-      "default": "cargo"
-    },
-    "skip-auditwheel": {
-      "description": "Skip audit wheel",
-      "type": "boolean",
-      "default": false
-    },
-    "strip": {
-      "description": "Strip the final binary",
-      "type": "boolean",
-      "default": false
-    },
-    "target": {
-      "description": "Target configuration",
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/TargetConfig"
-      },
-      "default": {}
-    },
-    "targets": {
-      "description": "Cargo compile targets",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/$defs/CargoTarget"
-      }
-    },
-    "unstable-flags": {
-      "description": "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
-    },
-    "use-base-python": {
-      "description": "Use base Python executable instead of venv Python executable in PEP 517 build.",
-      "type": "boolean",
-      "default": false
-    }
-  },
   "$defs": {
     "AuditWheelMode": {
       "description": "Auditwheel mode",
@@ -321,9 +81,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ]
+      "required": ["name"]
     },
     "FeatureSpec": {
       "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\", python-implementation = \"cpython\" },\n  { feature = \"pypy-compat\", python-implementation = \"pypy\" },\n]\n```",
@@ -342,22 +100,14 @@
             },
             "python-implementation": {
               "description": "Python implementation name, e.g. \"cpython\", \"pypy\", \"graalpy\"",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "python-version": {
               "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             }
           },
-          "required": [
-            "feature"
-          ]
+          "required": ["feature"]
         }
       ]
     },
@@ -380,8 +130,8 @@
       "description": "A single [Format] or multiple [Format] values for a [GlobPattern].",
       "anyOf": [
         {
-          "description": "A single [Format] value",
-          "$ref": "#/$defs/Format"
+          "$ref": "#/$defs/Format",
+          "description": "A single [Format] value"
         },
         {
           "description": "Multiple [Format] values",
@@ -426,10 +176,7 @@
         },
         "args": {
           "description": "Extra arguments to pass to maturin (applies to all platforms)",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "emscripten": {
           "description": "Emscripten platform configuration",
@@ -477,17 +224,11 @@
         },
         "pytest": {
           "description": "Enable pytest",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "skip-attestation": {
           "description": "Skip artifact attestation",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "windows": {
           "description": "Windows platform configuration",
@@ -502,10 +243,7 @@
         },
         "zig": {
           "description": "Use zig for cross compilation",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       }
     },
@@ -521,18 +259,15 @@
           "type": "object",
           "properties": {
             "format": {
-              "description": "One or more [Format] values",
-              "$ref": "#/$defs/Formats"
+              "$ref": "#/$defs/Formats",
+              "description": "One or more [Format] values"
             },
             "path": {
               "description": "A glob",
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "format"
-          ]
+          "required": ["path", "format"]
         },
         {
           "description": "A glob `path` relative to a crate's OUT_DIR",
@@ -540,15 +275,12 @@
           "properties": {
             "crate_name": {
               "description": "Optional crate name (defaults to the root crate)",
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": ["string", "null"],
               "default": null
             },
             "from": {
-              "description": "Source: must be \"out-dir\"",
-              "$ref": "#/$defs/IncludeFrom"
+              "$ref": "#/$defs/IncludeFrom",
+              "description": "Source: must be \"out-dir\""
             },
             "path": {
               "description": "A glob pattern relative to OUT_DIR",
@@ -559,11 +291,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "from",
-            "to"
-          ]
+          "required": ["path", "from", "to"]
         }
       ]
     },
@@ -583,76 +311,46 @@
       "properties": {
         "args": {
           "description": "Extra arguments to pass to maturin",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "before-script-linux": {
           "description": "Script to run before build on Linux",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "container": {
           "description": "Container image to use",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "docker-options": {
           "description": "Docker options",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "manylinux": {
           "description": "Manylinux version (e.g. \"auto\", \"2_28\", \"musllinux_1_2\")",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "runner": {
           "description": "Default runner for this platform",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "rust-toolchain": {
           "description": "Rust toolchain (e.g. \"nightly\", \"stable\")",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "rustup-components": {
           "description": "Rustup components to install",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "target": {
           "description": "Detailed per-target configuration (mutually exclusive with `targets`)",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/$defs/TargetCIConfig"
           }
         },
         "targets": {
           "description": "Simple list of target architectures (mutually exclusive with `target`)",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -684,16 +382,11 @@
                   "minimum": 0
                 }
               },
-              "required": [
-                "major",
-                "minor"
-              ]
+              "required": ["major", "minor"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "Manylinux"
-          ]
+          "required": ["Manylinux"]
         },
         {
           "description": "Use the `musllinux_<major>_<minor>` tag",
@@ -717,16 +410,11 @@
                   "minimum": 0
                 }
               },
-              "required": [
-                "major",
-                "minor"
-              ]
+              "required": ["major", "minor"]
             }
           },
           "additionalProperties": false,
-          "required": [
-            "Musllinux"
-          ]
+          "required": ["Musllinux"]
         },
         {
           "description": "Use the native linux tag",
@@ -746,27 +434,18 @@
       "properties": {
         "auditwheel": {
           "description": "Generate a CycloneDX SBOM for external shared libraries grafted during\nauditwheel repair. Defaults to `true` when repair copies libraries.\n\nThe SBOM is written to `<dist-info>/sboms/auditwheel.cdx.json` and\nrecords which OS packages (deb, rpm, apk) provided the grafted\nlibraries, following the same convention as Python's auditwheel.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         },
         "include": {
           "description": "Additional SBOM files to include in the `.dist-info/sboms` directory.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "rust": {
           "description": "Generate an SBOM for Rust crates. Defaults to `true`.",
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "type": ["boolean", "null"]
         }
       }
     },
@@ -795,64 +474,38 @@
         },
         "args": {
           "description": "Extra arguments to pass to maturin",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "before-script-linux": {
           "description": "Before-script-linux override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "container": {
           "description": "Container image override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "docker-options": {
           "description": "Docker options override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "manylinux": {
           "description": "Manylinux version override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "runner": {
           "description": "Runner override for this target",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "rust-toolchain": {
           "description": "Rust toolchain override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "rustup-components": {
           "description": "Rustup components override",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
-      "required": [
-        "arch"
-      ]
+      "required": ["arch"]
     },
     "TargetConfig": {
       "description": "Target configuration",
@@ -860,12 +513,192 @@
       "properties": {
         "macos-deployment-target": {
           "description": "macOS deployment target version",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
+    }
+  },
+  "title": "ToolMaturin",
+  "description": "The `[tool.maturin]` section of a pyproject.toml",
+  "type": "object",
+  "x-tombi-table-keys-order": "schema",
+  "properties": {
+    "all-features": {
+      "description": "Activate all available features",
+      "type": ["boolean", "null"]
+    },
+    "auditwheel": {
+      "description": "Audit wheel mode",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AuditWheelMode"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "bindings": {
+      "description": "Bindings type",
+      "type": ["string", "null"]
+    },
+    "compatibility": {
+      "description": "Platform compatibility",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PlatformTag"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "config": {
+      "description": "Override a configuration value (unstable)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "data": {
+      "description": "Path to the wheel directory, defaults to `<module_name>.data`",
+      "type": ["string", "null"]
+    },
+    "editable-profile": {
+      "description": "Same as `profile` but for \"editable\" builds",
+      "type": ["string", "null"]
+    },
+    "exclude": {
+      "description": "Exclude files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/GlobPattern"
+      }
+    },
+    "features": {
+      "description": "List of features to activate.\nEach entry can be a plain feature name string, or a conditional object\nwith `feature` and `python-version` keys.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/FeatureSpec"
+      }
+    },
+    "frozen": {
+      "description": "Require Cargo.lock and cache are up to date",
+      "type": ["boolean", "null"]
+    },
+    "generate-ci": {
+      "description": "CI generation configuration",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GenerateCIConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "include": {
+      "description": "Include files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.\nWhen `python-source` is configured, patterns are also tried relative to\nthat directory if no matches are found.",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/GlobPattern"
+      }
+    },
+    "include-import-lib": {
+      "description": "Include the import library (.dll.lib) in the wheel on Windows",
+      "type": "boolean",
+      "default": false
+    },
+    "locked": {
+      "description": "Require Cargo.lock is up to date",
+      "type": ["boolean", "null"]
+    },
+    "manifest-path": {
+      "description": "Path to Cargo.toml",
+      "type": ["string", "null"]
+    },
+    "module-name": {
+      "description": "Module name, accepts setuptools style import name like `foo.bar`",
+      "type": ["string", "null"]
+    },
+    "no-default-features": {
+      "description": "Do not activate the `default` feature",
+      "type": ["boolean", "null"]
+    },
+    "profile": {
+      "description": "Build artifacts with the specified Cargo profile",
+      "type": ["string", "null"]
+    },
+    "python-packages": {
+      "description": "Python packages to include",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "python-source": {
+      "description": "The directory with python module, contains `<module_name>/__init__.py`",
+      "type": ["string", "null"]
+    },
+    "rustc-args": {
+      "description": "Additional rustc arguments",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "sbom": {
+      "description": "SBOM configuration",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SbomConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "sdist-generator": {
+      "$ref": "#/$defs/SdistGenerator",
+      "description": "Source distribution generator",
+      "default": "cargo"
+    },
+    "skip-auditwheel": {
+      "description": "Skip audit wheel",
+      "type": "boolean",
+      "default": false
+    },
+    "strip": {
+      "description": "Strip the final binary",
+      "type": "boolean",
+      "default": false
+    },
+    "target": {
+      "description": "Target configuration",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/TargetConfig"
+      },
+      "default": {}
+    },
+    "targets": {
+      "description": "Cargo compile targets",
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "#/$defs/CargoTarget"
+      }
+    },
+    "unstable-flags": {
+      "description": "Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "use-base-python": {
+      "description": "Use base Python executable instead of venv Python executable in PEP 517 build.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/schemas/json/maturin.json
+++ b/src/schemas/json/maturin.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://json.schemastore.org/maturin.json",
   "$defs": {
     "AuditWheelMode": {
       "description": "Auditwheel mode",

--- a/src/test/pyproject/maturin.toml
+++ b/src/test/pyproject/maturin.toml
@@ -1,0 +1,36 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.maturin]
+profile = "release"
+editable-profile = "release"
+features = ["foo", "bar"]
+all-features = false
+no-default-features = false
+manifest-path = "Cargo.toml"
+frozen = false
+locked = false
+config = []
+unstable-flags = []
+rustc-args = []
+include = []
+exclude = []
+bindings = "pyo3"
+compatibility = "Pypi"
+auditwheel = "repair"
+skip-auditwheel = false
+python-source = "src"
+python-packages = ["foo", "bar"]
+strip = true
+sdist-generator = "cargo"
+include-import-lib = false
+use-base-python = false
+
+[tool.maturin.sbom]
+rust = true
+auditwheel = true
+include = ["sboms/vendor.cdx.json"]
+
+[tool.maturin.target."x86_64-apple-darwin"]
+macos-deployment-target = "11.0"
+
+[tool.maturin.target."aarch64-apple-darwin"]
+macos-deployment-target = "11.0"


### PR DESCRIPTION
An attempt to sync `maturin.json` with upstream https://github.com/PyO3/maturin/blob/v1.13.1/maturin.schema.json

I did read contributing but it wasn't too clear to me on how to handle this. I'm opening the PR early to get CI feedback first.