### PR TITLE
Add quikrun configuration schema and integrate with package manifests

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10172,6 +10172,12 @@
       "description": "Default configurations for creating new QTCP tasks (via the UI)",
       "fileMatch": ["**/qtcp_tasks/newTaskDefaults.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/newtaskdefaults.schema.json"
+    },
+    {
+      "name": "QuikRun Configuration",
+      "description": "Configuration for QuikRun",
+      "fileMatch": ["quikrun.toml"],
+      "url": "https://www.schemastore.org/quikrun.json"
     }
   ]
 }

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -937,7 +937,8 @@
         "cargo-lints-rust.json",
         "cargo-lints-rustdoc.json",
         "cargo-lints-clippy.json",
-        "cargo-lints-cargo.json"
+        "cargo-lints-cargo.json",
+        "quikrun.json"
       ],
       "unknownFormat": ["uint32", "semver", "semver-requirement"]
     },
@@ -1252,7 +1253,8 @@
         "semantic-release.json",
         "jscpd.json",
         "nodemon.json",
-        "base.json"
+        "base.json",
+        "quikrun.json"
       ],
       "unknownFormat": ["<app> <your args>"],
       "unknownKeywords": ["exec", "tsType"]
@@ -1360,7 +1362,8 @@
         "tombi.json",
         "ty.json",
         "uv.json",
-        "base.json"
+        "base.json",
+        "quikrun.json"
       ],
       "unknownFormat": [
         "uint64",

--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -664,6 +664,9 @@
           "properties": {
             "playdate": {
               "$ref": "#/definitions/PlaydateMetadata"
+            },
+            "quikrun": {
+              "$ref": "https://www.schemastore.org/quikrun.json"
             }
           },
           "x-tombi-table-keys-order": "schema",

--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -1098,6 +1098,9 @@
     "nodemonConfig": {
       "$ref": "nodemon.json"
     },
+    "quikrun": {
+      "$ref": "https://www.schemastore.org/quikrun.json"
+    },
     "pnpm": {
       "description": "Defines pnpm specific configuration.",
       "type": "object",

--- a/src/schemas/json/pyproject.json
+++ b/src/schemas/json/pyproject.json
@@ -1083,6 +1083,11 @@
           "$ref": "partial-dfc.json",
           "title": "docstring-format-checker",
           "description": "A CLI tool to check and validate Python docstring formatting and completeness"
+        },
+        "quikrun": {
+          "$ref": "https://www.schemastore.org/quikrun.json",
+          "title": "quikrun",
+          "description": "A CLI tool to run code files instantly without typing complex commands in terminal."
         }
       },
       "examples": [

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/quikrun.json",
+  "title": "quikrun",
+  "description": "Configuration for quikrun, a CLI tool to run code files instantly without typing complex commands in terminal.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Path to the JSON schema"
+    },
+    "shell": {
+      "type": ["string", "null"],
+      "description": "Custom shell to run commands in (e.g., 'bash', 'zsh', 'sh')"
+    },
+    "clear_terminal": {
+      "type": "boolean",
+      "description": "Whether to clear the terminal before executing commands",
+      "default": true
+    },
+    "show_time_took": {
+      "type": "boolean",
+      "description": "Show time taken to execute the script",
+      "default": true
+    },
+    "show_command": {
+      "type": "boolean",
+      "description": "Print the actual command that is being run",
+      "default": true
+    },
+    "show_shell": {
+      "type": "boolean",
+      "description": "Display the shell being used for execution",
+      "default": true
+    },
+    "show_divider": {
+      "type": "boolean",
+      "description": "Print a divider line before command stdout/stderr",
+      "default": true
+    },
+    "temp_dir": {
+      "type": ["string", "null"],
+      "description": "Directory to store temporary execution files",
+      "default": null
+    },
+    "cd_to_file_dir": {
+      "type": "boolean",
+      "description": "Change directory to the folder containing the file before execution",
+      "default": false
+    },
+    "keep_artifacts": {
+      "type": "boolean",
+      "description": "Keep generated binaries or temporary files after execution",
+      "default": false
+    },
+    "commands": {
+      "type": "object",
+      "description": "Mapping of file extensions to custom runner configurations",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "description": "The command template to execute (e.g. 'python {file}')"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "command": {
+                "type": "string",
+                "description": "The command template to execute"
+              },
+              "temp_file": {
+                "type": "boolean",
+                "description": "Whether to copy the file to a temporary location before executing"
+              },
+              "compile": {
+                "type": "string",
+                "description": "Command template to compile the file before running (e.g. 'g++ {file} -o {bin}')"
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -14,10 +14,11 @@
       "anyOf": [
         {
           "type": "string",
-          "description": "Cros-platform Custom shell to run commands"
+          "description": "Cross-platform custom shell to run commands"
         },
         {
           "type": "object",
+          "description": "Platform-specific custom shells",
           "properties": {
             "win": {
               "type": "string",
@@ -32,11 +33,7 @@
               "description": "Custom shell for macOS (Darwin)"
             }
           },
-          "additionalProperties": false,
-          "description": "Platform-specific custom shells"
-        },
-        {
-          "type": "null"
+          "additionalProperties": false
         }
       ]
     },
@@ -112,15 +109,15 @@
       "properties": {
         "linux": {
           "$ref": "#/definitions/commandValue",
-          "description": "Configuration for Linux"
+          "description": "Command for Linux"
         },
         "darwin": {
           "$ref": "#/definitions/commandValue",
-          "description": "Configuration for macOS (Darwin)"
+          "description": "Command for macOS (Darwin)"
         },
         "win": {
           "$ref": "#/definitions/commandValue",
-          "description": "Configuration for Windows"
+          "description": "Command for Windows"
         }
       },
       "additionalProperties": false
@@ -137,7 +134,7 @@
               "$ref": "#/definitions/osSpecific"
             }
           ],
