### PR TITLE
Add new Rust lints

### DIFF
--- a/src/schemas/json/cargo-lints-rust.json
+++ b/src/schemas/json/cargo-lints-rust.json
@@ -149,6 +149,12 @@
       "description": "The `const_evaluatable_unchecked` lint detects a generic constant used in a type.",
       "default": "warn"
     },
+    "const_item_interior_mutations": {
+      "$ref": "#/definitions/Lint",
+      "title": "Const Item Interior Mutations",
+      "description": "The `const_item_interior_mutations` lint checks for calls which mutates an interior mutable const-item.",
+      "default": "warn"
+    },
     "const_item_mutation": {
       "$ref": "#/definitions/Lint",
       "title": "Const Item Mutation",
@@ -333,6 +339,12 @@
       "$ref": "#/definitions/Lint",
       "title": "Forgetting References",
       "description": "The `forgetting_references` lint checks for calls to `std::mem::forget` with a reference instead of an owned value.",
+      "default": "warn"
+    },
+    "function_casts_as_integer": {
+      "$ref": "#/definitions/Lint",
+      "title": "Function Casts As Integer",
+      "description": "The `function_casts_as_integer` lint detects cases where a function item is cast to an integer.",
       "default": "warn"
     },
     "function_item_references": {
@@ -1305,6 +1317,12 @@
       "$ref": "#/definitions/Lint",
       "title": "Unused Variables",
       "description": "The `unused_variables` lint detects variables which are not used in any way.",
+      "default": "warn"
+    },
+    "unused_visibilities": {
+      "$ref": "#/definitions/Lint",
+      "title": "Unused Visibilities",
+      "description": "The `unused_visibilities` lint detects visibility qualifiers (like `pub`) on a `const _` item.",
       "default": "warn"
     },
     "useless_deprecated": {


### PR DESCRIPTION
Add new Rust lints: `function-casts-as-integer`, `const-item-interior-mutations`, and `unused_visibilities`

Details about the lints at https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
