### PR TITLE
Add Panache schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5458,6 +5458,12 @@
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pactspec.json"
     },
     {
+      "name": "Panache",
+      "description": "Configuration file for Panache, a language server, formatter, and linter for Markdown, Quarto, and R Markdown documents",
+      "fileMatch": ["panache.toml", ".panache.toml"],
+      "url": "https://panache.bz/panache.schema.json"
+    },
+    {
       "name": "Paper paper-plugin.yml",
       "description": "Paper Plugins YAML",
       "fileMatch": ["paper-plugin.yml"],


### PR DESCRIPTION
## Summary

Registers [Panache](https://github.com/jolars/panache) in the catalog so editors that consume `catalog.json` (Taplo, Tombi, Red Hat YAML, IntelliJ) auto-apply the schema to Panache config files.

Panache is a language server, formatter, and linter for Markdown, Quarto, and R Markdown documents.

## Details

- **Self-hosted schema.** The `url` points at `https://panache.bz/panache.schema.json`, served via GitHub Pages from the Panache docs site. The schema is generated from the Rust `Config` types using the [`schemars`](https://crates.io/crates/schemars) crate and kept in sync by a test, so upstream maintenance is automatic; no manual sync into SchemaStore is needed on each release.
- **`fileMatch`** is `["panache.toml", ".panache.toml"]`, both of which are the literal filenames Panache reads (`CANDIDATE_NAMES` in `src/config.rs`). Both are project-specific names, not generic patterns.
- Single catalog entry, no schema copy, no test fixtures, no `schema-validation.jsonc` change. Follows the "self-hosted/remote/external" recipe in `CONTRIBUTING.md`.

## Verification

- `npm run prettier:fix` passes; entry key order matches catalog convention.
- `node ./cli.js check` passes; no errors.

## Links

- Project: https://github.com/jolars/panache
- Hosted schema: https://panache.bz/panache.schema.json
- Documentation: https://panache.bz
