### PR TITLE
Add `code-quality` to GitHub Workflow permissions

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -250,7 +250,7 @@
         },
         "code-quality": {
           "$ref": "#/definitions/permissions-level"
-        },        
+        },
         "contents": {
           "$ref": "#/definitions/permissions-level"
         },

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -248,6 +248,9 @@
         "checks": {
           "$ref": "#/definitions/permissions-level"
         },
+        "code-quality": {
+          "$ref": "#/definitions/permissions-level"
+        },        
         "contents": {
           "$ref": "#/definitions/permissions-level"
         },


### PR DESCRIPTION
https://github.com/actions/upload-code-coverage#permissions

<blockquote>

```yaml
permissions:
  contents: read
  code-quality: write
```

</blockquote>

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

> `code-quality`	Work with code quality. For example, `code-quality: write` permits an action to upload code coverage reports. For more information, see [About GitHub Code Quality](https://docs.github.com/en/code-security/concepts/about-code-quality).