### PR TITLE
Add Codex skill metadata schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1970,6 +1970,12 @@
       "url": "https://www.schemastore.org/codex-hooks.json"
     },
     {
+      "name": "Codex Skill Metadata",
+      "description": "OpenAI Codex skill metadata file",
+      "fileMatch": ["**/agents/openai.yaml"],
+      "url": "https://www.schemastore.org/codex-skill-metadata.json"
+    },
+    {
       "name": "codemagic",
       "description": "Codemagic CI/CD file configuration",
       "fileMatch": ["codemagic.yaml", "codemagic.yml"],

--- a/src/negative_test/codex-skill-metadata/invalid-interface-type.yaml
+++ b/src/negative_test/codex-skill-metadata/invalid-interface-type.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/codex-skill-metadata.json
+interface:
+  display_name: 42

--- a/src/negative_test/codex-skill-metadata/invalid-policy-type.yaml
+++ b/src/negative_test/codex-skill-metadata/invalid-policy-type.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/codex-skill-metadata.json
+policy:
+  allow_implicit_invocation: 'false'

--- a/src/negative_test/codex-skill-metadata/invalid-tool-dependency.yaml
+++ b/src/negative_test/codex-skill-metadata/invalid-tool-dependency.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/codex-skill-metadata.json
+dependencies:
+  tools:
+    - description: 'Missing required dependency type and value'

--- a/src/schemas/json/codex-skill-metadata.json
+++ b/src/schemas/json/codex-skill-metadata.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/codex-skill-metadata.json",
+  "title": "Codex skill metadata",
+  "description": "Metadata for OpenAI Codex skills.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "title": "schema reference",
+      "type": "string",
+      "description": "JSON Schema reference for editor autocomplete and validation.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+    },
+    "dependencies": {
+      "title": "dependencies",
+      "type": "object",
+      "description": "Tool dependencies used by the skill.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+      "additionalProperties": true,
+      "properties": {
+        "tools": {
+          "title": "tools",
+          "type": "array",
+          "description": "External tools the skill depends on.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+          "items": {
+            "$ref": "#/definitions/toolDependency"
+          }
+        }
+      }
+    },
+    "interface": {
+      "title": "interface",
+      "type": "object",
+      "description": "UI metadata shown by Codex clients.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+      "additionalProperties": true,
+      "properties": {
+        "brand_color": {
+          "title": "brand color",
+          "type": "string",
+          "minLength": 1,
+          "description": "Hex color used for UI accents, such as badges.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "default_prompt": {
+          "title": "default prompt",
+          "type": "string",
+          "minLength": 1,
+          "description": "Default prompt snippet inserted when invoking the skill.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "display_name": {
+          "title": "display name",
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-facing skill name shown in UI skill lists and chips.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "icon_large": {
+          "title": "large icon",
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to a large icon asset, relative to the skill directory.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "icon_small": {
+          "title": "small icon",
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to a small icon asset, relative to the skill directory.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "short_description": {
+          "title": "short description",
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-facing short description for quick scanning.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        }
+      }
+    },
+    "policy": {
+      "title": "policy",
+      "type": "object",
+      "description": "Skill invocation policy.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+      "additionalProperties": true,
+      "properties": {
+        "allow_implicit_invocation": {
+          "title": "allow implicit invocation",
+          "type": "boolean",
+          "description": "When false, Codex will not implicitly invoke the skill based on the user prompt. Explicit $skill invocation still works.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "toolDependency": {
+      "title": "tool dependency",
+      "type": "object",
+      "description": "External tool dependency declaration.\nhttps://developers.openai.com/codex/skills#optional-metadata",
+      "required": ["type", "value"],
+      "additionalProperties": true,
+      "properties": {
+        "description": {
+          "title": "description",
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable explanation of the dependency.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "transport": {
+          "title": "transport",
+          "type": "string",
+          "minLength": 1,
+          "description": "Connection type for the dependency. The currently documented MCP transport is streamable_http.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "type": {
+          "title": "type",
+          "type": "string",
+          "minLength": 1,
+          "description": "Dependency category. The currently documented value is mcp.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "url": {
+          "title": "url",
+          "type": "string",
+          "format": "uri",
+          "description": "Dependency server URL.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        },
+        "value": {
+          "title": "value",
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier of the tool or dependency.\nhttps://developers.openai.com/codex/skills#optional-metadata"
+        }
+      }
+    }
+  }
+}

--- a/src/test/codex-skill-metadata/interface-only.yaml
+++ b/src/test/codex-skill-metadata/interface-only.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/codex-skill-metadata.json
+interface:
+  display_name: 'Commit Helper'
+  short_description: 'Prepare coherent commits'
+  default_prompt: 'Use $commit-helper to inspect the current git tree.'
+  unknown_future_field: 'allowed for forward compatibility'

--- a/src/test/codex-skill-metadata/openai.yaml
+++ b/src/test/codex-skill-metadata/openai.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../schemas/json/codex-skill-metadata.json
+interface:
+  display_name: 'Docs Research'
+  short_description: 'Research OpenAI docs'
+  icon_small: './assets/icon-small.svg'
+  icon_large: './assets/icon-large.png'
+  brand_color: '#3B82F6'
+  default_prompt: 'Use $docs-research to check the current OpenAI docs.'
+
+policy:
+  allow_implicit_invocation: false
+
+dependencies:
+  tools:
+    - type: 'mcp'
+      value: 'openaiDeveloperDocs'
+      description: 'OpenAI Docs MCP server'
+      transport: 'streamable_http'
+      url: 'https://developers.openai.com/mcp'


### PR DESCRIPTION
## Summary

- add a SchemaStore schema for OpenAI Codex skill metadata files at `agents/openai.yaml`
- register the schema with `**/agents/openai.yaml`
- add positive and negative YAML fixtures for documented `interface`, `policy`, and `dependencies.tools` fields

The schema follows the documented optional metadata shape from OpenAI Codex skills docs, while keeping `additionalProperties: true` so future metadata fields are not rejected by default.

## Validation

- `node ./cli.js check --schema-name=codex-skill-metadata.json`
- `npm run prettier`
- `npm run typecheck`
- `npm run eslint`
- `git diff --check`