-          "description": "Configuration for POSIX shells (bash, zsh, sh, etc.)"
+          "description": "Command for POSIX shells (bash, zsh, sh, etc.)"
         },
         "cmd": {
           "anyOf": [
@@ -148,7 +145,7 @@
               "$ref": "#/definitions/osSpecific"
             }
           ],
-          "description": "Configuration for Windows Command Prompt (cmd.exe)"
+          "description": "Command for Windows Command Prompt (cmd.exe)"
         },
         "pwsh": {
           "anyOf": [
@@ -159,7 +156,7 @@
               "$ref": "#/definitions/osSpecific"
             }
           ],
-          "description": "Configuration for PowerShell Core (pwsh)"
+          "description": "Command for PowerShell Core (pwsh)"
         }
       },
       "additionalProperties": false
@@ -168,7 +165,12 @@
       "anyOf": [
         {
           "type": "string",
-          "description": "The command template to execute or inheritance alias starting with @ (e.g., 'python {file}', '@js')"
+          "pattern": "^@.+$",
+          "description": "Inheritance alias starting with @ (e.g., '@js')"
+        },
+        {
+          "type": "string",
+          "description": "The command to execute (e.g., 'python {file}')"
         },
         {
           "$ref": "#/definitions/compileRun"
@@ -176,6 +178,7 @@
       ]
     },
     "commandValue": {
+      "description": "Command string, fallback array, or platform-specific object",
       "anyOf": [
         {
           "$ref": "#/definitions/singleCommand"
@@ -184,8 +187,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/commandValue"
-          },
-          "description": "Fallback list of command templates/aliases to try in order"
+          }
         },
         {
           "$ref": "#/definitions/shellFamilySpecific"

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -63,10 +63,7 @@
       "default": true
     },
     "temp_dir": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "Directory to store temporary execution files",
       "default": null
     },

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -10,10 +10,11 @@
       "description": "Path to the JSON schema"
     },
     "shell": {
+      "description": "Custom shell to run commands in",
       "anyOf": [
         {
           "type": "string",
-          "description": "Custom shell to run commands in (e.g., 'bash', 'zsh', 'sh', 'dash', 'ash', 'cmd', 'pwsh')"
+          "description": "Cros-platform Custom shell to run commands"
         },
         {
           "type": "object",
@@ -37,8 +38,7 @@
         {
           "type": "null"
         }
-      ],
-      "description": "Custom shell to run commands in"
+      ]
     },
     "clear_terminal": {
       "type": "boolean",
@@ -66,7 +66,10 @@
       "default": true
     },
     "temp_dir": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Directory to store temporary execution files",
       "default": null
     },

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -42,7 +42,7 @@
     },
     "clear_terminal": {
       "type": "boolean",
-      "description": "Whether to clear the terminal before executing commands",
+      "description": "Clear the terminal before executing commands",
       "default": true
     },
     "show_time_took": {
@@ -52,17 +52,17 @@
     },
     "show_command": {
       "type": "boolean",
-      "description": "Print the actual command that is being run",
+      "description": "Show the actual command that is being run",
       "default": true
     },
     "show_shell": {
       "type": "boolean",
-      "description": "Display the shell being used for execution",
+      "description": "Show the shell being used for execution",
       "default": true
     },
     "show_divider": {
       "type": "boolean",
-      "description": "Print a divider line before command stdout/stderr",
+      "description": "Show the divider line before command stdout/stderr",
       "default": true
     },
     "temp_dir": {
@@ -85,7 +85,7 @@
     },
     "commands": {
       "type": "object",
-      "description": "Mapping of file extensions to custom runner configurations",
+      "description": "Command Templates by file extension",
       "additionalProperties": {
         "$ref": "#/definitions/commandValue"
       }

--- a/src/schemas/json/quikrun.json
+++ b/src/schemas/json/quikrun.json
@@ -10,8 +10,35 @@
       "description": "Path to the JSON schema"
     },
     "shell": {
-      "type": ["string", "null"],
-      "description": "Custom shell to run commands in (e.g., 'bash', 'zsh', 'sh')"
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Custom shell to run commands in (e.g., 'bash', 'zsh', 'sh', 'dash', 'ash', 'cmd', 'pwsh')"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "win": {
+              "type": "string",
+              "description": "Custom shell for Windows"
+            },
+            "linux": {
+              "type": "string",
+              "description": "Custom shell for Linux"
+            },
+            "darwin": {
+              "type": "string",
+              "description": "Custom shell for macOS (Darwin)"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Platform-specific custom shells"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Custom shell to run commands in"
     },
     "clear_terminal": {
       "type": "boolean",
@@ -57,33 +84,110 @@
       "type": "object",
       "description": "Mapping of file extensions to custom runner configurations",
       "additionalProperties": {
-        "anyOf": [
-          {
-            "type": "string",
-            "description": "The command template to execute (e.g. 'python {file}')"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "command": {
-                "type": "string",
-                "description": "The command template to execute"
-              },
-              "temp_file": {
-                "type": "boolean",
-                "description": "Whether to copy the file to a temporary location before executing"
-              },
-              "compile": {
-                "type": "string",
-                "description": "Command template to compile the file before running (e.g. 'g++ {file} -o {bin}')"
-              }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-          }
-        ]
+        "$ref": "#/definitions/commandValue"
       }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "compileRun": {
+      "type": "object",
+      "properties": {
+        "compile": {
+          "type": "string",
+          "description": "Command template to compile the file before running (e.g. 'g++ {file} -o {out}')"
+        },
+        "run": {
+          "type": "string",
+          "description": "Command template to execute the compiled binary (e.g. '{out}')"
+        }
+      },
+      "additionalProperties": false
+    },
+    "osSpecific": {
+      "type": "object",
+      "properties": {
+        "linux": {
+          "$ref": "#/definitions/commandValue",
+          "description": "Configuration for Linux"
+        },
+        "darwin": {
+          "$ref": "#/definitions/commandValue",
+          "description": "Configuration for macOS (Darwin)"
+        },
+        "win": {
+          "$ref": "#/definitions/commandValue",
+          "description": "Configuration for Windows"
+        }
+      },
+      "additionalProperties": false
+    },
+    "shellFamilySpecific": {
+      "type": "object",
+      "properties": {
+        "posix": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/commandValue"
+            },
+            {
+              "$ref": "#/definitions/osSpecific"
+            }
+          ],
+          "description": "Configuration for POSIX shells (bash, zsh, sh, etc.)"
+        },
+        "cmd": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/commandValue"
+            },
+            {
+              "$ref": "#/definitions/osSpecific"
+            }
+          ],
+          "description": "Configuration for Windows Command Prompt (cmd.exe)"
+        },
+        "pwsh": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/commandValue"
+            },
+            {
+              "$ref": "#/definitions/osSpecific"
+            }
+          ],
+          "description": "Configuration for PowerShell Core (pwsh)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "singleCommand": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "The command template to execute or inheritance alias starting with @ (e.g., 'python {file}', '@js')"
+        },
+        {
+          "$ref": "#/definitions/compileRun"
+        }
+      ]
+    },
+    "commandValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/singleCommand"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/commandValue"
+          },
+          "description": "Fallback list of command templates/aliases to try in order"
+        },
+        {
+          "$ref": "#/definitions/shellFamilySpecific"
+        }
+      ]
+    }
+  }
 }

