### PR TITLE
feat(claude-code-settings): sync to Claude Code v2.1.138

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -17,6 +17,7 @@
     "CLAUDE_CODE_DEBUG_LOG_LEVEL": "trace",
     "CLAUDE_CODE_DISABLE_1M_CONTEXT": "yes",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "true",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": "yes",
     "CLAUDE_CODE_DISABLE_ATTACHMENTS": "off",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "yes",
     "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": "true",
@@ -39,11 +40,14 @@
     "CLAUDE_CODE_EFFORT_LEVEL": "extreme",
     "CLAUDE_CODE_ENABLE_AWAY_SUMMARY": "yes",
     "CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH": "on",
+    "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": "enabled",
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "enable",
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "yes",
     "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": "1",
     "CLAUDE_CODE_ENABLE_TASKS": "enable",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "yes",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "enable",
+    "CLAUDE_CODE_FORCE_SYNC_OUTPUT": "enabled",
     "CLAUDE_CODE_FORK_SUBAGENT": "true",
     "CLAUDE_CODE_GLOB_HIDDEN": "1",
     "CLAUDE_CODE_GLOB_NO_IGNORE": "yes",
@@ -53,6 +57,7 @@
     "CLAUDE_CODE_MCP_ALLOWLIST_ENV": "all",
     "CLAUDE_CODE_NEW_INIT": "start",
     "CLAUDE_CODE_NO_FLICKER": "maybe",
+    "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": "auto",
     "CLAUDE_CODE_PERFORCE_MODE": "on",
     "CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE": "always",
     "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": "true",
@@ -80,10 +85,14 @@
     "USE_BUILTIN_RIPGREP": "always"
   },
   "forceLoginMethod": "github",
+  "parentSettingsBehavior": "invalid-mode",
   "permissions": {
     "defaultMode": "invalid-mode",
     "disableAutoMode": "enabled",
     "disableBypassPermissionsMode": "enabled"
+  },
+  "skillOverrides": {
+    "test-skill": "invalid-mode"
   },
   "spinnerVerbs": {
     "mode": "merge",
@@ -91,5 +100,8 @@
   },
   "teammateMode": "split",
   "tui": "mini",
-  "viewMode": "list"
+  "viewMode": "list",
+  "worktree": {
+    "baseRef": "invalid-ref"
+  }
 }

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -974,6 +974,31 @@
           "type": "string",
           "description": "Use the bundled ripgrep binary instead of system ripgrep",
           "enum": ["0", "1"]
+        },
+        "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": {
+          "type": "string",
+          "description": "Disable alternate screen buffer rendering. When set to 1, keeps conversation in native scrollback instead of fullscreen renderer",
+          "enum": ["0", "1"]
+        },
+        "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": {
+          "type": "string",
+          "description": "Enable feedback survey collection via OpenTelemetry for enterprises",
+          "enum": ["0", "1"]
+        },
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": {
+          "type": "string",
+          "description": "Enable model discovery from LLM gateway /v1/models endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway",
+          "enum": ["0", "1"]
+        },
+        "CLAUDE_CODE_FORCE_SYNC_OUTPUT": {
+          "type": "string",
+          "description": "Force synchronous output flushing. When set to 1, forces synchronized output on terminals that auto-detection misses (e.g., Emacs eat)",
+          "enum": ["0", "1"]
+        },
+        "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": {
+          "type": "string",
+          "description": "Enable automatic package manager updates. When set, Claude Code runs the upgrade command in background on Homebrew/WinGet and prompts to restart",
+          "enum": ["0", "1"]
         }
       },
       "propertyNames": {
@@ -2137,6 +2162,16 @@
               "description": "Additional arguments to pass to the ripgrep binary"
             }
           }
+        },
+        "bwrapPath": {
+          "type": "string",
+          "minLength": 1,
+          "description": "(Managed setting only) Path to custom bubblewrap (bwrap) binary for Linux/WSL sandbox. Overrides default. See https://code.claude.com/docs/en/server-managed-settings"
+        },
+        "socatPath": {
+          "type": "string",
+          "minLength": 1,
+          "description": "(Managed setting only) Path to custom socat binary for Linux/WSL network proxying. Overrides default. See https://code.claude.com/docs/en/server-managed-settings"
         }
       },
       "additionalProperties": false
@@ -2200,6 +2235,15 @@
       "description": "Show turn duration messages after responses (e.g., \"Cooked for 1m 6s\"). Set to false to hide these messages (default: true)",
       "default": true
     },
