### PR TITLE
Add Glamour style schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3397,6 +3397,19 @@
       "url": "https://raw.githubusercontent.com/google-gemini/gemini-cli/refs/heads/main/schemas/settings.schema.json"
     },
     {
+      "name": "Glamour style",
+      "description": "Style configuration for Charmbracelet Glamour and Glow Markdown rendering",
+      "fileMatch": [
+        ".glamour-style.json",
+        "*.glamour-style.json",
+        "*.glamour.json",
+        "*.glow-style.json",
+        "glamour-style.json",
+        "glow-style.json"
+      ],
+      "url": "https://www.schemastore.org/glamour-style.json"
+    },
+    {
       "name": "Global Privacy Control",
       "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control",
       "fileMatch": ["**/.well-known/gpc.json"],

--- a/src/negative_test/glamour-style/invalid-style.json
+++ b/src/negative_test/glamour-style/invalid-style.json
@@ -1,0 +1,19 @@
+{
+  "code_block": {
+    "chroma": {
+      "text": {
+        "bold": "yes"
+      }
+    }
+  },
+  "document": {
+    "margin": -1
+  },
+  "list": {
+    "level_indent": "2"
+  },
+  "task": {
+    "ticked": true
+  },
+  "unknown_element": {}
+}

--- a/src/schemas/json/glamour-style.json
+++ b/src/schemas/json/glamour-style.json
@@ -1,0 +1,734 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/glamour-style.json",
+  "title": "Glamour style",
+  "description": "Style configuration for Charmbracelet Glamour and Glow Markdown rendering.\nhttps://github.com/charmbracelet/glamour/tree/main/styles",
+  "type": "object",
+  "definitions": {
+    "style-color": {
+      "title": "style color",
+      "description": "ANSI color number or color string accepted by Glamour.",
+      "type": "string",
+      "examples": ["252", "#C4C4C4", "red"]
+    },
+    "extension-metadata": {
+      "description": "Custom metadata ignored by Glamour.",
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "style-primitive": {
+      "title": "style primitive",
+      "description": "Inline element style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style-block": {
+      "title": "style block",
+      "description": "Block element style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "indent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indent_token": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "margin": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style-list": {
+      "title": "style list",
+      "description": "List style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "indent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indent_token": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "level_indent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "margin": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style-task": {
+      "title": "style task",
+      "description": "Task list item style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "ticked": {
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "unticked": {
+          "type": "string"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style-table": {
+      "title": "style table",
+      "description": "Table style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "center_separator": {
+          "type": "string"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "column_separator": {
+          "type": "string"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "indent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indent_token": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "margin": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "row_separator": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "chroma": {
+      "title": "chroma",
+      "description": "Chroma token group styles for fenced code block syntax highlighting.",
+      "type": "object",
+      "properties": {
+        "background": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "comment": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "comment_preproc": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "error": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "generic_deleted": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "generic_emph": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "generic_inserted": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "generic_strong": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "generic_subheading": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "keyword": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "keyword_namespace": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "keyword_reserved": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "keyword_type": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "literal": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "literal_date": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "literal_number": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "literal_string": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "literal_string_escape": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_attribute": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_builtin": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_class": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_constant": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_decorator": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_exception": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_function": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_other": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "name_tag": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "operator": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "punctuation": {
+          "$ref": "#/definitions/style-primitive"
+        },
+        "text": {
+          "$ref": "#/definitions/style-primitive"
+        }
+      },
+      "additionalProperties": false
+    },
+    "style-code-block": {
+      "title": "style code block",
+      "description": "Code block style settings.",
+      "type": "object",
+      "properties": {
+        "background_color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "blink": {
+          "type": "boolean"
+        },
+        "block_prefix": {
+          "type": "string"
+        },
+        "block_suffix": {
+          "type": "string"
+        },
+        "bold": {
+          "type": "boolean"
+        },
+        "chroma": {
+          "$ref": "#/definitions/chroma"
+        },
+        "color": {
+          "$ref": "#/definitions/style-color"
+        },
+        "conceal": {
+          "type": "boolean"
+        },
+        "crossed_out": {
+          "type": "boolean"
+        },
+        "faint": {
+          "type": "boolean"
+        },
+        "format": {
+          "type": "string"
+        },
+        "indent": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indent_token": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "italic": {
+          "type": "boolean"
+        },
+        "lower": {
+          "type": "boolean"
+        },
+        "margin": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overlined": {
+          "description": "DEPRECATED. Compatibility field for older Glamour style configurations.",
+          "type": "boolean"
+        },
+        "prefix": {
+          "type": "string"
+        },
+        "suffix": {
+          "type": "string"
+        },
+        "theme": {
+          "description": "Chroma theme name used for syntax highlighting.",
+          "type": "string"
+        },
+        "title": {
+          "type": "boolean"
+        },
+        "underline": {
+          "type": "boolean"
+        },
+        "upper": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "block_quote": {
+      "$ref": "#/definitions/style-block"
+    },
+    "code": {
+      "$ref": "#/definitions/style-block"
+    },
+    "code_block": {
+      "$ref": "#/definitions/style-code-block"
+    },
+    "definition_description": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "definition_list": {
+      "$ref": "#/definitions/style-block"
+    },
+    "definition_term": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "document": {
+      "$ref": "#/definitions/style-block"
+    },
+    "emph": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "enumeration": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "h1": {
+      "$ref": "#/definitions/style-block"
+    },
+    "h2": {
+      "$ref": "#/definitions/style-block"
+    },
+    "h3": {
+      "$ref": "#/definitions/style-block"
+    },
+    "h4": {
+      "$ref": "#/definitions/style-block"
+    },
+    "h5": {
+      "$ref": "#/definitions/style-block"
+    },
+    "h6": {
+      "$ref": "#/definitions/style-block"
+    },
+    "heading": {
+      "$ref": "#/definitions/style-block"
+    },
+    "hr": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "html_block": {
+      "$ref": "#/definitions/style-block"
+    },
+    "html_span": {
+      "$ref": "#/definitions/style-block"
+    },
+    "image": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "image_text": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "item": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "link": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "link_text": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "list": {
+      "$ref": "#/definitions/style-list"
+    },
+    "paragraph": {
+      "$ref": "#/definitions/style-block"
+    },
+    "strikethrough": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "strong": {
+      "$ref": "#/definitions/style-primitive"
+    },
+    "table": {
+      "$ref": "#/definitions/style-table"
+    },
+    "task": {
+      "$ref": "#/definitions/style-task"
+    },
+    "text": {
+      "$ref": "#/definitions/style-primitive"
+    }
+  },
+  "patternProperties": {
+    "^_": {
+      "$ref": "#/definitions/extension-metadata"
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "block_quote": {
+        "indent": 1,
+        "indent_token": "│ "
+      },
+      "code_block": {
+        "chroma": {
+          "text": {
+            "color": "#C4C4C4"
+          }
+        },
+        "margin": 2
+      },
+      "document": {
+        "block_prefix": "\n",
+        "block_suffix": "\n",
+        "color": "252",
+        "margin": 2
+      }
+    }
+  ]
+}

--- a/src/test/glamour-style/glamour-style.json
+++ b/src/test/glamour-style/glamour-style.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json.schemastore.org/glamour-style.json",
+  "_metadata": {
+    "source": "test fixture"
+  },
+  "block_quote": {
+    "background_color": "#000000",
+    "color": "#7A7AA6",
+    "indent": 1,
+    "indent_token": "│ ",
+    "italic": true
+  },
+  "code": {
+    "background_color": "236",
+    "color": "203",
+    "prefix": " ",
+    "suffix": " "
+  },
+  "code_block": {
+    "chroma": {
+      "background": {
+        "background_color": "#373737"
+      },
+      "error": {
+        "background_color": "#F05B5B",
+        "color": "#F1F1F1"
+      },
+      "literal_string": {
+        "color": "#C69669"
+      },
+      "name_function": {
+        "color": "#00D787"
+      },
+      "text": {
+        "color": "#C4C4C4"
+      }
+    },
+    "margin": 2
+  },
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "252",
+    "margin": 2
+  },
+  "h1": {
+    "background_color": "63",
+    "bold": true,
+    "color": "228",
+    "prefix": " ",
+    "suffix": " "
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "bold": true,
+    "color": "39"
+  },
+  "html_block": {},
+  "html_span": {},
+  "list": {
+    "level_indent": 2
+  },
+  "table": {
+    "center_separator": "┼",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  }
+}


### PR DESCRIPTION
## Summary

- add a draft-07 JSON Schema for Charmbracelet Glamour / Glow style files
- add catalog matches for explicit Glamour/Glow style filenames
- add positive and negative fixtures for primitive, block, list, task, table, and Chroma token styles

## Validation

- npm run prettier
- npm run typecheck
- npm run eslint
- node ./cli.js check --schema-name=glamour-style.json

## Notes

The schema is based on Glamour's public style guide and the exported `charm.land/glamour/v2/ansi` style structs. The file matches are intentionally narrow to avoid claiming arbitrary JSON files used as custom Glow styles.