### PR TITLE
fix: allow deps arrays in tox.toml schema

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -589,7 +589,17 @@
           "deprecated": true
         },
         "deps": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/subs"
+              }
+            }
+          ],
           "description": "python dependencies with optional version specifiers, as specified by PEP-440"
         },
         "dependency_groups": {

--- a/src/test/tox/tox-deps.toml
+++ b/src/test/tox/tox-deps.toml
@@ -1,0 +1,7 @@
+#:schema ../../schemas/json/tox.json
+env_list = ["py"]
+
+[env_run_base]
+description = "run tests"
+deps = ["pytest", "-r requirements.txt"]
+commands = [["python", "-m", "pytest"]]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Closes #5653

I've copied changes in official Tox schema from [this commit](https://github.com/tox-dev/tox/commit/86234dd57fc6a6dbf801aa98a91642cb9daf1dc8) to schema in SchemaStore. Additionally, I wrote test file and confirmed schema checkers don't fire errors for new tox.toml format anymore.