### PR TITLE
Support Cargo artifact dependency fields

### DIFF
--- a/src/schemas/json/cargo.json
+++ b/src/schemas/json/cargo.json
@@ -220,6 +220,44 @@
             "hidden": true
           }
         },
+        "artifact": {
+          "description": "Specifies the Cargo target to build for an artifact dependency.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true
+            }
+          ],
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
+        "lib": {
+          "description": "Whether to also build the dependency's library as a normal Rust lib dependency. This field can only be specified when artifact is specified.",
+          "type": "boolean",
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
+        "target": {
+          "description": "The platform target to build the artifact dependency for. This field can only be specified when artifact is specified.",
+          "type": "string",
+          "x-taplo": {
+            "links": {
+              "key": "https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies"
+            }
+          }
+        },
         "registry": {
           "description": "To specify a dependency from a registry other than [crates.io](https://crates.io), first the\nregistry must be configured in a `.cargo/config.toml` file. See the [registries\ndocumentation](https://doc.rust-lang.org/cargo/reference/registries.html) for more information. In the dependency, set the `registry` key\nto the name of the registry to use.\n\n```toml\n[dependencies]\nsome-crate = { version = \"1.0\", registry = \"my-registry\" }\n```\n\n> **Note**: [crates.io](https://crates.io) does not allow packages to be published with\n> dependencies on other registries.\n",
           "type": "string",

--- a/src/test/cargo/artifact-dependency.toml
+++ b/src/test/cargo/artifact-dependency.toml
@@ -1,0 +1,7 @@
+#:schema ../../schemas/json/cargo.json
+[package]
+name = "artifact-dependency"
+version = "0.0.0"
+
+[build-dependencies]
+kernel = { path = "kernel", artifact = "bin", target = "x86_64-unknown-none" }


### PR DESCRIPTION
Summary
- Fixes #5005.
- Adds Cargo artifact dependency fields to the Cargo manifest schema's detailed dependency object.
- Adds a positive TOML fixture covering the reported `[build-dependencies]` case.

Reproduction
- Before this change, this valid Cargo manifest dependency failed schema validation:

```toml
[build-dependencies]
kernel = { path = "kernel", artifact = "bin", target = "x86_64-unknown-none" }
```

- I reproduced that by adding the fixture first and running `node ./cli.js check --schema-name=cargo.json`; it failed against `src/test/cargo/artifact-dependency.toml`.

Root cause
- `DetailedDependency` has `additionalProperties: false` and did not include Cargo's artifact dependency keys.
- Cargo documents `artifact`, `lib`, and `target` as dependency declaration keys for artifact dependencies: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies

Changes
- Added `artifact` support as either a string or an array of strings.
- Added `lib` as a boolean field.
- Added `target` as a string field.
- Added `src/test/cargo/artifact-dependency.toml` to prevent regressions.

Tests
- `node ./cli.js check --schema-name=cargo.json`
- `npx prettier --check src/schemas/json/cargo.json src/test/cargo/artifact-dependency.toml`

Screenshots/Logs
- N/A; schema-only change.
