### PR TITLE
Add GitHub Pages Jekyll schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3179,6 +3179,11 @@
       "url": "https://www.schemastore.org/github-issue-forms.json"
     },
     {
+      "name": "GitHub Pages Jekyll",
+      "description": "YAML Jekyll configuration for sites built by GitHub Pages",
+      "url": "https://www.schemastore.org/github-pages-jekyll.json"
+    },
+    {
       "name": "GitHub Workflow",
       "description": "YAML GitHub Workflow",
       "fileMatch": [

--- a/src/negative_test/github-pages-jekyll/hardcoded-values.yml
+++ b/src/negative_test/github-pages-jekyll/hardcoded-values.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+safe: false
+lsi: true
+incremental: true
+highlighter: coderay
+gist:
+  noscript: true
+kramdown:
+  math_engine: katex
+  syntax_highlighter: coderay

--- a/src/negative_test/github-pages-jekyll/unsupported-plugin.yml
+++ b/src/negative_test/github-pages-jekyll/unsupported-plugin.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+plugins:
+  - jekyll-feed
+  - jekyll-archives

--- a/src/negative_test/github-pages-jekyll/unsupported-source.yml
+++ b/src/negative_test/github-pages-jekyll/unsupported-source.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+source: src

--- a/src/negative_test/github-pages-jekyll/unsupported-theme.yml
+++ b/src/negative_test/github-pages-jekyll/unsupported-theme.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+theme: jekyll-theme-awesome

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -1096,6 +1096,9 @@
     "hugo.json": {
       "externalSchema": ["base.json"]
     },
+    "github-pages-jekyll.json": {
+      "externalSchema": ["jekyll.json", "base.json"]
+    },
     "jasonette.json": {
       "unknownFormat": ["color", "text"],
       "unknownKeywords": ["links"]

--- a/src/schemas/json/github-pages-jekyll.json
+++ b/src/schemas/json/github-pages-jekyll.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-pages-jekyll.json",
+  "$comment": "GitHub Pages Jekyll configuration. Sources: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll, https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll, https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll, https://pages.github.com/versions/, https://github.com/github/pages-gem/blob/master/lib/github-pages/configuration.rb, https://github.com/github/pages-gem/blob/master/lib/github-pages/plugins.rb",
+  "title": "GitHub Pages Jekyll config schema",
+  "description": "A Jekyll _config.yml file for sites built by GitHub Pages.",
+  "definitions": {
+    "supportedPlugin": {
+      "description": "A Jekyll plugin supported by GitHub Pages.",
+      "type": "string",
+      "enum": [
+        "jekyll-avatar",
+        "jekyll-coffeescript",
+        "jekyll-commonmark-ghpages",
+        "jekyll-default-layout",
+        "jekyll-feed",
+        "jekyll-gist",
+        "jekyll-github-metadata",
+        "jekyll-include-cache",
+        "jekyll-mentions",
+        "jekyll-optional-front-matter",
+        "jekyll-paginate",
+        "jekyll-readme-index",
+        "jekyll-redirect-from",
+        "jekyll-relative-links",
+        "jekyll-remote-theme",
+        "jekyll-seo-tag",
+        "jekyll-sitemap",
+        "jekyll-titles-from-headings",
+        "jemoji"
+      ]
+    },
+    "supportedTheme": {
+      "description": "A Jekyll theme included in the github-pages gem.",
+      "type": "string",
+      "enum": [
+        "jekyll-swiss",
+        "jekyll-theme-architect",
+        "jekyll-theme-cayman",
+        "jekyll-theme-dinky",
+        "jekyll-theme-hacker",
+        "jekyll-theme-leap-day",
+        "jekyll-theme-merlot",
+        "jekyll-theme-midnight",
+        "jekyll-theme-minimal",
+        "jekyll-theme-modernist",
+        "jekyll-theme-primer",
+        "jekyll-theme-slate",
+        "jekyll-theme-tactile",
+        "jekyll-theme-time-machine",
+        "minima"
+      ]
+    },
+    "supportedPluginList": {
+      "description": "Jekyll plugins supported by GitHub Pages.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/supportedPlugin"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "jekyll.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "source": false,
+        "destination": false,
+        "incremental": {
+          "description": "GitHub Pages sets incremental builds to false.",
+          "const": false
+        },
+        "lsi": {
+          "description": "GitHub Pages sets LSI to false.",
+          "const": false
+        },
+        "safe": {
+          "description": "GitHub Pages always runs Jekyll in safe mode.",
+          "const": true
+        },
+        "plugins_dir": false,
+        "whitelist": {
+          "$ref": "#/definitions/supportedPluginList",
+          "description": "Plugins whitelisted by GitHub Pages."
+        },
+        "plugins": {
+          "$ref": "#/definitions/supportedPluginList",
+          "description": "Plugins supported by GitHub Pages."
+        },
+        "gems": {
+          "$ref": "#/definitions/supportedPluginList",
+          "description": "Legacy alias for plugins supported by GitHub Pages."
+        },
+        "theme": {
+          "description": "A supported GitHub Pages Jekyll theme. Use remote_theme for other themes hosted on GitHub.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/supportedTheme"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "remote_theme": {
+          "description": "A remote Jekyll theme hosted on GitHub, loaded by jekyll-remote-theme.",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["pages-themes/minimal@v0.2.0", "owner/repository"]
+        },
+        "markdown": {
+          "description": "GitHub Pages supports kramdown and GitHub Flavored Markdown.",
+          "type": "string",
+          "enum": [
+            "kramdown",
+            "GFM",
+            "gfm",
+            "CommonMarkGhPages",
+            "commonmarkghpages"
+          ],
+          "default": "kramdown"
+        },
+        "highlighter": {
+          "description": "GitHub Pages uses Rouge for syntax highlighting. Pygments falls back to Rouge.",
+          "type": "string",
+          "enum": ["rouge", "pygments"],
+          "default": "rouge"
+        },
+        "gist": {
+          "description": "GitHub Pages jekyll-gist configuration.",
+          "type": "object",
+          "properties": {
+            "noscript": {
+              "description": "GitHub Pages sets gist.noscript to false.",
+              "const": false
+            }
+          },
+          "additionalProperties": true
+        },
+        "kramdown": {
+          "description": "Kramdown options with values overridden by GitHub Pages narrowed where applicable.",
+          "type": "object",
+          "properties": {
+            "template": {
+              "description": "GitHub Pages sets kramdown.template to an empty string.",
+              "const": ""
+            },
+            "math_engine": {
+              "description": "GitHub Pages sets kramdown.math_engine to mathjax.",
+              "const": "mathjax"
+            },
+            "syntax_highlighter": {
+              "description": "GitHub Pages sets kramdown.syntax_highlighter to Rouge.",
+              "const": "rouge"
+            },
+            "syntax_highlighter_opts": {
+              "description": "Options passed to Rouge by kramdown.",
+              "type": "object",
+              "properties": {
+                "disable": {
+                  "description": "Disable Jekyll syntax highlighting.",
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/src/test/github-pages-jekyll/_config.yml
+++ b/src/test/github-pages-jekyll/_config.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+title: GitHub Pages site
+description: A site built by GitHub Pages
+url: https://example.github.io
+baseurl: /project
+theme: jekyll-theme-minimal
+markdown: GFM
+highlighter: rouge
+safe: true
+lsi: false
+incremental: false
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+  - jemoji
+gist:
+  noscript: false
+kramdown:
+  math_engine: mathjax
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    disable: true
+include:
+  - .well-known
+exclude:
+  - Gemfile
+  - Gemfile.lock

--- a/src/test/github-pages-jekyll/remote-theme.yml
+++ b/src/test/github-pages-jekyll/remote-theme.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../schemas/json/github-pages-jekyll.json
+title: Remote theme site
+theme: null
+remote_theme: pages-themes/cayman@v0.2.0
+markdown: kramdown
+plugins:
+  - jekyll-remote-theme
+  - jekyll-sitemap


### PR DESCRIPTION
## Summary

Adds a GitHub Pages-specific Jekyll configuration schema for `_config.yml` files used by sites built by GitHub Pages.

This schema builds on the existing generic `jekyll.json` schema and narrows the GitHub Pages-specific parts that are not valid or are hard-set in the Pages build environment:

- supported `plugins` / legacy `gems` values
- supported bundled `theme` values and `remote_theme`
- supported Markdown processors and syntax highlighters
- hard-set GitHub Pages values such as `safe`, `lsi`, `incremental`, `gist.noscript`, and selected `kramdown` values
- disallowed config fields that GitHub Pages controls, such as `source`, `destination`, and `plugins_dir`

The catalog entry intentionally omits `fileMatch` because the existing generic Jekyll schema already claims `_config.yml`; using the same broad filename would create an ambiguous association. Users can opt into this stricter schema with a YAML language-server schema directive when they need GitHub Pages validation.

## Sources

- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll
- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll
- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll
- https://pages.github.com/versions/
- https://github.com/github/pages-gem/blob/master/lib/github-pages/configuration.rb
- https://github.com/github/pages-gem/blob/master/lib/github-pages/plugins.rb

## Validation

- `node .\cli.js check --schema-name=github-pages-jekyll.json`
- `npm run prettier -- --cache --ignore-unknown .\src\schemas\json\github-pages-jekyll.json .\src\api\json\catalog.json .\src\schema-validation.jsonc .\src\test\github-pages-jekyll\_config.yml .\src\test\github-pages-jekyll\remote-theme.yml .\src\negative_test\github-pages-jekyll\hardcoded-values.yml .\src\negative_test\github-pages-jekyll\unsupported-plugin.yml .\src\negative_test\github-pages-jekyll\unsupported-source.yml .\src\negative_test\github-pages-jekyll\unsupported-theme.yml`
