### PR TITLE
Add Podman Desktop extension schema and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # the repo, unless a later match takes precedence.
 * @madskristensen @hyperupcall
 
-src/schema-validation.jsonc @ssbarnea @webknjaz @CircleCI-Public/developer-experience @meeech @gordonsyme @skoch13 @andrey-skl @zmaks @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj @VCecileKefelian @pandatix @NicoFgrx @ya7010 @chrissimon-au @danielbayley @btea @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi @domdomegg @bogini @sarahdeaton @ianmacartney @thomasballinger @Nicolapps
+src/schema-validation.jsonc @ssbarnea @webknjaz @CircleCI-Public/developer-experience @meeech @gordonsyme @skoch13 @andrey-skl @zmaks @vectorgrp/canoe-ci-tools @raphael-grimm @JoergSrj @VCecileKefelian @pandatix @NicoFgrx @ya7010 @chrissimon-au @danielbayley @btea @priyanshu92 @ashishchoudhary001 @amitjoshi438 @tyaginidhi @domdomegg @bogini @sarahdeaton @ianmacartney @thomasballinger @Nicolapps @podman-desktop-bot @simonrey1 @benoitf @jiridostal
 
 # Managed by Ansible DevTools Team members:
 src/schemas/json/ansible-* @ssbarnea @webknjaz
@@ -102,3 +102,6 @@ src/negative_test/specmatic/ @joelrosario @nashjain
 # Managed by Databricks team:
 src/schemas/json/databricks-asset-bundles.json @janniklasrose @shreyas-goenka @denik @andrewnester
 src/schemas/json/declarative-automation-bundles.json @janniklasrose @shreyas-goenka @denik @andrewnester
+
+# Managed by Podman Desktop Team:
+src/schemas/json/podman-desktop-extension.json @podman-desktop-bot @simonrey1 @benoitf @jiridostal

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10290,6 +10290,15 @@
         "amxbuild.*.yaml"
       ],
       "url": "https://raw.githubusercontent.com/AmxxModularEcosystem/amxx-builder/master/schema/amxbuild.schema.json"
+    },
+    {
+      "name": "Podman Desktop Extension",
+      "description": "Podman Desktop extension package.json manifest",
+      "fileMatch": [],
+      "url": "https://www.schemastore.org/podman-desktop-extension.json",
+      "versions": {
+        "1.27": "https://www.schemastore.org/podman-desktop-extension-1.27.json"
+      }
     }
   ]
 }

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -347,7 +347,9 @@
     "glazewm.json",
     "youtrack-app.json",
     "cinnamon-spice-settings.json",
-    "pnpm-workspace.json"
+    "pnpm-workspace.json",
+    "podman-desktop-extension.json",
+    "podman-desktop-extension-1.27.json"
   ],
   "fileMatchConflict": [
     // Name conflicts must be avoided. Do not add additional items here
@@ -1330,6 +1332,40 @@
         "quikrun.json"
       ],
       "unknownFormat": ["<app> <your args>"],
