### PR TITLE
Add SigmaCV CV schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "SigmaCV CV",
+      "description": "SigmaCV canonical academic-CV object — open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information.",
+      "fileMatch": ["**/*.sigmacv.json"],
+      "url": "https://www.schemastore.org/sigmacv.json"
+    },
+    {
       "name": "revola.json",
       "description": "Configuration file for Revola",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4,7 +4,7 @@
   "schemas": [
     {
       "name": "SigmaCV CV",
-      "description": "SigmaCV canonical academic-CV object — open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information.",
+      "description": "SigmaCV canonical academic-CV object — open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information",
       "fileMatch": ["**/*.sigmacv.json"],
       "url": "https://www.schemastore.org/sigmacv.json"
     },

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -252,6 +252,7 @@
     "renovate-inherited-schema-42.json",
     "resjson.json",
     "sarif-1.0.0.json",
+    "sigmacv.json",
     "size-limit.json",
     "solidaritySchema.json",
     "sprite.json",

--- a/src/schemas/json/sigmacv.json
+++ b/src/schemas/json/sigmacv.json
@@ -1,0 +1,1076 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/sigmacv.json",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 2
+    },
+    "id": {
+      "type": "string",
+      "maxLength": 128
+    },
+    "owner": {
+      "type": "object",
+      "properties": {
+        "orcid": {
+          "type": "string",
+          "maxLength": 64
+        },
+        "openAlexAuthorIds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "maxItems": 200
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 1000
+        },
+        "honorific": {
+          "type": "string",
+          "maxLength": 60
+        },
+        "headline": {
+          "type": "string",
+          "maxLength": 200
+        },
+        "summary": {
+          "type": "string",
+          "maxLength": 2000
+        },
+        "photo": {
+          "type": "string",
+          "maxLength": 1400000,
+          "pattern": "^data:image\\/(jpeg|png|webp|gif);base64,[A-Za-z0-9+/]+={0,2}$"
+        },
+        "contact": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "maxLength": 254
+            },
+            "phone": {
+              "type": "string",
+              "maxLength": 60
+            },
+            "website": {
+              "type": "string",
+              "maxLength": 2048
+            },
+            "location": {
+              "type": "string",
+              "maxLength": 200
+            }
+          },
+          "additionalProperties": false
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "maxLength": 120
+              },
+              "url": {
+                "type": "string",
+                "maxLength": 2048
+              }
+            },
+            "required": ["label", "url"],
+            "additionalProperties": false
+          },
+          "maxItems": 20,
+          "default": []
+        },
+        "personal": {
+          "type": "object",
+          "properties": {
+            "phoneticName": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "dateOfBirth": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "gender": {
+              "type": "string",
+              "maxLength": 40
+            },
+            "nationality": {
+              "type": "string",
+              "maxLength": 120
+            },
+            "address": {
+              "type": "string",
+              "maxLength": 400
+            }
+          },
+          "additionalProperties": false
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "h_index": {
+              "type": "integer"
+            },
+            "i10_index": {
+              "type": "integer"
+            },
+            "works_count": {
+              "type": "integer"
+            },
+            "cited_by_count": {
+              "type": "integer"
+            },
+            "fwci_mean": {
+              "type": "number"
+            },
+            "fwci_n": {
+              "type": "integer"
+            },
+            "top10pct_share": {
+              "type": "number"
+            },
+            "rcr_mean": {
+              "type": "number"
+            },
+            "rcr_n": {
+              "type": "integer"
+            },
+            "2yr_mean_citedness": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "countsByYear": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "year": {
+                "type": "integer"
+              },
+              "works": {
+                "type": "integer"
+              },
+              "citations": {
+                "type": "integer"
+              }
+            },
+            "required": ["year", "works", "citations"],
+            "additionalProperties": false
+          },
+          "default": []
+        },
+        "wikidataUri": {
+          "type": "string",
+          "maxLength": 2048
+        },
+        "wikidataSameAs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 2048
+          },
+          "maxItems": 20
+        }
+      },
+      "required": ["orcid", "openAlexAuthorIds", "displayName"],
+      "additionalProperties": false
+    },
+    "display": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "type": "string",
+          "enum": ["classic", "modern", "sidebar", "ats", "rirekisho"],
+          "default": "classic"
+        },
+        "cslStyle": {
+          "type": "string",
+          "maxLength": 200,
+          "default": "apa"
+        },
+        "customStyle": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "title": {
+              "type": "string",
+              "maxLength": 300
+            },
+            "xml": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 600000
+            }
+          },
+          "required": ["id", "title", "xml"],
+          "additionalProperties": false
+        },
+        "locale": {
+          "type": "string",
+          "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$",
+          "default": "en-US"
+        },
+        "highlightSelf": {
+          "type": "boolean",
+          "default": true
+        },
+        "highlightStyle": {
+          "type": "string",
+          "enum": ["accent", "bold", "underline", "accent-underline"],
+          "default": "accent"
+        },
+        "cvLicense": {
+          "type": "string",
+          "enum": [
+            "none",
+            "CC0-1.0",
+            "CC-BY-4.0",
+            "CC-BY-SA-4.0",
+            "all-rights-reserved"
+          ],
+          "default": "none"
+        },
+        "showMetrics": {
+          "type": "boolean",
+          "default": false
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 64
+          },
+          "maxItems": 100,
+          "default": []
+        },
+        "showCharts": {
+          "type": "boolean",
+          "default": false
+        },
+        "showOpenAccess": {
+          "type": "boolean",
+          "default": false
+        },
+        "showAuthorRole": {
+          "type": "boolean",
+          "default": false
+        },
+        "showCitationCounts": {
+          "type": "boolean",
+          "default": false
+        },
+        "showProvenance": {
+          "type": "boolean",
+          "default": false
+        },
+        "peerReviewedOnly": {
+          "type": "boolean",
+          "default": false
+        },
+        "countLetters": {
+          "type": "boolean",
+          "default": true
+        },
+        "publicationOrder": {
+          "type": "string",
+          "enum": ["custom", "citations", "year-desc", "year-asc"],
+          "default": "custom"
+        },
+        "publicationsLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 500
+        },
+        "excludedItems": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "maxLength": 200
+            },
+            "maxItems": 10000
+          },
+          "propertyNames": {
+            "maxLength": 200
+          }
+        },
+        "dismissedDuplicates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 2200
+          },
+          "maxItems": 20000
+        },
+        "sectionsCustomized": {
+          "type": "boolean",
+          "default": false
+        },
+        "showAuthorshipTable": {
+          "type": "boolean",
+          "default": false
+        },
+        "authorshipRoles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 64
+          },
+          "maxItems": 50,
+          "default": []
+        },
+        "accentColor": {
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}$",
+          "default": "#1f4fd8"
+        },
+        "fontPairing": {
+          "type": "string",
+          "enum": ["serif", "sans", "palatino"],
+          "default": "serif"
+        },
+        "density": {
+          "type": "string",
+          "enum": ["comfortable", "compact"],
+          "default": "comfortable"
+        },
+        "publicContact": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "boolean",
+              "default": false
+            },
+            "phone": {
+              "type": "boolean",
+              "default": false
+            },
+            "location": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "default": {}
+        },
+        "publicAttribution": {
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 200
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "publications",
+              "preprints",
+              "datasets",
+              "positions",
+              "education",
+              "conference",
+              "awards",
+              "talks",
+              "teaching",
+              "supervision",
+              "service",
+              "peer-review",
+              "editorial",
+              "grants",
+              "clinical-trials",
+              "patents",
+              "narrative-knowledge",
+              "narrative-individuals",
+              "narrative-community",
+              "narrative-society",
+              "statement",
+              "skills",
+              "languages",
+              "references",
+              "other"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "visible": {
+            "type": "boolean"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "maxLength": 1024
+                },
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "openalex",
+                    "orcid",
+                    "oep",
+                    "datacite",
+                    "crossref",
+                    "openaire",
+                    "dblp",
+                    "ukri",
+                    "nih",
+                    "nsf",
+                    "clinicaltrials",
+                    "ctis",
+                    "ictrp",
+                    "epo",
+                    "derived",
+                    "manual"
+                  ]
+                },
+                "sourceId": {
+                  "type": "string",
+                  "maxLength": 2048
+                },
+                "csl": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "author": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "family": {
+                            "type": "string"
+                          },
+                          "given": {
+                            "type": "string"
+                          },
+                          "literal": {
+                            "type": "string"
+                          },
+                          "dropping-particle": {
+                            "type": "string"
+                          },
+                          "non-dropping-particle": {
+                            "type": "string"
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "editor": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "family": {
+                            "type": "string"
+                          },
+                          "given": {
+                            "type": "string"
+                          },
+                          "literal": {
+                            "type": "string"
+                          },
+                          "dropping-particle": {
+                            "type": "string"
+                          },
+                          "non-dropping-particle": {
+                            "type": "string"
+                          },
+                          "suffix": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "issued": {
+                      "type": "object",
+                      "properties": {
+                        "date-parts": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": ["number", "string"]
+                            }
+                          }
+                        },
+                        "raw": {
+                          "type": "string"
+                        },
+                        "literal": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "container-title": {
+                      "type": "string"
+                    },
+                    "collection-title": {
+                      "type": "string"
+                    },
+                    "publisher": {
+                      "type": "string"
+                    },
+                    "publisher-place": {
+                      "type": "string"
+                    },
+                    "volume": {
+                      "type": "string"
+                    },
+                    "issue": {
+                      "type": "string"
+                    },
+                    "page": {
+                      "type": "string"
+                    },
+                    "number": {
+                      "type": "string"
+                    },
+                    "DOI": {
+                      "type": "string"
+                    },
+                    "URL": {
+                      "type": "string"
+                    },
+                    "ISSN": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    },
+                    "ISBN": {
+                      "type": "string"
+                    },
+                    "abstract": {
+                      "type": "string"
+                    },
+                    "language": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["id", "type"],
+                  "additionalProperties": false
+                },
+                "displayText": {
+                  "type": "string",
+                  "maxLength": 10000
+                },
+                "displayTextOverride": {
+                  "type": "string",
+                  "maxLength": 10000
+                },
+                "included": {
+                  "type": "boolean"
+                },
+                "notMine": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "notMineAssertedAt": {
+                  "type": "string"
+                },
+                "notMineReason": {
+                  "type": "string",
+                  "enum": [
+                    "different-person",
+                    "duplicate",
+                    "wrong-field",
+                    "other"
+                  ]
+                },
+                "order": {
+                  "type": "integer"
+                },
+                "authoredBySelf": {
+                  "type": "boolean"
+                },
+                "selfNameVariants": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "maxItems": 100
+                },
+                "meta": {
+                  "type": "object",
+                  "properties": {
+                    "year": {
+                      "type": "integer"
+                    },
+                    "type": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "doi": {
+                      "type": "string",
+                      "maxLength": 1000
+                    },
+                    "citedByCount": {
+                      "type": "integer"
+                    },
+                    "fwci": {
+                      "type": "number"
+                    },
+                    "topDecile": {
+                      "type": "boolean"
+                    },
+                    "oaStatus": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "oaIsOpen": {
+                      "type": "boolean"
+                    },
+                    "license": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "pmid": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "rcr": {
+                      "type": "number"
+                    },
+                    "rorId": {
+                      "type": "string",
+                      "maxLength": 2048
+                    },
+                    "institution": {
+                      "type": "string",
+                      "maxLength": 500
+                    },
+                    "funderId": {
+                      "type": "string",
+                      "maxLength": 2048
+                    },
+                    "funderName": {
+                      "type": "string",
+                      "maxLength": 1000
+                    },
+                    "awardId": {
+                      "type": "string",
+                      "maxLength": 500
+                    },
+                    "lastVerifiedAt": {
+                      "type": "string"
+                    },
+                    "authorRole": {
+                      "type": "string",
+                      "maxLength": 200
+                    },
+                    "authorCount": {
+                      "type": "integer"
+                    },
+                    "authorPosition": {
+                      "type": "integer"
+                    },
+                    "isCorresponding": {
+                      "type": "boolean"
+                    },
+                    "matchBasis": {
+                      "type": "string",
+                      "enum": ["orcid", "openalex-id", "both", "claimed"]
+                    },
+                    "claimed": {
+                      "type": "boolean"
+                    },
+                    "peerReviewed": {
+                      "type": "boolean"
+                    },
+                    "enriched": {
+                      "type": "boolean"
+                    },
+                    "reviewFlag": {
+                      "type": "string",
+                      "enum": [
+                        "orcid-conflict",
+                        "name-matched",
+                        "orcid-doi",
+                        "duplicate"
+                      ]
+                    },
+                    "duplicateOf": {
+                      "type": "object",
+                      "properties": {
+                        "itemId": {
+                          "type": "string",
+                          "maxLength": 1024
+                        },
+                        "tier": {
+                          "type": "string",
+                          "enum": ["exact", "related", "strong", "weak"]
+                        },
+                        "relationship": {
+                          "type": "string",
+                          "enum": [
+                            "same-work",
+                            "preprint-of",
+                            "published-version-of",
+                            "version-of",
+                            "translation-of",
+                            "erratum-of"
+                          ]
+                        },
+                        "groupId": {
+                          "type": "string",
+                          "maxLength": 1024
+                        }
+                      },
+                      "required": ["itemId", "groupId"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "id",
+                "source",
+                "sourceId",
+                "included",
+                "order",
+                "authoredBySelf",
+                "selfNameVariants",
+                "meta"
+              ],
+              "additionalProperties": false
+            },
+            "maxItems": 10000
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 8000
+          }
+        },
+        "required": ["id", "type", "title", "visible", "order", "items"],
+        "additionalProperties": false
+      },
+      "maxItems": 60
+    },
+    "presets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60
+          },
+          "display": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string",
+                "enum": ["classic", "modern", "sidebar", "ats", "rirekisho"],
+                "default": "classic"
+              },
+              "cslStyle": {
+                "type": "string",
+                "maxLength": 200,
+                "default": "apa"
+              },
+              "customStyle": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                  },
+                  "title": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "xml": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 600000
+                  }
+                },
+                "required": ["id", "title", "xml"],
+                "additionalProperties": false
+              },
+              "locale": {
+                "type": "string",
+                "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$",
+                "default": "en-US"
+              },
+              "highlightSelf": {
+                "type": "boolean",
+                "default": true
+              },
+              "highlightStyle": {
+                "type": "string",
+                "enum": ["accent", "bold", "underline", "accent-underline"],
+                "default": "accent"
+              },
+              "cvLicense": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "CC0-1.0",
+                  "CC-BY-4.0",
+                  "CC-BY-SA-4.0",
+                  "all-rights-reserved"
+                ],
+                "default": "none"
+              },
+              "showMetrics": {
+                "type": "boolean",
+                "default": false
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "maxLength": 64
+                },
+                "maxItems": 100,
+                "default": []
+              },
+              "showCharts": {
+                "type": "boolean",
+                "default": false
+              },
+              "showOpenAccess": {
+                "type": "boolean",
+                "default": false
+              },
+              "showAuthorRole": {
+                "type": "boolean",
+                "default": false
+              },
+              "showCitationCounts": {
+                "type": "boolean",
+                "default": false
+              },
+              "showProvenance": {
+                "type": "boolean",
+                "default": false
+              },
+              "peerReviewedOnly": {
+                "type": "boolean",
+                "default": false
+              },
+              "countLetters": {
+                "type": "boolean",
+                "default": true
+              },
+              "publicationOrder": {
+                "type": "string",
+                "enum": ["custom", "citations", "year-desc", "year-asc"],
+                "default": "custom"
+              },
+              "publicationsLimit": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 500
+              },
+              "excludedItems": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "maxItems": 10000
+                },
+                "propertyNames": {
+                  "maxLength": 200
+                }
+              },
+              "dismissedDuplicates": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "maxLength": 2200
+                },
+                "maxItems": 20000
+              },
+              "sectionsCustomized": {
+                "type": "boolean",
+                "default": false
+              },
+              "showAuthorshipTable": {
+                "type": "boolean",
+                "default": false
+              },
+              "authorshipRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "maxLength": 64
+                },
+                "maxItems": 50,
+                "default": []
+              },
+              "accentColor": {
+                "type": "string",
+                "pattern": "^#[0-9a-fA-F]{6}$",
+                "default": "#1f4fd8"
+              },
+              "fontPairing": {
+                "type": "string",
+                "enum": ["serif", "sans", "palatino"],
+                "default": "serif"
+              },
+              "density": {
+                "type": "string",
+                "enum": ["comfortable", "compact"],
+                "default": "comfortable"
+              },
+              "publicContact": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "phone": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "location": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false,
+                "default": {}
+              },
+              "publicAttribution": {
+                "type": "boolean",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          },
+          "sectionVisibility": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "default": {}
+          }
+        },
+        "required": ["id", "name", "display"],
+        "additionalProperties": false
+      },
+      "maxItems": 20,
+      "default": []
+    },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "generatedAt": {
+          "type": "string",
+          "maxLength": 64
+        },
+        "lastSyncedAt": {
+          "type": "string",
+          "maxLength": 64
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "openalex",
+              "orcid",
+              "oep",
+              "crossref",
+              "datacite",
+              "openaire",
+              "dblp",
+              "ukri",
+              "nih",
+              "nsf",
+              "clinicaltrials",
+              "ctis",
+              "ictrp",
+              "epo",
+              "ror",
+              "wikidata",
+              "derived",
+              "manual"
+            ]
+          }
+        }
+      },
+      "required": ["generatedAt", "sources"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "id",
+    "owner",
+    "display",
+    "sections",
+    "provenance"
+  ],
+  "additionalProperties": false,
+  "title": "SigmaCV canonical CV",
+  "description": "The canonical CV object SigmaCV produces and validates (schemaVersion 2). Derived from the Zod schema; source at https://github.com/BasileChretien/sigmacv."
+}

