### PR TITLE
test(cargo): cover unexpected cfg check-cfg lint

### DIFF
--- a/src/test/cargo/lints-rust-unexpected-cfgs.toml
+++ b/src/test/cargo/lints-rust-unexpected-cfgs.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/cargo.json
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_foo)"] }


### PR DESCRIPTION
Summary
- Add a Cargo.toml positive test for `[lints.rust].unexpected_cfgs.check-cfg`.
- Covers the false positive reported in #5064.

Reproduction
- The issue reports that this Cargo.toml snippet was rejected by editors using SchemaStore:
  ```toml
  [lints.rust]
  unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_foo)"] }
  ```

Root cause
- Current `master` already has schema support for `check-cfg`, but there was no positive Cargo fixture covering this shape.

Changes
- Add `src/test/cargo/lints-rust-unexpected-cfgs.toml` with the reported lint configuration.

Tests
- `node ./cli.js check --schema-name=cargo.json`
- `npx prettier --check src/test/cargo/lints-rust-unexpected-cfgs.toml`
- `git diff --check`

Screenshots/Logs
- Not applicable.

Closes #5064