### PR TITLE
fix: add file match for new config location of glazewm

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8893,7 +8893,7 @@
     {
       "name": "GlazeWM settings",
       "description": "GlazeWM settings",
-      "fileMatch": ["**/.glaze-wm/config.yaml"],
+      "fileMatch": ["**/.glaze-wm/config.yaml", "**/glazewm/config.yaml"],
       "url": "https://www.schemastore.org/glazewm.json"
     },
     {


### PR DESCRIPTION
As per documentation in https://github.com/glzr-io/glazewm#config-documentation, we can see that the default location is `.glzr\glazewm\config.yaml`.

Ive just added "**/glazewm/config.yaml" to the matches as I believe that will be sufficient and will allow for people who have placed their config elsewhere without adding a risk for false positives.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
