### PR TITLE
Add pgrls schema (Postgres Row-Level Security linter config)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5418,6 +5418,12 @@
       "url": "https://www.schemastore.org/pgap_yaml_input_reader.json"
     },
     {
+      "name": "pgrls",
+      "description": "Configuration for pgrls, the Postgres Row-Level Security linter (pgrls.toml)",
+      "fileMatch": ["pgrls.toml"],
+      "url": "https://www.schemastore.org/pgrls.json"
+    },
+    {
       "name": "pattern.json",
       "description": "Patternplate pattern manifest file",
       "fileMatch": ["pattern.json"],

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -324,6 +324,7 @@
   "highSchemaVersion": [
     // JSON schema 2019-09 and 2020-12 are not well supported by many IDEs and should not be used
     "jsone.json",
+    "pgrls.json",
     "license-report-config.json",
     "maestro-flow.json",
     "openweather.current.json",

--- a/src/schemas/json/pgrls.json
+++ b/src/schemas/json/pgrls.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.schemastore.org/pgrls.json",
+  "title": "pgrls configuration",
+  "description": "Configuration file (pgrls.toml) for pgrls, the Postgres Row-Level Security linter. Rule reference: https://github.com/pgrls/pgrls/blob/main/AGENTS.md",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "extends": {
+      "description": "Path, or list of paths, to base pgrls.toml file(s) merged beneath this one. Later list entries and this file's own keys take precedence.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Database connection and scan scope.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Postgres connection string. $VAR and ${VAR} are interpolated from the environment. Prefer leaving this unset and passing --database-url (or $DATABASE_URL) at runtime so secrets stay out of version control."
+        },
+        "schemas": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Schemas to lint.",
+          "default": ["public"]
+        }
+      }
+    },
+    "lint": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Lint behavior.",
+      "properties": {
+        "fail_on": {
+          "$ref": "#/$defs/severity",
+          "description": "Severity that makes `pgrls lint` exit non-zero. CI gates on this.",
+          "default": "warning"
+        },
+        "disable": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Rule IDs to disable entirely (case-insensitive), e.g. [\"SEC022\", \"PERF002\"]."
+        },
+        "rules": {
+          "type": "object",
+          "description": "Per-rule settings, keyed by rule ID — e.g. a [lint.rules.SEC001] table.",
+          "additionalProperties": { "$ref": "#/$defs/ruleOptions" }
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Behavior of `pgrls diff`.",
+      "properties": {
+        "fail_on": {
+          "type": "string",
+          "enum": ["safe", "breaking", "requires-review", "dangerous"],
+          "description": "Change classification at or above which `pgrls diff` exits non-zero.",
+          "default": "dangerous"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["error", "warning", "info"]
+    },
+    "ruleOptions": {
+      "type": "object",
+      "description": "Settings for a single rule.",
+      "properties": {
+        "severity": {
+          "$ref": "#/$defs/severity",
+          "description": "Remap this rule's emitted severity without disabling it (promote an info nudge to a CI-blocking error, or demote a noisy warning)."
+        },
+        "allowlist": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Objects exempt from this rule. Entry shape depends on the rule: a policy ID (schema.table.policy), a table reference (table or schema.table), a role name, a qualified view/function, etc."
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/schemas/json/pgrls.json
+++ b/src/schemas/json/pgrls.json
@@ -1,6 +1,28 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://www.schemastore.org/pgrls.json",
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["error", "warning", "info"]
+    },
+    "ruleOptions": {
+      "type": "object",
+      "description": "Settings for a single rule.",
+      "properties": {
+        "severity": {
+          "$ref": "#/$defs/severity",
+          "description": "Remap this rule's emitted severity without disabling it (promote an info nudge to a CI-blocking error, or demote a noisy warning)."
+        },
+        "allowlist": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Objects exempt from this rule. Entry shape depends on the rule: a policy ID (schema.table.policy), a table reference (table or schema.table), a role name, a qualified view/function, etc."
+        }
+      },
+      "additionalProperties": true
+    }
+  },
   "title": "pgrls configuration",
   "description": "Configuration file (pgrls.toml) for pgrls, the Postgres Row-Level Security linter. Rule reference: https://github.com/pgrls/pgrls/blob/main/AGENTS.md",
   "type": "object",
@@ -64,28 +86,6 @@
           "default": "dangerous"
         }
       }
-    }
-  },
-  "$defs": {
-    "severity": {
-      "type": "string",
-      "enum": ["error", "warning", "info"]
-    },
-    "ruleOptions": {
-      "type": "object",
-      "description": "Settings for a single rule.",
-      "properties": {
-        "severity": {
-          "$ref": "#/$defs/severity",
-          "description": "Remap this rule's emitted severity without disabling it (promote an info nudge to a CI-blocking error, or demote a noisy warning)."
-        },
-        "allowlist": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Objects exempt from this rule. Entry shape depends on the rule: a policy ID (schema.table.policy), a table reference (table or schema.table), a role name, a qualified view/function, etc."
-        }
-      },
-      "additionalProperties": true
     }
   }
 }

--- a/src/test/pgrls/pgrls.toml
+++ b/src/test/pgrls/pgrls.toml
@@ -1,3 +1,4 @@
+#:schema ../../schemas/json/pgrls.json
 # Positive test fixture for the pgrls schema — a valid pgrls.toml
 # exercising every config table.
 extends = "../pgrls.base.toml"

--- a/src/test/pgrls/pgrls.toml
+++ b/src/test/pgrls/pgrls.toml
@@ -1,0 +1,20 @@
+# Positive test fixture for the pgrls schema — a valid pgrls.toml
+# exercising every config table.
+extends = "../pgrls.base.toml"
+
+[database]
+url = "$DATABASE_URL"
+schemas = ["public", "tenant"]
+
+[lint]
+fail_on = "error"
+disable = ["SEC022", "PERF002"]
+
+[lint.rules.SEC001]
+allowlist = ["public.countries", "currencies"]
+
+[lint.rules.SEC030]
+severity = "error"
+
+[diff]
+fail_on = "requires-review"


### PR DESCRIPTION
Adds a JSON schema for **`pgrls.toml`**, the config file for [pgrls](https://github.com/pgrls/pgrls) — a static analyzer for Postgres Row-Level Security (43 lint rules; on PyPI as `pgrls`).

## Changes
- `src/schemas/json/pgrls.json` — the schema. Covers every config table: top-level `extends`, `[database]` (`url`, `schemas`), `[lint]` (`fail_on`, `disable`, `[lint.rules.<ID>]` with `severity` + `allowlist` and rule-specific options), `[diff]` (`fail_on`). Strict `additionalProperties: false` at the table level so typo'd keys are flagged; enums for severities and diff classifications.
- `src/api/json/catalog.json` — catalog entry with `fileMatch: ["pgrls.toml"]`.
- `src/test/pgrls/pgrls.toml` — positive test exercising all tables.

The schema mirrors the canonical copy in the pgrls repo (`pgrls.schema.json`); upstream config changes will be PR'd here to keep it in sync.