### PR TITLE
Add sandbox.enabledPlatforms to claude-code-settings.json

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -2217,6 +2217,14 @@
         "failIfUnavailable": {
           "type": "boolean",
           "description": "When true, make sandbox startup a hard failure if required sandbox dependencies are missing. Default: false (sandbox is skipped with a warning). See https://code.claude.com/docs/en/sandboxing#enable-sandboxing"
+        },
+        "enabledPlatforms": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["macos", "linux", "wsl", "windows"]
+          },
+          "description": "Limit the entire sandbox configuration to the listed platforms. On platforms not in the list the sandbox config is inert: no sandbox, no auto-allow, no startup warning, and no failIfUnavailable exit. When omitted, all supported platforms are included. Only honored from managed (policy) settings."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adds the `sandbox.enabledPlatforms` property to the Claude Code settings schema.

The property restricts the sandbox configuration to a specific set of platforms (`macos`, `linux`, `wsl`, `windows`) and is already accepted by the client at runtime. Because `sandbox` has `additionalProperties: false`, editors and validators currently flag it as an unknown property; declaring it here resolves that.