### PR TITLE
Add Caido configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10200,6 +10200,12 @@
       "description": "Configuration for QuikRun",
       "fileMatch": ["quikrun.toml"],
       "url": "https://www.schemastore.org/quikrun.json"
+    },
+    {
+      "name": "Caido Proxy Configuration",
+      "description": "Caido Proxy configuration file",
+      "fileMatch": ["caido.yml", "caido.yaml"],
+      "url": "https://raw.githubusercontent.com/caido/schemas/main/.schemastore/proxy/config.schema.json"
     }
   ]
 }


### PR DESCRIPTION
This add the schema for [caido](https://caido.io) configuration file. We maintain our own schema for each version so I have added it similar to Ory Hydra, hopefully this is ok. Please let me know if you need further modifications.