### PR TITLE
Add slang-server configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6501,6 +6501,17 @@
       "url": "https://www.schemastore.org/slack-app-manifest.json"
     },
     {
+      "name": "slang-server",
+      "description": "Configuration file for slang-server, a SystemVerilog language server",
+      "fileMatch": [
+        ".slang/server.json",
+        ".slang/local/server.json",
+        "**/.slang/server.json",
+        "**/.slang/local/server.json"
+      ],
+      "url": "https://www.schemastore.org/slang-server.json"
+    },
+    {
       "name": "skyuxconfig.json",
       "description": "SKY UX CLI configuration file",
       "fileMatch": ["skyuxconfig.json", "skyuxconfig.*.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6503,12 +6503,7 @@
     {
       "name": "slang-server",
       "description": "Configuration file for slang-server, a SystemVerilog language server",
-      "fileMatch": [
-        ".slang/server.json",
-        ".slang/local/server.json",
-        "**/.slang/server.json",
-        "**/.slang/local/server.json"
-      ],
+      "fileMatch": ["**/.slang/server.json", "**/.slang/local/server.json"],
       "url": "https://www.schemastore.org/slang-server.json"
     },
     {

--- a/src/negative_test/slang-server/invalid-doc-comment-format.json
+++ b/src/negative_test/slang-server/invalid-doc-comment-format.json
@@ -1,0 +1,5 @@
+{
+  "hovers": {
+    "docCommentFormat": "html"
+  }
+}

--- a/src/schemas/json/slang-server.json
+++ b/src/schemas/json/slang-server.json
@@ -1,0 +1,206 @@
+{
+  "$id": "https://www.schemastore.org/slang-server.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Config",
+  "definitions": {
+    "Config": {
+      "type": "object",
+      "properties": {
+        "flags": {
+          "type": "string",
+          "description": "Flags to pass to slang"
+        },
+        "indexGlobs": {
+          "type": "array",
+          "description": "DEPRECATED: Use 'index' instead. Globs of what to index. By default, indexes all .sv and .svh files in the workspace.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "index": {
+          "type": "array",
+          "description": "Index configurations; by default indexes all .sv, .svh, .v, and .vh files in the workspace.",
+          "items": {
+            "$ref": "#/definitions/Config__IndexConfig"
+          }
+        },
+        "excludeDirs": {
+          "type": "array",
+          "description": "DEPRECATED: Use 'index' instead. Directories to exclude.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "indexingThreads": {
+          "type": "integer",
+          "description": "Thread count to use for indexing"
+        },
+        "build": {
+          "description": "Build file to use",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buildPattern": {
+          "description": "Build file glob pattern, e.g. `builds/{}.f`. Used for selecting build files. If omitted and no other build source is configured, defaults to matching all `.f` files in the workspace.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buildRelativePaths": {
+          "description": "Whether build files use paths relative to that file",
+          "type": "boolean"
+        },
+        "wavesPattern": {
+          "description": "Waveform file glob to open given a build. Name and top variables can be passed with {name}, {top}.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wcpCommand": {
+          "description": "Waveform viewer command ({} will be replaced with the WCP port), used for direct wcp connection with neovim and surfer.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hovers": {
+          "$ref": "#/definitions/Config__HoverConfig",
+          "description": "Hover behavior settings"
+        },
+        "inlayHints": {
+          "$ref": "#/definitions/Config__InlayHints",
+          "description": "Inline hints for things like ordered arguments, wildcard ports, and others"
+        },
+        "builds": {
+          "type": "array",
+          "description": "Builds for direct .f selection or command-based .f generation",
+          "items": {
+            "$ref": "#/definitions/Config__Build"
+          }
+        }
+      },
+      "required": []
+    },
+    "Config__Build": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Optional name used for generated build files and UI labels",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "glob": {
+          "type": "string",
+          "description": "Glob pattern to find files, like .f files or makefiles"
+        },
+        "command": {
+          "type": "string",
+          "description": "Optional command that produces .f content on stdout when passed the selected file"
+        }
+      },
+      "required": []
+    },
+    "Config__HoverConfig": {
+      "type": "object",
+      "properties": {
+        "docCommentFormat": {
+          "description": "How to render leading doc comments in hovers: 'markdown' renders as markdown, 'plaintext' escapes markdown characters, 'raw' shows the comment text verbatim including comment markers.",
+          "oneOf": [
+            {
+              "description": "Strip comment markers and escape markdown characters so the text renders as-is.",
+              "const": "plaintext"
+            },
+            {
+              "description": "Strip comment markers and render the contents as markdown.",
+              "const": "markdown"
+            },
+            {
+              "description": "Show the comment text verbatim, including comment markers, in a code block.",
+              "const": "raw"
+            }
+          ]
+        }
+      },
+      "required": []
+    },
+    "Config__IndexConfig": {
+      "type": "object",
+      "properties": {
+        "dirs": {
+          "type": "array",
+          "description": "Directories to index",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeDirs": {
+          "description": "Directories to exclude; only supports single directory names and applies to all path levels",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": []
+    },
+    "Config__InlayHints": {
+      "type": "object",
+      "properties": {
+        "portTypes": {
+          "description": "Hints for port types",
+          "type": "boolean"
+        },
+        "orderedInstanceNames": {
+          "description": "Hints for names of ordered ports and params",
+          "type": "boolean"
+        },
+        "wildcardNames": {
+          "description": "Hints for port names in wildcard (.*) ports",
+          "type": "boolean"
+        },
+        "funcArgNames": {
+          "type": "integer",
+          "description": "Function argument hints: 0=off, N=only calls with >=N args"
+        },
+        "macroArgNames": {
+          "type": "integer",
+          "description": "Macro argument hints: 0=off, N=only calls with >=N args"
+        }
+      },
+      "required": []
+    }
+  }
+}

--- a/src/schemas/json/slang-server.json
+++ b/src/schemas/json/slang-server.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://www.schemastore.org/slang-server.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/slang-server.json",
   "$ref": "#/definitions/Config",
   "definitions": {
     "Config": {

--- a/src/test/slang-server/server.json
+++ b/src/test/slang-server/server.json
@@ -1,5 +1,22 @@
 {
+  "build": "sim/top.f",
+  "buildPattern": "builds/{}.f",
+  "buildRelativePaths": true,
+  "builds": [
+    {
+      "glob": "sim/*.f",
+      "name": "simulation"
+    },
+    {
+      "command": "make filelist",
+      "glob": "builds/*.mk",
+      "name": "generated"
+    }
+  ],
   "flags": "-Wall",
+  "hovers": {
+    "docCommentFormat": "markdown"
+  },
   "index": [
     {
       "dirs": ["rtl", "verification"],
@@ -7,30 +24,13 @@
     }
   ],
   "indexingThreads": 4,
-  "build": "sim/top.f",
-  "buildPattern": "builds/{}.f",
-  "buildRelativePaths": true,
-  "wavesPattern": "waves/{name}-{top}.fst",
-  "wcpCommand": "surfer --wcp {}",
-  "hovers": {
-    "docCommentFormat": "markdown"
-  },
   "inlayHints": {
-    "portTypes": true,
-    "orderedInstanceNames": true,
-    "wildcardNames": true,
     "funcArgNames": 2,
-    "macroArgNames": 1
+    "macroArgNames": 1,
+    "orderedInstanceNames": true,
+    "portTypes": true,
+    "wildcardNames": true
   },
-  "builds": [
-    {
-      "name": "simulation",
-      "glob": "sim/*.f"
-    },
-    {
-      "name": "generated",
-      "glob": "builds/*.mk",
-      "command": "make filelist"
-    }
-  ]
+  "wavesPattern": "waves/{name}-{top}.fst",
+  "wcpCommand": "surfer --wcp {}"
 }

--- a/src/test/slang-server/server.json
+++ b/src/test/slang-server/server.json
@@ -1,0 +1,36 @@
+{
+  "flags": "-Wall",
+  "index": [
+    {
+      "dirs": ["rtl", "verification"],
+      "excludeDirs": ["build"]
+    }
+  ],
+  "indexingThreads": 4,
+  "build": "sim/top.f",
+  "buildPattern": "builds/{}.f",
+  "buildRelativePaths": true,
+  "wavesPattern": "waves/{name}-{top}.fst",
+  "wcpCommand": "surfer --wcp {}",
+  "hovers": {
+    "docCommentFormat": "markdown"
+  },
+  "inlayHints": {
+    "portTypes": true,
+    "orderedInstanceNames": true,
+    "wildcardNames": true,
+    "funcArgNames": 2,
+    "macroArgNames": 1
+  },
+  "builds": [
+    {
+      "name": "simulation",
+      "glob": "sim/*.f"
+    },
+    {
+      "name": "generated",
+      "glob": "builds/*.mk",
+      "command": "make filelist"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a SchemaStore catalog entry for slang-server's `.slang/server.json` and `.slang/local/server.json` files
- add a draft-07 version of the generated slang-server configuration schema for broad editor compatibility
- cover the schema with positive and negative validation fixtures

Addresses hudson-trading/slang-server#360.

## Validation

- `git diff --check`
- `jq empty src/api/json/catalog.json src/schemas/json/slang-server.json src/test/slang-server/server.json src/negative_test/slang-server/invalid-doc-comment-format.json`
- Full SchemaStore validation deferred to CI
