### PR TITLE
Add MockServer expectations JSON Schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4449,6 +4449,16 @@
       "url": "https://raw.githubusercontent.com/getmockd/mockd/main/schema/mockd.schema.json"
     },
     {
+      "name": "MockServer Expectations",
+      "description": "MockServer expectations configuration for defining request matchers and response actions. See https://www.mock-server.com",
+      "fileMatch": [
+        "mockserverInitialization.json",
+        "*mockserver*Initialization.json",
+        "mockserver*.json"
+      ],
+      "url": "https://www.mock-server.com/schema/expectations.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],


### PR DESCRIPTION
## Summary

Adds the [MockServer](https://www.mock-server.com) expectations JSON Schema to the catalog as an external/self-hosted schema.

- **Schema URL:** https://www.mock-server.com/schema/expectations.json
- **Type:** Self-hosted (external)
- **Draft:** `draft-07`

### File match patterns

| Pattern | Description |
|---------|-------------|
| `mockserverInitialization.json` | Default MockServer initialization file |
| `*mockserver*Initialization.json` | Custom initialization files containing "mockserver" and "Initialization" |
| `mockserver*.json` | Any JSON file starting with "mockserver" |

### Context

MockServer is an open-source HTTP(S) mock server and proxy for testing ([GitHub](https://github.com/mock-server/mockserver)). Users configure expectations as JSON arrays. The schema enables IDE autocompletion and validation for these files.

This was requested in [mock-server/mockserver#1883](https://github.com/mock-server/mockserver/issues/1883).

The schema is self-contained (all `$ref` definitions inlined) and validates correctly with `jsonschema` and `ajv`.