### PR TITLE
Update prek schema to v0.3.12

### DIFF
--- a/src/schemas/json/prek.json
+++ b/src/schemas/json/prek.json
@@ -5,6 +5,10 @@
   "description": "The configuration file for prek, a git hook manager written in Rust.",
   "type": "object",
   "properties": {
+    "auto_update": {
+      "$ref": "#/definitions/AutoUpdateOptions",
+      "description": "Default settings for `prek auto-update` in this project."
+    },
     "repos": {
       "type": "array",
       "items": {
@@ -127,6 +131,17 @@
   "additionalProperties": true,
   "x-tombi-toml-version": "v1.1.0",
   "definitions": {
+    "AutoUpdateOptions": {
+      "description": "Controls how `prek auto-update` selects eligible releases.",
+      "type": "object",
+      "properties": {
+        "cooldown_days": {
+          "type": "integer",
+          "maximum": 255,
+          "minimum": 0
+        }
+      }
+    },
     "Repo": {
       "description": "A repository of hooks, which can be remote, local, meta, or builtin.",
       "type": "object",


### PR DESCRIPTION
Update to prek 0.3.12 to include the new `auto_update` config key.