+    "skillOverrides": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["on", "name-only", "user-invocable-only", "off"]
+      },
+      "description": "Per-skill visibility overrides. Controls whether skills appear to Claude and in the / picker. Values: 'on' (name and description shown, default), 'name-only' (name only), 'user-invocable-only' (hidden from Claude, visible in /), 'off' (hidden everywhere). Plugin skills are not affected by this setting. See https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings",
+      "examples": [{ "legacy-context": "name-only", "deploy": "off" }]
+    },
     "prefersReducedMotion": {
       "type": "boolean",
       "description": "Reduce or disable UI animations (spinners, shimmer, flash effects) for accessibility",
@@ -2241,8 +2285,20 @@
           },
           "description": "Directories to check out in each worktree via git sparse-checkout (cone mode). Only the listed paths are written to disk, which is faster in large monorepos. See https://code.claude.com/docs/en/settings#worktree-settings",
           "examples": [["packages/my-app", "shared/utils"]]
+        },
+        "baseRef": {
+          "type": "string",
+          "enum": ["fresh", "head"],
+          "default": "fresh",
+          "description": "Whether to branch worktrees from origin/<default> (fresh) or local HEAD (head). Default: fresh. Set to 'head' to preserve unpushed commits in new worktrees. See https://code.claude.com/docs/en/settings#worktree-settings"
         }
       }
+    },
+    "parentSettingsBehavior": {
+      "type": "string",
+      "enum": ["first-wins", "merge"],
+      "default": "first-wins",
+      "description": "(Admin/managed settings only) Controls how SDK managedSettings (parent tier) merge with inherited settings. 'first-wins': first non-empty value applies (default). 'merge': merge arrays and objects. See https://code.claude.com/docs/en/server-managed-settings"
     },
     "pluginTrustMessage": {
       "type": "string",
@@ -2508,6 +2564,13 @@
             "type": "string"
           },
           "description": "Entries for the auto mode classifier environment section. Replaces the built-in environment context entirely unless the literal string \"$defaults\" is included as an entry, which splices the built-in defaults in at that position."
+        },
+        "hard_deny": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Rules for the auto mode classifier hard-deny section. Hard-deny rules block unconditionally regardless of user intent. Replaces the built-in hard-deny rules entirely unless the literal string \"$defaults\" is included as an entry, which splices the built-in defaults in at that position. See https://code.claude.com/docs/en/permissions"
         }
       }
     },

--- a/src/test/claude-code-settings/edge-cases.json
+++ b/src/test/claude-code-settings/edge-cases.json
@@ -4,12 +4,18 @@
   "effortLevel": "low",
   "env": {
     "CLAUDE_CODE_DEBUG_LOG_LEVEL": "info",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": "0",
     "CLAUDE_CODE_DISABLE_ATTACHMENTS": "0",
     "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "0",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max"
+    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": "0",
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "0",
+    "CLAUDE_CODE_FORCE_SYNC_OUTPUT": "0",
+    "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": "0"
   },
   "fastMode": false,
   "forceLoginMethod": "claudeai",
+  "parentSettingsBehavior": "first-wins",
   "permissions": {
     "allow": [],
     "ask": [],
@@ -19,11 +25,17 @@
   "prefersReducedMotion": false,
   "respectGitignore": true,
   "showTurnDuration": true,
+  "skillOverrides": {
+    "custom-skill": "on"
+  },
   "spinnerTipsEnabled": true,
   "spinnerVerbs": {
     "mode": "append",
     "verbs": ["Thinking"]
   },
   "teammateMode": "in-process",
-  "terminalProgressBarEnabled": true
+  "terminalProgressBarEnabled": true,
+  "worktree": {
+    "baseRef": "fresh"
+  }
 }

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -16,6 +16,7 @@
   "autoMode": {
     "allow": ["$defaults", "All read-only operations"],
     "environment": ["$defaults", "WSL2 on Windows"],
+    "hard_deny": ["Running executable files", "Writing to system directories"],
     "soft_deny": ["$defaults", "Deleting files"]
   },
   "autoUpdatesChannel": "latest",
@@ -49,9 +50,14 @@
     "ANTHROPIC_BEDROCK_SERVICE_TIER": "priority",
     "ANTHROPIC_MODEL": "claude-3-5-sonnet-20241022",
     "ANTHROPIC_SMALL_FAST_MODEL": "claude-3-5-haiku-20241022",
