### PR TITLE
Update Hazelcast schema to version 5.7.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3522,7 +3522,7 @@
         "hz-*.yaml",
         "hz-*.json"
       ],
-      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.6.json"
+      "url": "https://hazelcast.com/schema/config/hazelcast-config-5.7.json"
     },
     {
       "name": "Home Assistant Integration Manifest",


### PR DESCRIPTION
Hazelcast 5.7.0 has been released which includes new schema