### PR TITLE
Sync bunfig schema with latest docs

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -129,6 +129,23 @@
         }
       }
     },
+    "serve": {
+      "$comment": "https://bun.com/docs/runtime/bunfig#serve",
+      "description": "Options for `Bun.serve` and `bun run` when serving HTTP.\nhttps://bun.com/docs/runtime/bunfig#serve",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#serve-port",
+          "description": "The default port for `Bun.serve` to listen on. Default `3000`. Can also be set via the `BUN_PORT` or `PORT` environment variables, or the `--port` flag.\nhttps://bun.com/docs/runtime/bunfig#serve-port",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "default": 3000,
+          "examples": [3000]
+        }
+      }
+    },
     "test": {
       "$comment": "https://bun.sh/docs/runtime/bunfig#test-runner",
       "description": "Test runner\nhttps://bun.sh/docs/runtime/bunfig#test-runner",
@@ -200,6 +217,12 @@
         "coverageSkipTestFiles": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#test-coverageskiptestfiles",
           "description": "Whether to skip test files when computing coverage statistics. Default false\nhttps://bun.sh/docs/runtime/bunfig#test-coverageskiptestfiles",
+          "type": "boolean",
+          "default": false
+        },
+        "coverageIgnoreSourcemaps": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#test-coverageignoresourcemaps",
+          "description": "Whether to report coverage against transpiled output instead of remapping line numbers through sourcemaps back to the original source. Default `false`. Primarily useful for debugging.\nhttps://bun.com/docs/runtime/bunfig#test-coverageignoresourcemaps",
           "type": "boolean",
           "default": false
         },
@@ -326,6 +349,19 @@
           "type": "boolean",
           "default": false
         },
+        "ignoreScripts": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-ignorescripts",
+          "description": "Whether to skip lifecycle scripts during install. Default `false`. Equivalent to the `--ignore-scripts` flag.\n\nWhen `true`, Bun will not run any `preinstall` / `install` / `postinstall` / `prepare` scripts — both for your project and for packages in `trustedDependencies`.\nhttps://bun.com/docs/runtime/bunfig#install-ignorescripts",
+          "type": "boolean",
+          "default": false
+        },
+        "concurrentScripts": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-concurrentscripts",
+          "description": "The maximum number of concurrent lifecycle scripts to run at once. Defaults to two times the number of CPU cores. Equivalent to the `--concurrent-scripts` flag.\nhttps://bun.com/docs/runtime/bunfig#install-concurrentscripts",
+          "type": "integer",
+          "minimum": 1,
+          "examples": [5]
+        },
         "saveTextLockfile": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-savetextlockfile",
           "description": "If false, generate a binary `bun.lockb` instead of a text-based `bun.lock` file when running `bun install` and no lockfile is present\nDefault `true` (since Bun v1.2)\nhttps://bun.sh/docs/runtime/bunfig#install-savetextlockfile",
@@ -338,6 +374,13 @@
           "type": "string",
           "enum": ["auto", "force", "disable", "fallback"],
           "default": "auto"
+        },
+        "prefer": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-prefer",
+          "description": "Configure how Bun resolves package versions against the npm registry when running scripts. Default `\"online\"`.\n\n- `\"online\"` — Check the registry for stale packages as needed.\n- `\"offline\"` — Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`.\n- `\"latest\"` — Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.\nhttps://bun.com/docs/runtime/bunfig#install-prefer",
+          "type": "string",
+          "enum": ["online", "offline", "latest"],
+          "default": "online"
         },
         "frozenLockfile": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-frozenlockfile",
@@ -469,6 +512,35 @@
           "enum": ["hoisted", "isolated"],
           "default": "hoisted"
         },
+        "globalStore": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-globalstore",
+          "description": "When using the `\"isolated\"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Default `false`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.\nhttps://bun.com/docs/runtime/bunfig#install-globalstore",
+          "type": "boolean",
+          "default": false
+        },
+        "publicHoistPattern": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-publichoistpattern",
+          "description": "When using the `\"isolated\"` linker, packages matching these glob patterns are hoisted to the root `node_modules` directory so they can be resolved by any package in the project. Default `[]`. Similar to pnpm's `public-hoist-pattern`.\nhttps://bun.com/docs/runtime/bunfig#install-publichoistpattern",
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["*eslint*", "*prettier*"]]
+        },
+        "hoistPattern": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-hoistpattern",
+          "description": "When using the `\"isolated\"` linker, packages matching these glob patterns are hoisted to the virtual store root (`node_modules/.bun`) so they can be resolved by other packages in the virtual store. Default `[]`. Similar to pnpm's `hoist-pattern`.\nhttps://bun.com/docs/runtime/bunfig#install-hoistpattern",
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "examples": [["*"]]
+        },
+        "logLevel": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-loglevel",
+          "description": "Set the log level for `bun install`. This can be one of `\"debug\"`, `\"warn\"`, or `\"error\"`.\nhttps://bun.com/docs/runtime/bunfig#install-loglevel",
+          "type": "string",
+          "enum": ["debug", "warn", "error"],
+          "examples": ["warn"]
+        },
         "security": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-security-scanner",
           "description": "Security configuration for package installation\nhttps://bun.sh/docs/runtime/bunfig#install-security-scanner",
