### PR TITLE
Update uv.json to include audit options

### DIFF
--- a/src/schemas/json/uv.json
+++ b/src/schemas/json/uv.json
@@ -23,6 +23,16 @@
         "$ref": "#/definitions/TrustedHost"
       }
     },
+    "audit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AuditOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "build-backend": {
       "description": "Configuration for the uv build backend.\n\nNote that those settings only apply when using the `uv_build` backend, other build backends\n(such as hatchling) have their own configuration.",
       "anyOf": [
@@ -176,7 +186,7 @@
       }
     },
     "exclude-newer": {
-      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
+      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
       "anyOf": [
         {
           "$ref": "#/definitions/ExcludeNewerValue"
@@ -187,7 +197,7 @@
       ]
     },
     "exclude-newer-package": {
-      "description": "Limit candidate packages for specific packages to those that were uploaded prior to the\ngiven date.\n\nAccepts a dictionary format of `PACKAGE = \"DATE\"` pairs, where `DATE` is an RFC 3339\ntimestamp (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g., `24 hours`, `1 week`,\n`30 days`), or a ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
+      "description": "Limit candidate packages for specific packages to those that were uploaded prior to the\ngiven date.\n\nAccepts a dictionary format of `PACKAGE = \"DATE\"` pairs, where `DATE` is an RFC 3339\ntimestamp (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g., `24 hours`, `1 week`,\n`30 days`), or a ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.\n\nSet a package to `false` to exempt it from the global [`exclude-newer`](#exclude-newer)\nconstraint entirely.",
       "anyOf": [
         {
           "$ref": "#/definitions/ExcludeNewerPackage"
@@ -267,7 +277,7 @@
       ]
     },
     "index": {
-      "description": "The indexes to use when resolving dependencies.\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)\n(the simple repository API), or a local directory laid out in the same format.\n\nIndexes are considered in the order in which they're defined, such that the first-defined\nindex has the highest priority. Further, the indexes provided by this setting are given\nhigher priority than any indexes specified via [`index_url`](#index-url) or\n[`extra_index_url`](#extra-index-url). uv will only consider the first index that contains\na given package, unless an alternative [index strategy](#index-strategy) is specified.\n\nIf an index is marked as `explicit = true`, it will be used exclusively for the\ndependencies that select it explicitly via `[tool.uv.sources]`, as in:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu121\"\nexplicit = true\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```\n\nIf an index is marked as `default = true`, it will be moved to the end of the prioritized list, such that it is\ngiven the lowest priority when resolving packages. Additionally, marking an index as default will disable the\nPyPI default index.",
+      "description": "The indexes to use when resolving dependencies.\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)\n(the simple repository API), or a local directory laid out in the same format.\n\nIndexes are considered in the order in which they're defined, such that the first-defined\nindex has the highest priority. Further, the indexes provided by this setting are given\nhigher priority than any indexes specified via [`index_url`](#index-url) or\n[`extra_index_url`](#extra-index-url). uv will only consider the first index that contains\na given package, unless an alternative [index strategy](#index-strategy) is specified.\n\nIf an index is marked as `explicit = true`, it will be used exclusively for the\ndependencies that select it explicitly via `[tool.uv.sources]`, as in:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu130\"\nexplicit = true\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```\n\nIf an index is marked as `default = true`, it will be moved to the end of the prioritized list, such that it is\ngiven the lowest priority when resolving packages. Additionally, marking an index as default will disable the\nPyPI default index.",
       "type": ["array", "null"],
       "default": null,
       "items": {
@@ -322,12 +332,8 @@
       "description": "Whether the project is managed by uv. If `false`, uv will ignore the project when\n`uv run` is invoked.",
       "type": ["boolean", "null"]
     },
-    "system-certs": {
-      "description": "Whether to load TLS certificates from the platform's native certificate store.\n\nBy default, uv loads certificates from the bundled `webpki-roots` crate. The\n`webpki-roots` are a reliable set of trust roots from Mozilla, and including them in uv\nimproves portability and performance (especially on macOS).\n\nHowever, in some cases, you may want to use the platform's native certificate store,\nespecially if you're relying on a corporate trust root (e.g., for a mandatory proxy) that's\nincluded in your system's certificate store.",
-      "type": ["boolean", "null"]
-    },
     "native-tls": {
-      "description": "(Deprecated: use `system-certs` instead.) Whether to load TLS certificates from the platform's native certificate store.\n\nBy default, uv loads certificates from the bundled `webpki-roots` crate. The\n`webpki-roots` are a reliable set of trust roots from Mozilla, and including them in uv\nimproves portability and performance (especially on macOS).\n\nHowever, in some cases, you may want to use the platform's native certificate store,\nespecially if you're relying on a corporate trust root (e.g., for a mandatory proxy) that's\nincluded in your system's certificate store.",
+      "description": "Whether to load TLS certificates from the platform's native certificate store.\n\nBy default, uv uses bundled Mozilla root certificates. When enabled, this loads\ncertificates from the platform's native certificate store instead.\n\n(Deprecated: use `system-certs` instead.)",
       "type": ["boolean", "null"]
     },
     "no-binary": {
@@ -525,6 +531,10 @@
         }
       ]
     },
+    "system-certs": {
+      "description": "Whether to load TLS certificates from the platform's native certificate store.\n\nBy default, uv uses bundled Mozilla root certificates. When enabled, this loads\ncertificates from the platform's native certificate store instead.",
+      "type": ["boolean", "null"]
+    },
     "torch-backend": {
       "description": "The backend to use when fetching packages in the PyTorch ecosystem.\n\nWhen set, uv will ignore the configured index URLs for packages in the PyTorch ecosystem,\nand will instead use the defined backend.\n\nFor example, when set to `cpu`, uv will use the CPU-only PyTorch index; when set to `cu126`,\nuv will use the PyTorch index for CUDA 12.6.\n\nThe `auto` mode will attempt to detect the appropriate PyTorch index based on the currently\ninstalled CUDA drivers.\n\nThis setting is only respected by `uv pip` commands.\n\nThis option is in preview and may change in any future release.",
       "anyOf": [
@@ -611,6 +621,25 @@
           "const": "split"
         }
       ]
+    },
+    "AuditOptions": {
+      "type": "object",
+      "properties": {
+        "ignore": {
+          "description": "A list of vulnerability IDs to ignore during auditing.\n\nVulnerabilities matching any of the provided IDs (including aliases) will be excluded from\nthe audit results.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignore-until-fixed": {
+          "description": "A list of vulnerability IDs to ignore during auditing, but only while no fix is available.\n\nVulnerabilities matching any of the provided IDs (including aliases) will be excluded from\nthe audit results as long as they have no known fix versions. Once a fix version becomes\navailable, the vulnerability will be reported again.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "AuthPolicy": {
       "description": "When to use authentication.",
@@ -805,14 +834,26 @@
       }
     },
     "DisplaySafeUrl": {
-      "description": "A [`Url`] wrapper that redacts credentials when displaying the URL.\n\n`DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask\nsecrets by default when the URL is displayed or logged. This helps prevent accidental\nexposure of sensitive information in logs and debug output.\n\n# Examples\n\n```\nuse uv_redacted::DisplaySafeUrl;\nuse std::str::FromStr;\n\n// Create a `DisplaySafeUrl` from a `&str`\nlet mut url = DisplaySafeUrl::parse(\"https://user:password@example.com\").unwrap();\n\n// Display will mask secrets\nassert_eq!(url.to_string(), \"https://user:****@example.com/\");\n\n// You can still access the username and password\nassert_eq!(url.username(), \"user\");\nassert_eq!(url.password(), Some(\"password\"));\n\n// And you can still update the username and password\nlet _ = url.set_username(\"new_user\");\nlet _ = url.set_password(Some(\"new_password\"));\nassert_eq!(url.username(), \"new_user\");\nassert_eq!(url.password(), Some(\"new_password\"));\n\n// It is also possible to remove the credentials entirely\nurl.remove_credentials();\nassert_eq!(url.username(), \"\");\nassert_eq!(url.password(), None);\n```",
+      "description": "A [`Url`] wrapper that redacts credentials and sensitive query parameters when displaying the URL.\n\n`DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask\nsecrets by default when the URL is displayed or logged. This helps prevent accidental\nexposure of sensitive information in logs and debug output.\n\n# Examples\n\n```\nuse uv_redacted::DisplaySafeUrl;\nuse std::str::FromStr;\n\n// Create a `DisplaySafeUrl` from a `&str`\nlet mut url = DisplaySafeUrl::parse(\"https://user:password@example.com\").unwrap();\n\n// Display will mask secrets\nassert_eq!(url.to_string(), \"https://user:****@example.com/\");\n\n// You can still access the username and password\nassert_eq!(url.username(), \"user\");\nassert_eq!(url.password(), Some(\"password\"));\n\n// And you can still update the username and password\nlet _ = url.set_username(\"new_user\");\nlet _ = url.set_password(Some(\"new_password\"));\nassert_eq!(url.username(), \"new_user\");\nassert_eq!(url.password(), Some(\"new_password\"));\n\n// It is also possible to remove the credentials entirely\nurl.remove_credentials();\nassert_eq!(url.username(), \"\");\nassert_eq!(url.password(), None);\n```",
       "type": "string",
       "format": "uri"
+    },
+    "ExcludeNewerOverride": {
+      "oneOf": [
+        {
+          "description": "Disable exclude-newer.",
+          "type": "boolean",
+          "const": false
+        },
+        {
+          "$ref": "#/definitions/ExcludeNewerValue"
+        }
+      ]
     },
     "ExcludeNewerPackage": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/PackageExcludeNewer"
+        "$ref": "#/definitions/ExcludeNewerOverride"
       }
     },
     "ExcludeNewerValue": {
@@ -930,8 +971,16 @@
           "type": "boolean",
           "default": false
         },
