### PR TITLE
Add memnex schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9789,11 +9789,8 @@
     {
       "name": "memnex",
       "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://github.com/UladzKha/memnex",
-      "fileMatch": [
-        "*.memnex.json",
-        "meeting-output.json"
-      ],
-       "url": "https://raw.githubusercontent.com/UladzKha/memnex/main/schema/v0.1/meeting-output.schema.json"
+      "fileMatch": ["*.memnex.json", "meeting-output.json"],
+      "url": "https://raw.githubusercontent.com/UladzKha/memnex/main/schema/v0.1/meeting-output.schema.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9785,6 +9785,15 @@
       "description": "Configuration file for Acton projects",
       "fileMatch": ["Acton.toml"],
       "url": "https://raw.githubusercontent.com/ton-blockchain/acton/master/crates/acton-config/schemas/acton.schema.json"
+    },
+    {
+      "name": "memnex",
+      "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://github.com/UladzKha/memnex",
+      "fileMatch": [
+        "*.memnex.json",
+        "meeting-output.json"
+      ],
+       "url": "https://raw.githubusercontent.com/UladzKha/memnex/main/schema/v0.1/meeting-output.schema.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds [memnex](https://github.com/UladzKha/memnex) — an open specification for portable meeting outputs (transcripts, summaries, action items, decisions) from local-first meeting processing tools.

## About memnex

memnex is a published JSON Schema for structured meeting data. It serves as an interop format between meeting processing pipelines (Whisper transcription + LLM analysis) and downstream consumers (note-taking apps, knowledge bases, AI agents via MCP).

- **Spec repo:** https://github.com/UladzKha/memnex
- **Reference implementation:** [`memnex-spec`](https://www.npmjs.com/package/memnex-spec) on npm
- **Conformance suite:** 15 test cases (7 valid, 8 invalid) — included in the spec repo
- **License:** Dual — MIT (code) + CC0 1.0 (spec)
- **First adopter:** [Samuraizer](https://github.com/UladzKha/samuraizer-cli) (local-first meeting CLI)

## Schema details

- **JSON Schema draft:** 2020-12
- **fileMatch:**
  - `*.memnex.json` — suffix convention for spec-aware tooling
  - `meeting-output.json` — default filename used by the reference implementation

## Notes for reviewers

- The schema uses JSON Schema Draft 2020-12. I see Schemastore now supports it (#1977 was merged) — happy to discuss if draft-07 is preferred for this entry.
- The URL points to the `main` branch of the spec repo. A custom domain (`memnex.org`) is owned and will host the schema directly in a future iteration; once GitHub Pages is configured with the CNAME, I'll open a follow-up PR to update the URL.
- No tests included in this initial PR. The conformance suite lives in the spec repo and runs against the schema directly. I can submit Schemastore test cases as a follow-up if useful.

Thanks for maintaining Schemastore!