### PR TITLE
feat(ryl): update schema to v0.15.0

### DIFF
--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -433,6 +433,7 @@
       "description": "A built-in lint rule name.",
       "enum": [
         "anchors",
+        "block-scalar-chomping",
         "braces",
         "brackets",
         "colons",
@@ -1432,6 +1433,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/RuleEntryForTomlAnchorsOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "block-scalar-chomping": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleEntryForNoOptions"
             },
             {
               "type": "null"


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.15.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/cd4119c4245efef7e16a7466e4419df8c8c62e3b/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/cd4119c4245efef7e16a7466e4419df8c8c62e3b/.github/workflows/sync-schemastore.yml