### PR TITLE
Add Codex hooks schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1948,6 +1948,12 @@
       "url": "https://developers.openai.com/codex/config-schema.json"
     },
     {
+      "name": "Codex Hooks",
+      "description": "OpenAI Codex hooks configuration file",
+      "fileMatch": ["**/.codex/hooks.json"],
+      "url": "https://www.schemastore.org/codex-hooks.json"
+    },
+    {
       "name": "codemagic",
       "description": "Codemagic CI/CD file configuration",
       "fileMatch": ["codemagic.yaml", "codemagic.yml"],

--- a/src/negative_test/codex-hooks/invalid-event-shape.json
+++ b/src/negative_test/codex-hooks/invalid-event-shape.json
@@ -1,0 +1,13 @@
+{
+  "hooks": {
+    "SessionStart": {
+      "hooks": [
+        {
+          "command": "python3 .codex/hooks/session_start.py",
+          "type": "command"
+        }
+      ],
+      "matcher": "startup"
+    }
+  }
+}

--- a/src/negative_test/codex-hooks/missing-command.json
+++ b/src/negative_test/codex-hooks/missing-command.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schemas/json/codex-hooks.json
+++ b/src/schemas/json/codex-hooks.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/codex-hooks.json",
+  "title": "Codex hooks configuration",
+  "description": "Configuration for OpenAI Codex lifecycle hooks.\nhttps://developers.openai.com/codex/hooks",
+  "type": "object",
+  "required": ["hooks"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for Codex hooks configuration."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the hooks file."
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Hook event registrations grouped by Codex lifecycle event.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/matcherGroups"
+      },
+      "properties": {
+        "SessionStart": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs when a Codex session starts. The matcher filters the start source, such as startup, resume, or clear."
+        },
+        "PreToolUse": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs before supported tool calls. The matcher filters tool names and aliases."
+        },
+        "PermissionRequest": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs before Codex asks for approval. The matcher filters tool names and aliases."
+        },
+        "PostToolUse": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs after supported tool calls. The matcher filters tool names and aliases."
+        },
+        "UserPromptSubmit": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs before a user prompt is submitted. Codex currently ignores matcher for this event."
+        },
+        "Stop": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs when a turn stops. Codex currently ignores matcher for this event."
+        }
+      }
+    }
+  },
+  "definitions": {
+    "matcherGroups": {
+      "type": "array",
+      "description": "Matcher groups for one Codex hook event.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/matcherGroup"
+      }
+    },
+    "matcherGroup": {
+      "type": "object",
+      "description": "Matcher group that decides when one or more hook handlers run.",
+      "required": ["hooks"],
+      "additionalProperties": true,
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Regex string that filters when hooks fire. Use *, an empty string, or omit matcher to match every supported occurrence."
+        },
+        "hooks": {
+          "type": "array",
+          "description": "Handlers to run when this matcher group matches.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/hookHandler"
+          }
+        }
+      }
+    },
+    "hookHandler": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/commandHandler"
+        },
+        {
+          "$ref": "#/definitions/skippedHandler"
+        }
+      ]
+    },
+    "commandHandler": {
+      "type": "object",
+      "description": "Command hook handler. Commands run with the session cwd as their working directory.",
+      "required": ["type", "command"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "const": "command",
+          "description": "Command handlers are the only hook handler type that runs in the current Codex runtime."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command to execute.",
+          "minLength": 1
+        },
+        "timeout": {
+          "type": "number",
+          "description": "Timeout in seconds. Codex uses 600 seconds when omitted.",
+          "minimum": 0
+        },
+        "statusMessage": {
+          "type": "string",
+          "description": "Optional status text shown while the hook runs."
+        },
+        "async": {
+          "type": "boolean",
+          "description": "Parsed by Codex, but async command hooks are not supported yet and async handlers are skipped."
+        }
+      }
+    },
+    "skippedHandler": {
+      "type": "object",
+      "description": "Prompt and agent handlers are parsed by Codex but skipped in the current runtime.",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["prompt", "agent"]
+        }
+      }
+    }
+  }
+}

--- a/src/test/codex-hooks/hooks.json
+++ b/src/test/codex-hooks/hooks.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json.schemastore.org/codex-hooks.json",
+  "description": "Project-level Codex hooks",
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/permission_request.py",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|apply_patch"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "async": false,
+            "command": "python3 .codex/hooks/post_tool_use.py",
+            "statusMessage": "Reviewing tool output",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__filesystem__.*"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/session_start.py",
+            "statusMessage": "Loading session notes",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/stop.py",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/user_prompt_submit.py",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add a SchemaStore-hosted schema for OpenAI Codex hooks configuration
- register `**/.codex/hooks.json` in the JSON schema catalog
- add positive and negative test fixtures for the Codex hooks schema

## Sources

- OpenAI Codex hooks docs: https://developers.openai.com/codex/hooks
- Source gist used as the starting point: https://gist.github.com/Nick2bad4u/5e292b76df83830b0a2192cb2f22d470

## Validation

- `node ./cli.js check --schema-name=codex-hooks.json`
- `npm run prettier -- --cache --ignore-unknown src/schemas/json/codex-hooks.json src/api/json/catalog.json src/test/codex-hooks/hooks.json src/negative_test/codex-hooks/invalid-event-shape.json src/negative_test/codex-hooks/missing-command.json`