+      "unknownKeywords": ["exec", "tsType"]
+    },
+    "podman-desktop-extension.json": {
+      "externalSchema": [
+        "package.json",
+        "eslintrc.json",
+        "partial-eslint-plugins.json",
+        "prettierrc.json",
+        "ava.json",
+        "npm-badges.json",
+        "stylelintrc.json",
+        "semantic-release.json",
+        "jscpd.json",
+        "nodemon.json",
+        "base.json",
+        "quikrun.json"
+      ],
+      "unknownKeywords": ["exec", "tsType"]
+    },
+    "podman-desktop-extension-1.27.json": {
+      "externalSchema": [
+        "package.json",
+        "eslintrc.json",
+        "partial-eslint-plugins.json",
+        "prettierrc.json",
+        "ava.json",
+        "npm-badges.json",
+        "stylelintrc.json",
+        "semantic-release.json",
+        "jscpd.json",
+        "nodemon.json",
+        "base.json",
+        "quikrun.json"
+      ],
       "unknownKeywords": ["exec", "tsType"]
     },
     "partial-pdm.json": {

--- a/src/schemas/json/podman-desktop-extension-1.27.json
+++ b/src/schemas/json/podman-desktop-extension-1.27.json
@@ -1,0 +1,601 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/podman-desktop-extension-1.27.json",
+  "title": "Podman Desktop Extension Manifest",
+  "description": "Schema for Podman Desktop extension package.json files",
+  "allOf": [
+    {
+      "$ref": "https://json.schemastore.org/package.json"
+    },
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "main": {
+          "type": "string"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "light": {
+                  "type": "string"
+                },
+                "dark": {
+                  "type": "string"
+                }
+              },
+              "required": ["light", "dark"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "extensionDependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extensionPack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "engines": {
+          "type": "object",
+          "properties": {
+            "podman-desktop": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "contributes": {
+          "type": "object",
+          "properties": {
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "markdown",
+                              "string",
+                              "number",
+                              "integer",
+                              "boolean",
+                              "null",
+                              "array",
+                              "object"
+                            ]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "markdown",
+                                "string",
+                                "number",
+                                "integer",
+                                "boolean",
+                                "null",
+                                "array",
+                                "object"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "default": {},
+                      "group": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "placeholder": {
+                        "type": "string"
+                      },
+                      "markdownDescription": {
+                        "type": "string"
+                      },
+                      "minimum": {
+                        "type": "number"
+                      },
+                      "maximum": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "format": {
+                        "type": "string"
+                      },
+                      "step": {
+                        "type": "number"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "DEFAULT",
+                              "ContainerConnection",
+                              "KubernetesConnection",
+                              "VmConnection",
+                              "ContainerProviderConnectionFactory",
+                              "KubernetesProviderConnectionFactory",
+                              "VmProviderConnectionFactory",
+                              "DockerCompatibility",
+                              "Onboarding"
+                            ]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DEFAULT",
+                                "ContainerConnection",
+                                "KubernetesConnection",
+                                "VmConnection",
+                                "ContainerProviderConnectionFactory",
+                                "KubernetesProviderConnectionFactory",
+                                "VmProviderConnectionFactory",
+                                "DockerCompatibility",
+                                "Onboarding"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "readonly": {
+                        "type": "boolean"
+                      },
+                      "hidden": {
+                        "type": "boolean"
+                      },
+                      "enum": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "experimental": {
+                        "type": "object",
+                        "properties": {
+                          "githubDiscussionLink": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "scope": {
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "ContainerConnection",
+                    "KubernetesConnection",
+                    "VmConnection",
+                    "ContainerProviderConnectionFactory",
+                    "KubernetesProviderConnectionFactory",
+                    "VmProviderConnectionFactory",
+                    "DockerCompatibility",
+                    "Onboarding"
+                  ]
+                },
+                "extension": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["title"],
+              "additionalProperties": false
+            },
+            "commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "light": {
+                            "type": "string"
+                          },
+                          "dark": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["light", "dark"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "keybinding": {
+                    "type": "string"
+                  },
+                  "enablement": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "menus": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "command": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "when": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["command", "title"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "icons": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "default": {
+                    "type": "object",
+                    "properties": {
+                      "fontPath": {
+                        "type": "string"
+                      },
+                      "fontCharacter": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["fontCharacter"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "themes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "parent": {
+                    "type": "string"
+                  },
+                  "colors": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["id", "name", "parent", "colors"],
+                "additionalProperties": false
+              }
+            },
+            "views": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["icon"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "badge": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "light": {
+                                      "type": "string"
+                                    },
+                                    "dark": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["light", "dark"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["label"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["badge"],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            },
+            "onboarding": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "number"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "media": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "altText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["path", "altText"],
+                  "additionalProperties": false
+                },
+                "steps": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "altText": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["path", "altText"],
+                        "additionalProperties": false
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "completionEvents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "content": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "string"
+                              },
+                              "highlight": {
+                                "type": "boolean"
+                              },
+                              "when": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["value"],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "component": {
+                        "type": "string",
+                        "enum": [
+                          "createContainerProviderConnection",
+                          "createKubernetesProviderConnection"
+                        ]
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": ["completed", "failed", "skipped"]
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": ["completed", "failed"]
+                      }
+                    },
+                    "required": ["id", "title"],
+                    "additionalProperties": false
+                  }
+                },
+                "enablement": {
+                  "type": "string"
+                }
+              },
+              "required": ["title", "steps", "enablement"],
+              "additionalProperties": false
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "displayName",
+        "version",
+        "publisher",
+        "description"
+      ],
+      "additionalProperties": {}
+    }
+  ]
+}

