### PR TITLE
Add setuptools ext-modules schema support

### DIFF
--- a/src/negative_test/pyproject/setuptools-ext-modules-missing-sources.toml
+++ b/src/negative_test/pyproject/setuptools-ext-modules-missing-sources.toml
@@ -1,0 +1,11 @@
+#:schema ../../schemas/json/pyproject.json
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "extension-project"
+version = "0.1.0"
+
+[tool.setuptools]
+ext-modules = [{ name = "extension_project.foo" }]

--- a/src/schemas/json/partial-setuptools.json
+++ b/src/schemas/json/partial-setuptools.json
@@ -152,6 +152,14 @@
         "format": "python-module-name"
       }
     },
+    "ext-modules": {
+      "$comment": "https://setuptools.pypa.io/en/latest/userguide/ext_modules.html",
+      "description": "Extension modules to be compiled by setuptools",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ext-module"
+      }
+    },
     "data-files": {
       "type": "object",
       "patternProperties": {
@@ -308,6 +316,126 @@
       },
       "required": ["attr"],
       "description": "Value is read from a module attribute. Supports callables and iterables; unsupported types are cast via ``str()``"
+    },
+    "ext-module": {
+      "title": "Extension module",
+      "description": "Parameters to construct a :class:`setuptools.Extension` object",
+      "type": "object",
+      "required": ["name", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "format": "python-module-name"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "define-macros": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+              {
+                "description": "macro name",
+                "type": "string"
+              },
+              {
+                "description": "macro value",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            ],
+            "additionalItems": false
+          }
+        },
+        "undef-macros": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "library-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "libraries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runtime-library-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-objects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-compile-args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-link-args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "export-symbols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "swig-opts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "language": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "py-limited-api": {
+          "type": "boolean"
+        }
+      }
     },
     "find-directive": {
       "title": "'find:' directive",

--- a/src/test/pyproject/10-setuptools-ext-modules.toml
+++ b/src/test/pyproject/10-setuptools-ext-modules.toml
@@ -1,0 +1,46 @@
+#:schema ../../schemas/json/pyproject.json
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "extension-project"
+version = "0.1.0"
+
+[tool.setuptools]
+ext-modules = [
+  { name = "extension_project.foo", sources = [
+    "src/extension_project/foo.c",
+  ], include-dirs = [
+    "include",
+  ], define-macros = [
+    [
+      "FOO",
+      "1",
+    ],
+    [
+      "BAR",
+      "",
+    ],
+  ], undef-macros = [
+    "BAZ",
+  ], library-dirs = [
+    "lib",
+  ], libraries = [
+    "foo",
+  ], runtime-library-dirs = [
+    "runtime-lib",
+  ], extra-objects = [
+    "build/helper.o",
+  ], extra-compile-args = [
+    "-Wall",
+  ], extra-link-args = [
+    "-Wl,--as-needed",
+  ], export-symbols = [
+    "PyInit_foo",
+  ], swig-opts = [
+    "-modern",
+  ], depends = [
+    "src/extension_project/foo.h",
+  ], language = "c", optional = true, py-limited-api = true },
+]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Summary
- Add `tool.setuptools.ext-modules` support to `partial-setuptools.json`.
- Add positive and negative `pyproject.toml` tests for setuptools extension modules.

## Reproduction
A valid setuptools configuration such as:

```toml
[tool.setuptools]
ext-modules = [
  { name = "extension_project.foo", sources = ["src/extension_project/foo.c"] },
]
```

was rejected because `partial-setuptools.json` disallowed the `ext-modules` property.

## Root cause
`partial-setuptools.json` has `additionalProperties: false` for `tool.setuptools`, but it did not include the documented `ext-modules` property from setuptools' pyproject schema.

## Changes
- Add an `ext-modules` property that references a new `ext-module` definition.
- Model the extension module fields from the upstream setuptools schema, including required `name` and `sources`.
- Add a positive test covering extension module options.
- Add a negative test for an extension module missing `sources`.

## Tests
- `npm ci`
- `node ./cli.js check --schema-name=partial-setuptools.json`
- `node ./cli.js check --schema-name=pyproject.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/partial-setuptools.json src/test/pyproject/10-setuptools-ext-modules.toml src/negative_test/pyproject/setuptools-ext-modules-missing-sources.toml`
- `git diff --check`

## Screenshots/Logs
Not applicable; schema-only change.

Fixes #4092.
