### PR TITLE
Add ORT project package manager definition schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5370,6 +5370,19 @@
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/package-configuration-schema.json"
     },
     {
+      "name": "OSS Review Toolkit project package manager definition",
+      "description": "ORT project package manager definition file for describing a project when using a custom or non-supported package manager with ORT",
+      "fileMatch": [
+        "ortproject.yml",
+        "ortproject.yaml",
+        "ortproject.json",
+        "*.ortproject.yml",
+        "*.ortproject.yaml",
+        "*.ortproject.json"
+      ],
+      "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/refs/heads/main/integrations/schemas/ort-project-schema.json"
+    },
+    {
       "name": "OSS Review Toolkit repository configuration",
       "description": "ORT's repository configuration file",
       "fileMatch": ["*.ort.yml", "*.ort.yaml"],


### PR DESCRIPTION
See [1] for the schema and [2] for the documentation.

[1]: https://raw.githubusercontent.com/oss-review-toolkit/ort/refs/heads/main/integrations/schemas/ort-project-schema.json
[2]: https://oss-review-toolkit.org/ort/docs/guides/ort-project-package-manager

