### PR TITLE
fix: add ".rustfmt.toml" to file matches

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5860,8 +5860,8 @@
     },
     {
       "name": "rustfmt",
-      "description": "rustfmt, a tool to format Rust code",
-      "fileMatch": ["rustfmt.toml"],
+      "description": "rustfmt, a tool to format Rust code. Documentation: https://rust-lang.github.io/rustfmt",
+      "fileMatch": ["rustfmt.toml", ".rustfmt.toml"],
       "url": "https://www.schemastore.org/rustfmt.json"
     },
     {


### PR DESCRIPTION
[Rustfmt](https://rust-lang.github.io/rustfmt) accepts both `rustfmt.toml` and `.rustfmt.toml`. This PR adds the latter to the fileMatch list.