### PR TITLE
Add Emmet and ESLint suppressions schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3100,6 +3100,12 @@
       "url": "https://www.schemastore.org/eslintrc.json"
     },
     {
+      "name": "ESLint Suppressions",
+      "description": "ESLint bulk suppressions file",
+      "fileMatch": ["eslint-suppressions.json"],
+      "url": "https://www.schemastore.org/eslint-suppressions.json"
+    },
+    {
       "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
       "fileMatch": ["fabric.mod.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9195,14 +9195,6 @@
     {
       "name": "Emmet",
       "description": "Emmet snippets file",
-      "fileMatch": [
-        "snippets.json",
-        "snippets-*.json",
-        "snippets_*.json",
-        "**/snippets.json",
-        "**/snippets-*.json",
-        "**/snippets_*.json"
-      ],
       "url": "https://www.schemastore.org/emmet.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -9187,6 +9187,19 @@
       "url": "https://www.schemastore.org/elm.json"
     },
     {
+      "name": "Emmet",
+      "description": "Emmet snippets file",
+      "fileMatch": [
+        "snippets.json",
+        "snippets-*.json",
+        "snippets_*.json",
+        "**/snippets.json",
+        "**/snippets-*.json",
+        "**/snippets_*.json"
+      ],
+      "url": "https://www.schemastore.org/emmet.json"
+    },
+    {
       "name": "Cloud Run Spec v1",
       "description": "Specification for Cloud Run Admin API v1",
       "fileMatch": ["cloud-run-v1.yml", "cloud-run-v1.yaml"],

--- a/src/negative_test/emmet/emmet.invalid.json
+++ b/src/negative_test/emmet/emmet.invalid.json
@@ -1,11 +1,11 @@
 {
-  "variables": {
-    "lang": 123
-  },
   "css": {
     "filters": 42,
     "snippets": {
       "d": 7
     }
+  },
+  "variables": {
+    "lang": 123
   }
 }

--- a/src/negative_test/emmet/emmet.invalid.json
+++ b/src/negative_test/emmet/emmet.invalid.json
@@ -1,0 +1,11 @@
+{
+  "variables": {
+    "lang": 123
+  },
+  "css": {
+    "filters": 42,
+    "snippets": {
+      "d": 7
+    }
+  }
+}

--- a/src/negative_test/eslint-suppressions/eslint-suppressions.invalid.json
+++ b/src/negative_test/eslint-suppressions/eslint-suppressions.invalid.json
@@ -1,0 +1,10 @@
+{
+  "src/index.js": {
+    "no-console": {
+      "count": 0
+    },
+    "prefer-const": {
+      "count": "1"
+    }
+  }
+}

--- a/src/schemas/json/emmet.json
+++ b/src/schemas/json/emmet.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/emmet.json",
+  "title": "Emmet Snippets",
+  "description": "Configuration file for Emmet snippets and abbreviations.",
+  "type": "object",
+  "properties": {
+    "variables": {
+      "$ref": "#/definitions/variables"
+    }
+  },
+  "patternProperties": {
+    "^(?!variables$).+$": {
+      "$ref": "#/definitions/syntax"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "syntax": {
+      "type": "object",
+      "properties": {
+        "snippets": {
+          "$ref": "#/definitions/snippets"
+        },
+        "abbreviations": {
+          "$ref": "#/definitions/snippets"
+        },
+        "extends": {
+          "type": "string",
+          "description": "Name of a base syntax to inherit snippets from."
+        },
+        "profile": {
+          "type": "string",
+          "description": "Profile name for the current syntax."
+        },
+        "filters": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "Comma-separated list of filter names."
+            },
+            {
+              "type": "array",
+              "description": "List of filter names.",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "snippets": {
+      "type": "object",
+      "description": "Map of Emmet snippet/abbreviation keys to expansion strings.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "patternProperties": {
+        "^.+$": {
+          "type": "string"
+        }
+      }
+    },
+    "variables": {
+      "type": "object",
+      "description": "Global Emmet variable map.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/schemas/json/eslint-suppressions.json
+++ b/src/schemas/json/eslint-suppressions.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/eslint-suppressions.json",
+  "title": "ESLint Suppressions",
+  "description": "Suppressions file generated and consumed by ESLint bulk suppressions.",
+  "type": "object",
+  "propertyNames": {
+    "minLength": 1
+  },
+  "additionalProperties": {
+    "$ref": "#/definitions/fileSuppressions"
+  },
+  "definitions": {
+    "fileSuppressions": {
+      "type": "object",
+      "description": "Rules suppressed for a single file path.",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/ruleSuppression"
+      }
+    },
+    "ruleSuppression": {
+      "type": "object",
+      "description": "Suppression metadata for one ESLint rule.",
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "type": "integer",
+          "description": "Number of existing violations suppressed for this rule in this file.",
+          "minimum": 1
+        }
+      },
+      "required": ["count"]
+    }
+  }
+}

--- a/src/test/emmet/emmet.json
+++ b/src/test/emmet/emmet.json
@@ -1,0 +1,24 @@
+{
+  "variables": {
+    "lang": "en"
+  },
+  "css": {
+    "filters": "css",
+    "profile": "css",
+    "snippets": {
+      "d": "display:${1:block};",
+      "@i": "@import url(|);"
+    },
+    "abbreviations": {
+      "m5": "margin: 0.5rem;"
+    }
+  },
+  "html": {
+    "extends": "xml",
+    "filters": "html",
+    "abbreviations": {
+      "!": "<!DOCTYPE html>",
+      "html:5": "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"></head><body></body></html>"
+    }
+  }
+}

--- a/src/test/emmet/emmet.json
+++ b/src/test/emmet/emmet.json
@@ -1,24 +1,24 @@
 {
-  "variables": {
-    "lang": "en"
-  },
   "css": {
+    "abbreviations": {
+      "m5": "margin: 0.5rem;"
+    },
     "filters": "css",
     "profile": "css",
     "snippets": {
-      "d": "display:${1:block};",
-      "@i": "@import url(|);"
-    },
-    "abbreviations": {
-      "m5": "margin: 0.5rem;"
+      "@i": "@import url(|);",
+      "d": "display:${1:block};"
     }
   },
   "html": {
-    "extends": "xml",
-    "filters": "html",
     "abbreviations": {
       "!": "<!DOCTYPE html>",
       "html:5": "<!DOCTYPE html><html><head><meta charset=\"UTF-8\"></head><body></body></html>"
-    }
+    },
+    "extends": "xml",
+    "filters": "html"
+  },
+  "variables": {
+    "lang": "en"
   }
 }

--- a/src/test/eslint-suppressions/eslint-suppressions.json
+++ b/src/test/eslint-suppressions/eslint-suppressions.json
@@ -1,0 +1,15 @@
+{
+  "src/index.js": {
+    "no-console": {
+      "count": 2
+    },
+    "unicorn/prefer-module": {
+      "count": 1
+    }
+  },
+  "tests/example.test.js": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new JSON Schema for Emmet snippet files at src/schemas/json/emmet.json.
- Register emmet.json in the catalog for snippets*.json and snippets_*.json filename patterns.
- Add a new JSON Schema for ESLint bulk suppressions at src/schemas/json/eslint-suppressions.json.
- Register eslint-suppressions.json in the catalog for the default ESLint suppressions filename.
- Add positive and negative fixtures for both schemas.

## Sources

- Emmet customization format was based on Emmet snippets structure and local snippet usage.
- ESLint suppressions format was based on the official ESLint bulk suppressions docs and the packaged ESLint SuppressionsService typedef: Record<string, Record<string, { count: number }>>.

## Validation

- 
node ./cli.js check --schema-name=emmet.json
- 
node ./cli.js check --schema-name=eslint-suppressions.json
- Targeted Prettier check/write on touched schema, catalog, and fixture files.
- Confirmed slint-suppressions.json matches only the new catalog entry.
- Validated a real generated suppressions file from C:/Repos/UserStyles/eslint-suppressions.json against the new schema.