### PR TITLE
Add host minMessageBatchSize option

### DIFF
--- a/src/schemas/json/host.json
+++ b/src/schemas/json/host.json
@@ -1387,6 +1387,11 @@
                       "type": "integer",
                       "default": 1000
                     },
+                    "minMessageBatchSize": {
+                      "description": "The minimum number of messages desired in a batch. This setting only applies when the function is receiving multiple messages and must be less than maxMessageBatchSize. Using this setting requires Microsoft.Azure.WebJobs.Extensions.ServiceBus 5.10.0 or later.",
+                      "type": "integer",
+                      "default": 1
+                    },
                     "maxBatchWaitTime": {
                       "description": "The maximum interval that the trigger should wait to fill a batch before invoking the function. The wait time is only considered when minMessageBatchSize is larger than 1 and is ignored otherwise. If less than minMessageBatchSize messages were available before the wait time elapses, the function is invoked with a partial batch. The longest allowed wait time is 50% of the entity message lock duration, meaning the maximum allowed is 2 minutes and 30 seconds. Otherwise, you may get lock exceptions. NOTE: This interval is not a strict guarantee for the exact timing on which the function is invoked. There is a small margin of error due to timer precision.",
                       "type": "string",

--- a/src/test/host/host.v2.servicebus-v5.json
+++ b/src/test/host/host.v2.servicebus-v5.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "serviceBus": {
+      "maxBatchWaitTime": "00:00:30",
+      "maxMessageBatchSize": 100,
+      "minMessageBatchSize": 10
+    }
+  },
+  "version": "2.0"
+}


### PR DESCRIPTION
Fixes #4911

## Summary
- Add `minMessageBatchSize` to the Azure Functions `host.json` Service Bus extension settings.
- Add a positive host.json fixture for the Service Bus extension 5.x batch settings.

## Reproduction
- Create a `host.json` file with `extensions.serviceBus.minMessageBatchSize`.
- The current SchemaStore `host.json` schema reports that field as an unsupported additional property, even though Microsoft documents it for Service Bus extension 5.x.

## Root cause
- The schema already includes the neighboring `maxMessageBatchSize` and `maxBatchWaitTime` settings.
- `maxBatchWaitTime` also references `minMessageBatchSize` in its description, but the `minMessageBatchSize` property itself was missing from the modern Service Bus settings branch.

## Changes
- Added `minMessageBatchSize` as an integer setting with the documented default of `1`.
- Included the documented Service Bus extension 5.10.0+ requirement in the property description.
- Added `src/test/host/host.v2.servicebus-v5.json` to cover the modern batch settings shape.

## Tests
- `npx prettier --check src/schemas/json/host.json src/test/host/host.v2.servicebus-v5.json`
- `node ./cli.js check --schema-name=host.json`
- `git diff --check`

## Screenshots/Logs
- Not applicable; this is a schema-only change validated by the commands above.