+        "exclude-newer": {
+          "description": "An index-specific `exclude-newer` cutoff.\n\nAccepts the same date, timestamp, and duration values as the global `exclude-newer`\nsetting. Set this to `false` to disable `exclude-newer` for this index entirely.\n\nWhen set to a value, packages resolved from this index will use that cutoff instead of the\nglobally-specified value, unless a package-specific `exclude-newer-package` override is\npresent.\n\nThis option is in preview and may change in any future release.\n\n```toml\n[tool.uv]\nexclude-newer = \"2025-01-01T00:00:00Z\"\n\n[[tool.uv.index]]\nname = \"internal\"\nurl = \"https://internal.example.com/simple\"\nexclude-newer = \"7 days\"\n```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ExcludeNewerOverride"
+            }
+          ]
+        },
         "explicit": {
-          "description": "Mark the index as explicit.\n\nExplicit indexes will _only_ be used when explicitly requested via a `[tool.uv.sources]`\ndefinition, as in:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu121\"\nexplicit = true\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```",
+          "description": "Mark the index as explicit.\n\nExplicit indexes will _only_ be used when explicitly requested via a `[tool.uv.sources]`\ndefinition, as in:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu130\"\nexplicit = true\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```",
           "type": "boolean",
           "default": false
         },
@@ -953,7 +1002,7 @@
           }
         },
         "name": {
-          "description": "The name of the index.\n\nIndex names can be used to reference indexes elsewhere in the configuration. For example,\nyou can pin a package to a specific index by name:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu121\"\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```",
+          "description": "The name of the index.\n\nIndex names can be used to reference indexes elsewhere in the configuration. For example,\nyou can pin a package to a specific index by name:\n\n```toml\n[[tool.uv.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu130\"\n\n[tool.uv.sources]\ntorch = { index = \"pytorch\" }\n```",
           "anyOf": [
             {
               "$ref": "#/definitions/IndexName"
@@ -1056,7 +1105,7 @@
       ]
     },
     "LinkMode": {
-      "description": "The method to use when linking.\n\nDefaults to [`Clone`](LinkMode::Clone) on macOS and Linux (which support copy-on-write on\nAPFS and btrfs/xfs/bcachefs respectively), and [`Hardlink`](LinkMode::Hardlink) on other\nplatforms.",
+      "description": "The method to use when linking.\n\nDefaults to [`LinkMode::Clone`] on macOS and Linux (which support copy-on-write on\nAPFS and btrfs/xfs/bcachefs respectively), and [`LinkMode::Hardlink`] on other\nplatforms.",
       "oneOf": [
         {
           "description": "Clone (i.e., copy-on-write) packages from the source into the destination.",
@@ -1106,18 +1155,6 @@
       "additionalProperties": {
         "$ref": "#/definitions/ConfigSettings"
       }
-    },
-    "PackageExcludeNewer": {
-      "oneOf": [
-        {
-          "description": "Disable exclude-newer for this package.",
-          "type": "boolean",
-          "const": false
-        },
-        {
-          "$ref": "#/definitions/ExcludeNewerValue"
-        }
-      ]
     },
     "PackageName": {
       "description": "The normalized name of a package.\n\nConverts the name to lowercase and collapses runs of `-`, `_`, and `.` down to a single `-`.\nFor example, `---`, `.`, and `__` are all converted to a single `-`.\n\nSee: <https://packaging.python.org/en/latest/specifications/name-normalization/>",
@@ -1226,7 +1263,7 @@
           "type": ["boolean", "null"]
         },
         "exclude-newer": {
-          "description": "Limit candidate packages to those that were uploaded prior to a given point in time.\n\nAccepts a superset of [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) (e.g.,\n`2006-12-02T02:07:43Z`). A full timestamp is required to ensure that the resolver will\nbehave consistently across timezones.",
+          "description": "Limit candidate packages to those that were uploaded prior to a given point in time.\n\nThe date is compared against the upload time of each individual distribution artifact\n(i.e., when each file was uploaded to the package index), not the release date of the\npackage version.\n\nAccepts RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g.,\n`24 hours`, `1 week`, `30 days`), or an ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.",
           "anyOf": [
             {
               "$ref": "#/definitions/ExcludeNewerValue"
@@ -1237,7 +1274,7 @@
           ]
         },
         "exclude-newer-package": {
-          "description": "Limit candidate packages for specific packages to those that were uploaded prior to the given date.\n\nAccepts package-date pairs in a dictionary format.",
+          "description": "Limit candidate packages for specific packages to those that were uploaded prior to the given date.\n\nAccepts a dictionary format of `PACKAGE = \"DATE\"` pairs, where `DATE` is an RFC 3339\ntimestamp (e.g., `2006-12-02T02:07:43Z`), a \"friendly\" duration (e.g., `24 hours`, `1 week`,\n`30 days`), or a ISO 8601 duration (e.g., `PT24H`, `P7D`, `P30D`).\n\nDurations do not respect semantics of the local time zone and are always resolved to a fixed\nnumber of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).\nCalendar units such as months and years are not allowed.\n\nSet a package to `false` to exempt it from the global [`exclude-newer`](#exclude-newer)\nconstraint entirely.",
           "anyOf": [
             {
               "$ref": "#/definitions/ExcludeNewerPackage"
@@ -1764,11 +1801,22 @@
             "marker": {
               "$ref": "#/definitions/MarkerTree"
             },
+            "path": {
+              "description": "The path to the archive within the repository.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PortablePathBuf"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "rev": {
               "type": ["string", "null"]
             },
             "subdirectory": {
-              "description": "The path to the directory with the `pyproject.toml`, if it's not in the archive root.",
+              "description": "The path to the directory with the `pyproject.toml`, if it's not in the repository root.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/PortablePathBuf"
@@ -2403,6 +2451,11 @@
           "description": "Use the PyTorch index for CUDA 8.0.",
           "type": "string",
           "const": "cu80"
+        },
+        {
+          "description": "Use the PyTorch index for ROCm 7.2.",
+          "type": "string",
+          "const": "rocm7.2"
         },
         {
           "description": "Use the PyTorch index for ROCm 7.1.",

--- a/src/test/pyproject/uv-audit-config.toml
+++ b/src/test/pyproject/uv-audit-config.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/pyproject.json
+[tool.uv.audit]
+ignore = ["PYSEC-2022-43017", "GHSA-5239-wwwm-4pmq"]
+ignore-until-fixed = ["PYSEC-2022-12345"]


### PR DESCRIPTION
Update uv schema to 0.11.16

The main user-visible fix is that `[tool.uv.audit]` is now recognized.
