### PR TITLE
Add amxx-builder manifest schema (amxbuild.yml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10206,6 +10206,12 @@
       "description": "Caido Proxy configuration file",
       "fileMatch": ["caido.yml", "caido.yaml"],
       "url": "https://raw.githubusercontent.com/caido/schemas/main/.schemastore/proxy/config.schema.json"
+    },
+    {
+      "name": "amxx-builder manifest",
+      "description": "amxx-builder (amxb) project manifest",
+      "fileMatch": ["amxbuild.yml"],
+      "url": "https://raw.githubusercontent.com/AmxxModularEcosystem/amxx-builder/master/schema/amxbuild.schema.json"
     }
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10210,7 +10210,12 @@
     {
       "name": "amxx-builder manifest",
       "description": "amxx-builder (amxb) project manifest",
-      "fileMatch": ["amxbuild.yml", "amxbuild.yaml", "amxbuild.*.yml", "amxbuild.*.yaml"],
+      "fileMatch": [
+        "amxbuild.yml",
+        "amxbuild.yaml",
+        "amxbuild.*.yml",
+        "amxbuild.*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/AmxxModularEcosystem/amxx-builder/master/schema/amxbuild.schema.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10210,7 +10210,7 @@
     {
       "name": "amxx-builder manifest",
       "description": "amxx-builder (amxb) project manifest",
-      "fileMatch": ["amxbuild.yml"],
+      "fileMatch": ["amxbuild.yml", "amxbuild.yaml", "amxbuild.*.yml", "amxbuild.*.yaml"],
       "url": "https://raw.githubusercontent.com/AmxxModularEcosystem/amxx-builder/master/schema/amxbuild.schema.json"
     }
   ]


### PR DESCRIPTION
Adds schema for [amxx-builder](https://github.com/AmxxModularEcosystem/amxx-builder) - a CLI tool for building and packaging AMX Mod X server plugins.

The manifest file is always named `amxbuild.yml`.

Schema: https://raw.githubusercontent.com/AmxxModularEcosystem/amxx-builder/master/schema/amxbuild.schema.json