### PR TITLE
memnex: switch to canonical memnex.org URL, add versions block

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9832,9 +9832,13 @@
     },
     {
       "name": "memnex",
-      "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://github.com/UladzKha/memnex",
+      "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://memnex.org",
       "fileMatch": ["*.memnex.json", "meeting-output.json"],
-      "url": "https://raw.githubusercontent.com/UladzKha/memnex/main/schema/v0.1/meeting-output.schema.json"
+      "url": "https://memnex.org/schema/v0.2/meeting-output.schema.json",
+      "versions": {
+        "0.1": "https://memnex.org/schema/v0.1/meeting-output.schema.json",
+        "0.2": "https://memnex.org/schema/v0.2/meeting-output.schema.json"
+      }
     }
   ]
 }


### PR DESCRIPTION
The memnex specification now has a permanent home at memnex.org with both v0.1 and v0.2 schemas published under stable URLs that match the schemas' own $id fields.

Changes:
- Replace raw.githubusercontent.com URL with canonical https://memnex.org
- Bump default URL from v0.1 (previous) to v0.2 (current)
- Add 'versions' block listing both v0.1 (frozen) and v0.2 (current)
- Update description URL accordingly

All URLs verified live: schemas resolve with HTTP 200 and Content-Type application/json.

Refs: #5676 (original memnex entry)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
