### PR TITLE
Add Azure DevOps dependabot file matches

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2440,8 +2440,13 @@
     },
     {
       "name": "dependabot-v2.json",
-      "description": "GitHub Actions' dependabot.yml files",
-      "fileMatch": ["**/.github/dependabot.yml", "**/.github/dependabot.yaml"],
+      "description": "Dependabot v2 configuration files",
+      "fileMatch": [
+        "**/.azuredevops/dependabot.yml",
+        "**/.azuredevops/dependabot.yaml",
+        "**/.github/dependabot.yml",
+        "**/.github/dependabot.yaml"
+      ],
       "url": "https://www.schemastore.org/dependabot-2.0.json"
     },
     {


### PR DESCRIPTION
Summary
- Add Azure DevOps dependabot v2 config paths to the SchemaStore catalog.
- Update the catalog description so the entry is not limited to GitHub-hosted dependabot files.

Reproduction
- Azure DevOps dependabot supports `.azuredevops/dependabot.yml` and `.azuredevops/dependabot.yaml` in addition to `.github/dependabot.yml`.
- SchemaStore currently only associates `dependabot-2.0.json` with `.github/dependabot.yml` and `.github/dependabot.yaml`, so editors using the catalog do not auto-apply the schema for Azure DevOps config files.

Root cause
- The `dependabot-v2.json` catalog entry was missing the Azure DevOps-specific `.azuredevops` file matches.

Changes
- Added `**/.azuredevops/dependabot.yml` and `**/.azuredevops/dependabot.yaml` to the `dependabot-v2.json` catalog entry.
- Changed the entry description to “Dependabot v2 configuration files”.

Tests
- `git diff --check`
- `npx prettier --config .prettierrc.cjs --check src/api/json/catalog.json`
- `node ./cli.js check --schema-name=dependabot-2.0.json`

Screenshots/Logs
- N/A

Fixes #4654