### PR TITLE
Add AgentLoopKit config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10178,6 +10178,12 @@
       }
     },
     {
+      "name": "AgentLoopKit",
+      "description": "Configuration file for AgentLoopKit, a repo-level engineering loop for coding agents",
+      "fileMatch": ["agentloop.config.json"],
+      "url": "https://raw.githubusercontent.com/abhiyoheswaran1/AgentLoopKit/main/schema/agentloop.config.schema.json"
+    },
+    {
       "name": "Ethereum ERC721",
       "description": "ERC-721 Non-Fungible Token Standard",
       "url": "https://www.schemastore.org/ethereum-erc721.json"


### PR DESCRIPTION
## Summary

Adds AgentLoopKit agentloop.config.json schema to the JSON Schema Store catalog using the canonical raw GitHub schema URL from the AgentLoopKit repository.

AgentLoopKit is a repo-level engineering loop for coding agents. The schema is already shipped in the npm package and referenced by generated agentloop.config.json files.

## Validation

- npm run typecheck
- npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/api/json/catalog.json
- git diff --check
- Parsed src/api/json/catalog.json and confirmed exactly one AgentLoopKit / agentloop.config.json entry
