### PR TITLE
Add AlgoVoi Compliance Receipt v1 schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -87,6 +87,16 @@
       "url": "https://developer.1password.com/schema/ssh-agent-config.json"
     },
     {
+      "name": "AlgoVoi Compliance Receipt v1",
+      "description": "Categorical compliance screening receipt for agentic-payment flows; emitted at admission time and retained as part of an audit chain under UK MLR 2017, EU AMLD5/6, MiCA Art 80, AMLR Art 56, DORA Art 14",
+      "fileMatch": [
+        "algovoi-compliance-receipt.json",
+        "algovoi-compliance-receipt-*.json",
+        "**/algovoi/compliance-receipt-*.json"
+      ],
+      "url": "https://www.schemastore.org/algovoi-compliance-receipt-v1.json"
+    },
+    {
       "name": "Application Accelerator",
       "description": "Application Accelerator for VMware Tanzu",
       "fileMatch": ["accelerator.yaml"],

--- a/src/negative_test/algovoi-compliance-receipt-v1/empty-jurisdiction-flags.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/empty-jurisdiction-flags.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": [],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:abc123",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/empty-jurisdiction-flags.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/empty-jurisdiction-flags.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": [],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/extra-field-score.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/extra-field-score.json
@@ -1,9 +1,9 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
-  "jurisdiction_flags": ["UK"],
   "canon_version": "jcs-rfc8785-v1",
-  "score": 75
+  "jurisdiction_flags": ["UK"],
+  "payer_ref": "sha256:abc123",
+  "score": 75,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/extra-field-score.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/extra-field-score.json
@@ -1,0 +1,9 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1",
+  "score": 75
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/float-timestamp.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/float-timestamp.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000.5,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/float-timestamp.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/float-timestamp.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000.5,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:abc123",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000.5
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/invalid-did-format.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/invalid-did-format.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "plain-string-not-did",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/invalid-did-format.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/invalid-did-format.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "plain-string-not-did",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:abc123",
+  "screen_provider_did": "plain-string-not-did",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/invalid-screen-result.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/invalid-screen-result.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "MAYBE",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:abc123",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "MAYBE",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/invalid-screen-result.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/invalid-screen-result.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "MAYBE",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/missing-payer-ref.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/missing-payer-ref.json
@@ -1,7 +1,7 @@
 {
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v1"
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/negative_test/algovoi-compliance-receipt-v1/missing-payer-ref.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/missing-payer-ref.json
@@ -1,0 +1,7 @@
+{
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/unknown-canon-version.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/unknown-canon-version.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:abc123",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v2"
+}

--- a/src/negative_test/algovoi-compliance-receipt-v1/unknown-canon-version.json
+++ b/src/negative_test/algovoi-compliance-receipt-v1/unknown-canon-version.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:abc123",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v2",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v2"
+  "payer_ref": "sha256:abc123",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/schemas/json/algovoi-compliance-receipt-v1.json
+++ b/src/schemas/json/algovoi-compliance-receipt-v1.json
@@ -18,7 +18,9 @@
       "type": "string",
       "minLength": 1,
       "description": "Content-addressed identity reference for the payer. Typically of the form 'sha256:<lowercase-hex>' where the hash is taken over the JCS-canonical bytes of an identity object. The receipt MUST NOT carry cleartext identity content -- only the content-addressed reference -- so the screening provider's retention layer is GDPR Art. 5(1)(c) minimal by construction.",
-      "examples": ["sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f"]
+      "examples": [
+        "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f"
+      ]
     },
     "screen_result": {
       "type": "string",
@@ -47,11 +49,7 @@
       },
       "uniqueItems": false,
       "description": "Ordered list of jurisdictions under which the screening was performed. Element order is load-bearing: per RFC 8785 §3.2.3 array element order is preserved in canonicalisation, so ['UK','EU'] and ['EU','UK'] produce distinct canonical bytes and distinct SHA-256 hashes. Producer-side ordering MUST match the order under which the regulatory rules were applied.",
-      "examples": [
-        ["UK", "EU"],
-        ["UK"],
-        ["EU", "DE"]
-      ]
+      "examples": [["UK", "EU"], ["UK"], ["EU", "DE"]]
     },
     "canon_version": {
       "type": "string",

--- a/src/schemas/json/algovoi-compliance-receipt-v1.json
+++ b/src/schemas/json/algovoi-compliance-receipt-v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/algovoi-compliance-receipt-v1.json",
+  "title": "AlgoVoi Compliance Receipt v1",
+  "description": "Categorical compliance screening receipt for agentic-payment flows. Emitted by a screening provider when a wallet, agent, or payee passes the regulatory gate at admission time. Retained as part of an audit chain under framework-bound retention obligations (UK MLR 2017, EU AMLD5/6, MiCA Art. 80, AMLR Art. 56, DORA Art. 14). The categorical screen result (ALLOW / REFER / DENY) is load-bearing for downstream regulatory obligations -- a REFER under UK POCA 2002 s.330 carries a mandatory SAR obligation that a DENY does not, so a score / tier projection is NOT a valid substitute. Canonicalisation discipline pinned in-band via canon_version; see https://github.com/x402-foundation/x402/pull/2436.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "payer_ref",
+    "screen_result",
+    "screen_timestamp_ms",
+    "screen_provider_did",
+    "jurisdiction_flags",
+    "canon_version"
+  ],
+  "properties": {
+    "payer_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Content-addressed identity reference for the payer. Typically of the form 'sha256:<lowercase-hex>' where the hash is taken over the JCS-canonical bytes of an identity object. The receipt MUST NOT carry cleartext identity content -- only the content-addressed reference -- so the screening provider's retention layer is GDPR Art. 5(1)(c) minimal by construction.",
+      "examples": ["sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f"]
+    },
+    "screen_result": {
+      "type": "string",
+      "enum": ["ALLOW", "REFER", "DENY"],
+      "description": "Categorical screening outcome. ALLOW = clear to proceed under regulatory gate. REFER = enhanced due diligence required (and under UK POCA 2002 s.330 a mandatory SAR obligation if jurisdiction includes UK). DENY = transaction refused under sanctions / AML rule. Closed set; a score / tier projection is NOT a valid substitute and would lose the SAR distinction."
+    },
+    "screen_timestamp_ms": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Epoch-millisecond integer timestamp of the screening decision. Substrate Rule 1: timestamp_ms MUST be an integer, not a float, not an RFC 3339 string -- the integer-millisecond shape is what makes year-five re-canonicalisation deterministic from retained bytes alone."
+    },
+    "screen_provider_did": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^did:[a-z0-9]+:.+$",
+      "description": "Decentralised Identifier of the screening provider. Most production deployments use did:web (e.g. did:web:api.algovoi.co.uk) so the public key for verification is resolvable via the DID Document at https://<host>/.well-known/did.json.",
+      "examples": ["did:web:api.algovoi.co.uk"]
+    },
+    "jurisdiction_flags": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Jurisdiction code (typically ISO 3166-1 alpha-2 or the regional aggregate code such as EU)."
+      },
+      "uniqueItems": false,
+      "description": "Ordered list of jurisdictions under which the screening was performed. Element order is load-bearing: per RFC 8785 §3.2.3 array element order is preserved in canonicalisation, so ['UK','EU'] and ['EU','UK'] produce distinct canonical bytes and distinct SHA-256 hashes. Producer-side ordering MUST match the order under which the regulatory rules were applied.",
+      "examples": [
+        ["UK", "EU"],
+        ["UK"],
+        ["EU", "DE"]
+      ]
+    },
+    "canon_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "In-band canonicalisation rule version pin. Carries the version of the JCS canonicalisation discipline active at emission time, so a year-five re-canonicalisation against retained bytes alone knows which rule to apply. The discipline is defined in x402-foundation/x402 PR #2436 (three-voice coalition co-signed). Current value: jcs-rfc8785-v1.",
+      "enum": ["jcs-rfc8785-v1"],
+      "examples": ["jcs-rfc8785-v1"]
+    }
+  }
+}

