### PR TITLE
fix: add engines.runtime to package.json

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -336,6 +336,33 @@
           "description": "What action to take if validation fails"
         }
       }
+    },
+    "runtimeEngineDependency": {
+      "description": "Specifies a supported JavaScript runtime.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The runtime name"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version range for the runtime"
+        },
+        "onFail": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "error",
+            "download"
+          ],
+          "description": "What action to take if runtime validation fails"
+        }
+      }
     }
   },
   "type": "object",
@@ -811,6 +838,20 @@
       "properties": {
         "node": {
           "type": "string"
+        },
+        "runtime": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/runtimeEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/runtimeEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which JavaScript runtimes (like Node.js, Deno, Bun) are supported. Values should use WinterCG Runtime Keys (see https://runtime-keys.proposal.wintercg.org/)."
         }
       },
       "additionalProperties": {

--- a/src/test/package/pnpm-fields.json
+++ b/src/test/package/pnpm-fields.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../schemas/json/package.json",
+  "engines": {
+    "runtime": [
+      {
+        "name": "deno",
+        "onFail": "warn",
+        "version": "^2.0.0"
+      },
+      {
+        "name": "node",
+        "onFail": "download",
+        "version": ">=24"
+      }
+    ]
+  },
   "name": "pnpm-fields",
   "pnpm": {
     "allowNonAppliedPatches": true,


### PR DESCRIPTION
closes #5662

uses type information from https://github.com/pnpm/pnpm/blob/main/core/types/src/package.ts#L112