### PR TITLE
Add Event Hubs batch settings to host schema

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1426,6 +1426,18 @@
                       "default": 10,
                       "minimum": 1
                     },
+                    "minEventBatchSize": {
+                      "description": "The minimum number of events desired in a batch. The minimum applies only when the function is receiving multiple events and must be less than maxEventBatchSize.",
+                      "type": "integer",
+                      "default": 1,
+                      "minimum": 1
+                    },
+                    "maxWaitTime": {
+                      "description": "The maximum interval that the trigger should wait to fill a batch before invoking the function.",
+                      "type": "string",
+                      "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
+                      "default": "00:01:00"
+                    },
                     "batchCheckpointFrequency": {
                       "description": "The number of batches to process before creating a checkpoint for the Event Hub.",
                       "type": "integer",

--- a/src/test/host/host.v2.json
+++ b/src/test/host/host.v2.json
@@ -89,6 +89,8 @@
         "type": "fromStart"
       },
       "maxEventBatchSize": 10,
+      "maxWaitTime": "00:01:00",
+      "minEventBatchSize": 1,
       "prefetchCount": 300,
       "transportType": "amqpWebSockets",
       "webProxy": "https://proxyserver:8080"


### PR DESCRIPTION
## Summary

Adds the Azure Functions Event Hubs `host.json` settings `minEventBatchSize` and `maxWaitTime` to the current `extensions.eventHubs` schema branch.

Fixes #5147.

## Reproduction

Before this change, a `host.json` file that followed the Microsoft Event Hubs host.json documentation and included `extensions.eventHubs.minEventBatchSize` or `extensions.eventHubs.maxWaitTime` was rejected by the SchemaStore `host.json` schema because that object disallowed additional properties.

## Root cause

The current Event Hubs v5/v6+ schema branch already included `maxEventBatchSize`, `targetUnprocessedEventThreshold`, retry options, and related settings, but it was missing the documented `minEventBatchSize` and `maxWaitTime` properties.

## Changes

- Added `minEventBatchSize` as an integer Event Hubs setting with a minimum of 1 and default of 1.
- Added `maxWaitTime` as a time-span string Event Hubs setting with the existing `HH:MM:SS` pattern and default `00:01:00`.
- Updated the positive `host.v2.json` test fixture to cover both properties.

## Tests

- `node ./cli.js check --schema-name=host.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/host.json src/test/host/host.v2.json`
- `git diff --check`

## Screenshots/Logs

Not applicable; schema-only change.