### PR TITLE
Allow Chrome manifest media command keys

### DIFF
--- a/src/negative_test/chrome-manifest/v3_unknown_media_key.json
+++ b/src/negative_test/chrome-manifest/v3_unknown_media_key.json
@@ -1,0 +1,12 @@
+{
+  "commands": {
+    "unknown-media-key": {
+      "suggested_key": {
+        "default": "MediaFastForward"
+      }
+    }
+  },
+  "manifest_version": 3,
+  "name": "v3-test-unknown-media-key",
+  "version": "0.0.1"
+}

--- a/src/schemas/json/chrome-manifest.json
+++ b/src/schemas/json/chrome-manifest.json
@@ -124,7 +124,7 @@
             "patternProperties": {
               "^(default|mac|windows|linux|chromeos)$": {
                 "type": "string",
-                "pattern": "^(Ctrl|Command|MacCtrl)\\+Shift\\+[0-9]"
+                "pattern": "^(?:(Ctrl|Command|MacCtrl)\\+Shift\\+[0-9]|Media(?:NextTrack|PlayPause|PrevTrack|Stop))$"
               }
             }
           }
@@ -146,7 +146,7 @@
             "patternProperties": {
               "^(default|mac|windows|linux|chromeos)$": {
                 "type": "string",
-                "pattern": "^(Ctrl|Command|MacCtrl|Alt|Option)\\+(Shift\\+)?[A-Z]"
+                "pattern": "^(?:(Ctrl|Command|MacCtrl|Alt|Option)\\+(Shift\\+)?[A-Z]|Media(?:NextTrack|PlayPause|PrevTrack|Stop))$"
               }
             }
           }

--- a/src/test/chrome-manifest/media-keys.json
+++ b/src/test/chrome-manifest/media-keys.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../schemas/json/chrome-manifest.json",
+  "commands": {
+    "next-track": {
+      "description": "Play next track",
+      "suggested_key": {
+        "default": "MediaNextTrack"
+      }
+    },
+    "play-pause": {
+      "description": "Play or pause media",
+      "global": true,
+      "suggested_key": {
+        "default": "MediaPlayPause"
+      }
+    },
+    "prev-track": {
+      "description": "Play previous track",
+      "suggested_key": {
+        "default": "MediaPrevTrack"
+      }
+    },
+    "stop": {
+      "description": "Stop playback",
+      "suggested_key": {
+        "default": "MediaStop"
+      }
+    }
+  },
+  "manifest_version": 3,
+  "name": "media-keys",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

- Allow Chrome extension command `suggested_key` values to use the documented media keys.
- Add positive coverage for the supported media keys and negative coverage for an unknown media key.

Fixes #5587.

## Reproduction

A Chrome extension manifest with media keys currently fails schema validation, for example:

```json
{
  "commands": {
    "play-pause": {
      "global": true,
      "suggested_key": {
        "default": "MediaPlayPause"
      }
    }
  },
  "manifest_version": 3,
  "name": "media-keys",
  "version": "1.0.0"
}
```

Chrome's commands API docs list `MediaNextTrack`, `MediaPlayPause`, `MediaPrevTrack`, and `MediaStop` as supported command shortcut keys.

## Root cause

The `chrome-manifest.json` schema only accepted modifier-based key combinations for `commands.*.suggested_key`, so documented media key values did not match the pattern.

## Changes

- Extend the global and non-global `suggested_key` patterns to accept the four documented media key values.
- Anchor both patterns with `$` so partial matches do not pass accidentally.
- Add a positive manifest fixture covering all four media keys.
- Add a negative fixture for an unsupported `MediaFastForward` key.

## Tests

- `npm ci`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --write src/schemas/json/chrome-manifest.json src/test/chrome-manifest/media-keys.json src/negative_test/chrome-manifest/v3_unknown_media_key.json`
- `node ./cli.js check --schema-name=chrome-manifest.json`
- `git diff --check`

## Screenshots/Logs

N/A. Schema validation passed for `chrome-manifest.json`. Node printed its existing experimental JSON module warning during the schema check.