### PR TITLE
feat(ryl): update schema to v0.13.0

### DIFF
--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -382,6 +382,20 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
+    "RuleEntryForTagsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForTagsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
     "RuleEntryForTomlQuotedStringsOptions": {
       "anyOf": [
         {
@@ -439,6 +453,7 @@
         "new-lines",
         "octal-values",
         "quoted-strings",
+        "tags",
         "trailing-spaces",
         "truthy"
       ],
@@ -1221,6 +1236,55 @@
       },
       "type": "object"
     },
+    "RuleOptionsForTagsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "allowed-tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": ["array", "null"]
+        },
+        "forbid-removed-types": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-unsafe-tags": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RuleOptionsForTomlQuotedStringsOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1557,6 +1621,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RuleEntryForTomlQuotedStringsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForTagsOptions"
             },
             {
               "type": "null"


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.13.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/21943c6bd8dcda4c01a982709eea6a5c8a7dba8b/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/21943c6bd8dcda4c01a982709eea6a5c8a7dba8b/.github/workflows/sync-schemastore.yml