### PR TITLE
Adds support for *.hex.yaml format

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1888,6 +1888,12 @@
       "url": "https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json"
     },
     {
+      "name": "Hex file",
+      "description": "Hex notebook file format - create and maintain data notebooks on Hex.tech",
+      "fileMatch": ["*.hex.yaml"],
+      "url": "https://static.hex.site/hex-file-schema.json"
+    },
+    {
       "name": "CircleCI config.yml",
       "description": "CircleCI config files",
       "fileMatch": ["**/.circleci/config.yml"],


### PR DESCRIPTION
# Summary

Adds support for the *.hex.yaml file format to the SchemaStore catalog. The *.hex.yaml file format was traditionally used as a backup file format for hex notebooks, but is now starting to be used for Notebook authorship in our platform.

We host an up to date version of the live schema at https://static.hex.site/hex-file-schema.json

## Validation

```bash
npm ci
node ./cli.js check
npm run prettier -- src/api/json/catalog.json
```

EDIT: 

Just adding a link to the product if that is helpful for any reason: https://hex.tech