### PR TITLE
Fix package name validation

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -377,8 +377,7 @@
       "description": "The name of the package.",
       "type": "string",
       "maxLength": 214,
-      "minLength": 1,
-      "pattern": "^(?:(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?/[a-z0-9-._~])|[a-z0-9-~])[a-z0-9-._~]*$"
+      "minLength": 1
     },
     "version": {
       "description": "Version must be parsable by node-semver, which is bundled with npm as a dependency.",

--- a/src/test/package/issue-5230.json
+++ b/src/test/package/issue-5230.json
@@ -1,0 +1,3 @@
+{
+  "name": "@is-(unknown)/is-one"
+}


### PR DESCRIPTION
Summary
- Fixes #5230.
- Relax the `package.json` schema's top-level `name` validation so valid URL-safe package names such as `@is-(unknown)/is-one` are accepted.
- Adds a positive fixture covering the reported scoped package name.

Reproduction
- A package.json with this content is currently rejected by the schema:

```json
{
  "name": "@is-(unknown)/is-one"
}
```

Root cause
- The schema used a custom regex for `name` that only allowed a subset of valid npm package-name characters.
- Parentheses are URL-safe characters and can be used in valid npm package names, but the regex rejected them.
- The project contribution guide also recommends avoiding over-constraining complex string formats where false positives are likely.

Changes
- Removed the over-constraining `name.pattern` from `src/schemas/json/package.json`.
- Kept the existing `type`, `minLength`, and `maxLength` checks.
- Added `src/test/package/issue-5230.json` as a regression fixture.

Tests
- `node ./cli.js check --schema-name=package.json`
- `npx prettier --check src/schemas/json/package.json src/test/package/issue-5230.json`

Screenshots/Logs
- N/A; schema-only change.
