### PR TITLE
Use base Dev Container schema in catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2000,7 +2000,7 @@
       "name": "devcontainer.json",
       "description": "dev container configuration files",
       "fileMatch": ["devcontainer.json", ".devcontainer.json"],
-      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
+      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json"
     },
     {
       "name": "Codecov configuration files",


### PR DESCRIPTION
Summary
- Fixes #5310.
- Update the SchemaStore catalog entry for `devcontainer.json` to use the upstream Dev Container base schema.

Reproduction
- The current catalog entry points at `https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json`.
- That wrapper schema also pulls in the Codespaces and VS Code-specific schema layers, which can expose non-Dev-Container refs such as VS Code settings schemas to non-VS Code clients.
- The upstream `devContainer.base.schema.json` contains the base Dev Container schema without those VS Code/Codespaces layers.

Root cause
- SchemaStore was cataloging the upstream aggregate schema instead of the base Dev Container spec schema.
- The aggregate schema is useful for VS Code/Codespaces integrations, but it is too broad for generic JSON Schema consumers.

Changes
- Change the `devcontainer.json` catalog URL from `devContainer.schema.json` to `devContainer.base.schema.json`.

Tests
- `node ./cli.js check`
- `npx prettier --check src/api/json/catalog.json`
- Fetched and parsed the new upstream schema URL with Python, and confirmed the fetched schema does not contain `vscode://` references.

Screenshots/Logs
- N/A; catalog-only schema URL update.
