### PR TITLE
Add MockServer expectation JSON schemas (external)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4449,6 +4449,23 @@
       "url": "https://raw.githubusercontent.com/getmockd/mockd/main/schema/mockd.schema.json"
     },
     {
+      "name": "MockServer Expectation",
+      "description": "MockServer expectation configuration. MockServer enables easy mocking of any system you integrate with via HTTP or HTTPS. See https://www.mock-server.com",
+      "fileMatch": [
+        "mockserver-expectations.json",
+        "mockserver-expectations.yaml",
+        "mockserver-expectations.yml",
+        "mockserverInitialization.json"
+      ],
+      "url": "https://www.mock-server.com/schema/expectation.json"
+    },
+    {
+      "name": "MockServer Expectations Array",
+      "description": "MockServer expectations array configuration. See https://www.mock-server.com",
+      "fileMatch": [],
+      "url": "https://www.mock-server.com/schema/expectations.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],


### PR DESCRIPTION
## Summary

Add catalog entries for [MockServer](https://www.mock-server.com) expectation JSON schemas.

MockServer is an open-source HTTP(S) mock server and proxy for testing, with over 4,500 GitHub stars. It enables easy mocking of any system you integrate with via HTTP or HTTPS.

## Schemas

The schemas are **self-hosted** at `https://www.mock-server.com/schema/`:

| Schema | URL | Description |
|--------|-----|-------------|
| `expectation.json` | https://www.mock-server.com/schema/expectation.json | Single expectation configuration |
| `expectations.json` | https://www.mock-server.com/schema/expectations.json | Array of expectations |

Both schemas are self-contained (all `$ref`s are resolved inline) and use `draft-07`.

## File Matches

- `mockserver-expectations.json` / `.yaml` / `.yml` — common expectation initializer filenames
- `mockserverInitialization.json` — default MockServer initialization file

## Links

- Repository: https://github.com/mock-server/mockserver
- Documentation: https://www.mock-server.com
- Schema docs: https://www.mock-server.com/mock_server/creating_expectations.html