### PR TITLE
Add Dev Container Feature schema entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2003,6 +2003,12 @@
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json"
     },
     {
+      "name": "devcontainer-feature.json",
+      "description": "Dev Container Feature metadata files",
+      "fileMatch": ["devcontainer-feature.json"],
+      "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
+    },
+    {
       "name": "Codecov configuration files",
       "description": "codecov.yml files",
       "fileMatch": [


### PR DESCRIPTION
Summary
- Add a SchemaStore catalog entry for Dev Container Feature declaration files.
- Closes #4827.

Reproduction
- `devcontainer-feature.json` files define Dev Container Features.
- SchemaStore currently has an entry for `devcontainer.json`, but not for Feature declaration files.
- The Dev Containers spec provides an upstream JSON Schema for Feature metadata at `devContainerFeature.schema.json`.

Root cause
- The upstream Dev Containers Feature metadata schema exists, but SchemaStore did not expose it through `catalog.json`.

Changes
- Add a `devcontainer-feature.json` catalog entry.
- Match `devcontainer-feature.json` files and point them to the official upstream Dev Containers schema URL.

Tests
- `node ./cli.js check --schema-name=schema-catalog.json`
- `node ./cli.js check`
- `npx prettier --check src/api/json/catalog.json`
- Fetched and parsed the upstream schema URL with Python, confirming it is a draft-07 schema titled `Development Container Feature Metadata`.

Screenshots/Logs
- N/A; catalog-only schema entry.