--- a/src/test/quikrun/quikrun.toml
+++ b/src/test/quikrun/quikrun.toml
@@ -1,0 +1,16 @@
+#:schema ../../schemas/json/quikrun.json
+# quikrun.toml test file
+shell = "bash"
+clear_terminal = false
+show_time_took = true
+show_command = true
+show_shell = false
+show_divider = true
+temp_dir = "/tmp/quikrun"
+cd_to_file_dir = true
+keep_artifacts = false
+
+[commands]
+py = "python {file}"
+go = { command = "go run {file}", temp_file = true }
+cpp = { command = "./{bin}", compile = "g++ {file} -o {bin}" }

--- a/src/test/quikrun/quikrun.toml
+++ b/src/test/quikrun/quikrun.toml
@@ -1,6 +1,5 @@
 #:schema ../../schemas/json/quikrun.json
 # quikrun.toml test file
-shell = "bash"
 clear_terminal = false
 show_time_took = true
 show_command = true
@@ -9,8 +8,12 @@ show_divider = true
 temp_dir = "/tmp/quikrun"
 cd_to_file_dir = true
 keep_artifacts = false
+shell = { linux = "bash", darwin = "zsh", win = "pwsh.exe" }
 
 [commands]
 py = "python {file}"
-go = { command = "go run {file}", temp_file = true }
-cpp = { command = "./{bin}", compile = "g++ {file} -o {bin}" }
+go = { compile = "go build -o {out} {file}", run = "{out}" }
+cpp = { posix = { linux = { compile = "g++ -Wall {file} -o {out}", run = "{out}" }, darwin = { compile = "clang++ -Wall {file} -o {out}", run = "{out}" } } }
+js = ["bun run {file}", "deno run {file}", "node {file}"]
+ts = ["@js", "tsc {file}"]
+cxx = "@cpp"


