### PR TITLE
Add poetry 2.0 dependency support

### DIFF
--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -91,14 +91,7 @@
     },
     "poetry-long-dependency": {
       "type": "object",
-      "anyOf": [
-        {
-          "required": ["version"]
-        },
-        {
-          "required": ["source"]
-        }
-      ],
+      "minProperties": 1,
       "additionalProperties": false,
       "properties": {
         "version": {

--- a/src/schemas/json/partial-poetry.json
+++ b/src/schemas/json/partial-poetry.json
@@ -91,7 +91,14 @@
     },
     "poetry-long-dependency": {
       "type": "object",
-      "required": ["version"],
+      "anyOf": [
+        {
+          "required": ["version"]
+        },
+        {
+          "required": ["source"]
+        }
+      ],
       "additionalProperties": false,
       "properties": {
         "version": {

--- a/src/test/pyproject/poetry-pep808-dependencies.toml
+++ b/src/test/pyproject/poetry-pep808-dependencies.toml
@@ -2,9 +2,7 @@
 [project]
 name = "example-project"
 version = "0.0.0"
-dependencies = [
-    "basic-example>=2"
-]
+dependencies = ["basic-example>=2"]
 
 [tool.poetry.dependencies]
 basic-example = { source = "private-source" }

--- a/src/test/pyproject/poetry-pep808-dependencies.toml
+++ b/src/test/pyproject/poetry-pep808-dependencies.toml
@@ -1,0 +1,14 @@
+#:schema ../../schemas/json/pyproject.json
+[project]
+name = "example-project"
+version = "0.0.0"
+dependencies = [
+    "basic-example>=2"
+]
+
+[tool.poetry.dependencies]
+basic-example = { source = "private-source" }
+
+[[tool.poetry.source]]
+name = "private-source"
+url = "https://private-source/pypi"


### PR DESCRIPTION
In the update to poetry 2.0 it is now possible to split dependency definitions between `tool.poetry.dependencies` and `project.dependencies` as formally described here:
https://python-poetry.org/docs/dependency-specification/#projectdependencies-and-toolpoetrydependencies

> [!NOTE]
> A minimal relaxation of constraints is to allow either `source` or `version`m which satisfies the documentation examples, however this could still be over-constrained if the `poetry-long-dependency` object's purpose is now to provide extensions to `project.dependencies`.
>
> Less constrained alternatives are:
> * Use `"minProperties": 1`
> * remove the constraint

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