@@ -522,6 +594,20 @@
           "$comment": "https://bun.sh/docs/runtime/bunfig#run-silent-suppress-reporting-the-command-being-run",
           "type": "boolean",
           "description": "When `true`, suppresses the output of the command being run by `bun run` or `bun`\nhttps://bun.sh/docs/runtime/bunfig#run-silent-suppress-reporting-the-command-being-run",
+          "default": false
+        },
+        "elide-lines": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#run-elide-lines-truncate-filtered-output",
+          "description": "The number of lines of script output shown per script when using `--filter`. Default `10`. Set to `0` to show all lines. Equivalent to the `--elide-lines` flag.\nhttps://bun.com/docs/runtime/bunfig#run-elide-lines-truncate-filtered-output",
+          "type": "integer",
+          "minimum": 0,
+          "default": 10,
+          "examples": [10]
+        },
+        "noOrphans": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#run-noorphans-don-t-leave-orphan-processes-behind",
+          "description": "When `true`, Bun watches the process that spawned it and exits as soon as that parent goes away — even if the parent was `SIGKILL`ed and never got a chance to forward a signal. On its own exit, Bun also recursively `SIGKILL`s every descendant process so nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.\n\nLinux and macOS only (no-op on Windows and other platforms). Equivalent to the `--no-orphans` CLI flag or the `BUN_FEATURE_FLAG_NO_ORPHANS=1` environment variable.\nhttps://bun.com/docs/runtime/bunfig#run-noorphans-don-t-leave-orphan-processes-behind",
+          "type": "boolean",
           "default": false
         }
       }

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -19,6 +19,9 @@ env = false
 [console]
 depth = 3
 
+[serve]
+port = 3000
+
 [define]
 # Replace any usage of "process.env.bagel" with the string `lox`.
 # The values are parsed as JSON, except single-quoted strings are supported and `'undefined'` becomes `undefined` in JS.
@@ -27,10 +30,13 @@ depth = 3
 
 [install]
 auto = "auto"
+prefer = "online"
 dev = true
 dryRun = false
 saveTextLockfile = true
 exact = false
+ignoreScripts = false
+concurrentScripts = 5
 frozenLockfile = false
 globalBinDir = "~/.bun/bin"
 # where `bun install --global` installs packages
@@ -40,6 +46,11 @@ peer = true
 production = false
 registry = "https://registry.npmjs.org"
 linkWorkspacePackages = true
+linker = "isolated"
+globalStore = true
+publicHoistPattern = ["*eslint*", "*prettier*"]
+hoistPattern = ["*"]
+logLevel = "warn"
 # The CA certificate as a string
 ca = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
 # A path to a CA certificate file. The file can contain multiple certificates.
@@ -73,11 +84,14 @@ bun = true
 # default on Windows
 shell = "bun"
 silent = true
+elide-lines = 10
+noOrphans = true
 
 [test]
 coverage = false
 coveragePathIgnorePatterns = ["**/*.spec.ts", "src/utils/**"]
 coverageSkipTestFiles = false
+coverageIgnoreSourcemaps = false
 # to require 90% line-level and function-level coverage
 coverageThreshold = 0.9
 concurrentTestGlob = "**/concurrent-*.test.ts"


### PR DESCRIPTION
## Summary

This PR updates Bun configuration support to match the latest `bunfig.toml` [docs](https://bun.com/docs/runtime/bunfig), continuing the work from #5501.

## What Changed

- Updated [`bunfig` JSON schema](/src/schemas/json/bunfig.json) with newly documented options.
- Updated [`bunfig` TOML test fixture](/src/test/bunfig/bunfig.toml) to include examples for the new fields.

Each added field was cross-referenced against the authoritative docs source at [`oven-sh/bun/docs/runtime/bunfig.mdx`](https://github.com/oven-sh/bun/blob/main/docs/runtime/bunfig.mdx) — only fields with clear documentation have been added.

## New Schema Coverage

- Top-level:
  - new `[serve]` section
    - `serve.port`
- `[test]`:
  - `coverageIgnoreSourcemaps`
- `[install]`:
  - `ignoreScripts`
  - `concurrentScripts`
  - `prefer` (`"online"` | `"offline"` | `"latest"`)
  - `globalStore`
  - `publicHoistPattern`
  - `hoistPattern`
  - `logLevel`
- `[run]`:
  - `elide-lines`
  - `noOrphans`

## Validation

- `jq empty src/schemas/json/bunfig.json`
- `node ./cli.js check`
- `prettier --check src/schemas/json/bunfig.json src/test/bunfig/bunfig.toml`