### PR TITLE
AzFunc: Add connector extension configuration to host.json

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -521,7 +521,7 @@
       },
       "additionalProperties": false
     },
-   "connector-extension": {
+    "connector-extension": {
       "type": "object",
       "description": "Configuration settings for connector extension.",
       "properties": {

--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -521,6 +521,26 @@
       },
       "additionalProperties": false
     },
+   "connector-extension": {
+      "type": "object",
+      "description": "Configuration settings for connector extension.",
+      "properties": {
+        "system": {
+          "type": "object",
+          "description": "System-level options for the connector extension.",
+          "properties": {
+            "webhookAuthorizationLevel": {
+              "type": "string",
+              "description": "Defines the authorization level for the webhook endpoint. Defaults to \"System\". Use \"Anonymous\" only when alternative authentication (for example, Easy Auth) is configured, as requests will not require an access key.",
+              "enum": ["System", "Anonymous"],
+              "default": "System"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "version-1": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This pull request introduces a new configuration section for connector extensions in the `host.json` schema. The main change is the addition of a `connector-extension` object, which allows for system-level configuration of webhook authorization.

**Connector extension configuration:**

* Added a new `connector-extension` object to the `host.json` schema for configuring connector extension settings.
* Within `connector-extension`, introduced a `system` property for system-level options, including a `webhookAuthorizationLevel` setting to define the authorization required for the webhook endpoint (with options "System" or "Anonymous" and defaulting to "System").


Connector Extension code - [azure-functions-connector-extension](https://github.com/Azure/azure-functions-connector-extension)
Host Json example usage - [functions-connectors-net-builtinauth](https://github.com/Azure-Samples/functions-connectors-net-builtinauth/blob/main/src/host.json)
