### PR TITLE
Update OpenTelemetry Declarative Configuration to v1.1.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5196,8 +5196,9 @@
         "otel*.yaml",
         "otel*.yml"
       ],
-      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json",
+      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
       "versions": {
+        "1.1.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
         "1.0.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json"
       }
     },


### PR DESCRIPTION
Reflects the latest release of this schema: https://github.com/open-telemetry/opentelemetry-configuration/releases/tag/v1.1.0