### PR TITLE
✨ Add JSON Schema for `scheduled` in `pyproject.toml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@ src/schemas/json/pyproject.json @ya7010
 
 # Managed by FastAPI Team:
 src/schemas/json/partial-fastapi.json @tiangolo
+src/schemas/json/partial-scheduled.json @tiangolo
 
 # Managed by Contextive Team:
 src/schemas/json/contextive-glossary.json @chrissimon-au

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1226,6 +1226,12 @@
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-fastapi.json"
     },
     {
+      "name": "partial-scheduled.json",
+      "description": "Scheduled job configuration for pyproject.toml",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/partial-scheduled.json"
+    },
+    {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
       "fileMatch": [".suite.json", ".xsuite.json"],

--- a/src/negative_test/pyproject/scheduled-invalid-cadence.toml
+++ b/src/negative_test/pyproject/scheduled-invalid-cadence.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/pyproject.json
+
+[tool.scheduled.cleanup]
+every = "daily"
+entrypoint = "jobs.cleanup:run"

--- a/src/negative_test/pyproject/scheduled-invalid-cadence.toml
+++ b/src/negative_test/pyproject/scheduled-invalid-cadence.toml
@@ -2,4 +2,4 @@
 
 [tool.scheduled.cleanup]
 every = "daily"
-entrypoint = "jobs.cleanup:run"
+entrypoint = "app.jobs:clean_files"

--- a/src/negative_test/pyproject/scheduled-missing-entrypoint.toml
+++ b/src/negative_test/pyproject/scheduled-missing-entrypoint.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
+
+[tool.scheduled.clean-files]
+every = "day"

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -333,13 +333,13 @@
     "partial-cibuildwheel.json", // pyproject.json[tool.cibuildwheel]
     "partial-dfc.json", // pyproject.json[tool.dfc]
     "partial-fastapi.json", // pyproject.json[tool.fastapi]
-    "partial-scheduled.json", // pyproject.json[tool.scheduled]
     "partial-mypy.json", // pyproject.json[tool.mypy]
     "partial-pdm.json", // pyproject.json[tool.pdm]
     "partial-pdm-dockerize.json", // pyproject.json[tool.pdm.dockerize]
     "partial-poe.json", // pyproject.json[tool.poe]
     "partial-poetry.json", // pyproject.json[tool.poetry]
     "partial-repo-review.json", // pyproject.json[tool.repo-review]
+    "partial-scheduled.json", // pyproject.json[tool.scheduled]
     "partial-tox.json", // classic pyproject.json[tool.tox]
     "tox.json",
     "partial-eslint-plugins.json", // eslintrc.json[rules.*]
@@ -1269,7 +1269,6 @@
         "partial-cibuildwheel.json",
         "partial-dfc.json",
         "partial-fastapi.json",
-        "partial-scheduled.json",
         "partial-mypy.json",
         "partial-pdm.json",
         "partial-pdm-dockerize.json",
@@ -1279,6 +1278,7 @@
         "partial-pyright.json",
         "partial-pytest.json",
         "partial-repo-review.json",
+        "partial-scheduled.json",
         "partial-scikit-build.json",
         "partial-setuptools.json",
         "partial-setuptools-scm.json",

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -333,6 +333,7 @@
     "partial-cibuildwheel.json", // pyproject.json[tool.cibuildwheel]
     "partial-dfc.json", // pyproject.json[tool.dfc]
     "partial-fastapi.json", // pyproject.json[tool.fastapi]
+    "partial-scheduled.json", // pyproject.json[tool.scheduled]
     "partial-mypy.json", // pyproject.json[tool.mypy]
     "partial-pdm.json", // pyproject.json[tool.pdm]
     "partial-pdm-dockerize.json", // pyproject.json[tool.pdm.dockerize]
@@ -1268,6 +1269,7 @@
         "partial-cibuildwheel.json",
         "partial-dfc.json",
         "partial-fastapi.json",
+        "partial-scheduled.json",
         "partial-mypy.json",
         "partial-pdm.json",
         "partial-pdm-dockerize.json",

--- a/src/schemas/json/partial-scheduled.json
+++ b/src/schemas/json/partial-scheduled.json
@@ -4,20 +4,34 @@
   "type": "object",
   "additionalProperties": {
     "type": "object",
+    "title": "Scheduled Job",
+    "description": "A recurring scheduled job. The table key under `[tool.scheduled]` is the unique job ID.\n\n```toml\n[tool.scheduled.<job-id>]\nevery = \"<cadence>\"\nentrypoint = \"<module>:<function>\"\n```",
     "additionalProperties": false,
