### PR TITLE
Use base devcontainer schema in catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1999,7 +1999,7 @@
       "name": "devcontainer.json",
       "description": "dev container configuration files",
       "fileMatch": ["devcontainer.json", ".devcontainer.json"],
-      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
+      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json"
     },
     {
       "name": "Codecov configuration files",


### PR DESCRIPTION
## Summary

Updates the SchemaStore catalog entry for `devcontainer.json` to use the upstream Dev Container base schema.

## Reproduction

SchemaStore currently points `devcontainer.json` files at:

`https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json`

That schema references VS Code-specific schemas, including `devContainer.vscode.schema.json`, which can surface unsupported `vscode://schemas/...` references in non-VS Code editors such as Neovim.

## Root cause

The upstream `devContainer.schema.json` combines the base Dev Container schema with VS Code and Codespaces-specific schema layers. SchemaStore's catalog entry is intended for broad editor/language-server consumption, so the VS Code-specific layer can break consumers that do not implement VS Code schema URI handling.

## Changes

- Point the `devcontainer.json` catalog entry to `devContainer.base.schema.json` instead of `devContainer.schema.json`.

## Tests

- `python3 -m json.tool src/api/json/catalog.json > /tmp/schemastore-catalog.json.checked`
- `git diff --check`
- `node ./cli.js check --schema-name=schema-catalog.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/api/json/catalog.json`
- Verified the old upstream schema references `devContainer.vscode.schema.json`.
- Verified the new base schema does not contain VS Code-only schema references.

## Screenshots/Logs

N/A; catalog URL change only.

Fixes #5310.
