### PR TITLE
fix(cargo): allow artifact dependency fields

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -153,6 +153,44 @@
         "version": {
           "$ref": "#/definitions/SemVerRequirement"
         },
+        "artifact": {
+          "description": "Specifies a build artifact dependency target.\nhttps://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          ],
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
+        "lib": {
+          "description": "Whether to also build the dependency as a normal Rust library dependency when `artifact` is specified.\nhttps://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies",
+          "type": "boolean",
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
+        "target": {
+          "description": "The platform target to build the artifact dependency for.\nhttps://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies",
+          "type": "string",
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
         "default-features": {
           "description": "Use the default features of the dependency.",
           "type": "boolean",

--- a/src/test/cargo/artifact-dependencies.toml
+++ b/src/test/cargo/artifact-dependencies.toml
@@ -1,0 +1,8 @@
+#:schema ../../schemas/json/cargo.json
+[dependencies]
+bar = { version = "1.0", artifact = "bin", lib = true }
+zoo = { version = "1.0", artifact = ["bin:cat", "bin:dog"] }
+
+[build-dependencies]
+kernel = { path = "kernel", artifact = "bin", target = "x86_64-unknown-none" }
+same-target = { version = "1.0", artifact = "bin", target = "target" }


### PR DESCRIPTION
Summary
- Allow Cargo artifact dependency fields in detailed dependency declarations.
- Add a positive TOML test for normal and build artifact dependencies.

Reproduction
- Issue #5005 reports that a valid Cargo unstable artifact dependency fails schema validation.
- Before the schema change, adding the new positive test failed `node ./cli.js check --schema-name=cargo.json` with dependency objects rejected by the existing dependency schema.

Root cause
- `DetailedDependency` allowed known dependency fields such as `version`, `path`, and `features`, but did not include Cargo artifact dependency keys `artifact`, `lib`, or `target`.

Changes
- Added `artifact` as a string or unique string array.
- Added `lib` as a boolean.
- Added `target` as a string.
- Added `src/test/cargo/artifact-dependencies.toml`.

Tests
- `node ./cli.js check --schema-name=cargo.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/cargo.json src/test/cargo/artifact-dependencies.toml`
- `git diff --check`

Screenshots/Logs
- Not applicable.

Fixes #5005