### PR TITLE
pyproject: PEP 808

### DIFF
--- a/src/negative_test/pyproject/pep808-string-dynamic.toml
+++ b/src/negative_test/pyproject/pep808-string-dynamic.toml
@@ -1,0 +1,10 @@
+#:schema ../../schemas/json/pyproject.json
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pep808-negative-example"
+description = "An example package that incorrectly lists a string field in dynamic"
+requires-python = ">=3.9"
+dynamic = ["version", "requires-python"]

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -143,9 +143,9 @@
       "additionalProperties": false,
       "required": ["name"],
       "title": "Project core metadata",
-      "description": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
-      "markdownDescription": "There are two kinds of metadata: _static_ and _dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.",
-      "x-intellij-html-description": "<p>There are two kinds of metadata: <em>static</em> and <em>dynamic</em>.</p><ul><li>Static metadata is listed in the <code>[project]</code> table directly and cannot be specified or changed by a tool.</li><li>Dynamic metadata key names are listed inside the <code>dynamic</code> key and represents metadata that a tool will later provide.</li></ul>",
+      "description": "There are two kinds of metadata: _static_, _dynamic_, and _partially dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.\n- Partially dynamic metadata is specified in the `[project]` table as a list or table, and also listed in `dynamic`, allowing the build backend to add entries but not modify or remove existing ones.",
+      "markdownDescription": "There are two kinds of metadata: _static_, _dynamic_, and _partially dynamic_.\n- Static metadata is listed in the `[project]` table directly and cannot be specified or changed by a tool.\n- Dynamic metadata key names are listed inside the `dynamic` key and represents metadata that a tool will later provide.\n- Partially dynamic metadata is specified in the `[project]` table as a list or table, and also listed in `dynamic`, allowing the build backend to add entries but not modify or remove existing ones.",
+      "x-intellij-html-description": "<p>There are two kinds of metadata: <em>static</em>, <em>dynamic</em>, and <em>partially dynamic</em>.</p><ul><li>Static metadata is listed in the <code>[project]</code> table directly and cannot be specified or changed by a tool.</li><li>Dynamic metadata key names are listed inside the <code>dynamic</code> key and represents metadata that a tool will later provide.</li><li>Partially dynamic metadata is specified in the <code>[project]</code> table as a list or table, and also listed in <code>dynamic</code>, allowing the build backend to add entries but not modify or remove existing ones.</li></ul>",
       "x-taplo": {
         "links": {
           "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table",
@@ -631,10 +631,10 @@
           },
           "uniqueItems": true,
           "title": "Dynamic metadata values",
-          "description": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]`.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
-          "markdownDescription": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]`.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
+          "description": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]` unless the key is a list or table with arbitrary entries (PEP 808), in which case the build backend may extend it.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
+          "markdownDescription": "Specifies which keys are intentionally unspecified under `[project]` table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in `dynamic` and use the key directly in `[project]` unless the key is a list or table with arbitrary entries (PEP 808), in which case the build backend may extend it.\nOne of the most common usage is `version`, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in `pyproject.toml`.",
           "x-tombi-array-values-order": "version-sort",
-          "x-intellij-html-description": "<p>Specifies which keys are intentionally unspecified under <code>[project]</code> table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in <code>dynamic</code> and use the key directly in <code>[project]</code>.</p><p>One of the most common usage is <code>version</code>, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in <code>pyproject.toml</code>.</p>",
+          "x-intellij-html-description": "<p>Specifies which keys are intentionally unspecified under <code>[project]</code> table so build backend can/will provide such metadata dynamically. Each key must be listed only once. It is an error to both list a key in <code>dynamic</code> and use the key directly in <code>[project]</code> unless the key is a list or table with arbitrary entries (PEP 808), in which case the build backend may extend it.</p><p>One of the most common usage is <code>version</code>, which allows build backend to retrieve project version from source code or version control system instead of hardcoding it in <code>pyproject.toml</code>.</p>",
           "x-taplo": {
             "links": {
               "key": "https://packaging.python.org/en/latest/specifications/pyproject-toml/#dynamic"
@@ -729,182 +729,9 @@
           }
         },
         "license-files": {
-          "allOf": [
-            {
-              "not": {
-                "required": ["dynamic"],
-                "properties": {
-                  "dynamic": {
-                    "type": "array",
-                    "contains": {
-                      "const": "license-files"
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "properties": {
-                "license": {
-                  "type": "string"
-                }
-              }
-            }
-          ]
-        },
-        "authors": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "authors"
-                }
-              }
-            }
-          }
-        },
-        "maintainers": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "maintainers"
-                }
-              }
-            }
-          }
-        },
-        "keywords": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "keywords"
-                }
-              }
-            }
-          }
-        },
-        "classifiers": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "classifiers"
-                }
-              }
-            }
-          }
-        },
-        "urls": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "urls"
-                }
-              }
-            }
-          }
-        },
-        "scripts": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "scripts"
-                }
-              }
-            }
-          }
-        },
-        "gui-scripts": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "gui-scripts"
-                }
-              }
-            }
-          }
-        },
-        "entry-points": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "entry-points"
-                }
-              }
-            }
-          }
-        },
-        "dependencies": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "dependencies"
-                }
-              }
-            }
-          }
-        },
-        "optional-dependencies": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "optional-dependencies"
-                }
-              }
-            }
-          }
-        },
-        "import-names": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "import-names"
-                }
-              }
-            }
-          }
-        },
-        "import-namespaces": {
-          "not": {
-            "required": ["dynamic"],
-            "properties": {
-              "dynamic": {
-                "type": "array",
-                "contains": {
-                  "const": "import-namespaces"
-                }
-              }
+          "properties": {
+            "license": {
+              "type": "string"
             }
           }
         }

--- a/src/test/pyproject/pep808.toml
+++ b/src/test/pyproject/pep808.toml
@@ -7,26 +7,26 @@ build-backend = "hatchling.build"
 name = "pep808-example"
 description = "An example PEP 808 package"
 dynamic = [
-    "version",
-    "dependencies",
-    "optional-dependencies",
-    "classifiers",
-    "authors",
-    "maintainers",
-    "keywords",
-    "license-files",
-    "urls",
-    "scripts",
-    "gui-scripts",
-    "entry-points",
-    "import-names",
-    "import-namespaces",
+  "version",
+  "dependencies",
+  "optional-dependencies",
+  "classifiers",
+  "authors",
+  "maintainers",
+  "keywords",
+  "license-files",
+  "urls",
+  "scripts",
+  "gui-scripts",
+  "entry-points",
+  "import-names",
+  "import-namespaces",
 ]
 dependencies = ["torch", "packaging"]
 keywords = ["example", "pep808"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3",
 ]
 license-files = ["LICENSE"]
 import-names = ["example_package"]

--- a/src/test/pyproject/pep808.toml
+++ b/src/test/pyproject/pep808.toml
@@ -1,0 +1,56 @@
+#:schema ../../schemas/json/pyproject.json
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pep808-example"
+description = "An example PEP 808 package"
+dynamic = [
+    "version",
+    "dependencies",
+    "optional-dependencies",
+    "classifiers",
+    "authors",
+    "maintainers",
+    "keywords",
+    "license-files",
+    "urls",
+    "scripts",
+    "gui-scripts",
+    "entry-points",
+    "import-names",
+    "import-namespaces",
+]
+dependencies = ["torch", "packaging"]
+keywords = ["example", "pep808"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+]
+license-files = ["LICENSE"]
+import-names = ["example_package"]
+import-namespaces = ["example_namespace"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[[project.authors]]
+name = "Example Author"
+email = "author@example.com"
+
+[project.urls]
+Homepage = "https://example.com"
+
+[project.scripts]
+cli = "package.module:main"
+
+[project.gui-scripts]
+gui = "package.module:gui_main"
+
+[project.entry-points."pygments.styles"]
+monokai = "package.module:monokai"
+
+[[project.maintainers]]
+name = "Maintainer"
+email = "maintainer@example.com"


### PR DESCRIPTION
https://peps.python.org/pep-0808/ has been accepted. This allows list and table static entries to be extended with dynamic metadata if present and listed in the dynamic field too. String fields remain fully static.

Added a test with mixed fields, and a neg test for a string field.

Assisted-by: OpenCode:glm-5.1

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
