### PR TITLE
feat(ryl): update schema to v0.14.0

### DIFF
--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -144,20 +144,6 @@
       "enum": ["only-when-needed"],
       "type": "string"
     },
-    "RuleEntryForAnchorsOptions": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/definitions/RuleSwitch"
-        },
-        {
-          "$ref": "#/definitions/RuleOptionsForAnchorsOptions"
-        }
-      ],
-      "description": "Common rule entry shape used by TOML config."
-    },
     "RuleEntryForBraceLikeOptions": {
       "anyOf": [
         {
@@ -298,20 +284,6 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
-    "RuleEntryForKeyDuplicatesOptions": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "$ref": "#/definitions/RuleSwitch"
-        },
-        {
-          "$ref": "#/definitions/RuleOptionsForKeyDuplicatesOptions"
-        }
-      ],
-      "description": "Common rule entry shape used by TOML config."
-    },
     "RuleEntryForKeyOrderingOptions": {
       "anyOf": [
         {
@@ -396,6 +368,34 @@
       ],
       "description": "Common rule entry shape used by TOML config."
     },
+    "RuleEntryForTomlAnchorsOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForTomlAnchorsOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
+    "RuleEntryForTomlKeyDuplicatesOptions": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/RuleSwitch"
+        },
+        {
+          "$ref": "#/definitions/RuleOptionsForTomlKeyDuplicatesOptions"
+        }
+      ],
+      "description": "Common rule entry shape used by TOML config."
+    },
     "RuleEntryForTomlQuotedStringsOptions": {
       "anyOf": [
         {
@@ -449,61 +449,17 @@
         "key-duplicates",
         "key-ordering",
         "line-length",
+        "merge-keys",
         "new-line-at-end-of-file",
         "new-lines",
         "octal-values",
         "quoted-strings",
         "tags",
         "trailing-spaces",
-        "truthy"
+        "truthy",
+        "unicode-line-breaks"
       ],
       "type": "string"
-    },
-    "RuleOptionsForAnchorsOptions": {
-      "additionalProperties": false,
-      "description": "Common rule fields plus rule-specific options.",
-      "properties": {
-        "forbid-duplicated-anchors": {
-          "type": ["boolean", "null"]
-        },
-        "forbid-undeclared-aliases": {
-          "type": ["boolean", "null"]
-        },
-        "forbid-unused-anchors": {
-          "type": ["boolean", "null"]
-        },
-        "ignore": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "ignore-from-file": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "level": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleLevel"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
     },
     "RuleOptionsForBraceLikeOptions": {
       "additionalProperties": false,
@@ -980,46 +936,6 @@
       },
       "type": "object"
     },
-    "RuleOptionsForKeyDuplicatesOptions": {
-      "additionalProperties": false,
-      "description": "Common rule fields plus rule-specific options.",
-      "properties": {
-        "forbid-duplicated-merge-keys": {
-          "type": ["boolean", "null"]
-        },
-        "ignore": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "ignore-from-file": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringOrVec"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "level": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/RuleLevel"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
     "RuleOptionsForKeyOrderingOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1285,6 +1201,101 @@
       },
       "type": "object"
     },
+    "RuleOptionsForTomlAnchorsOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "forbid-ambiguous-anchor-alias-names": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-duplicated-anchors": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-undeclared-aliases": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-unused-anchors": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RuleOptionsForTomlKeyDuplicatesOptions": {
+      "additionalProperties": false,
+      "description": "Common rule fields plus rule-specific options.",
+      "properties": {
+        "check-canonical": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-duplicated-merge-keys": {
+          "type": ["boolean", "null"]
+        },
+        "forbid-merge-key-shadowing": {
+          "type": ["boolean", "null"]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ignore-from-file": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrVec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "level": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleLevel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RuleOptionsForTomlQuotedStringsOptions": {
       "additionalProperties": false,
       "description": "Common rule fields plus rule-specific options.",
@@ -1420,7 +1431,7 @@
         "anchors": {
           "anyOf": [
             {
-              "$ref": "#/definitions/RuleEntryForAnchorsOptions"
+              "$ref": "#/definitions/RuleEntryForTomlAnchorsOptions"
             },
             {
               "type": "null"
@@ -1560,7 +1571,7 @@
         "key-duplicates": {
           "anyOf": [
             {
-              "$ref": "#/definitions/RuleEntryForKeyDuplicatesOptions"
+              "$ref": "#/definitions/RuleEntryForTomlKeyDuplicatesOptions"
             },
             {
               "type": "null"
@@ -1581,6 +1592,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RuleEntryForLineLengthOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "merge-keys": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
             },
             {
               "type": "null"
@@ -1651,6 +1672,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RuleEntryForTruthyOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unicode-line-breaks": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
             },
             {
               "type": "null"


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.14.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/0585725aeb13ce0c961f856a1fb413c1d9bd0768/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/0585725aeb13ce0c961f856a1fb413c1d9bd0768/.github/workflows/sync-schemastore.yml