--- a/src/schemas/json/podman-desktop-extension.json
+++ b/src/schemas/json/podman-desktop-extension.json
@@ -1,0 +1,601 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/podman-desktop-extension.json",
+  "title": "Podman Desktop Extension Manifest",
+  "description": "Schema for Podman Desktop extension package.json files",
+  "allOf": [
+    {
+      "$ref": "https://json.schemastore.org/package.json"
+    },
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "main": {
+          "type": "string"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "light": {
+                  "type": "string"
+                },
+                "dark": {
+                  "type": "string"
+                }
+              },
+              "required": ["light", "dark"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "extensionDependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extensionPack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "engines": {
+          "type": "object",
+          "properties": {
+            "podman-desktop": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "contributes": {
+          "type": "object",
+          "properties": {
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "markdown",
+                              "string",
+                              "number",
+                              "integer",
+                              "boolean",
+                              "null",
+                              "array",
+                              "object"
+                            ]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "markdown",
+                                "string",
+                                "number",
+                                "integer",
+                                "boolean",
+                                "null",
+                                "array",
+                                "object"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "default": {},
+                      "group": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "placeholder": {
+                        "type": "string"
+                      },
+                      "markdownDescription": {
+                        "type": "string"
+                      },
+                      "minimum": {
+                        "type": "number"
+                      },
+                      "maximum": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "format": {
+                        "type": "string"
+                      },
+                      "step": {
+                        "type": "number"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "DEFAULT",
+                              "ContainerConnection",
+                              "KubernetesConnection",
+                              "VmConnection",
+                              "ContainerProviderConnectionFactory",
+                              "KubernetesProviderConnectionFactory",
+                              "VmProviderConnectionFactory",
+                              "DockerCompatibility",
+                              "Onboarding"
+                            ]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DEFAULT",
+                                "ContainerConnection",
+                                "KubernetesConnection",
+                                "VmConnection",
+                                "ContainerProviderConnectionFactory",
+                                "KubernetesProviderConnectionFactory",
+                                "VmProviderConnectionFactory",
+                                "DockerCompatibility",
+                                "Onboarding"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "readonly": {
+                        "type": "boolean"
+                      },
+                      "hidden": {
+                        "type": "boolean"
+                      },
+                      "enum": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "experimental": {
+                        "type": "object",
+                        "properties": {
+                          "githubDiscussionLink": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "scope": {
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "ContainerConnection",
+                    "KubernetesConnection",
+                    "VmConnection",
+                    "ContainerProviderConnectionFactory",
+                    "KubernetesProviderConnectionFactory",
+                    "VmProviderConnectionFactory",
+                    "DockerCompatibility",
+                    "Onboarding"
+                  ]
+                },
+                "extension": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["title"],
+              "additionalProperties": false
+            },
+            "commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "light": {
+                            "type": "string"
+                          },
+                          "dark": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["light", "dark"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "keybinding": {
+                    "type": "string"
+                  },
+                  "enablement": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "menus": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "command": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "when": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["command", "title"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "icons": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "default": {
+                    "type": "object",
+                    "properties": {
+                      "fontPath": {
+                        "type": "string"
+                      },
+                      "fontCharacter": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["fontCharacter"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "themes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "parent": {
+                    "type": "string"
+                  },
+                  "colors": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["id", "name", "parent", "colors"],
+                "additionalProperties": false
+              }
+            },
+            "views": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["icon"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "badge": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "light": {
+                                      "type": "string"
+                                    },
+                                    "dark": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["light", "dark"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["label"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["badge"],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            },
+            "onboarding": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "number"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "media": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "altText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["path", "altText"],
+                  "additionalProperties": false
+                },
+                "steps": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "altText": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["path", "altText"],
+                        "additionalProperties": false
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "completionEvents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "content": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "string"
+                              },
+                              "highlight": {
+                                "type": "boolean"
+                              },
+                              "when": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["value"],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "component": {
+                        "type": "string",
+                        "enum": [
+                          "createContainerProviderConnection",
+                          "createKubernetesProviderConnection"
+                        ]
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": ["completed", "failed", "skipped"]
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": ["completed", "failed"]
+                      }
+                    },
+                    "required": ["id", "title"],
+                    "additionalProperties": false
+                  }
+                },
+                "enablement": {
+                  "type": "string"
+                }
+              },
+              "required": ["title", "steps", "enablement"],
+              "additionalProperties": false
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "displayName",
+        "version",
+        "publisher",
+        "description"
+      ],
+      "additionalProperties": {}
+    }
+  ]
+}


### PR DESCRIPTION
This bootstrap PR adds Podman Desktop extension schema support in SchemaStore and sets code ownership for future automated updates.

Changes included:
- add `src/schemas/json/podman-desktop-extension.json` (stable filename)
- add a new `Podman Desktop Extension` entry in `src/api/json/catalog.json` with:
  - `fileMatch: []`
  - stable URL: `https://www.schemastore.org/podman-desktop-extension.json`
- add CODEOWNERS rule for `src/schemas/json/podman-desktop-extension.json`

Context:
- podman-desktop/podman-desktop issue: https://github.com/podman-desktop/podman-desktop/issues/16051
- this bootstrap allows future automation PRs to update only the schema file (no recurring catalog.json edits).