--- a/src/test/algovoi-compliance-receipt-v1/receipt-allow-uk-eu.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-allow-uk-eu.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK", "EU"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/test/algovoi-compliance-receipt-v1/receipt-allow-uk-eu.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-allow-uk-eu.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f",
-  "screen_result": "ALLOW",
-  "screen_timestamp_ms": 1716460800000,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK", "EU"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1716460800000
 }

--- a/src/test/algovoi-compliance-receipt-v1/receipt-deny-sanctions.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-deny-sanctions.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:10779e0aeb2e1d3aa2c419c91d1e0cd0c14d9a8a3f6c2f25b3d0aa1075c3e438",
+  "screen_result": "DENY",
+  "screen_timestamp_ms": 1716460800100,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK", "EU", "US"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/test/algovoi-compliance-receipt-v1/receipt-deny-sanctions.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-deny-sanctions.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:10779e0aeb2e1d3aa2c419c91d1e0cd0c14d9a8a3f6c2f25b3d0aa1075c3e438",
-  "screen_result": "DENY",
-  "screen_timestamp_ms": 1716460800100,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK", "EU", "US"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:10779e0aeb2e1d3aa2c419c91d1e0cd0c14d9a8a3f6c2f25b3d0aa1075c3e438",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "DENY",
+  "screen_timestamp_ms": 1716460800100
 }

