### PR TITLE
fix: update shopware-cli schema URLs to GitHub Pages

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8005,7 +8005,7 @@
       "name": "Shopware CLI Extension Store Configuration",
       "description": "Shopware CLI Extension Store Configuration",
       "fileMatch": [".shopware-extension.yml", ".shopware-extension.yaml"],
-      "url": "https://raw.githubusercontent.com/shopware/shopware-cli/main/shopware-extension-schema.json"
+      "url": "https://shopware.github.io/shopware-cli/shopware-extension-schema.json"
     },
     {
       "name": "Shopware CLI Project Store Configuration",
@@ -8016,7 +8016,7 @@
         ".shopware-project.local.yml",
         ".shopware-project.local.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/shopware/shopware-cli/main/shopware-project-schema.json"
+      "url": "https://shopware.github.io/shopware-cli/shopware-project-schema.json"
     },
     {
       "name": "Qodana",


### PR DESCRIPTION
Replace raw.githubusercontent.com URLs with shopware.github.io URLs for both shopware-extension-schema and shopware-project-schema.
