### PR TITLE
feat: register eleckit schema for *.eleckit.json files

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2661,6 +2661,12 @@
       "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"
     },
     {
+      "name": "Eleckit",
+      "description": "Command request payloads for the eleckit deterministic electronics design CLI (https://github.com/adamNewell/eleckit)",
+      "fileMatch": ["*.eleckit.json"],
+      "url": "https://eleckit.dev/schemas/v1/command_request.json"
+    },
+    {
       "name": "Elgato Stream Deck",
       "description": "Elgato Stream Deck plugin manifest file",
       "fileMatch": [


### PR DESCRIPTION
### Summary

Adds a single self-hosted catalog entry for [eleckit](https://github.com/adamNewell/eleckit), a deterministic electronics-design CLI that exchanges JSON command-request payloads with plugins and AI agents.

The schema is hosted on the eleckit project's own site at `https://eleckit.dev/schemas/v1/` (see the [v1 rebuild plan](https://github.com/adamNewell/eleckit/blob/main/docs/v1-rebuild-plan.md), section 7), so this PR does not vendor any schema files into SchemaStore.

### Pattern

| field         | value                                                                  |
|---------------|------------------------------------------------------------------------|
| `name`        | `Eleckit`                                                              |
| `fileMatch`   | `*.eleckit.json`                                                       |
| `url`         | `https://eleckit.dev/schemas/v1/command_request.json`                  |

The `*.eleckit.json` pattern is project-prefixed, so it cannot collide with unrelated tooling — see [`Avoid Generic fileMatch Patterns`](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#avoid-generic-filematch-patterns) in `CONTRIBUTING.md`.

### Schema target

The `url` points to `command_request.json` — the canonical wire-input envelope for eleckit commands. The full set of 54 v1 schemas is published [in the eleckit repository](https://github.com/adamNewell/eleckit/tree/main/schemas/v1) and mirrored at `https://eleckit.dev/schemas/v1/<name>.json`.

### Validation

- `node ./cli.js check --schema-name=schema-catalog.json` — all preconditions pass (catalog validates against its schema, no duplicate `fileMatch` values, no invalid URLs, no field-guideline violations).
- `prettier --check src/api/json/catalog.json` — clean.

### Notes

- A separate TOML constraint pattern (`eleckit.constraints.toml`) was considered but **deferred**: eleckit currently models TOML constraint files as opaque artifact payloads under `command_request.json` rather than as a standalone JSON-Schema-validated TOML document. A dedicated TOML schema can be proposed later once the constraint format stabilizes.
- The schema URL is the canonical eleckit-web URL. eleckit-web schema hosting lands in a parallel PR; the host serves `https://eleckit.dev/` over HTTPS today, so the URL will resolve as soon as that PR ships.