### PR TITLE
Add ContractGuard contract schema (self-hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8144,6 +8144,12 @@
       "url": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/clab.schema.json"
     },
     {
+      "name": "ContractGuard",
+      "description": "ContractGuard API contract prescribing the signatures a built .NET assembly must expose",
+      "fileMatch": ["*.contract.json"],
+      "url": "https://raw.githubusercontent.com/lxman/ContractGuard/main/schema/contractguard.schema.json"
+    },
+    {
       "name": "User Journey Map",
       "description": "user journey map definition files",
       "fileMatch": ["*.jm.yaml", "*.jm.yml"],


### PR DESCRIPTION
Adds a self-hosted catalog entry for [ContractGuard](https://github.com/lxman/ContractGuard), a build gate for .NET that verifies a built assembly's API surface against a prescribed contract file.

- **Schema**: draft-07, served from the repository it's developed in; the schema's `$id` matches the catalog URL.
- **fileMatch**: `*.contract.json` — the tool's MSBuild integration looks for `<AssemblyName>.contract.json` next to each project file, so contracts in the wild follow that naming.
- **Sample document**: [samples/MyCompany.Orders.contract.json](https://github.com/lxman/ContractGuard/blob/main/samples/MyCompany.Orders.contract.json)
- The packages consuming this format are published on NuGet (`ContractGuard`, `ContractGuard.MSBuild`).

I checked the existing catalog for `fileMatch` collisions: the nearest is Data Contract Specification, which matches YAML filenames only, so `*.contract.json` doesn't overlap.