+    "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": "1",
     "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+    "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": "1",
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+    "CLAUDE_CODE_FORCE_SYNC_OUTPUT": "1",
     "CLAUDE_CODE_FORK_SUBAGENT": "1",
     "CLAUDE_CODE_HIDE_CWD": "1",
+    "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": "1",
     "CLAUDE_LOG_LEVEL": "debug",
     "PROJECT_ROOT": "/home/user/projects"
   },
@@ -241,6 +247,7 @@
   },
   "otelHeadersHelper": "/usr/local/bin/otel-headers.sh",
   "outputStyle": "Explanatory",
+  "parentSettingsBehavior": "merge",
   "permissions": {
     "additionalDirectories": ["~/Documents/reference", "~/.config/claude-code"],
     "allow": [
@@ -289,6 +296,7 @@
   "sandbox": {
     "allowUnsandboxedCommands": false,
     "autoAllowBashIfSandboxed": false,
+    "bwrapPath": "/usr/bin/bwrap",
     "enableWeakerNestedSandbox": false,
     "enableWeakerNetworkIsolation": true,
     "enabled": true,
@@ -314,11 +322,17 @@
     "ripgrep": {
       "args": ["--hidden"],
       "command": "/usr/bin/rg"
-    }
+    },
+    "socatPath": "/usr/bin/socat"
   },
   "showClearContextOnPlanAccept": true,
   "showThinkingSummaries": true,
   "showTurnDuration": false,
+  "skillOverrides": {
+    "deploy": "off",
+    "internal-tool": "user-invocable-only",
+    "legacy-context": "name-only"
+  },
   "skipDangerousModePermissionPrompt": true,
   "skipWebFetchPreflight": false,
   "skippedMarketplaces": ["untrusted-marketplace"],
@@ -346,6 +360,7 @@
   "viewMode": "focus",
   "voiceEnabled": true,
   "worktree": {
+    "baseRef": "head",
     "sparsePaths": ["packages/my-app", "shared/utils"]
   },
   "wslInheritsWindowsSettings": false


### PR DESCRIPTION
## Schema

- Add `worktree.baseRef` enum [fresh, head] to control whether worktrees branch from origin/<default> or local HEAD. Default: fresh. ([v2.1.133](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21133), [settings#worktree-settings](https://code.claude.com/docs/en/settings#worktree-settings))
- Add `sandbox.bwrapPath` and `sandbox.socatPath` managed-only string properties for Linux/WSL custom sandbox binary paths. ([v2.1.133](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21133), [server-managed-settings](https://code.claude.com/docs/en/server-managed-settings))
- Add `parentSettingsBehavior` admin-tier enum [first-wins, merge] to control SDK managedSettings merge behavior. Default: first-wins. ([v2.1.133](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21133), [server-managed-settings](https://code.claude.com/docs/en/server-managed-settings))
- Add `autoMode.hard_deny` array for unconditional-block classifier rules (parallel to existing allow/soft_deny). ([v2.1.136](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21136), [permissions](https://code.claude.com/docs/en/permissions))
- Add `skillOverrides` object for per-skill visibility control with enum [on, name-only, user-invocable-only, off]. ([v2.1.129](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21129), [skills#override-skill-visibility-from-settings](https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings))
- Add 5 missing environment variables to `$.env.properties`:
  - `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN` — disable fullscreen renderer (v2.1.132)
  - `CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL` — enable feedback survey for OpenTelemetry (v2.1.136)
  - `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` — opt-in gateway model discovery (v2.1.129)
  - `CLAUDE_CODE_FORCE_SYNC_OUTPUT` — force synchronized output (v2.1.129)
  - `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE` — enable auto-upgrade background task (v2.1.129)

## Tests

- Update `modern-complete-config.json` with all new properties: `worktree.baseRef: "head"`, `sandbox.bwrapPath`/`socatPath`, `parentSettingsBehavior: "merge"`, `autoMode.hard_deny`, `skillOverrides`, all 5 new env vars set to "1"
- Update `edge-cases.json` with default/boundary values: `worktree.baseRef: "fresh"`, `parentSettingsBehavior: "first-wins"`, all 5 new env vars set to "0"
- All 8 coverage checks passing (test completeness, enum coverage, default values, negative tests)

## Negative tests

- Update `invalid-enum-values.json` with invalid enum values for all new properties and env vars

## Coverage

✅ All 8 coverage checks passing
✅ Test completeness: 83/83 top-level properties covered
✅ Enum coverage: 94/94 enums with positive and negative tests
✅ Default value coverage: all defaults tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)