-    "required": ["every", "entrypoint"],
+    "required": [
+      "every",
+      "entrypoint"
+    ],
     "properties": {
       "every": {
         "type": "string",
-        "title": "Cadence",
-        "description": "Cadence unit for the scheduled job. For example, `every = \"day\"` would run the job once per day. Supported values are: `minute`, `hour`, `day`, `week`, and `month`.",
-        "enum": ["minute", "hour", "day", "week", "month"]
+        "title": "Every",
+        "description": "How often to run the job. For example, `every = \"day\"` would run the job once per day.\n\n```toml\n[tool.scheduled.clean-files]\nevery = \"day\"\nentrypoint = \"app.jobs:clean_files\"\n```\n\nSupported values are:\n\n* `minute`\n* `hour`\n* `day`\n* `week`\n* `month`\n\nProviders should run each job at least once per configured cadence and may support only a subset of these values.",
+        "enum": [
+          "minute",
+          "hour",
+          "day",
+          "week",
+          "month"
+        ]
       },
       "entrypoint": {
         "type": "string",
         "title": "Entrypoint",
-        "description": "Python callable to run, in the format:\n```\nimportable.module:function\n```\n\nFor example, for a scheduled job like:\n\n```python\ndef run():\n    ...\n```\n\nin a file at `jobs/cleanup.py`, the config could look like:\n\n```toml\n[tool.scheduled.cleanup]\nevery = \"day\"\nentrypoint = \"jobs.cleanup:run\"\n```",
-        "examples": ["jobs.cleanup:run", "backend.tasks:send_digest"]
+        "description": "Python callable to run, in the format:\n```\nimportable.module:some_callable\n```\n\nFor example, for a scheduled job like:\n\n```python\ndef clean_files():\n    ...\n```\n\nin a file at `app/jobs.py`, the config could look like:\n\n```toml\n[tool.scheduled.clean-files]\nevery = \"day\"\nentrypoint = \"app.jobs:clean_files\"\n```\n\nThis is equivalent to:\n\n```python\nfrom importable.module import some_callable\n\nsome_callable()\n```\n\nSo, `app.jobs:clean_files` is equivalent to:\n\n```python\nfrom app.jobs import clean_files\n\nclean_files()\n```",
+        "examples": [
+          "app.jobs:clean_files",
+          "backend.tasks:send_notifications"
+        ]
       }
     }
   }

--- a/src/schemas/json/partial-scheduled.json
+++ b/src/schemas/json/partial-scheduled.json
@@ -7,31 +7,19 @@
     "title": "Scheduled Job",
     "description": "A recurring scheduled job. The table key under `[tool.scheduled]` is the unique job ID.\n\n```toml\n[tool.scheduled.<job-id>]\nevery = \"<cadence>\"\nentrypoint = \"<module>:<function>\"\n```",
     "additionalProperties": false,
-    "required": [
-      "every",
-      "entrypoint"
-    ],
+    "required": ["every", "entrypoint"],
     "properties": {
       "every": {
         "type": "string",
         "title": "Every",
         "description": "How often to run the job. For example, `every = \"day\"` would run the job once per day.\n\n```toml\n[tool.scheduled.clean-files]\nevery = \"day\"\nentrypoint = \"app.jobs:clean_files\"\n```\n\nSupported values are:\n\n* `minute`\n* `hour`\n* `day`\n* `week`\n* `month`\n\nProviders should run each job at least once per configured cadence and may support only a subset of these values.",
-        "enum": [
-          "minute",
-          "hour",
-          "day",
-          "week",
-          "month"
-        ]
+        "enum": ["minute", "hour", "day", "week", "month"]
       },
       "entrypoint": {
         "type": "string",
         "title": "Entrypoint",
         "description": "Python callable to run, in the format:\n```\nimportable.module:some_callable\n```\n\nFor example, for a scheduled job like:\n\n```python\ndef clean_files():\n    ...\n```\n\nin a file at `app/jobs.py`, the config could look like:\n\n```toml\n[tool.scheduled.clean-files]\nevery = \"day\"\nentrypoint = \"app.jobs:clean_files\"\n```\n\nThis is equivalent to:\n\n```python\nfrom importable.module import some_callable\n\nsome_callable()\n```\n\nSo, `app.jobs:clean_files` is equivalent to:\n\n```python\nfrom app.jobs import clean_files\n\nclean_files()\n```",
-        "examples": [
-          "app.jobs:clean_files",
-          "backend.tasks:send_notifications"
-        ]
+        "examples": ["app.jobs:clean_files", "backend.tasks:send_notifications"]
       }
     }
   }

