### PR TITLE
fix(claude-code-settings): allow MultiEdit permission rule

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
-      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\([^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Bash|Edit|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|MultiEdit|NotebookEdit|PowerShell|Read|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Write)(\\([^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",
@@ -16,6 +16,7 @@
         "Edit",
         "Edit(/src/**/*.ts)",
         "Read(*)",
+        "MultiEdit",
         "Skill(*)",
         "Read(./.env)",
         "Read(./secrets/**)",

--- a/src/test/claude-code-settings/permissions-advanced.json
+++ b/src/test/claude-code-settings/permissions-advanced.json
@@ -11,6 +11,7 @@
       "Edit(~/projects/**)",
       "ToolSearch",
       "LSP",
+      "MultiEdit",
       "NotebookEdit",
       "TodoWrite",
       "WebFetch(domain:github.com)",


### PR DESCRIPTION
Fixes #5210

## Summary

Allow `MultiEdit` in `claude-code-settings.json` permission rules and cover it in the positive permissions fixture.

## Reproduction

A Claude Code settings file with the following permission currently fails schema validation because `MultiEdit` is not included in the `permissionRule` regex:

```json
{
  "$schema": "https://json.schemastore.org/claude-code-settings.json",
  "permissions": {
    "allow": ["MultiEdit"]
  }
}
```

## Root cause

`$defs.permissionRule.pattern` enumerates supported Claude Code tool names. It already includes tools such as `Edit`, `NotebookEdit`, and `Skill`, but it does not include `MultiEdit`.

## Changes

- Add `MultiEdit` to the Claude Code settings `permissionRule` tool-name pattern.
- Add `MultiEdit` to the permission rule examples.
- Add `MultiEdit` to `src/test/claude-code-settings/permissions-advanced.json` so the schema validation test covers it.

## Tests

- `npm ci`
- `node ./cli.js check --schema-name=claude-code-settings.json`
- `npx prettier --check src/schemas/json/claude-code-settings.json src/test/claude-code-settings/permissions-advanced.json`
- `git diff --check`

## Screenshots/Logs

Not applicable; schema-only change.
