### PR TITLE
feat(ryl): update schema to v0.9.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9736,7 +9736,7 @@
     },
     {
       "name": "OpenDecree",
-      "description": "OpenDecree definition file (https://opendecree.dev) — describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications",
+      "description": "OpenDecree definition file (https://opendecree.dev) \u2014 describes typed configuration fields, constraints, and metadata that the OpenDecree configuration management service serves to applications",
       "fileMatch": [
         "decree.schema.yaml",
         "decree.schema.yml",
@@ -9750,7 +9750,7 @@
     },
     {
       "name": "OpenDecree Configuration",
-      "description": "OpenDecree configuration values file (https://opendecree.dev) — concrete values for fields declared in a paired main decree yaml",
+      "description": "OpenDecree configuration values file (https://opendecree.dev) \u2014 concrete values for fields declared in a paired main decree yaml",
       "fileMatch": [
         "decree.config.yaml",
         "decree.config.yml",

--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -11,7 +11,8 @@
         "comments",
         "comments-indentation",
         "new-line-at-end-of-file",
-        "new-lines"
+        "new-lines",
+        "quoted-strings"
       ],
       "type": "string"
     },
@@ -44,7 +45,8 @@
         "comments",
         "comments-indentation",
         "new-line-at-end-of-file",
-        "new-lines"
+        "new-lines",
+        "quoted-strings"
       ],
       "type": "string"
     },


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.9.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/0bdcede888596b65b09a7b06a12db20024665246/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/0bdcede888596b65b09a7b06a12db20024665246/.github/workflows/sync-schemastore.yml