--- a/src/test/sigmacv/cv.sigmacv.json
+++ b/src/test/sigmacv/cv.sigmacv.json
@@ -1,0 +1,58 @@
+{
+  "display": {
+    "accentColor": "#1f4fd8",
+    "authorshipRoles": [],
+    "countLetters": true,
+    "cslStyle": "apa",
+    "cvLicense": "none",
+    "density": "comfortable",
+    "fontPairing": "serif",
+    "highlightSelf": true,
+    "highlightStyle": "accent",
+    "locale": "en-US",
+    "metrics": [],
+    "peerReviewedOnly": false,
+    "publicAttribution": true,
+    "publicContact": {
+      "email": false,
+      "location": false,
+      "phone": false
+    },
+    "publicationOrder": "custom",
+    "sectionsCustomized": false,
+    "showAuthorRole": false,
+    "showAuthorshipTable": false,
+    "showCharts": false,
+    "showCitationCounts": false,
+    "showMetrics": false,
+    "showOpenAccess": false,
+    "showProvenance": false,
+    "template": "classic"
+  },
+  "id": "sample-cv",
+  "owner": {
+    "countsByYear": [],
+    "displayName": "Ada Lovelace",
+    "links": [],
+    "metrics": {},
+    "openAlexAuthorIds": ["A5001069481"],
+    "orcid": "0000-0002-7483-2489"
+  },
+  "presets": [],
+  "provenance": {
+    "generatedAt": "2026-06-10T00:00:00.000Z",
+    "lastSyncedAt": "2026-06-10T00:00:00.000Z",
+    "sources": ["openalex"]
+  },
+  "schemaVersion": 2,
+  "sections": [
+    {
+      "id": "publications",
+      "items": [],
+      "order": 2,
+      "title": "Publications",
+      "type": "publications",
+      "visible": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds a JSON Schema for **SigmaCV**'s canonical academic-CV object — an open, machine-readable representation of a researcher's CV (publications, positions, education, funding and narrative sections).

- **Project:** https://sigmacv.org · **Source:** https://github.com/BasileChretien/sigmacv (Apache-2.0, [DOI 10.5281/zenodo.20594123](https://doi.org/10.5281/zenodo.20594123))
- The schema is **derived from the project's source-of-truth Zod schema** (and published at `https://sigmacv.org/schema/cv/v2.json`), so it stays in sync with what the app validates.
- `fileMatch`: `**/*.sigmacv.json`.
- Includes a positive test (`src/test/sigmacv/cv.sigmacv.json`) — a real, valid CV instance.
- Added to `ajvNotStrictMode` because the embedded CSL `issued.date-parts` values are `number | string` (a union, per the CSL-JSON spec), which trips ajv strict mode.

draft-07; `additionalProperties` left as generated. Happy to adjust naming, `fileMatch`, or scope per maintainer preference.
