### PR TITLE
claude-code-settings: add MultiEdit to permission rule regex

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|MultiEdit|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\((?=.*[^)*?])[^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",

--- a/src/test/claude-code-settings/permissions-advanced.json
+++ b/src/test/claude-code-settings/permissions-advanced.json
@@ -7,6 +7,8 @@
       "Grep",
       "Read(~/projects/**)",
       "Edit(~/projects/**)",
+      "MultiEdit",
+      "MultiEdit(~/projects/**)",
       "ToolSearch",
       "LSP",
       "NotebookEdit",


### PR DESCRIPTION
Filed in #5210. `MultiEdit` is a valid Claude Code tool but it's missing from the `permissionRule` regex, so a settings file like

```json
"permissions": { "allow": ["MultiEdit", "MultiEdit(~/projects/**)"] }
```

is flagged as not matching the schema.

The reporter also mentioned `Skill(name)`, but that already passes — `Skill` is in the alternation and the optional `(...)` part accepts kebab-cased names.

Added a couple of `MultiEdit` entries to `permissions-advanced.json` so the new tool name is covered by the existing test suite.

Closes #5210