### PR TITLE
Add Mermaid configuration catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4820,6 +4820,11 @@
       "url": "https://raw.githubusercontent.com/Mergifyio/docs/main/public/mergify-configuration-schema.json"
     },
     {
+      "name": "Mermaid Configuration",
+      "description": "Mermaid configuration file",
+      "url": "https://mermaid.js.org/schemas/config.schema.json"
+    },
+    {
       "name": ".mocharc",
       "description": "MochaJS configuration files",
       "fileMatch": [


### PR DESCRIPTION
## Summary

Adds Mermaid's hosted configuration schema to the SchemaStore catalog so users can discover the maintained Mermaid config schema through the catalog API.

The entry points to Mermaid's upstream schema at `https://mermaid.js.org/schemas/config.schema.json`.

Closes #5095.

## Validation

- `npm ci`
- `node ./cli.js check`
- `npm run prettier -- src/api/json/catalog.json`
