### PR TITLE
Add Traefik v3 notAppendXForwardedFor option

### DIFF
--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -1017,6 +1017,9 @@
             "type": "string"
           },
           "type": ["array", "null"]
+        },
+        "notAppendXForwardedFor": {
+          "type": "boolean"
         }
       },
       "type": "object"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
## Summary

Adds the missing `notAppendXForwardedFor` property to the Traefik v3 JSON schema.

This option is [documented by Traefik](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/) as a boolean setting for forwarded headers. It disables appending `RemoteAddr` to the `X-Forwarded-For` header. This feature was only recently introduced to Traefik.

## Changes

* Updated `src/schemas/json/traefik-v3.json`
* Added `notAppendXForwardedFor` as a boolean property for Traefik v3 forwarded headers

## Validation

* [ ] Ran `node ./cli.js check --schema-name=traefik-v3.json`
