### PR TITLE
Add DTCG schema catalog entries

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1777,6 +1777,18 @@
       "url": "https://cdnx.deploystack.io/schema/config.yml.json"
     },
     {
+      "name": "Design Tokens Community Group format",
+      "description": "Design token files using the DTCG format",
+      "fileMatch": ["*.tokens", "*.tokens.json"],
+      "url": "https://www.designtokens.org/schemas/2025.10/format.json"
+    },
+    {
+      "name": "Design Tokens Community Group resolver",
+      "description": "DTCG resolver documents",
+      "fileMatch": ["*.resolver.json"],
+      "url": "https://www.designtokens.org/schemas/2025.10/resolver.json"
+    },
+    {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",
       "fileMatch": ["Spacefile"],


### PR DESCRIPTION
Summary
- Add catalog entries for the Design Tokens Community Group 2025.10 format and resolver schemas.
- Closes #5290.

Reproduction
- SchemaStore does not currently include catalog entries for DTCG design token files or resolver documents.
- The DTCG 2025.10 format specification recommends `.tokens` and `.tokens.json` for design token files.
- The DTCG resolver specification recommends `.resolver.json` for resolver documents.

Root cause
- The DTCG schemas are hosted upstream at `designtokens.org`, but SchemaStore did not yet expose them through `catalog.json`.

Changes
- Add a catalog entry for DTCG format files using `*.tokens` and `*.tokens.json`.
- Add a catalog entry for DTCG resolver documents using `*.resolver.json`.
- Point both entries at the official DTCG 2025.10 JSON Schema URLs.

Tests
- `node ./cli.js check --schema-name=schema-catalog.json`
- `node ./cli.js check`
- `npx prettier --check src/api/json/catalog.json`
- Fetched and parsed both upstream schema URLs with Python, confirming they are draft-07 schemas and their `$id` values match the catalog URLs.

Screenshots/Logs
- N/A; catalog-only schema entries.
