### PR TITLE
Add Anodizer schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3634,6 +3634,12 @@
       "url": "https://goreleaser.com/static/schema-pro.json"
     },
     {
+      "name": "Anodizer",
+      "description": "Anodizer Rust release-automation configuration file",
+      "fileMatch": [".anodizer.yaml", ".anodizer.yml"],
+      "url": "https://tj-smith47.github.io/anodizer/schema.json"
+    },
+    {
       "name": "Goss",
       "description": "Goss - Quick and Easy server validation",
       "fileMatch": ["goss.yaml", "goss.yml", "goss.json"],


### PR DESCRIPTION
Registers [Anodizer](https://github.com/tj-smith47/anodizer), a Rust release-automation tool (GoReleaser parity for Rust).

The schema is generated and self-hosted at https://tj-smith47.github.io/anodizer/schema.json (HTTP 200, ~386 KB), regenerated on every push to master.

Catalog entry placed in the Go* cluster directly after Goreleaser / Goreleaser Pro since Anodizer is the equivalent for the Rust ecosystem.

`fileMatch`: `.anodizer.yaml`, `.anodizer.yml`