### PR TITLE
Add PRML manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5257,6 +5257,16 @@
       "url": "https://www.schemastore.org/pre-commit-hooks.json"
     },
     {
+      "name": "PRML manifest",
+      "description": "Pre-Registered ML Manifest — open spec for committing ML evaluation claims to a SHA-256 hash before the run (CC BY 4.0). https://spec.falsify.dev/v0.1",
+      "fileMatch": ["*.prml.yaml", "*.prml.yml", "manifest.prml.yaml", "prml-manifest.yaml", "prml-manifest.yml"],
+      "url": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",
+      "versions": {
+        "v0.1": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",
+        "v0.2-rfc": "https://spec.falsify.dev/schema/prml-v0.2.schema.json"
+      }
+    },
+    {
       "name": ".phrase.yml",
       "description": "Phrase configuration file",
       "fileMatch": [".phrase.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5259,7 +5259,13 @@
     {
       "name": "PRML manifest",
       "description": "Pre-Registered ML Manifest — open spec for committing ML evaluation claims to a SHA-256 hash before the run (CC BY 4.0). https://spec.falsify.dev/v0.1",
-      "fileMatch": ["*.prml.yaml", "*.prml.yml", "manifest.prml.yaml", "prml-manifest.yaml", "prml-manifest.yml"],
+      "fileMatch": [
+        "*.prml.yaml",
+        "*.prml.yml",
+        "manifest.prml.yaml",
+        "prml-manifest.yaml",
+        "prml-manifest.yml"
+      ],
       "url": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",
       "versions": {
         "v0.1": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",


### PR DESCRIPTION
## What

Adds an entry for **PRML - Pre-Registered ML Manifest** to the SchemaStore catalog.

PRML is an open CC BY 4.0 specification for committing machine-learning evaluation claims to a SHA-256 hash before the experiment runs. It is used by researchers, audit firms, and AI evaluation programmes to make threshold and dataset commitments cryptographically verifiable.

## Diff

`src/api/json/catalog.json`, alphabetically near `.pre-commit-hooks.yml`:

```json
{
  "name": "PRML manifest",
  "description": "Pre-Registered ML Manifest - open spec for committing ML evaluation claims to a SHA-256 hash before the run (CC BY 4.0). https://spec.falsify.dev/v0.1",
  "fileMatch": ["*.prml.yaml", "*.prml.yml", "manifest.prml.yaml", "prml-manifest.yaml", "prml-manifest.yml"],
  "url": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",
  "versions": {
    "v0.1": "https://spec.falsify.dev/schema/prml-v0.1.schema.json",
    "v0.2-rfc": "https://spec.falsify.dev/schema/prml-v0.2.schema.json"
  }
}
```

## Schema verification

- **Draft:** JSON Schema 2020-12
- **`$id` matches URL:** [OK] verified
- **JSON valid:** [OK] `python3 -c "import json; json.load(open('catalog.json'))"`
- **Validates own examples:** [OK] both v0.1 and v0.2 schemas include working manifest examples
- **Validates against locked test vectors:** [OK] 32/32 (12 v0.1 + 8 v0.2 + 12 v0.1 inputs against v0.2 for backwards-compat)

The schema URLs are served via Cloudflare Pages from a dedicated subdomain controlled by Studio 11. They have been live since 2026-05-09 and are part of the stable `spec.falsify.dev` deployment.

## Where the schemas live

- Spec home: https://spec.falsify.dev/v0.1
- Schema landing: https://spec.falsify.dev/schema/
- v0.1 schema: https://spec.falsify.dev/schema/prml-v0.1.schema.json
- v0.2 schema: https://spec.falsify.dev/schema/prml-v0.2.schema.json
- GitHub: https://github.com/studio-11-co/falsify (CC BY 4.0 spec, MIT reference impls)

## File pattern justification

All five patterns include the literal string `prml` to avoid collisions:

- `*.prml.yaml`, `*.prml.yml` - extension convention for PRML-formatted files
- `manifest.prml.yaml` - when paired with other manifests in the same project
- `prml-manifest.yaml`, `prml-manifest.yml` - community convention for the canonical filename

No overlap with existing entries in the catalog.

## Maintainer commitment

I am the editor of the PRML specification and a co-founder of Studio 11 Turkey Ltd. Sti., which maintains the four reference implementations (Python, JS, Go, Rust). Contact: hello@studio-11.co. The schemas are CC BY 4.0; the reference implementations are MIT; an irrevocable patent non-assertion grant is published with the spec.

If the schema URLs ever need to be re-homed, I will submit a follow-up PR to update the catalog.

## Disclosure

Self-submission per SchemaStore norm. Maintainer of the schemas, not affiliated with the SchemaStore project.

Happy to revise file patterns, description, or version-block structure based on reviewer preference.
