### PR TITLE
Add Agent Permission Policy schema (.agents/permissions.json)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9710,6 +9710,12 @@
       "url": "https://raw.githubusercontent.com/nexus-rpc/nexus-rpc-gen/main/schemas/nexus-rpc-gen.json"
     },
     {
+      "name": "Agent Permission Policy",
+      "description": "Cross-agent permission policy for AI coding agents",
+      "fileMatch": ["**/.agents/permissions.json", "**/.agents/permissions.local.json"],
+      "url": "https://raw.githubusercontent.com/Mearman/agent-permissions/main/agent-permissions.schema.json"
+    },
+    {
       "name": "AgentCore CLI",
       "description": "Configuration file for Amazon Bedrock AgentCore CLI projects",
       "fileMatch": ["**/agentcore/agentcore.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9712,7 +9712,10 @@
     {
       "name": "Agent Permission Policy",
       "description": "Cross-agent permission policy for AI coding agents",
-      "fileMatch": ["**/.agents/permissions.json", "**/.agents/permissions.local.json"],
+      "fileMatch": [
+        "**/.agents/permissions.json",
+        "**/.agents/permissions.local.json"
+      ],
       "url": "https://raw.githubusercontent.com/Mearman/agent-permissions/main/agent-permissions.schema.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds the **Agent Permission Policy** schema for `.agents/permissions.json` and `.agents/permissions.local.json` files.

This is a cross-agent permission policy format for AI coding agents (Claude Code, Pi, OpenCode, Codex, Cursor, etc.). The schema defines what tools agents may use, under what conditions, and how subagents are constrained.

- **Self-hosted schema**: [raw.githubusercontent.com/Mearman/agent-permissions/main/agent-permissions.schema.json](https://raw.githubusercontent.com/Mearman/agent-permissions/main/agent-permissions.schema.json)
- **npm package**: [agent-perms](https://www.npmjs.com/package/agent-perms) — Zod schemas, validators, and bidirectional codecs for each agent
- **Repository**: [Mearman/agent-permissions](https://github.com/Mearman/agent-permissions)

### File matches
- `**/.agents/permissions.json` — team-shared policy (committed to git)
- `**/.agents/permissions.local.json` — personal overrides (gitignored)

### Schema highlights
- Deny-first evaluation (deny rules short-circuit before allow)
- Compatible with Claude Code permission syntax (`Tool(pattern)`, `prefix:*`, wildcards)
- Conditional rules with `when.cwd` / `when.branch` conditions
- MCP tool wildcards (`mcp__server`, `mcp__*__tool*`)
- Agent delegation controls (subagent constraints, per-agent overrides)
- Sandbox and network configuration
- Named permission profiles

### Validation
- `node cli.js check` passes ✓