--- a/src/schemas/json/partial-scheduled.json
+++ b/src/schemas/json/partial-scheduled.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-scheduled.json",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["every", "entrypoint"],
+    "properties": {
+      "every": {
+        "type": "string",
+        "title": "Cadence",
+        "description": "Cadence unit for the scheduled job. For example, `every = \"day\"` would run the job once per day. Supported values are: `minute`, `hour`, `day`, `week`, and `month`.",
+        "enum": ["minute", "hour", "day", "week", "month"]
+      },
+      "entrypoint": {
+        "type": "string",
+        "title": "Entrypoint",
+        "description": "Python callable to run, in the format:\n```\nimportable.module:function\n```\n\nFor example, for a scheduled job like:\n\n```python\ndef run():\n    ...\n```\n\nin a file at `jobs/cleanup.py`, the config could look like:\n\n```toml\n[tool.scheduled.cleanup]\nevery = \"day\"\nentrypoint = \"jobs.cleanup:run\"\n```",
+        "examples": ["jobs.cleanup:run", "backend.tasks:send_digest"]
+      }
+    }
+  }
+}

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -980,7 +980,7 @@
         "scheduled": {
           "$ref": "partial-scheduled.json",
           "title": "Scheduled Jobs",
-          "description": "Scheduled job configuration."
+          "description": "Scheduled jobs in Python's `pyproject.toml`.\n\nThis is a specification for declaring recurring scheduled jobs in Python projects, in `pyproject.toml`.\n\nIt defines how jobs are declared and how providers would run them.\n\nIt does not provide a specific implementation for running scheduled jobs, because that is provider specific.\n\nFor example, a file at `app/jobs.py` could define:\n\n```python\ndef clean_files():\n    print(\"Running cleanup...\")\n```\n\nYou could define a scheduled job to run that function once per day with:\n\n```toml\n[tool.scheduled.clean-files]\nevery = \"day\"\nentrypoint = \"app.jobs:clean_files\"\n```"
         },
         "mypy": {
           "$ref": "partial-mypy.json",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -977,6 +977,11 @@
           "title": "Web Framework",
           "description": "FastAPI web framework configuration."
         },
+        "scheduled": {
+          "$ref": "partial-scheduled.json",
+          "title": "Scheduled Jobs",
+          "description": "Scheduled job configuration."
+        },
         "mypy": {
           "$ref": "partial-mypy.json",
           "title": "Static Type Checker",

--- a/src/test/pyproject/scheduled.toml
+++ b/src/test/pyproject/scheduled.toml
@@ -1,0 +1,9 @@
+#:schema ../../schemas/json/pyproject.json
+
+[tool.scheduled.cleanup]
+every = "day"
+entrypoint = "jobs.cleanup:run"
+
+[tool.scheduled.send_digest]
+every = "week"
+entrypoint = "backend.tasks:send_digest"

--- a/src/test/pyproject/scheduled.toml
+++ b/src/test/pyproject/scheduled.toml
@@ -1,9 +1,9 @@
 #:schema ../../schemas/json/pyproject.json
 
-[tool.scheduled.cleanup]
+[tool.scheduled.clean-files]
 every = "day"
-entrypoint = "jobs.cleanup:run"
+entrypoint = "app.jobs:clean_files"
 
-[tool.scheduled.send_digest]
+[tool.scheduled.send_notifications]
 every = "week"
-entrypoint = "backend.tasks:send_digest"
+entrypoint = "backend.tasks:send_notifications"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

✨ Add JSON Schema for `scheduled` in `pyproject.toml` (I own the PyPI package, currently empty, work in progress: https://pypi.org/project/scheduled/). The main feature of that PyPI package is this JSON Schema here. :upside_down_face: 

I based this PR on the one I made for FastAPI: https://github.com/SchemaStore/schemastore/pull/5579

I'm also adding the `CODEOWNERS` config to allow me to edit it in the future if I add extra configs.

I tested it by temporarily copying the contents of the partial manually to the JSON Schema for `pyproject.toml` and triggering autocompletion on VS Code with Tombi and Better Toml installed. That's also how I tweaked the description format and confirmed the Markdown was rendered properly.

### AI Disclaimer

I used Codex with GPT 5.5 in several iterative prompts, plus some manual tweaks written by hand.