### PR TITLE
add schemas for cargo-nextest repo and user configs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4581,6 +4581,18 @@
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/config/agent_config.schema.json"
     },
     {
+      "name": "cargo-nextest repository configuration",
+      "description": "Repository configuration for cargo-nextest. Documentation: https://nexte.st/docs/configuration/",
+      "fileMatch": ["**/.config/nextest.toml"],
+      "url": "https://nexte.st/schemas/repo-config.json"
+    },
+    {
+      "name": "cargo-nextest user configuration",
+      "description": "User configuration for cargo-nextest. Documentation: https://nexte.st/docs/user-config/",
+      "fileMatch": ["**/nextest/config.toml"],
+      "url": "https://nexte.st/schemas/user-config.json"
+    },
+    {
       "name": "nFPM",
       "description": "nFPM configuration file",
       "fileMatch": ["nfpm.yaml"],


### PR DESCRIPTION
The schemas are available at

* repo config: https://nexte.st/schemas/repo-config.json
* user config: https://nexte.st/schemas/user-config.json

I've validated that both work with Tombi.

cc @ya7010 who did the work to generate the schema (thanks!)