### PR TITLE
Fix launchsettings.json missing WSL commandName option

### DIFF
--- a/src/schemas/json/launchsettings.json
+++ b/src/schemas/json/launchsettings.json
@@ -83,6 +83,7 @@
             "DockerCompose",
             "MsixPackage",
             "SdkContainer",
+            "WSL",
             "WSL2"
           ],
           "default": "",


### PR DESCRIPTION
Adds `WSL` to the `commandName` enum in launchsettings.json. 

Reference [Microsoft's Visual Studio docs](https://learn.microsoft.com/en-us/visualstudio/debugger/debug-dotnet-core-in-wsl-2?view=visualstudio): 

> Starting in Visual Studio 2022 Preview 3, the command name in the Launch Profile changed from WSL2 to WSL.

