### PR TITLE
Allow Prometheus scrape_native_histograms

### DIFF
--- a/src/negative_test/prometheus/scrape_native_histograms_string.yaml
+++ b/src/negative_test/prometheus/scrape_native_histograms_string.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../schemas/json/prometheus.json
+scrape_configs:
+  - job_name: prometheus
+    scrape_native_histograms: 'true'
+    static_configs:
+      - targets:
+          - nativehisto:8080

--- a/src/schemas/json/prometheus.json
+++ b/src/schemas/json/prometheus.json
@@ -1216,6 +1216,11 @@
             "$ref": "#/definitions/duration",
             "description": "Per-scrape timeout when scraping this job. Defaults to `global.scrape_timeout`."
           },
+          "scrape_native_histograms": {
+            "description": "Controls whether to scrape a target's native histograms.",
+            "type": ["boolean", "null"],
+            "default": false
+          },
           "fallback_scrape_protocol": {
             "description": "Fallback protocol to use if a scrape returns blank, unparsable, or otherwise invalid Content-Type.",
             "type": ["string", "null"],

--- a/src/test/prometheus/prometheus.json
+++ b/src/test/prometheus/prometheus.json
@@ -106,6 +106,7 @@
           "target_label": "abc"
         }
       ],
+      "scrape_native_histograms": true,
       "static_configs": [
         {
           "labels": {


### PR DESCRIPTION
## Summary

- Allow Prometheus `scrape_configs[*].scrape_native_histograms` in `prometheus.json`.
- Add positive and negative fixtures for the new scrape config option.

Fixes #5606.

## Reproduction

The schema currently rejects a valid Prometheus scrape config using `scrape_native_histograms`:

```yaml
scrape_configs:
  - job_name: prometheus
    scrape_native_histograms: true
    static_configs:
      - targets: ["nativehisto:8080"]
```

## Root cause

Prometheus added `scrape_native_histograms` to scrape configs, but SchemaStore's `prometheus.json` schema has `additionalProperties: false` for scrape config objects and did not include this property.

## Changes

- Add `scrape_native_histograms` as a boolean/null scrape config property.
- Add a positive fixture in `src/test/prometheus/prometheus.json`.
- Add a negative YAML fixture to ensure non-boolean values remain invalid.

## Tests

- `npm ci`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --write src/schemas/json/prometheus.json src/test/prometheus/prometheus.json src/negative_test/prometheus/scrape_native_histograms_string.yaml`
- `node ./cli.js check --schema-name=prometheus.json`
- `git diff --check`

## Screenshots/Logs

N/A. Schema validation passed for `prometheus.json`. Node printed its existing experimental JSON module warning during the schema check.