### PR TITLE
feat: add deno field for dependabot-2.json

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -678,6 +678,7 @@
         "cargo",
         "composer",
         "conda",
+        "deno",
         "devcontainers",
         "docker",
         "docker-compose",


### PR DESCRIPTION
dependabot has add deno support recently, so I want to add the field for the preparation

https://github.com/dependabot/dependabot-core/pull/14364
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
