### PR TITLE
Relax package name schema validation

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -377,8 +377,7 @@
       "description": "The name of the package.",
       "type": "string",
       "maxLength": 214,
-      "minLength": 1,
-      "pattern": "^(?:(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?/[a-z0-9-._~])|[a-z0-9-~])[a-z0-9-._~]*$"
+      "minLength": 1
     },
     "version": {
       "description": "Version must be parsable by node-semver, which is bundled with npm as a dependency.",

--- a/src/test/package/issue-5230.json
+++ b/src/test/package/issue-5230.json
@@ -1,0 +1,3 @@
+{
+  "name": "@is-(unknown)/is-one"
+}


### PR DESCRIPTION
## Summary

Relaxes the `package.json` schema's top-level `name` validation so valid npm package names containing URL-safe characters such as parentheses are accepted.

## Reproduction

A `package.json` with this name is currently rejected by the SchemaStore schema:

```json
{
  "name": "@is-(unknown)/is-one"
}
```

Issue #5230 reports this false positive for scoped package names containing parentheses.

## Root cause

The schema had a custom `pattern` for the top-level `name` field. That regular expression was narrower than npm package-name handling and rejected valid URL-safe characters. In the issue thread, removing the regex was recommended to avoid over-constraining this field.

## Changes

- Removed the custom `name` pattern while keeping the existing `type`, `minLength`, and `maxLength` constraints.
- Added a positive test fixture for the reported scoped package name.

## Tests

- `python3 -m json.tool src/schemas/json/package.json > /tmp/package-schema.json.checked`
- `python3 -m json.tool src/test/package/issue-5230.json > /tmp/package-issue-5230.json.checked`
- `git diff --check`
- `node ./cli.js check --schema-name=package.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/package.json src/test/package/issue-5230.json`

## Screenshots/Logs

N/A; schema/test change only.

Note: I also tried `node ./cli.js check-strict --schema-name=package.json`. It fails on the existing root schema metadata because `src/schemas/json/package.json` does not have a top-level `description`; this appears unrelated to this change.

Fixes #5230.
