### PR TITLE
Fix pytest ini_options schema annotations

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -12,9 +12,8 @@
   ],
   "definitions": {
     "LegacyConfig": {
-      "description": "Legacy configuration using ini_options table (pytest <9)",
+      "description": "INI-style configuration using the ini_options table (pytest >=6)",
       "type": "object",
-      "deprecated": true,
       "properties": {
         "ini_options": {
           "allOf": [
@@ -25,8 +24,8 @@
               "$ref": "#/definitions/IniOptionsAsyncio"
             }
           ],
-          "title": "Bridge Configuration Options for `pytest.ini` File",
-          "description": "The `ini_options` table is used as a bridge between the existing `pytest.ini` configuration system and future configuration formats. `pytest.ini` takes precedence over `[tool.pytest.ini_options]` in `pyproject.toml`."
+          "title": "INI-style pytest Configuration Options",
+          "description": "Use `[tool.pytest.ini_options]` for INI-style pytest configuration in `pyproject.toml` (supported since pytest 6.0). `pytest.ini` takes precedence over `[tool.pytest.ini_options]` in `pyproject.toml`."
         }
       },
       "required": ["ini_options"],
@@ -35,7 +34,6 @@
     },
     "IniOptionsPytest": {
       "type": "object",
-      "deprecated": true,
       "properties": {
         "addopts": {
           "oneOf": [
@@ -624,9 +622,7 @@
     },
     "IniOptionsAsyncio": {
       "$comment": "additionalProperties is true because the schema is merged with other schemas",
-      "description": "Configuration options for pytest-asyncio.\nhttps://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html",
       "type": "object",
-      "deprecated": true,
       "properties": {
         "asyncio_default_fixture_loop_scope": {
           "$ref": "#/definitions/AsyncioScope",
@@ -1076,7 +1072,6 @@
     },
     "ConfigOptionsAsyncio": {
       "type": "object",
-      "description": "Configuration options for pytest-asyncio.\nhttps://pytest-asyncio.readthedocs.io/en/latest/reference/configuration.html",
       "properties": {
         "asyncio_default_fixture_loop_scope": {
           "$ref": "#/definitions/AsyncioScope",

--- a/src/test/pyproject/pytest-ini-options.toml
+++ b/src/test/pyproject/pytest-ini-options.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.pytest.ini_options]
+pythonpath = "src/python"
+testpaths = ["src/python/tests"]


### PR DESCRIPTION
## Summary
- remove the deprecated annotation from the `[tool.pytest.ini_options]` schema path
- keep the table description aligned with pytest's supported INI-style pyproject configuration
- add a pyproject positive fixture covering `[tool.pytest.ini_options]`

## Tests
- `node ./cli.js check --schema-name=partial-pytest.json`
- `node ./cli.js check --schema-name=pyproject.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/partial-pytest.json src/test/pyproject/pytest-ini-options.toml`
- `npm run typecheck`

Fixes #5278