### PR TITLE
feat(platformsh): add applications.yml file match patterns

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -64,7 +64,9 @@
       "fileMatch": [
         ".platform.app.yml",
         ".platform.app.yaml",
-        "**/.platform.app.yml"
+        "**/.platform.app.yml",
+        "**/.platform/applications.yml",
+        "**/.platform/applications.yaml"
       ],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/platformsh.application.json"
     },


### PR DESCRIPTION
## Summary

- Add `**/.platform/applications.yml` and `**/.platform/applications.yaml` to the Platform.sh application schema `fileMatch` patterns
- This covers the multi-app configuration file format used by Platform.sh

## Test plan

- [x] Verify schema validation works for `.platform/applications.yml` files