### PR TITLE
➕ Add umpire.json to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7180,6 +7180,12 @@
       }
     },
     {
+      "name": "umpire.json",
+      "description": "Umpire form-logic configuration",
+      "fileMatch": ["*.umpire.json"],
+      "url": "https://spec.umpire.tools/umpire.schema.json"
+    },
+    {
       "name": "UNCORS configuration",
       "description": "Configuration file for UNCORS reverse proxy",
       "fileMatch": [


### PR DESCRIPTION
Self-hosted schema for [Umpire](https://github.com/umpire-tools/umpire-spec) form-logic configuration files.

- Schema URL: https://spec.umpire.tools/umpire.schema.json
- Draft version: draft-07
- File pattern: `*.umpire.json`

Had a bit of a saga getting my fork to behave and accidentally had the wrong change in here for a moment but sorted now. Thanks!