### PR DESCRIPTION
This PR adds the JSON schema and integration for `quikrun`, a CLI tool to run code files instantly without typing complex commands in the terminal (Project repository: https://github.com/soymadip/quikrun).

### Changes

1. **New Schema**: Added `src/schemas/json/quikrun.json` supporting all config fields (`shell`, `clear_terminal`, `show_time_took`, `commands` object, etc.).
2. **Catalog Entry**: Registered `quikrun.toml` in `src/api/json/catalog.json`.
3. **Integration with Manifests**:
   - Added `$ref` pointing to the absolute URL `https://www.schemastore.org/quikrun.json` in:
     - `pyproject.json` (under `[tool.quikrun]`)
     - `cargo.json` (under `[package.metadata.quikrun]`)
     - `package.json` (under `"quikrun"`)
   - Listed `quikrun.json` in `src/schema-validation.jsonc` under `externalSchema` for those files.
4. **Test Case**: Added a valid `quikrun.toml` test file under `src/test/quikrun/quikrun.toml`.

### Validation

Ran the following tests locally and verified that they pass validation under strict-mode Ajv rules:
```bash
node cli.js check --schema-name=quikrun.json
node cli.js check --schema-name=pyproject.json
node cli.js check --schema-name=cargo.json
node cli.js check --schema-name=package.json
