### PR TITLE
feat(ryl): update schema to v0.11.0

### DIFF
--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -2,6 +2,27 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/ryl.json",
   "definitions": {
+    "FilesTable": {
+      "additionalProperties": false,
+      "description": "File-to-source-kind glob mapping (ryl-only; TOML). Each kind selects which\nfiles are linted as that kind. A file matching more than one kind is an error.",
+      "properties": {
+        "markdown": {
+          "description": "Glob patterns for markdown files whose embedded YAML is linted.",
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        },
+        "yaml": {
+          "description": "Glob patterns for files linted directly as YAML.",
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        }
+      },
+      "type": "object"
+    },
     "FixRuleName": {
       "description": "A fixable rule name accepted by `fix.unfixable`.",
       "enum": [
@@ -85,6 +106,21 @@
           "$ref": "#/definitions/IndentSequencesMode"
         }
       ]
+    },
+    "MarkdownTable": {
+      "additionalProperties": false,
+      "description": "Markdown embedding behaviour. ryl-only (TOML); yamllint has no equivalent.",
+      "properties": {
+        "fenced-blocks": {
+          "description": "Lint fenced `yaml`/`yml` code blocks. Defaults to `true`.",
+          "type": ["boolean", "null"]
+        },
+        "front-matter": {
+          "description": "Lint the leading YAML front matter block. Defaults to `true`.",
+          "type": ["boolean", "null"]
+        }
+      },
+      "type": "object"
     },
     "NewLinesType": {
       "enum": ["unix", "dos", "platform"],
@@ -1604,6 +1640,17 @@
   },
   "description": "JSON Schema root for `ryl` TOML configuration.",
   "properties": {
+    "files": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilesTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Glob patterns assigning files to source kinds (`yaml`, `markdown`)."
+    },
     "fix": {
       "anyOf": [
         {
@@ -1641,6 +1688,17 @@
       "description": "Locale identifier used by diagnostics.",
       "type": ["string", "null"]
     },
+    "markdown": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MarkdownTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Behaviour for YAML embedded in markdown (front matter and fenced blocks)."
+    },
     "per-file-ignores": {
       "additionalProperties": {
         "items": {
@@ -1661,13 +1719,6 @@
         }
       ],
       "description": "Rule configuration table."
-    },
-    "yaml-files": {
-      "description": "Glob patterns used to identify YAML files while scanning directories.",
-      "items": {
-        "type": "string"
-      },
-      "type": ["array", "null"]
     }
   },
   "title": "ryl TOML config",


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.11.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/3567bd6d8fdb27d3c7fd7d929a589c718498b232/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/3567bd6d8fdb27d3c7fd7d929a589c718498b232/.github/workflows/sync-schemastore.yml