--- a/src/test/algovoi-compliance-receipt-v1/receipt-refer-uk-sar-obligation.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-refer-uk-sar-obligation.json
@@ -1,0 +1,8 @@
+{
+  "payer_ref": "sha256:4b781b0d3f8a82c5e6e91077928d3c9156b1ab51c19d7eef03f1d2956b1a3e72",
+  "screen_result": "REFER",
+  "screen_timestamp_ms": 1716460800050,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK"],
+  "canon_version": "jcs-rfc8785-v1"
+}

--- a/src/test/algovoi-compliance-receipt-v1/receipt-refer-uk-sar-obligation.json
+++ b/src/test/algovoi-compliance-receipt-v1/receipt-refer-uk-sar-obligation.json
@@ -1,8 +1,8 @@
 {
-  "payer_ref": "sha256:4b781b0d3f8a82c5e6e91077928d3c9156b1ab51c19d7eef03f1d2956b1a3e72",
-  "screen_result": "REFER",
-  "screen_timestamp_ms": 1716460800050,
-  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "canon_version": "jcs-rfc8785-v1",
   "jurisdiction_flags": ["UK"],
-  "canon_version": "jcs-rfc8785-v1"
+  "payer_ref": "sha256:4b781b0d3f8a82c5e6e91077928d3c9156b1ab51c19d7eef03f1d2956b1a3e72",
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "screen_result": "REFER",
+  "screen_timestamp_ms": 1716460800050
 }


### PR DESCRIPTION
## Summary

Adds a new JSON Schema (`algovoi-compliance-receipt-v1.json`) for the AlgoVoi compliance receipt -- a categorical screening decision record emitted at agentic-payment admission time and retained under framework-bound retention obligations (UK MLR 2017, EU AMLD5/6, MiCA Art 80, AMLR Art 56, DORA Art 14).

The schema enforces:

- Closed enum on `screen_result` (`ALLOW` / `REFER` / `DENY`). The categorical outcome is load-bearing for downstream regulatory obligations -- under UK POCA 2002 s 330 a `REFER` carries a mandatory SAR obligation that a `DENY` does not. A score / tier projection would lose this distinction and break year-five auditability.
- Integer-only `screen_timestamp_ms` (Substrate Rule 1 from `x402-foundation/x402` PR #2436).
- DID pattern enforcement on `screen_provider_did`.
- `canon_version` pinned to `jcs-rfc8785-v1` (canonicalisation discipline pin).
- Closed envelope (`additionalProperties: false`) so retained bytes are unambiguous.

## Files added

- `src/schemas/json/algovoi-compliance-receipt-v1.json` -- the schema itself (draft-07).
- `src/test/algovoi-compliance-receipt-v1/` -- 3 positive tests:
  - `receipt-allow-uk-eu.json` (ALLOW under UK + EU joint jurisdiction)
  - `receipt-refer-uk-sar-obligation.json` (REFER under UK, mandatory SAR)
  - `receipt-deny-sanctions.json` (DENY across UK + EU + US sanctions)
- `src/negative_test/algovoi-compliance-receipt-v1/` -- 7 negative tests:
  - `missing-payer-ref.json`, `invalid-screen-result.json`, `float-timestamp.json`, `empty-jurisdiction-flags.json`, `invalid-did-format.json`, `unknown-canon-version.json`, `extra-field-score.json`
- `src/api/json/catalog.json` -- new catalog entry.

## Validation

`node cli.js check --SchemaName algovoi-compliance-receipt-v1` passes all pre-checks and Ajv validation.

## Context

The substrate underneath this receipt is formalised in `x402-foundation/x402` PR #2436 (three-voice coalition co-signed) and pinned to `urn:x402:canonicalisation:jcs-rfc8785-v1`. Reference implementations in Python ([`algovoi-substrate`](https://pypi.org/project/algovoi-substrate/)) and TypeScript ([`@algovoi/substrate`](https://www.npmjs.com/package/@algovoi/substrate)) produce schema-valid receipts via `build_compliance_receipt(...)` / `buildComplianceReceipt(...)`.

The canonical home of the schema with examples and per-anchor-set conformance vectors is at <https://github.com/chopmob-cloud/algovoi-jcs-conformance-vectors>.

## Test plan

- [x] Schema validates against its own meta-schema (draft-07)
- [x] Three positive tests validate against the schema
- [x] Seven negative tests are correctly rejected
- [x] `node cli.js check --SchemaName algovoi-compliance-receipt-v1` passes
- [x] Catalog entry has no trailing forbidden characters, valid URL pattern (`https://www.schemastore.org/...`), specific (non-generic) `fileMatch` patterns