### PR TITLE
Update claude-code-settings.json to match Claude Code extension v2.1.177 (84 -> 134 properties)

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -1,7 +1,11 @@
 {
   "autoUpdatesChannel": "beta",
+  "daemonColdStart": "always",
   "defaultShell": "zsh",
+  "defaultView": "split",
+  "disableAutoMode": "enabled",
   "disableDeepLinkRegistration": "enabled",
+  "editorMode": "emacs",
   "effortLevel": "extreme",
   "env": {
     "ANTHROPIC_BEDROCK_SERVICE_TIER": "turbo",
@@ -94,6 +98,7 @@
     "disableAutoMode": "enabled",
     "disableBypassPermissionsMode": "enabled"
   },
+  "preferredNotifChannel": "sms",
   "skillOverrides": {
     "test-skill": "invalid-mode"
   },
@@ -104,6 +109,9 @@
   "teammateMode": "split",
   "tui": "mini",
   "viewMode": "list",
+  "voice": {
+    "mode": "shout"
+  },
   "worktree": {
     "baseRef": "invalid-ref",
     "bgIsolation": "isolated"

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -34,10 +34,7 @@
           "type": "object",
           "description": "Bash command hook",
           "additionalProperties": false,
-          "required": [
-            "type",
-            "command"
-          ],
+          "required": ["type", "command"],
           "properties": {
             "type": {
               "type": "string",
@@ -64,10 +61,7 @@
             },
             "shell": {
               "type": "string",
-              "enum": [
-                "bash",
-                "powershell"
-              ],
+              "enum": ["bash", "powershell"],
               "description": "Shell interpreter for the command. \"bash\" uses the login shell (bash/zsh/sh); \"powershell\" uses pwsh. Defaults to bash."
             },
             "if": {
@@ -91,10 +85,7 @@
           "type": "object",
           "description": "LLM prompt hook. See https://code.claude.com/docs/en/hooks#prompt-based-hooks",
           "additionalProperties": false,
-          "required": [
-            "type",
-            "prompt"
-          ],
+          "required": ["type", "prompt"],
           "properties": {
             "type": {
               "type": "string",
@@ -134,10 +125,7 @@
           "type": "object",
           "description": "Agent hook with multi-turn tool access for verification. See https://code.claude.com/docs/en/hooks#agent-based-hooks",
           "additionalProperties": false,
-          "required": [
-            "type",
-            "prompt"
-          ],
+          "required": ["type", "prompt"],
           "properties": {
             "type": {
               "type": "string",
@@ -172,10 +160,7 @@
           "type": "object",
           "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hook-fields",
           "additionalProperties": false,
-          "required": [
-            "type",
-            "url"
-          ],
+          "required": ["type", "url"],
           "properties": {
             "type": {
               "type": "string",
@@ -221,11 +206,7 @@
           "type": "object",
           "description": "MCP tool hook. Call a tool on an already-connected MCP server. See https://code.claude.com/docs/en/hooks#mcp-tool-hook-fields",
           "additionalProperties": false,
-          "required": [
-            "type",
-            "server",
-            "tool"
-          ],
+          "required": ["type", "server", "tool"],
           "properties": {
             "type": {
               "type": "string",
@@ -268,9 +249,7 @@
       "type": "object",
       "description": "Hook matcher configuration with multiple hooks",
       "additionalProperties": false,
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "matcher": {
           "type": "string",
@@ -298,9 +277,7 @@
     "apiKeyHelper": {
       "type": "string",
       "description": "Path to a script that outputs authentication values. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "/bin/generate_temp_api_key.sh"
-      ],
+      "examples": ["/bin/generate_temp_api_key.sh"],
       "minLength": 1
     },
     "autoMemoryEnabled": {
@@ -310,27 +287,20 @@
     },
     "autoUpdatesChannel": {
       "type": "string",
-      "enum": [
-        "stable",
-        "latest"
-      ],
+      "enum": ["stable", "latest"],
       "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release. Set DISABLE_AUTOUPDATER=1 to disable background auto-updates, or DISABLE_UPDATES=1 (added in v2.1.118) to block all update paths including manual `claude update`.",
       "default": "latest"
     },
     "awsCredentialExport": {
       "type": "string",
       "description": "Path to a script that exports AWS credentials. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "/bin/generate_aws_grant.sh"
-      ],
+      "examples": ["/bin/generate_aws_grant.sh"],
       "minLength": 1
     },
     "awsAuthRefresh": {
       "type": "string",
       "description": "Path to a script that refreshes AWS authentication. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "aws sso login --profile myprofile"
-      ],
+      "examples": ["aws sso login --profile myprofile"],
       "minLength": 1
     },
     "claudeMdExcludes": {
@@ -351,11 +321,7 @@
       "type": "integer",
       "minimum": 1,
       "description": "Number of days to retain sessions, orphaned subagent worktrees, tasks, shell snapshots, and backups. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        20,
-        30,
-        60
-      ],
+      "examples": [20, 30, 60],
       "default": 30
     },
     "env": {
@@ -392,11 +358,7 @@
         "ANTHROPIC_BEDROCK_SERVICE_TIER": {
           "type": "string",
           "description": "Select Bedrock service tier; sent as X-Amzn-Bedrock-Service-Tier header. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21122",
-          "enum": [
-            "default",
-            "flex",
-            "priority"
-          ]
+          "enum": ["default", "flex", "priority"]
         },
         "ANTHROPIC_BETAS": {
           "type": "string",
@@ -489,26 +451,17 @@
         "CCR_FORCE_BUNDLE": {
           "type": "string",
           "description": "Force local repo bundling for --remote invocations",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS": {
           "type": "string",
           "description": "Disable built-in subagent types in Agent SDK",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_AGENT_SDK_MCP_NO_PREFIX": {
           "type": "string",
           "description": "Skip 'mcp__<server>__' prefix on MCP tool names in Agent SDK",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": {
           "type": "string",
@@ -517,34 +470,22 @@
         "CLAUDE_AUTO_BACKGROUND_TASKS": {
           "type": "string",
           "description": "Force-enable automatic backgrounding of tasks",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": {
           "type": "string",
           "description": "Return to original project directory after each bash command",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ACCESSIBILITY": {
           "type": "string",
           "description": "Keep native cursor visible for screen magnifiers and assistive tools",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": {
           "type": "string",
           "description": "Load CLAUDE.md memory files from additional directories",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": {
           "type": "string",
@@ -553,10 +494,7 @@
         "CLAUDE_CODE_ATTRIBUTION_HEADER": {
           "type": "string",
           "description": "Include attribution block in the system prompt",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_AUTO_COMPACT_WINDOW": {
           "type": "string",
@@ -565,10 +503,7 @@
         "CLAUDE_CODE_AUTO_CONNECT_IDE": {
           "type": "string",
           "description": "Override automatic IDE connection behavior",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_CERT_STORE": {
           "type": "string",
@@ -593,265 +528,162 @@
         "CLAUDE_CODE_DEBUG_LOG_LEVEL": {
           "type": "string",
           "description": "Debug log verbosity level",
-          "enum": [
-            "verbose",
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["verbose", "debug", "info", "warn", "error"]
         },
         "CLAUDE_CODE_DISABLE_1M_CONTEXT": {
           "type": "string",
           "description": "Disable 1M context window models",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": {
           "type": "string",
           "description": "Disable adaptive reasoning",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": {
           "type": "string",
           "description": "Disable alternate screen buffer rendering. When set to 1, keeps conversation in native scrollback instead of fullscreen renderer",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_ATTACHMENTS": {
           "type": "string",
           "description": "Disable attachment processing",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_AUTO_MEMORY": {
           "type": "string",
           "description": "Disable automatic memory feature",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": {
           "type": "string",
           "description": "Disable all background task functionality",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_CLAUDE_MDS": {
           "type": "string",
           "description": "Prevent loading CLAUDE.md memory files",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_CRON": {
           "type": "string",
           "description": "Disable scheduled/cron tasks",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": {
           "type": "string",
           "description": "Strip anthropic-beta headers from API requests. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21123",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_FAST_MODE": {
           "type": "string",
           "description": "Disable fast mode toggle",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": {
           "type": "string",
           "description": "Disable session quality feedback surveys",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING": {
           "type": "string",
           "description": "Disable file checkpointing for undo/restore",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": {
           "type": "string",
           "description": "Remove git commit and PR workflow instructions from the system prompt",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_LEGACY_MODEL_REMAP": {
           "type": "string",
           "description": "Prevent automatic remapping of legacy model names",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_MOUSE": {
           "type": "string",
           "description": "Disable mouse tracking in fullscreen mode",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": {
           "type": "string",
           "description": "Disable auto-update checks, telemetry, and feedback in one setting",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK": {
           "type": "string",
           "description": "Disable fallback to non-streaming API mode",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": {
           "type": "string",
           "description": "Skip automatic installation of official marketplace plugins",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_POLICY_SKILLS": {
           "type": "string",
           "description": "Skip loading system-wide policy skills",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": {
           "type": "string",
           "description": "Disable terminal title updates",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_THINKING": {
           "type": "string",
           "description": "Force-disable extended thinking",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL": {
           "type": "string",
           "description": "Disable virtual scrolling in fullscreen mode",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_EFFORT_LEVEL": {
           "type": "string",
           "description": "Reasoning effort level",
-          "enum": [
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-            "max",
-            "auto"
-          ]
+          "enum": ["low", "medium", "high", "xhigh", "max", "auto"]
         },
         "CLAUDE_CODE_ENABLE_AWAY_SUMMARY": {
           "type": "string",
           "description": "Override session recap/away summary availability",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH": {
           "type": "string",
           "description": "Refresh plugins at turn boundaries",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": {
           "type": "string",
           "description": "Enable feedback survey collection via OpenTelemetry for enterprises",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": {
           "type": "string",
           "description": "Force fine-grained tool output streaming",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": {
           "type": "string",
           "description": "Enable model discovery from LLM gateway /v1/models endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": {
           "type": "string",
           "description": "Enable prompt suggestions",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_ENABLE_TASKS": {
           "type": "string",
           "description": "Enable task tracking in non-interactive mode",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_ENABLE_TELEMETRY": {
           "type": "string",
           "description": "Enable OpenTelemetry collection",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY": {
           "type": "string",
@@ -860,10 +692,7 @@
         "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": {
           "type": "string",
           "description": "Enable experimental agent teams feature",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_EXTRA_BODY": {
           "type": "string",
@@ -876,18 +705,12 @@
         "CLAUDE_CODE_FORCE_SYNC_OUTPUT": {
           "type": "string",
           "description": "Force synchronous output flushing. When set to 1, forces synchronized output on terminals that auto-detection misses (e.g., Emacs eat)",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_FORK_SUBAGENT": {
           "type": "string",
           "description": "Fork subagent processes in non-interactive sessions. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21120",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_GIT_BASH_PATH": {
           "type": "string",
@@ -896,18 +719,12 @@
         "CLAUDE_CODE_GLOB_HIDDEN": {
           "type": "string",
           "description": "Include dotfiles/hidden files in Glob results",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_GLOB_NO_IGNORE": {
           "type": "string",
           "description": "Don't respect .gitignore rules in Glob results",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_GLOB_TIMEOUT_SECONDS": {
           "type": "string",
@@ -916,10 +733,7 @@
         "CLAUDE_CODE_HIDE_CWD": {
           "type": "string",
           "description": "Hide the working directory in the startup logo. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21126",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_IDE_HOST_OVERRIDE": {
           "type": "string",
@@ -928,18 +742,12 @@
         "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": {
           "type": "string",
           "description": "Skip automatic IDE extension installation",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_IDE_SKIP_VALID_CHECK": {
           "type": "string",
           "description": "Skip IDE lockfile validation",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_MAX_CONTEXT_TOKENS": {
           "type": "string",
@@ -960,26 +768,17 @@
         "CLAUDE_CODE_MCP_ALLOWLIST_ENV": {
           "type": "string",
           "description": "Isolate MCP server environments to allowlisted variables",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_NEW_INIT": {
           "type": "string",
           "description": "Use the interactive /init setup flow",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_NO_FLICKER": {
           "type": "string",
           "description": "Enable fullscreen rendering mode to reduce flicker",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_OAUTH_REFRESH_TOKEN": {
           "type": "string",
@@ -995,10 +794,7 @@
         },
         "CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE": {
           "type": "string",
-          "enum": [
-            "0",
-            "1"
-          ],
+          "enum": ["0", "1"],
           "description": "Set to 1 to pin fast mode to Claude Opus 4.6 instead of the default Opus 4.7. With this set, /fast runs on Opus 4.6. Without it, /fast runs on Opus 4.7. See https://code.claude.com/docs/en/fast-mode and https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_OTEL_FLUSH_TIMEOUT_MS": {
@@ -1016,18 +812,12 @@
         "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": {
           "type": "string",
           "description": "Enable automatic package manager updates. When set, Claude Code runs the upgrade command in background on Homebrew/WinGet and prompts to restart",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_PERFORCE_MODE": {
           "type": "string",
           "description": "Enable Perforce write protection mode",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_PLUGIN_CACHE_DIR": {
           "type": "string",
@@ -1040,17 +830,11 @@
         "CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE": {
           "type": "string",
           "description": "Keep plugin cache on update failure",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_PLUGIN_PREFER_HTTPS": {
           "type": "string",
-          "enum": [
-            "0",
-            "1"
-          ],
+          "enum": ["0", "1"],
           "description": "Set to 1 to clone GitHub owner/repo plugin sources over HTTPS instead of SSH. Useful in CI runners, containers, or environments without a configured SSH key for github.com. See https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_PLUGIN_SEED_DIR": {
@@ -1059,35 +843,23 @@
         },
         "CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY": {
           "type": "string",
-          "enum": [
-            "0",
-            "1"
-          ],
+          "enum": ["0", "1"],
           "description": "Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when spawning PowerShell for tool calls, hooks, and status line commands. By default Claude Code bypasses execution policy so .ps1 scripts work on default-Restricted Windows installs. See https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": {
           "type": "string",
           "description": "Indicate that the host application manages provider routing",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_PROXY_RESOLVES_HOSTS": {
           "type": "string",
           "description": "Allow proxy to handle DNS resolution",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_REMOTE": {
           "type": "string",
           "description": "Indicates a remote web environment session",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_REMOTE_SESSION_ID": {
           "type": "string",
@@ -1096,10 +868,7 @@
         "CLAUDE_CODE_RESUME_INTERRUPTED_TURN": {
           "type": "string",
           "description": "Automatically resume from a mid-turn interruption",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SCRIPT_CAPS": {
           "type": "string",
@@ -1124,58 +893,37 @@
         "CLAUDE_CODE_SIMPLE": {
           "type": "string",
           "description": "Minimal mode with core tools only",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT": {
           "type": "string",
           "description": "Use a shortened system prompt",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": {
           "type": "string",
           "description": "Skip AWS authentication for Bedrock",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SKIP_FOUNDRY_AUTH": {
           "type": "string",
           "description": "Skip Azure authentication for Foundry",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SKIP_MANTLE_AUTH": {
           "type": "string",
           "description": "Skip AWS authentication for Mantle",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SKIP_PROMPT_HISTORY": {
           "type": "string",
           "description": "Disable transcript writes entirely. See https://code.claude.com/docs/en/settings#environment-variables",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SKIP_VERTEX_AUTH": {
           "type": "string",
           "description": "Skip Google authentication for Vertex AI",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_STOP_HOOK_BLOCK_CAP": {
           "type": "string",
@@ -1188,18 +936,12 @@
         "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": {
           "type": "string",
           "description": "Strip credentials from subprocess environments",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SYNC_PLUGIN_INSTALL": {
           "type": "string",
           "description": "Wait synchronously for plugin installation",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_SYNC_PLUGIN_INSTALL_TIMEOUT_MS": {
           "type": "string",
@@ -1208,10 +950,7 @@
         "CLAUDE_CODE_SYNTAX_HIGHLIGHT": {
           "type": "string",
           "description": "Enable syntax highlighting in diffs",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "CLAUDE_CODE_TASK_LIST_ID": {
           "type": "string",
@@ -1228,18 +967,12 @@
         "CLAUDE_CODE_TMUX_TRUECOLOR": {
           "type": "string",
           "description": "Allow 24-bit truecolor rendering in tmux",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_CODE_USE_POWERSHELL_TOOL": {
           "type": "string",
           "description": "Enable PowerShell as default shell for interactive commands (Windows)",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "CLAUDE_ENV_FILE": {
           "type": "string",
@@ -1252,50 +985,32 @@
         "DISABLE_AUTOUPDATER": {
           "type": "string",
           "description": "Stop background auto-update checks",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "DISABLE_ERROR_REPORTING": {
           "type": "string",
           "description": "Disable Sentry error reporting",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "DISABLE_FEEDBACK_COMMAND": {
           "type": "string",
           "description": "Disable the /feedback command",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "DISABLE_TELEMETRY": {
           "type": "string",
           "description": "Disable Statsig telemetry collection",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "DISABLE_UPDATES": {
           "type": "string",
           "description": "Block all update paths including manual updates",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         },
         "ENABLE_CLAUDEAI_MCP_SERVERS": {
           "type": "string",
           "description": "Opt in/out of claude.ai MCP servers. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163",
-          "enum": [
-            "true",
-            "false"
-          ]
+          "enum": ["true", "false"]
         },
         "HTTPS_PROXY": {
           "type": "string",
@@ -1320,10 +1035,7 @@
         "USE_BUILTIN_RIPGREP": {
           "type": "string",
           "description": "Use the bundled ripgrep binary instead of system ripgrep",
-          "enum": [
-            "0",
-            "1"
-          ]
+          "enum": ["0", "1"]
         }
       },
       "propertyNames": {
@@ -1363,9 +1075,7 @@
       "type": "string",
       "description": "Customize where plan files are stored. Path is relative to project root (default: ~/.claude/plans)",
       "default": "~/.claude/plans",
-      "examples": [
-        "./plans"
-      ]
+      "examples": ["./plans"]
     },
     "respectGitignore": {
       "type": "boolean",
@@ -1414,16 +1124,12 @@
         },
         "disableBypassPermissionsMode": {
           "type": "string",
-          "enum": [
-            "disable"
-          ],
+          "enum": ["disable"],
           "description": "Disable the ability to bypass permission prompts"
         },
         "disableAutoMode": {
           "type": "string",
-          "enum": [
-            "disable"
-          ],
+          "enum": ["disable"],
           "description": "Set to \"disable\" to prevent auto mode from being activated. Removes `auto` from the Shift+Tab cycle and rejects `--permission-mode auto` at startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/permissions"
         },
         "additionalDirectories": {
@@ -1433,12 +1139,7 @@
             "minLength": 1
           },
           "description": "Additional directories to include in the permission scope",
-          "examples": [
-            [
-              "//Users/alice/Documents",
-              "~/projects"
-            ]
-          ],
+          "examples": [["//Users/alice/Documents", "~/projects"]],
           "uniqueItems": true
         }
       },
@@ -1446,18 +1147,9 @@
       "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
       "examples": [
         {
-          "allow": [
-            "Bash(git add:*)"
-          ],
-          "ask": [
-            "Bash(gh pr create:*)",
-            "Bash(git commit:*)"
-          ],
-          "deny": [
-            "Read(*.env)",
-            "Bash(rm:*)",
-            "Bash(curl:*)"
-          ],
+          "allow": ["Bash(git add:*)"],
+          "ask": ["Bash(gh pr create:*)", "Bash(git commit:*)"],
+          "deny": ["Read(*.env)", "Bash(rm:*)", "Bash(curl:*)"],
           "defaultMode": "default"
         }
       ]
@@ -1465,11 +1157,7 @@
     "language": {
       "type": "string",
       "description": "Configure Claude's preferred response language (e.g., \"japanese\", \"spanish\", \"french\"). Claude will respond in this language by default. Also sets the voice dictation language and terminal tab session title generation. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "japanese",
-        "spanish",
-        "french"
-      ]
+      "examples": ["japanese", "spanish", "french"]
     },
     "model": {
       "type": "string",
@@ -1481,12 +1169,7 @@
         "type": "string"
       },
       "description": "Restrict which models users can select. When defined at multiple settings levels (user, project, etc.), arrays are merged and deduplicated. See https://code.claude.com/docs/en/model-config#restrict-model-selection",
-      "examples": [
-        [
-          "sonnet",
-          "haiku"
-        ]
-      ]
+      "examples": [["sonnet", "haiku"]]
     },
     "modelOverrides": {
       "type": "object",
@@ -1502,13 +1185,7 @@
     },
     "effortLevel": {
       "type": "string",
-      "enum": [
-        "low",
-        "medium",
-        "high",
-        "xhigh",
-        "max"
-      ],
+      "enum": ["low", "medium", "high", "xhigh", "max"],
       "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high on all plans (Pro/Max raised from medium to high in v2.1.117); Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
@@ -1526,16 +1203,12 @@
       "minimum": 0,
       "maximum": 1,
       "description": "Probability (0–1) that the session quality survey appears when eligible. A value of 0.05 means 5% of eligible sessions. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        0.05
-      ]
+      "examples": [0.05]
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
       "description": "Whether to automatically approve all MCP servers in the project. See https://code.claude.com/docs/en/mcp",
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "enabledMcpjsonServers": {
       "type": "array",
@@ -1544,12 +1217,7 @@
         "minLength": 1
       },
       "description": "List of approved MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
-      "examples": [
-        [
-          "memory",
-          "github"
-        ]
-      ]
+      "examples": [["memory", "github"]]
     },
     "disabledMcpjsonServers": {
       "type": "array",
@@ -1558,11 +1226,7 @@
         "minLength": 1
       },
       "description": "List of rejected MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
-      "examples": [
-        [
-          "filesystem"
-        ]
-      ]
+      "examples": [["filesystem"]]
     },
     "allowedMcpServers": {
       "type": "array",
@@ -1577,9 +1241,7 @@
                 "description": "Name of the MCP server that users are allowed to configure"
               }
             },
-            "required": [
-              "serverName"
-            ],
+            "required": ["serverName"],
             "additionalProperties": false
           },
           {
@@ -1593,9 +1255,7 @@
                 "description": "Exact command and arguments used to start stdio servers"
               }
             },
-            "required": [
-              "serverCommand"
-            ],
+            "required": ["serverCommand"],
             "additionalProperties": false
           },
           {
@@ -1606,9 +1266,7 @@
                 "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
               }
             },
-            "required": [
-              "serverUrl"
-            ],
+            "required": ["serverUrl"],
             "additionalProperties": false
           }
         ]
@@ -1628,9 +1286,7 @@
                 "description": "Name of the MCP server that is explicitly blocked"
               }
             },
-            "required": [
-              "serverName"
-            ],
+            "required": ["serverName"],
             "additionalProperties": false
           },
           {
@@ -1644,9 +1300,7 @@
                 "description": "Exact command and arguments used to start stdio servers"
               }
             },
-            "required": [
-              "serverCommand"
-            ],
+            "required": ["serverCommand"],
             "additionalProperties": false
           },
           {
@@ -1657,9 +1311,7 @@
                 "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
               }
             },
-            "required": [
-              "serverUrl"
-            ],
+            "required": ["serverUrl"],
             "additionalProperties": false
           }
         ]
@@ -1673,12 +1325,7 @@
         "minLength": 1
       },
       "description": "Allowlist of environment variable names HTTP hooks may interpolate into headers. When set, each hook's effective allowedEnvVars is the intersection with this list. Undefined = no restriction. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
-      "examples": [
-        [
-          "MY_TOKEN",
-          "HOOK_SECRET"
-        ]
-      ]
+      "examples": [["MY_TOKEN", "HOOK_SECRET"]]
     },
     "hooks": {
       "type": "object",
@@ -1925,12 +1572,7 @@
         "minLength": 1
       },
       "description": "Allowlist of URL patterns that HTTP hooks may target. Supports * as a wildcard. When set, hooks with non-matching URLs are blocked. Undefined = no restriction, empty array = block all HTTP hooks. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
-      "examples": [
-        [
-          "https://hooks.example.com/*",
-          "http://localhost:*"
-        ]
-      ]
+      "examples": [["https://hooks.example.com/*", "http://localhost:*"]]
     },
     "allowManagedHooksOnly": {
       "type": "boolean",
@@ -1966,10 +1608,7 @@
           "description": "Set to true when your status line script renders the vim mode indicator itself, to suppress the built-in vim mode display. See https://code.claude.com/docs/en/statusline#manually-configure-a-status-line"
         }
       },
-      "required": [
-        "type",
-        "command"
-      ],
+      "required": ["type", "command"],
       "additionalProperties": false,
       "description": "Custom status line display configuration. See https://code.claude.com/docs/en/statusline",
       "examples": [
@@ -1992,10 +1631,7 @@
           "description": "Shell command to execute for file suggestions"
         }
       },
-      "required": [
-        "type",
-        "command"
-      ],
+      "required": ["type", "command"],
       "additionalProperties": false,
       "description": "Configure a custom script for @ file autocomplete. See https://code.claude.com/docs/en/settings#file-suggestion-settings",
       "examples": [
@@ -2046,10 +1682,7 @@
                     "description": "Direct URL to marketplace.json file"
                   }
                 },
-                "required": [
-                  "source",
-                  "url"
-                ],
+                "required": ["source", "url"],
                 "additionalProperties": false
               },
               {
@@ -2065,10 +1698,7 @@
                     "description": "Git host pattern to trust for repositories in source specifications"
                   }
                 },
-                "required": [
-                  "source",
-                  "hostPattern"
-                ],
+                "required": ["source", "hostPattern"],
                 "additionalProperties": false
               },
               {
@@ -2092,10 +1722,7 @@
                     "description": "Path to marketplace.json within repo (defaults to .claude-plugin/marketplace.json)"
                   }
                 },
-                "required": [
-                  "source",
-                  "repo"
-                ],
+                "required": ["source", "repo"],
                 "additionalProperties": false
               },
               {
@@ -2120,10 +1747,7 @@
                     "description": "Path to marketplace.json within repo (defaults to .claude-plugin/marketplace.json)"
                   }
                 },
-                "required": [
-                  "source",
-                  "url"
-                ],
+                "required": ["source", "url"],
                 "additionalProperties": false
               },
               {
@@ -2139,10 +1763,7 @@
                     "description": "NPM package containing marketplace.json"
                   }
                 },
-                "required": [
-                  "source",
-                  "package"
-                ],
+                "required": ["source", "package"],
                 "additionalProperties": false
               },
               {
@@ -2158,10 +1779,7 @@
                     "description": "Local file path to marketplace.json"
                   }
                 },
-                "required": [
-                  "source",
-                  "path"
-                ],
+                "required": ["source", "path"],
                 "additionalProperties": false
               },
               {
@@ -2177,10 +1795,7 @@
                     "description": "Local directory containing .claude-plugin/marketplace.json"
                   }
                 },
-                "required": [
-                  "source",
-                  "path"
-                ],
+                "required": ["source", "path"],
                 "additionalProperties": false
               }
             ],
@@ -2199,9 +1814,7 @@
             "description": "ISO 8601 timestamp of the last marketplace refresh. Written automatically by Claude Code"
           }
         },
-        "required": [
-          "source"
-        ],
+        "required": ["source"],
         "additionalProperties": false
       },
       "description": "Additional marketplaces to make available for this repository. Typically used in repository .claude/settings.json to ensure team members have required plugin sources. See https://code.claude.com/docs/en/plugin-marketplaces"
@@ -2224,10 +1837,7 @@
                 "description": "Git host pattern to trust for repositories in source specifications"
               }
             },
-            "required": [
-              "source",
-              "hostPattern"
-            ],
+            "required": ["source", "hostPattern"],
             "additionalProperties": false
           },
           {
@@ -2251,10 +1861,7 @@
                 "description": "Subdirectory path"
               }
             },
-            "required": [
-              "source",
-              "repo"
-            ],
+            "required": ["source", "repo"],
             "additionalProperties": false
           },
           {
@@ -2278,10 +1885,7 @@
                 "description": "Subdirectory path"
               }
             },
-            "required": [
-              "source",
-              "url"
-            ],
+            "required": ["source", "url"],
             "additionalProperties": false
           },
           {
@@ -2305,10 +1909,7 @@
                 "description": "HTTP headers for authenticated access"
               }
             },
-            "required": [
-              "source",
-              "url"
-            ],
+            "required": ["source", "url"],
             "additionalProperties": false
           },
           {
@@ -2324,10 +1925,7 @@
                 "description": "NPM package name (supports scoped packages)"
               }
             },
-            "required": [
-              "source",
-              "package"
-            ],
+            "required": ["source", "package"],
             "additionalProperties": false
           },
           {
@@ -2343,10 +1941,7 @@
                 "description": "Absolute path to marketplace.json file"
               }
             },
-            "required": [
-              "source",
-              "path"
-            ],
+            "required": ["source", "path"],
             "additionalProperties": false
           },
           {
@@ -2362,10 +1957,7 @@
                 "description": "Absolute path to directory containing .claude-plugin/marketplace.json"
               }
             },
-            "required": [
-              "source",
-              "path"
-            ],
+            "required": ["source", "path"],
             "additionalProperties": false
           },
           {
@@ -2381,10 +1973,7 @@
                 "description": "Regex pattern to match file or directory paths for marketplace sources"
               }
             },
-            "required": [
-              "source",
-              "pathPattern"
-            ],
+            "required": ["source", "pathPattern"],
             "additionalProperties": false
           }
         ]
@@ -2420,21 +2009,14 @@
     },
     "forceLoginMethod": {
       "type": "string",
-      "enum": [
-        "claudeai",
-        "console"
-      ],
+      "enum": ["claudeai", "console"],
       "description": "Force a specific login method: \"claudeai\" for Claude Pro/Max, \"console\" for Console billing",
-      "examples": [
-        "claudeai"
-      ]
+      "examples": ["claudeai"]
     },
     "forceLoginOrgUUID": {
       "type": "string",
       "description": "Organization UUID to use for OAuth login",
-      "examples": [
-        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-      ],
+      "examples": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"],
       "minLength": 1
     },
     "otelHeadersHelper": {
@@ -2445,11 +2027,7 @@
     "outputStyle": {
       "type": "string",
       "description": "Controls the output style for assistant responses. Built-in styles: default, Explanatory, Learning. Custom styles can be added in ~/.claude/output-styles/ or .claude/output-styles/. See https://code.claude.com/docs/en/output-styles",
-      "examples": [
-        "default",
-        "Explanatory",
-        "Learning"
-      ],
+      "examples": ["default", "Explanatory", "Learning"],
       "minLength": 1
     },
     "skipWebFetchPreflight": {
@@ -2518,11 +2096,7 @@
                 "minLength": 1
               },
               "description": "macOS only. Additional XPC/Mach service names the sandbox may look up. Supports a single trailing * for prefix matching. Needed for tools that communicate via XPC such as the iOS Simulator or Playwright. See https://code.claude.com/docs/en/sandboxing#network-isolation",
-              "examples": [
-                [
-                  "com.apple.coresimulator.*"
-                ]
-              ]
+              "examples": [["com.apple.coresimulator.*"]]
             }
           },
           "additionalProperties": false
@@ -2614,9 +2188,7 @@
           "type": "object",
           "description": "Custom ripgrep configuration for Claude Code's bundled ripgrep support. Overrides the bundled binary and arguments.",
           "additionalProperties": false,
-          "required": [
-            "command"
-          ],
+          "required": ["command"],
           "properties": {
             "command": {
               "type": "string",
@@ -2650,12 +2222,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": [
-              "macos",
-              "linux",
-              "wsl",
-              "windows"
-            ]
+            "enum": ["macos", "linux", "wsl", "windows"]
           },
           "description": "Limit the entire sandbox configuration to the listed platforms. On platforms not in the list the sandbox config is inert: no sandbox, no auto-allow, no startup warning, and no failIfUnavailable exit. When omitted, all supported platforms are included. Only honored from managed (policy) settings."
         }
@@ -2668,10 +2235,7 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": [
-            "append",
-            "replace"
-          ],
+          "enum": ["append", "replace"],
           "description": "How to combine custom verbs with default spinner verbs: 'append' adds custom verbs to the default list, 'replace' uses only custom verbs"
         },
         "verbs": {
@@ -2684,9 +2248,7 @@
           "description": "Custom verbs used in spinner progress text"
         }
       },
-      "required": [
-        "verbs"
-      ],
+      "required": ["verbs"],
       "additionalProperties": false
     },
     "spinnerTipsEnabled": {
@@ -2713,9 +2275,7 @@
           "minItems": 1
         }
       },
-      "required": [
-        "tips"
-      ],
+      "required": ["tips"],
       "additionalProperties": false
     },
     "terminalProgressBarEnabled": {
@@ -2732,12 +2292,7 @@
       "type": "object",
       "additionalProperties": {
         "type": "string",
-        "enum": [
-          "on",
-          "name-only",
-          "user-invocable-only",
-          "off"
-        ]
+        "enum": ["on", "name-only", "user-invocable-only", "off"]
       },
       "description": "Per-skill visibility overrides. Controls whether skills appear to Claude and in the / picker. Values: 'on' (name and description shown, default), 'name-only' (name only), 'user-invocable-only' (hidden from Claude, visible in /), 'off' (hidden everywhere). Plugin skills are not affected by this setting. See https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings",
       "examples": [
@@ -2755,9 +2310,7 @@
     "prUrlTemplate": {
       "type": "string",
       "description": "URL template for the PR badge shown in the footer and in tool-result summaries. Substitutes placeholders {host}, {owner}, {repo}, {number}, {url} from the gh-reported PR URL. Use this to point PR links at an internal code-review tool instead of github.com. Does not affect #123 autolinks in Claude's prose. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "https://reviews.example.com/{owner}/{repo}/pull/{number}"
-      ]
+      "examples": ["https://reviews.example.com/{owner}/{repo}/pull/{number}"]
     },
     "alwaysThinkingEnabled": {
       "type": "boolean",
@@ -2773,11 +2326,7 @@
     },
     "teammateMode": {
       "type": "string",
-      "enum": [
-        "auto",
-        "in-process",
-        "tmux"
-      ],
+      "enum": ["auto", "in-process", "tmux"],
       "description": "How agent team teammates display: \"auto\" picks split panes in tmux or iTerm2, in-process otherwise. Agent teams are experimental and disabled by default. Enable them by adding CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to your settings.json or environment. See https://code.claude.com/docs/en/agent-teams",
       "default": "auto"
     },
@@ -2793,28 +2342,17 @@
             "minLength": 1
           },
           "description": "Directories to check out in each worktree via git sparse-checkout (cone mode). Only the listed paths are written to disk, which is faster in large monorepos. See https://code.claude.com/docs/en/settings#worktree-settings",
-          "examples": [
-            [
-              "packages/my-app",
-              "shared/utils"
-            ]
-          ]
+          "examples": [["packages/my-app", "shared/utils"]]
         },
         "baseRef": {
           "type": "string",
-          "enum": [
-            "fresh",
-            "head"
-          ],
+          "enum": ["fresh", "head"],
           "default": "fresh",
           "description": "Whether to branch worktrees from origin/<default> (fresh) or local HEAD (head). Default: fresh. Set to 'head' to preserve unpushed commits in new worktrees. See https://code.claude.com/docs/en/settings#worktree-settings"
         },
         "bgIsolation": {
           "type": "string",
-          "enum": [
-            "worktree",
-            "none"
-          ],
+          "enum": ["worktree", "none"],
           "default": "worktree",
           "description": "Isolation mode for background sessions. \"worktree\" blocks Edit/Write in main checkout until EnterWorktree is called; \"none\" lets background jobs edit the working copy directly without EnterWorktree, for repos where worktrees are impractical. See https://code.claude.com/docs/en/settings#worktree-settings"
         }
@@ -2822,10 +2360,7 @@
     },
     "parentSettingsBehavior": {
       "type": "string",
-      "enum": [
-        "first-wins",
-        "merge"
-      ],
+      "enum": ["first-wins", "merge"],
       "default": "first-wins",
       "description": "(Admin/managed settings only) Controls how SDK managedSettings (parent tier) merge with inherited settings. 'first-wins': first non-empty value applies (default). 'merge': merge arrays and objects. See https://code.claude.com/docs/en/server-managed-settings"
     },
@@ -2924,10 +2459,7 @@
                 "description": "Custom HTTP headers (e.g., for authentication)"
               }
             },
-            "required": [
-              "source",
-              "url"
-            ]
+            "required": ["source", "url"]
           },
           {
             "type": "object",
@@ -2951,10 +2483,7 @@
                 "description": "Path to marketplace.json within repo"
               }
             },
-            "required": [
-              "source",
-              "repo"
-            ]
+            "required": ["source", "repo"]
           },
           {
             "type": "object",
@@ -2979,10 +2508,7 @@
                 "description": "Path to marketplace.json within repo"
               }
             },
-            "required": [
-              "source",
-              "url"
-            ]
+            "required": ["source", "url"]
           },
           {
             "type": "object",
@@ -2998,10 +2524,7 @@
                 "description": "NPM package containing marketplace.json"
               }
             },
-            "required": [
-              "source",
-              "package"
-            ]
+            "required": ["source", "package"]
           },
           {
             "type": "object",
@@ -3017,10 +2540,7 @@
                 "description": "Local file path to marketplace.json"
               }
             },
-            "required": [
-              "source",
-              "path"
-            ]
+            "required": ["source", "path"]
           },
           {
             "type": "object",
@@ -3036,10 +2556,7 @@
                 "description": "Local directory containing .claude-plugin/marketplace.json"
               }
             },
-            "required": [
-              "source",
-              "path"
-            ]
+            "required": ["source", "path"]
           },
           {
             "type": "object",
@@ -3055,10 +2572,7 @@
                 "description": "Regex pattern to match the host/domain extracted from any marketplace source type"
               }
             },
-            "required": [
-              "source",
-              "hostPattern"
-            ]
+            "required": ["source", "hostPattern"]
           },
           {
             "type": "object",
@@ -3074,10 +2588,7 @@
                 "description": "Regex pattern to match file or directory paths for marketplace sources"
               }
             },
-            "required": [
-              "source",
-              "pathPattern"
-            ]
+            "required": ["source", "pathPattern"]
           }
         ]
       }
@@ -3134,17 +2645,12 @@
     },
     "defaultShell": {
       "type": "string",
-      "enum": [
-        "bash",
-        "powershell"
-      ],
+      "enum": ["bash", "powershell"],
       "description": "Default shell for input-box ! commands. Default: bash. Using \"powershell\" routes ! commands through PowerShell on Windows and requires CLAUDE_CODE_USE_POWERSHELL_TOOL=1 with pwsh on PATH. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "disableDeepLinkRegistration": {
       "type": "string",
-      "enum": [
-        "disable"
-      ],
+      "enum": ["disable"],
       "description": "Set to \"disable\" to prevent Claude Code from registering the `claude://` deep-link protocol handler on startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "disableSkillShellExecution": {
@@ -3158,9 +2664,7 @@
     "minimumVersion": {
       "type": "string",
       "description": "Minimum Claude Code version to stay on. Prevents downgrades when switching release channels. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [
-        "2.1.0"
-      ],
+      "examples": ["2.1.0"],
       "minLength": 1
     },
     "showClearContextOnPlanAccept": {
@@ -3188,31 +2692,19 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "enum": [
-              "skills",
-              "agents",
-              "hooks",
-              "mcp"
-            ]
+            "enum": ["skills", "agents", "hooks", "mcp"]
           }
         }
       ]
     },
     "tui": {
       "type": "string",
-      "enum": [
-        "fullscreen",
-        "default"
-      ],
+      "enum": ["fullscreen", "default"],
       "description": "TUI rendering mode. Use \"fullscreen\" for the flicker-free alt-screen renderer with virtualized scrollback; \"default\" for the classic main-screen renderer. Corresponds to the /tui command. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "viewMode": {
       "type": "string",
-      "enum": [
-        "default",
-        "verbose",
-        "focus"
-      ],
+      "enum": ["default", "verbose", "focus"],
       "description": "Transcript view mode. \"default\" shows standard interactive view; \"verbose\" shows expanded tool details; \"focus\" shows prompt, one-line tool summaries, and final response only (Ctrl+O toggle). See https://code.claude.com/docs/en/settings#available-settings"
     },
     "useAutoModeDuringPlan": {
@@ -3231,10 +2723,7 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Status line configuration for subagent sessions. See https://code.claude.com/docs/en/statusline#subagent-status-lines",
-      "required": [
-        "type",
-        "command"
-      ],
+      "required": ["type", "command"],
       "properties": {
         "type": {
           "type": "string",
@@ -3289,18 +2778,12 @@
     "daemonColdStart": {
       "description": "When no background service is running: 'transient' spawns one for this login session; 'ask' offers to install it persistently",
       "type": "string",
-      "enum": [
-        "transient",
-        "ask"
-      ]
+      "enum": ["transient", "ask"]
     },
     "defaultView": {
       "description": "Default transcript view: chat (SendUserMessage checkpoints only) or transcript (full)",
       "type": "string",
-      "enum": [
-        "chat",
-        "transcript"
-      ]
+      "enum": ["chat", "transcript"]
     },
     "disableAgentView": {
       "description": "Disable agent view (`claude agents`, `--bg`, /background, the on-demand daemon). Typically set in managed settings. Equivalent to CLAUDE_CODE_DISABLE_AGENT_VIEW=1.",
@@ -3313,9 +2796,7 @@
     "disableAutoMode": {
       "description": "Disable auto mode",
       "type": "string",
-      "enum": [
-        "disable"
-      ]
+      "enum": ["disable"]
     },
     "disableBundledSkills": {
       "description": "Disable the skills and workflows that ship with Claude Code: bundled skills and workflows are removed entirely; built-in slash commands stay typable but are hidden from the model. Plugins, .claude/skills/, and .claude/commands/ are unaffected. Equivalent to CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1.",
@@ -3332,10 +2813,7 @@
     "editorMode": {
       "description": "Key binding mode for the prompt input",
       "type": "string",
-      "enum": [
-        "normal",
-        "vim"
-      ]
+      "enum": ["normal", "vim"]
     },
     "enableWorkflows": {
       "description": "Enable or disable the Workflows feature for this user. Unset = default by plan once the feature is available.",
@@ -3385,11 +2863,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "type",
-              "pattern",
-              "url"
-            ],
+            "required": ["type", "pattern", "url"],
             "additionalProperties": {}
           },
           {
@@ -3400,9 +2874,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "additionalProperties": {}
           }
         ]
@@ -3454,9 +2926,7 @@
           ]
         }
       },
-      "required": [
-        "path"
-      ]
+      "required": ["path"]
     },
     "preferredNotifChannel": {
       "description": "Preferred OS notification channel",
@@ -3550,11 +3020,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "name",
-          "sshHost"
-        ]
+        "required": ["id", "name", "sshHost"]
       }
     },
     "switchModelsOnFlag": {
@@ -3612,10 +3078,7 @@
         "mode": {
           "description": "'hold' (default): hold to talk. 'tap': tap to start, tap to stop+submit.",
           "type": "string",
-          "enum": [
-            "hold",
-            "tap"
-          ]
+          "enum": ["hold", "tap"]
         },
         "autoSubmit": {
           "description": "Submit the prompt when hold-to-talk is released (hold mode only)",

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -34,7 +34,10 @@
           "type": "object",
           "description": "Bash command hook",
           "additionalProperties": false,
-          "required": ["type", "command"],
+          "required": [
+            "type",
+            "command"
+          ],
           "properties": {
             "type": {
               "type": "string",
@@ -61,7 +64,10 @@
             },
             "shell": {
               "type": "string",
-              "enum": ["bash", "powershell"],
+              "enum": [
+                "bash",
+                "powershell"
+              ],
               "description": "Shell interpreter for the command. \"bash\" uses the login shell (bash/zsh/sh); \"powershell\" uses pwsh. Defaults to bash."
             },
             "if": {
@@ -85,7 +91,10 @@
           "type": "object",
           "description": "LLM prompt hook. See https://code.claude.com/docs/en/hooks#prompt-based-hooks",
           "additionalProperties": false,
-          "required": ["type", "prompt"],
+          "required": [
+            "type",
+            "prompt"
+          ],
           "properties": {
             "type": {
               "type": "string",
@@ -125,7 +134,10 @@
           "type": "object",
           "description": "Agent hook with multi-turn tool access for verification. See https://code.claude.com/docs/en/hooks#agent-based-hooks",
           "additionalProperties": false,
-          "required": ["type", "prompt"],
+          "required": [
+            "type",
+            "prompt"
+          ],
           "properties": {
             "type": {
               "type": "string",
@@ -160,7 +172,10 @@
           "type": "object",
           "description": "HTTP webhook hook. POST JSON to a URL and receive JSON response. See https://code.claude.com/docs/en/hooks#http-hook-fields",
           "additionalProperties": false,
-          "required": ["type", "url"],
+          "required": [
+            "type",
+            "url"
+          ],
           "properties": {
             "type": {
               "type": "string",
@@ -206,7 +221,11 @@
           "type": "object",
           "description": "MCP tool hook. Call a tool on an already-connected MCP server. See https://code.claude.com/docs/en/hooks#mcp-tool-hook-fields",
           "additionalProperties": false,
-          "required": ["type", "server", "tool"],
+          "required": [
+            "type",
+            "server",
+            "tool"
+          ],
           "properties": {
             "type": {
               "type": "string",
@@ -249,7 +268,9 @@
       "type": "object",
       "description": "Hook matcher configuration with multiple hooks",
       "additionalProperties": false,
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "matcher": {
           "type": "string",
@@ -277,7 +298,9 @@
     "apiKeyHelper": {
       "type": "string",
       "description": "Path to a script that outputs authentication values. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["/bin/generate_temp_api_key.sh"],
+      "examples": [
+        "/bin/generate_temp_api_key.sh"
+      ],
       "minLength": 1
     },
     "autoMemoryEnabled": {
@@ -287,20 +310,27 @@
     },
     "autoUpdatesChannel": {
       "type": "string",
-      "enum": ["stable", "latest"],
+      "enum": [
+        "stable",
+        "latest"
+      ],
       "description": "Release channel to follow for updates. Use \"stable\" for a version that is typically about one week old and skips versions with major regressions, or \"latest\" (default) for the most recent release. Set DISABLE_AUTOUPDATER=1 to disable background auto-updates, or DISABLE_UPDATES=1 (added in v2.1.118) to block all update paths including manual `claude update`.",
       "default": "latest"
     },
     "awsCredentialExport": {
       "type": "string",
       "description": "Path to a script that exports AWS credentials. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["/bin/generate_aws_grant.sh"],
+      "examples": [
+        "/bin/generate_aws_grant.sh"
+      ],
       "minLength": 1
     },
     "awsAuthRefresh": {
       "type": "string",
       "description": "Path to a script that refreshes AWS authentication. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["aws sso login --profile myprofile"],
+      "examples": [
+        "aws sso login --profile myprofile"
+      ],
       "minLength": 1
     },
     "claudeMdExcludes": {
@@ -321,7 +351,11 @@
       "type": "integer",
       "minimum": 1,
       "description": "Number of days to retain sessions, orphaned subagent worktrees, tasks, shell snapshots, and backups. Minimum is 1; setting 0 is rejected with a validation error. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [20, 30, 60],
+      "examples": [
+        20,
+        30,
+        60
+      ],
       "default": 30
     },
     "env": {
@@ -358,7 +392,11 @@
         "ANTHROPIC_BEDROCK_SERVICE_TIER": {
           "type": "string",
           "description": "Select Bedrock service tier; sent as X-Amzn-Bedrock-Service-Tier header. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21122",
-          "enum": ["default", "flex", "priority"]
+          "enum": [
+            "default",
+            "flex",
+            "priority"
+          ]
         },
         "ANTHROPIC_BETAS": {
           "type": "string",
@@ -451,17 +489,26 @@
         "CCR_FORCE_BUNDLE": {
           "type": "string",
           "description": "Force local repo bundling for --remote invocations",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS": {
           "type": "string",
           "description": "Disable built-in subagent types in Agent SDK",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_AGENT_SDK_MCP_NO_PREFIX": {
           "type": "string",
           "description": "Skip 'mcp__<server>__' prefix on MCP tool names in Agent SDK",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": {
           "type": "string",
@@ -470,22 +517,34 @@
         "CLAUDE_AUTO_BACKGROUND_TASKS": {
           "type": "string",
           "description": "Force-enable automatic backgrounding of tasks",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": {
           "type": "string",
           "description": "Return to original project directory after each bash command",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ACCESSIBILITY": {
           "type": "string",
           "description": "Keep native cursor visible for screen magnifiers and assistive tools",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": {
           "type": "string",
           "description": "Load CLAUDE.md memory files from additional directories",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": {
           "type": "string",
@@ -494,7 +553,10 @@
         "CLAUDE_CODE_ATTRIBUTION_HEADER": {
           "type": "string",
           "description": "Include attribution block in the system prompt",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_AUTO_COMPACT_WINDOW": {
           "type": "string",
@@ -503,7 +565,10 @@
         "CLAUDE_CODE_AUTO_CONNECT_IDE": {
           "type": "string",
           "description": "Override automatic IDE connection behavior",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_CERT_STORE": {
           "type": "string",
@@ -528,162 +593,265 @@
         "CLAUDE_CODE_DEBUG_LOG_LEVEL": {
           "type": "string",
           "description": "Debug log verbosity level",
-          "enum": ["verbose", "debug", "info", "warn", "error"]
+          "enum": [
+            "verbose",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
         },
         "CLAUDE_CODE_DISABLE_1M_CONTEXT": {
           "type": "string",
           "description": "Disable 1M context window models",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": {
           "type": "string",
           "description": "Disable adaptive reasoning",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": {
           "type": "string",
           "description": "Disable alternate screen buffer rendering. When set to 1, keeps conversation in native scrollback instead of fullscreen renderer",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_ATTACHMENTS": {
           "type": "string",
           "description": "Disable attachment processing",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_AUTO_MEMORY": {
           "type": "string",
           "description": "Disable automatic memory feature",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS": {
           "type": "string",
           "description": "Disable all background task functionality",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_CLAUDE_MDS": {
           "type": "string",
           "description": "Prevent loading CLAUDE.md memory files",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_CRON": {
           "type": "string",
           "description": "Disable scheduled/cron tasks",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": {
           "type": "string",
           "description": "Strip anthropic-beta headers from API requests. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21123",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_FAST_MODE": {
           "type": "string",
           "description": "Disable fast mode toggle",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": {
           "type": "string",
           "description": "Disable session quality feedback surveys",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING": {
           "type": "string",
           "description": "Disable file checkpointing for undo/restore",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": {
           "type": "string",
           "description": "Remove git commit and PR workflow instructions from the system prompt",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_LEGACY_MODEL_REMAP": {
           "type": "string",
           "description": "Prevent automatic remapping of legacy model names",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_MOUSE": {
           "type": "string",
           "description": "Disable mouse tracking in fullscreen mode",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": {
           "type": "string",
           "description": "Disable auto-update checks, telemetry, and feedback in one setting",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK": {
           "type": "string",
           "description": "Disable fallback to non-streaming API mode",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": {
           "type": "string",
           "description": "Skip automatic installation of official marketplace plugins",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_POLICY_SKILLS": {
           "type": "string",
           "description": "Skip loading system-wide policy skills",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": {
           "type": "string",
           "description": "Disable terminal title updates",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_THINKING": {
           "type": "string",
           "description": "Force-disable extended thinking",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL": {
           "type": "string",
           "description": "Disable virtual scrolling in fullscreen mode",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_EFFORT_LEVEL": {
           "type": "string",
           "description": "Reasoning effort level",
-          "enum": ["low", "medium", "high", "xhigh", "max", "auto"]
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+            "auto"
+          ]
         },
         "CLAUDE_CODE_ENABLE_AWAY_SUMMARY": {
           "type": "string",
           "description": "Override session recap/away summary availability",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH": {
           "type": "string",
           "description": "Refresh plugins at turn boundaries",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL": {
           "type": "string",
           "description": "Enable feedback survey collection via OpenTelemetry for enterprises",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": {
           "type": "string",
           "description": "Force fine-grained tool output streaming",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": {
           "type": "string",
           "description": "Enable model discovery from LLM gateway /v1/models endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION": {
           "type": "string",
           "description": "Enable prompt suggestions",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_ENABLE_TASKS": {
           "type": "string",
           "description": "Enable task tracking in non-interactive mode",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_ENABLE_TELEMETRY": {
           "type": "string",
           "description": "Enable OpenTelemetry collection",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY": {
           "type": "string",
@@ -692,7 +860,10 @@
         "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": {
           "type": "string",
           "description": "Enable experimental agent teams feature",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_EXTRA_BODY": {
           "type": "string",
@@ -705,12 +876,18 @@
         "CLAUDE_CODE_FORCE_SYNC_OUTPUT": {
           "type": "string",
           "description": "Force synchronous output flushing. When set to 1, forces synchronized output on terminals that auto-detection misses (e.g., Emacs eat)",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_FORK_SUBAGENT": {
           "type": "string",
           "description": "Fork subagent processes in non-interactive sessions. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21120",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_GIT_BASH_PATH": {
           "type": "string",
@@ -719,12 +896,18 @@
         "CLAUDE_CODE_GLOB_HIDDEN": {
           "type": "string",
           "description": "Include dotfiles/hidden files in Glob results",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_GLOB_NO_IGNORE": {
           "type": "string",
           "description": "Don't respect .gitignore rules in Glob results",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_GLOB_TIMEOUT_SECONDS": {
           "type": "string",
@@ -733,7 +916,10 @@
         "CLAUDE_CODE_HIDE_CWD": {
           "type": "string",
           "description": "Hide the working directory in the startup logo. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#21126",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_IDE_HOST_OVERRIDE": {
           "type": "string",
@@ -742,12 +928,18 @@
         "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL": {
           "type": "string",
           "description": "Skip automatic IDE extension installation",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_IDE_SKIP_VALID_CHECK": {
           "type": "string",
           "description": "Skip IDE lockfile validation",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_MAX_CONTEXT_TOKENS": {
           "type": "string",
@@ -768,17 +960,26 @@
         "CLAUDE_CODE_MCP_ALLOWLIST_ENV": {
           "type": "string",
           "description": "Isolate MCP server environments to allowlisted variables",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_NEW_INIT": {
           "type": "string",
           "description": "Use the interactive /init setup flow",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_NO_FLICKER": {
           "type": "string",
           "description": "Enable fullscreen rendering mode to reduce flicker",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_OAUTH_REFRESH_TOKEN": {
           "type": "string",
@@ -794,7 +995,10 @@
         },
         "CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE": {
           "type": "string",
-          "enum": ["0", "1"],
+          "enum": [
+            "0",
+            "1"
+          ],
           "description": "Set to 1 to pin fast mode to Claude Opus 4.6 instead of the default Opus 4.7. With this set, /fast runs on Opus 4.6. Without it, /fast runs on Opus 4.7. See https://code.claude.com/docs/en/fast-mode and https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_OTEL_FLUSH_TIMEOUT_MS": {
@@ -812,12 +1016,18 @@
         "CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE": {
           "type": "string",
           "description": "Enable automatic package manager updates. When set, Claude Code runs the upgrade command in background on Homebrew/WinGet and prompts to restart",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_PERFORCE_MODE": {
           "type": "string",
           "description": "Enable Perforce write protection mode",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_PLUGIN_CACHE_DIR": {
           "type": "string",
@@ -830,11 +1040,17 @@
         "CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE": {
           "type": "string",
           "description": "Keep plugin cache on update failure",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_PLUGIN_PREFER_HTTPS": {
           "type": "string",
-          "enum": ["0", "1"],
+          "enum": [
+            "0",
+            "1"
+          ],
           "description": "Set to 1 to clone GitHub owner/repo plugin sources over HTTPS instead of SSH. Useful in CI runners, containers, or environments without a configured SSH key for github.com. See https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_PLUGIN_SEED_DIR": {
@@ -843,23 +1059,35 @@
         },
         "CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY": {
           "type": "string",
-          "enum": ["0", "1"],
+          "enum": [
+            "0",
+            "1"
+          ],
           "description": "Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when spawning PowerShell for tool calls, hooks, and status line commands. By default Claude Code bypasses execution policy so .ps1 scripts work on default-Restricted Windows installs. See https://code.claude.com/docs/en/env-vars"
         },
         "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST": {
           "type": "string",
           "description": "Indicate that the host application manages provider routing",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_PROXY_RESOLVES_HOSTS": {
           "type": "string",
           "description": "Allow proxy to handle DNS resolution",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_REMOTE": {
           "type": "string",
           "description": "Indicates a remote web environment session",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_REMOTE_SESSION_ID": {
           "type": "string",
@@ -868,7 +1096,10 @@
         "CLAUDE_CODE_RESUME_INTERRUPTED_TURN": {
           "type": "string",
           "description": "Automatically resume from a mid-turn interruption",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SCRIPT_CAPS": {
           "type": "string",
@@ -893,37 +1124,58 @@
         "CLAUDE_CODE_SIMPLE": {
           "type": "string",
           "description": "Minimal mode with core tools only",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT": {
           "type": "string",
           "description": "Use a shortened system prompt",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SKIP_BEDROCK_AUTH": {
           "type": "string",
           "description": "Skip AWS authentication for Bedrock",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SKIP_FOUNDRY_AUTH": {
           "type": "string",
           "description": "Skip Azure authentication for Foundry",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SKIP_MANTLE_AUTH": {
           "type": "string",
           "description": "Skip AWS authentication for Mantle",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SKIP_PROMPT_HISTORY": {
           "type": "string",
           "description": "Disable transcript writes entirely. See https://code.claude.com/docs/en/settings#environment-variables",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SKIP_VERTEX_AUTH": {
           "type": "string",
           "description": "Skip Google authentication for Vertex AI",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_STOP_HOOK_BLOCK_CAP": {
           "type": "string",
@@ -936,12 +1188,18 @@
         "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": {
           "type": "string",
           "description": "Strip credentials from subprocess environments",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SYNC_PLUGIN_INSTALL": {
           "type": "string",
           "description": "Wait synchronously for plugin installation",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_SYNC_PLUGIN_INSTALL_TIMEOUT_MS": {
           "type": "string",
@@ -950,7 +1208,10 @@
         "CLAUDE_CODE_SYNTAX_HIGHLIGHT": {
           "type": "string",
           "description": "Enable syntax highlighting in diffs",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "CLAUDE_CODE_TASK_LIST_ID": {
           "type": "string",
@@ -967,12 +1228,18 @@
         "CLAUDE_CODE_TMUX_TRUECOLOR": {
           "type": "string",
           "description": "Allow 24-bit truecolor rendering in tmux",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_CODE_USE_POWERSHELL_TOOL": {
           "type": "string",
           "description": "Enable PowerShell as default shell for interactive commands (Windows)",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "CLAUDE_ENV_FILE": {
           "type": "string",
@@ -985,32 +1252,50 @@
         "DISABLE_AUTOUPDATER": {
           "type": "string",
           "description": "Stop background auto-update checks",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "DISABLE_ERROR_REPORTING": {
           "type": "string",
           "description": "Disable Sentry error reporting",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "DISABLE_FEEDBACK_COMMAND": {
           "type": "string",
           "description": "Disable the /feedback command",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "DISABLE_TELEMETRY": {
           "type": "string",
           "description": "Disable Statsig telemetry collection",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "DISABLE_UPDATES": {
           "type": "string",
           "description": "Block all update paths including manual updates",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         },
         "ENABLE_CLAUDEAI_MCP_SERVERS": {
           "type": "string",
           "description": "Opt in/out of claude.ai MCP servers. See https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2163",
-          "enum": ["true", "false"]
+          "enum": [
+            "true",
+            "false"
+          ]
         },
         "HTTPS_PROXY": {
           "type": "string",
@@ -1035,7 +1320,10 @@
         "USE_BUILTIN_RIPGREP": {
           "type": "string",
           "description": "Use the bundled ripgrep binary instead of system ripgrep",
-          "enum": ["0", "1"]
+          "enum": [
+            "0",
+            "1"
+          ]
         }
       },
       "propertyNames": {
@@ -1075,7 +1363,9 @@
       "type": "string",
       "description": "Customize where plan files are stored. Path is relative to project root (default: ~/.claude/plans)",
       "default": "~/.claude/plans",
-      "examples": ["./plans"]
+      "examples": [
+        "./plans"
+      ]
     },
     "respectGitignore": {
       "type": "boolean",
@@ -1124,12 +1414,16 @@
         },
         "disableBypassPermissionsMode": {
           "type": "string",
-          "enum": ["disable"],
+          "enum": [
+            "disable"
+          ],
           "description": "Disable the ability to bypass permission prompts"
         },
         "disableAutoMode": {
           "type": "string",
-          "enum": ["disable"],
+          "enum": [
+            "disable"
+          ],
           "description": "Set to \"disable\" to prevent auto mode from being activated. Removes `auto` from the Shift+Tab cycle and rejects `--permission-mode auto` at startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/permissions"
         },
         "additionalDirectories": {
@@ -1139,7 +1433,12 @@
             "minLength": 1
           },
           "description": "Additional directories to include in the permission scope",
-          "examples": [["//Users/alice/Documents", "~/projects"]],
+          "examples": [
+            [
+              "//Users/alice/Documents",
+              "~/projects"
+            ]
+          ],
           "uniqueItems": true
         }
       },
@@ -1147,9 +1446,18 @@
       "description": "Tool usage permissions configuration.\nSee https://code.claude.com/docs/en/permissions and https://code.claude.com/docs/en/settings#permission-settings\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
       "examples": [
         {
-          "allow": ["Bash(git add:*)"],
-          "ask": ["Bash(gh pr create:*)", "Bash(git commit:*)"],
-          "deny": ["Read(*.env)", "Bash(rm:*)", "Bash(curl:*)"],
+          "allow": [
+            "Bash(git add:*)"
+          ],
+          "ask": [
+            "Bash(gh pr create:*)",
+            "Bash(git commit:*)"
+          ],
+          "deny": [
+            "Read(*.env)",
+            "Bash(rm:*)",
+            "Bash(curl:*)"
+          ],
           "defaultMode": "default"
         }
       ]
@@ -1157,7 +1465,11 @@
     "language": {
       "type": "string",
       "description": "Configure Claude's preferred response language (e.g., \"japanese\", \"spanish\", \"french\"). Claude will respond in this language by default. Also sets the voice dictation language and terminal tab session title generation. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["japanese", "spanish", "french"]
+      "examples": [
+        "japanese",
+        "spanish",
+        "french"
+      ]
     },
     "model": {
       "type": "string",
@@ -1169,7 +1481,12 @@
         "type": "string"
       },
       "description": "Restrict which models users can select. When defined at multiple settings levels (user, project, etc.), arrays are merged and deduplicated. See https://code.claude.com/docs/en/model-config#restrict-model-selection",
-      "examples": [["sonnet", "haiku"]]
+      "examples": [
+        [
+          "sonnet",
+          "haiku"
+        ]
+      ]
     },
     "modelOverrides": {
       "type": "object",
@@ -1185,7 +1502,13 @@
     },
     "effortLevel": {
       "type": "string",
-      "enum": ["low", "medium", "high", "xhigh", "max"],
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ],
       "description": "Persist adaptive reasoning effort across sessions. Effort is supported on Opus 4.7, Opus 4.6, and Sonnet 4.6. Opus 4.7 supports low/medium/high/xhigh/max (xhigh sits between high and max, added in v2.1.111); Opus 4.6 and Sonnet 4.6 support low/medium/high/max (xhigh falls back to high). Defaults: Opus 4.6 and Sonnet 4.6 default to high on all plans (Pro/Max raised from medium to high in v2.1.117); Opus 4.7 defaults to xhigh on Max plan. The max value is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL. Use /effort auto to reset to model default. Also configurable via CLAUDE_CODE_EFFORT_LEVEL environment variable. See https://code.claude.com/docs/en/model-config#adjust-effort-level"
     },
     "fastMode": {
@@ -1203,12 +1526,16 @@
       "minimum": 0,
       "maximum": 1,
       "description": "Probability (0–1) that the session quality survey appears when eligible. A value of 0.05 means 5% of eligible sessions. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": [0.05]
+      "examples": [
+        0.05
+      ]
     },
     "enableAllProjectMcpServers": {
       "type": "boolean",
       "description": "Whether to automatically approve all MCP servers in the project. See https://code.claude.com/docs/en/mcp",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "enabledMcpjsonServers": {
       "type": "array",
@@ -1217,7 +1544,12 @@
         "minLength": 1
       },
       "description": "List of approved MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
-      "examples": [["memory", "github"]]
+      "examples": [
+        [
+          "memory",
+          "github"
+        ]
+      ]
     },
     "disabledMcpjsonServers": {
       "type": "array",
@@ -1226,7 +1558,11 @@
         "minLength": 1
       },
       "description": "List of rejected MCP servers from .mcp.json. See https://code.claude.com/docs/en/mcp",
-      "examples": [["filesystem"]]
+      "examples": [
+        [
+          "filesystem"
+        ]
+      ]
     },
     "allowedMcpServers": {
       "type": "array",
@@ -1241,7 +1577,9 @@
                 "description": "Name of the MCP server that users are allowed to configure"
               }
             },
-            "required": ["serverName"],
+            "required": [
+              "serverName"
+            ],
             "additionalProperties": false
           },
           {
@@ -1255,7 +1593,9 @@
                 "description": "Exact command and arguments used to start stdio servers"
               }
             },
-            "required": ["serverCommand"],
+            "required": [
+              "serverCommand"
+            ],
             "additionalProperties": false
           },
           {
@@ -1266,7 +1606,9 @@
                 "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
               }
             },
-            "required": ["serverUrl"],
+            "required": [
+              "serverUrl"
+            ],
             "additionalProperties": false
           }
         ]
@@ -1286,7 +1628,9 @@
                 "description": "Name of the MCP server that is explicitly blocked"
               }
             },
-            "required": ["serverName"],
+            "required": [
+              "serverName"
+            ],
             "additionalProperties": false
           },
           {
@@ -1300,7 +1644,9 @@
                 "description": "Exact command and arguments used to start stdio servers"
               }
             },
-            "required": ["serverCommand"],
+            "required": [
+              "serverCommand"
+            ],
             "additionalProperties": false
           },
           {
@@ -1311,7 +1657,9 @@
                 "description": "URL pattern for remote servers, supports wildcards (e.g., https://*.example.com/*)"
               }
             },
-            "required": ["serverUrl"],
+            "required": [
+              "serverUrl"
+            ],
             "additionalProperties": false
           }
         ]
@@ -1325,7 +1673,12 @@
         "minLength": 1
       },
       "description": "Allowlist of environment variable names HTTP hooks may interpolate into headers. When set, each hook's effective allowedEnvVars is the intersection with this list. Undefined = no restriction. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
-      "examples": [["MY_TOKEN", "HOOK_SECRET"]]
+      "examples": [
+        [
+          "MY_TOKEN",
+          "HOOK_SECRET"
+        ]
+      ]
     },
     "hooks": {
       "type": "object",
@@ -1572,7 +1925,12 @@
         "minLength": 1
       },
       "description": "Allowlist of URL patterns that HTTP hooks may target. Supports * as a wildcard. When set, hooks with non-matching URLs are blocked. Undefined = no restriction, empty array = block all HTTP hooks. Arrays merge across settings sources. See https://code.claude.com/docs/en/settings#hook-configuration",
-      "examples": [["https://hooks.example.com/*", "http://localhost:*"]]
+      "examples": [
+        [
+          "https://hooks.example.com/*",
+          "http://localhost:*"
+        ]
+      ]
     },
     "allowManagedHooksOnly": {
       "type": "boolean",
@@ -1608,7 +1966,10 @@
           "description": "Set to true when your status line script renders the vim mode indicator itself, to suppress the built-in vim mode display. See https://code.claude.com/docs/en/statusline#manually-configure-a-status-line"
         }
       },
-      "required": ["type", "command"],
+      "required": [
+        "type",
+        "command"
+      ],
       "additionalProperties": false,
       "description": "Custom status line display configuration. See https://code.claude.com/docs/en/statusline",
       "examples": [
@@ -1631,7 +1992,10 @@
           "description": "Shell command to execute for file suggestions"
         }
       },
-      "required": ["type", "command"],
+      "required": [
+        "type",
+        "command"
+      ],
       "additionalProperties": false,
       "description": "Configure a custom script for @ file autocomplete. See https://code.claude.com/docs/en/settings#file-suggestion-settings",
       "examples": [
@@ -1682,7 +2046,10 @@
                     "description": "Direct URL to marketplace.json file"
                   }
                 },
-                "required": ["source", "url"],
+                "required": [
+                  "source",
+                  "url"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1698,7 +2065,10 @@
                     "description": "Git host pattern to trust for repositories in source specifications"
                   }
                 },
-                "required": ["source", "hostPattern"],
+                "required": [
+                  "source",
+                  "hostPattern"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1722,7 +2092,10 @@
                     "description": "Path to marketplace.json within repo (defaults to .claude-plugin/marketplace.json)"
                   }
                 },
-                "required": ["source", "repo"],
+                "required": [
+                  "source",
+                  "repo"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1747,7 +2120,10 @@
                     "description": "Path to marketplace.json within repo (defaults to .claude-plugin/marketplace.json)"
                   }
                 },
-                "required": ["source", "url"],
+                "required": [
+                  "source",
+                  "url"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1763,7 +2139,10 @@
                     "description": "NPM package containing marketplace.json"
                   }
                 },
-                "required": ["source", "package"],
+                "required": [
+                  "source",
+                  "package"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1779,7 +2158,10 @@
                     "description": "Local file path to marketplace.json"
                   }
                 },
-                "required": ["source", "path"],
+                "required": [
+                  "source",
+                  "path"
+                ],
                 "additionalProperties": false
               },
               {
@@ -1795,7 +2177,10 @@
                     "description": "Local directory containing .claude-plugin/marketplace.json"
                   }
                 },
-                "required": ["source", "path"],
+                "required": [
+                  "source",
+                  "path"
+                ],
                 "additionalProperties": false
               }
             ],
@@ -1814,7 +2199,9 @@
             "description": "ISO 8601 timestamp of the last marketplace refresh. Written automatically by Claude Code"
           }
         },
-        "required": ["source"],
+        "required": [
+          "source"
+        ],
         "additionalProperties": false
       },
       "description": "Additional marketplaces to make available for this repository. Typically used in repository .claude/settings.json to ensure team members have required plugin sources. See https://code.claude.com/docs/en/plugin-marketplaces"
@@ -1837,7 +2224,10 @@
                 "description": "Git host pattern to trust for repositories in source specifications"
               }
             },
-            "required": ["source", "hostPattern"],
+            "required": [
+              "source",
+              "hostPattern"
+            ],
             "additionalProperties": false
           },
           {
@@ -1861,7 +2251,10 @@
                 "description": "Subdirectory path"
               }
             },
-            "required": ["source", "repo"],
+            "required": [
+              "source",
+              "repo"
+            ],
             "additionalProperties": false
           },
           {
@@ -1885,7 +2278,10 @@
                 "description": "Subdirectory path"
               }
             },
-            "required": ["source", "url"],
+            "required": [
+              "source",
+              "url"
+            ],
             "additionalProperties": false
           },
           {
@@ -1909,7 +2305,10 @@
                 "description": "HTTP headers for authenticated access"
               }
             },
-            "required": ["source", "url"],
+            "required": [
+              "source",
+              "url"
+            ],
             "additionalProperties": false
           },
           {
@@ -1925,7 +2324,10 @@
                 "description": "NPM package name (supports scoped packages)"
               }
             },
-            "required": ["source", "package"],
+            "required": [
+              "source",
+              "package"
+            ],
             "additionalProperties": false
           },
           {
@@ -1941,7 +2343,10 @@
                 "description": "Absolute path to marketplace.json file"
               }
             },
-            "required": ["source", "path"],
+            "required": [
+              "source",
+              "path"
+            ],
             "additionalProperties": false
           },
           {
@@ -1957,7 +2362,10 @@
                 "description": "Absolute path to directory containing .claude-plugin/marketplace.json"
               }
             },
-            "required": ["source", "path"],
+            "required": [
+              "source",
+              "path"
+            ],
             "additionalProperties": false
           },
           {
@@ -1973,7 +2381,10 @@
                 "description": "Regex pattern to match file or directory paths for marketplace sources"
               }
             },
-            "required": ["source", "pathPattern"],
+            "required": [
+              "source",
+              "pathPattern"
+            ],
             "additionalProperties": false
           }
         ]
@@ -2009,14 +2420,21 @@
     },
     "forceLoginMethod": {
       "type": "string",
-      "enum": ["claudeai", "console"],
+      "enum": [
+        "claudeai",
+        "console"
+      ],
       "description": "Force a specific login method: \"claudeai\" for Claude Pro/Max, \"console\" for Console billing",
-      "examples": ["claudeai"]
+      "examples": [
+        "claudeai"
+      ]
     },
     "forceLoginOrgUUID": {
       "type": "string",
       "description": "Organization UUID to use for OAuth login",
-      "examples": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"],
+      "examples": [
+        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      ],
       "minLength": 1
     },
     "otelHeadersHelper": {
@@ -2027,7 +2445,11 @@
     "outputStyle": {
       "type": "string",
       "description": "Controls the output style for assistant responses. Built-in styles: default, Explanatory, Learning. Custom styles can be added in ~/.claude/output-styles/ or .claude/output-styles/. See https://code.claude.com/docs/en/output-styles",
-      "examples": ["default", "Explanatory", "Learning"],
+      "examples": [
+        "default",
+        "Explanatory",
+        "Learning"
+      ],
       "minLength": 1
     },
     "skipWebFetchPreflight": {
@@ -2096,7 +2518,11 @@
                 "minLength": 1
               },
               "description": "macOS only. Additional XPC/Mach service names the sandbox may look up. Supports a single trailing * for prefix matching. Needed for tools that communicate via XPC such as the iOS Simulator or Playwright. See https://code.claude.com/docs/en/sandboxing#network-isolation",
-              "examples": [["com.apple.coresimulator.*"]]
+              "examples": [
+                [
+                  "com.apple.coresimulator.*"
+                ]
+              ]
             }
           },
           "additionalProperties": false
@@ -2188,7 +2614,9 @@
           "type": "object",
           "description": "Custom ripgrep configuration for Claude Code's bundled ripgrep support. Overrides the bundled binary and arguments.",
           "additionalProperties": false,
-          "required": ["command"],
+          "required": [
+            "command"
+          ],
           "properties": {
             "command": {
               "type": "string",
@@ -2222,7 +2650,12 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["macos", "linux", "wsl", "windows"]
+            "enum": [
+              "macos",
+              "linux",
+              "wsl",
+              "windows"
+            ]
           },
           "description": "Limit the entire sandbox configuration to the listed platforms. On platforms not in the list the sandbox config is inert: no sandbox, no auto-allow, no startup warning, and no failIfUnavailable exit. When omitted, all supported platforms are included. Only honored from managed (policy) settings."
         }
@@ -2235,7 +2668,10 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["append", "replace"],
+          "enum": [
+            "append",
+            "replace"
+          ],
           "description": "How to combine custom verbs with default spinner verbs: 'append' adds custom verbs to the default list, 'replace' uses only custom verbs"
         },
         "verbs": {
@@ -2248,7 +2684,9 @@
           "description": "Custom verbs used in spinner progress text"
         }
       },
-      "required": ["verbs"],
+      "required": [
+        "verbs"
+      ],
       "additionalProperties": false
     },
     "spinnerTipsEnabled": {
@@ -2275,7 +2713,9 @@
           "minItems": 1
         }
       },
-      "required": ["tips"],
+      "required": [
+        "tips"
+      ],
       "additionalProperties": false
     },
     "terminalProgressBarEnabled": {
@@ -2292,7 +2732,12 @@
       "type": "object",
       "additionalProperties": {
         "type": "string",
-        "enum": ["on", "name-only", "user-invocable-only", "off"]
+        "enum": [
+          "on",
+          "name-only",
+          "user-invocable-only",
+          "off"
+        ]
       },
       "description": "Per-skill visibility overrides. Controls whether skills appear to Claude and in the / picker. Values: 'on' (name and description shown, default), 'name-only' (name only), 'user-invocable-only' (hidden from Claude, visible in /), 'off' (hidden everywhere). Plugin skills are not affected by this setting. See https://code.claude.com/docs/en/skills#override-skill-visibility-from-settings",
       "examples": [
@@ -2310,7 +2755,9 @@
     "prUrlTemplate": {
       "type": "string",
       "description": "URL template for the PR badge shown in the footer and in tool-result summaries. Substitutes placeholders {host}, {owner}, {repo}, {number}, {url} from the gh-reported PR URL. Use this to point PR links at an internal code-review tool instead of github.com. Does not affect #123 autolinks in Claude's prose. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["https://reviews.example.com/{owner}/{repo}/pull/{number}"]
+      "examples": [
+        "https://reviews.example.com/{owner}/{repo}/pull/{number}"
+      ]
     },
     "alwaysThinkingEnabled": {
       "type": "boolean",
@@ -2326,7 +2773,11 @@
     },
     "teammateMode": {
       "type": "string",
-      "enum": ["auto", "in-process", "tmux"],
+      "enum": [
+        "auto",
+        "in-process",
+        "tmux"
+      ],
       "description": "How agent team teammates display: \"auto\" picks split panes in tmux or iTerm2, in-process otherwise. Agent teams are experimental and disabled by default. Enable them by adding CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS to your settings.json or environment. See https://code.claude.com/docs/en/agent-teams",
       "default": "auto"
     },
@@ -2342,17 +2793,28 @@
             "minLength": 1
           },
           "description": "Directories to check out in each worktree via git sparse-checkout (cone mode). Only the listed paths are written to disk, which is faster in large monorepos. See https://code.claude.com/docs/en/settings#worktree-settings",
-          "examples": [["packages/my-app", "shared/utils"]]
+          "examples": [
+            [
+              "packages/my-app",
+              "shared/utils"
+            ]
+          ]
         },
         "baseRef": {
           "type": "string",
-          "enum": ["fresh", "head"],
+          "enum": [
+            "fresh",
+            "head"
+          ],
           "default": "fresh",
           "description": "Whether to branch worktrees from origin/<default> (fresh) or local HEAD (head). Default: fresh. Set to 'head' to preserve unpushed commits in new worktrees. See https://code.claude.com/docs/en/settings#worktree-settings"
         },
         "bgIsolation": {
           "type": "string",
-          "enum": ["worktree", "none"],
+          "enum": [
+            "worktree",
+            "none"
+          ],
           "default": "worktree",
           "description": "Isolation mode for background sessions. \"worktree\" blocks Edit/Write in main checkout until EnterWorktree is called; \"none\" lets background jobs edit the working copy directly without EnterWorktree, for repos where worktrees are impractical. See https://code.claude.com/docs/en/settings#worktree-settings"
         }
@@ -2360,7 +2822,10 @@
     },
     "parentSettingsBehavior": {
       "type": "string",
-      "enum": ["first-wins", "merge"],
+      "enum": [
+        "first-wins",
+        "merge"
+      ],
       "default": "first-wins",
       "description": "(Admin/managed settings only) Controls how SDK managedSettings (parent tier) merge with inherited settings. 'first-wins': first non-empty value applies (default). 'merge': merge arrays and objects. See https://code.claude.com/docs/en/server-managed-settings"
     },
@@ -2459,7 +2924,10 @@
                 "description": "Custom HTTP headers (e.g., for authentication)"
               }
             },
-            "required": ["source", "url"]
+            "required": [
+              "source",
+              "url"
+            ]
           },
           {
             "type": "object",
@@ -2483,7 +2951,10 @@
                 "description": "Path to marketplace.json within repo"
               }
             },
-            "required": ["source", "repo"]
+            "required": [
+              "source",
+              "repo"
+            ]
           },
           {
             "type": "object",
@@ -2508,7 +2979,10 @@
                 "description": "Path to marketplace.json within repo"
               }
             },
-            "required": ["source", "url"]
+            "required": [
+              "source",
+              "url"
+            ]
           },
           {
             "type": "object",
@@ -2524,7 +2998,10 @@
                 "description": "NPM package containing marketplace.json"
               }
             },
-            "required": ["source", "package"]
+            "required": [
+              "source",
+              "package"
+            ]
           },
           {
             "type": "object",
@@ -2540,7 +3017,10 @@
                 "description": "Local file path to marketplace.json"
               }
             },
-            "required": ["source", "path"]
+            "required": [
+              "source",
+              "path"
+            ]
           },
           {
             "type": "object",
@@ -2556,7 +3036,10 @@
                 "description": "Local directory containing .claude-plugin/marketplace.json"
               }
             },
-            "required": ["source", "path"]
+            "required": [
+              "source",
+              "path"
+            ]
           },
           {
             "type": "object",
@@ -2572,7 +3055,10 @@
                 "description": "Regex pattern to match the host/domain extracted from any marketplace source type"
               }
             },
-            "required": ["source", "hostPattern"]
+            "required": [
+              "source",
+              "hostPattern"
+            ]
           },
           {
             "type": "object",
@@ -2588,7 +3074,10 @@
                 "description": "Regex pattern to match file or directory paths for marketplace sources"
               }
             },
-            "required": ["source", "pathPattern"]
+            "required": [
+              "source",
+              "pathPattern"
+            ]
           }
         ]
       }
@@ -2645,12 +3134,17 @@
     },
     "defaultShell": {
       "type": "string",
-      "enum": ["bash", "powershell"],
+      "enum": [
+        "bash",
+        "powershell"
+      ],
       "description": "Default shell for input-box ! commands. Default: bash. Using \"powershell\" routes ! commands through PowerShell on Windows and requires CLAUDE_CODE_USE_POWERSHELL_TOOL=1 with pwsh on PATH. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "disableDeepLinkRegistration": {
       "type": "string",
-      "enum": ["disable"],
+      "enum": [
+        "disable"
+      ],
       "description": "Set to \"disable\" to prevent Claude Code from registering the `claude://` deep-link protocol handler on startup. Most useful in managed settings where users cannot override it. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "disableSkillShellExecution": {
@@ -2664,7 +3158,9 @@
     "minimumVersion": {
       "type": "string",
       "description": "Minimum Claude Code version to stay on. Prevents downgrades when switching release channels. See https://code.claude.com/docs/en/settings#available-settings",
-      "examples": ["2.1.0"],
+      "examples": [
+        "2.1.0"
+      ],
       "minLength": 1
     },
     "showClearContextOnPlanAccept": {
@@ -2692,19 +3188,31 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "enum": ["skills", "agents", "hooks", "mcp"]
+            "enum": [
+              "skills",
+              "agents",
+              "hooks",
+              "mcp"
+            ]
           }
         }
       ]
     },
     "tui": {
       "type": "string",
-      "enum": ["fullscreen", "default"],
+      "enum": [
+        "fullscreen",
+        "default"
+      ],
       "description": "TUI rendering mode. Use \"fullscreen\" for the flicker-free alt-screen renderer with virtualized scrollback; \"default\" for the classic main-screen renderer. Corresponds to the /tui command. See https://code.claude.com/docs/en/settings#available-settings"
     },
     "viewMode": {
       "type": "string",
-      "enum": ["default", "verbose", "focus"],
+      "enum": [
+        "default",
+        "verbose",
+        "focus"
+      ],
       "description": "Transcript view mode. \"default\" shows standard interactive view; \"verbose\" shows expanded tool details; \"focus\" shows prompt, one-line tool summaries, and final response only (Ctrl+O toggle). See https://code.claude.com/docs/en/settings#available-settings"
     },
     "useAutoModeDuringPlan": {
@@ -2723,7 +3231,10 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Status line configuration for subagent sessions. See https://code.claude.com/docs/en/statusline#subagent-status-lines",
-      "required": ["type", "command"],
+      "required": [
+        "type",
+        "command"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2736,6 +3247,393 @@
           "minLength": 1
         }
       }
+    },
+    "advisorModel": {
+      "description": "Advisor model for the server-side advisor tool.",
+      "type": "string"
+    },
+    "agentPushNotifEnabled": {
+      "description": "Allow Claude to push proactive mobile notifications",
+      "type": "boolean"
+    },
+    "allowAllClaudeAiMcps": {
+      "description": "When true (and set in managed settings), claude.ai cloud MCP connectors load alongside managed-mcp.json instead of being suppressed by its exclusive-control lockdown. Default off preserves the lockdown. Read from managed settings only.",
+      "type": "boolean"
+    },
+    "autoCompactEnabled": {
+      "description": "Automatically compact conversation when context fills",
+      "type": "boolean"
+    },
+    "autoCompactWindow": {
+      "description": "Auto-compact window size",
+      "type": "integer",
+      "minimum": 100000,
+      "maximum": 1000000
+    },
+    "autoDreamEnabled": {
+      "description": "Enable background memory consolidation (auto-dream). When set, overrides the server-side default.",
+      "type": "boolean"
+    },
+    "autoScrollEnabled": {
+      "description": "Auto-scroll the conversation view to bottom (fullscreen mode only)",
+      "type": "boolean"
+    },
+    "autoUploadSessions": {
+      "description": "Mirror local sessions to claude.ai as view-only (no remote control)",
+      "type": "boolean"
+    },
+    "claudeMd": {
+      "description": "CLAUDE.md-style instructions injected as organization-managed memory. Only honored from managed/policy settings.",
+      "type": "string"
+    },
+    "daemonColdStart": {
+      "description": "When no background service is running: 'transient' spawns one for this login session; 'ask' offers to install it persistently",
+      "type": "string",
+      "enum": [
+        "transient",
+        "ask"
+      ]
+    },
+    "defaultView": {
+      "description": "Default transcript view: chat (SendUserMessage checkpoints only) or transcript (full)",
+      "type": "string",
+      "enum": [
+        "chat",
+        "transcript"
+      ]
+    },
+    "disableAgentView": {
+      "description": "Disable agent view (`claude agents`, `--bg`, /background, the on-demand daemon). Typically set in managed settings. Equivalent to CLAUDE_CODE_DISABLE_AGENT_VIEW=1.",
+      "type": "boolean"
+    },
+    "disableArtifact": {
+      "description": "Disable the Artifact tool (also via CLAUDE_CODE_DISABLE_ARTIFACT).",
+      "type": "boolean"
+    },
+    "disableAutoMode": {
+      "description": "Disable auto mode",
+      "type": "string",
+      "enum": [
+        "disable"
+      ]
+    },
+    "disableBundledSkills": {
+      "description": "Disable the skills and workflows that ship with Claude Code: bundled skills and workflows are removed entirely; built-in slash commands stay typable but are hidden from the model. Plugins, .claude/skills/, and .claude/commands/ are unaffected. Equivalent to CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1.",
+      "type": "boolean"
+    },
+    "disableRemoteControl": {
+      "description": "Disable Remote Control (claude.ai/code, `claude remote-control`, `--remote-control`/`--rc`, auto-start, and the in-session toggle). Typically set in managed settings.",
+      "type": "boolean"
+    },
+    "disableWorkflows": {
+      "description": "Disable the Workflows feature (also via CLAUDE_CODE_DISABLE_WORKFLOWS).",
+      "type": "boolean"
+    },
+    "editorMode": {
+      "description": "Key binding mode for the prompt input",
+      "type": "string",
+      "enum": [
+        "normal",
+        "vim"
+      ]
+    },
+    "enableWorkflows": {
+      "description": "Enable or disable the Workflows feature for this user. Unset = default by plan once the feature is available.",
+      "type": "boolean"
+    },
+    "enforceAvailableModels": {
+      "description": "When true and availableModels is a non-empty array, the Default model selection is also constrained: if the default model for the user tier is not in availableModels, Default resolves to the first allowed availableModels entry instead. Has no effect when availableModels is unset or an empty array. Typically set in managed settings by enterprise administrators.",
+      "type": "boolean"
+    },
+    "fallbackModel": {
+      "description": "Fallback model(s) tried in order when the primary model is overloaded or unavailable. Each element accepts a model name or alias; \"default\" expands to the default model. CLI --fallback-model takes precedence.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "fileCheckpointingEnabled": {
+      "description": "Snapshot files before edits so /rewind can restore them",
+      "type": "boolean"
+    },
+    "footerLinksRegexes": {
+      "description": "Extra clickable footer badges that appear when a regex matches turn output (tool results and assistant responses). Read from user, flag, and managed settings only; ignored in project .claude/settings.json and local .claude/settings.local.json. At most 5 badges render; the oldest is displaced by newer matches and /clear removes them. Use to surface IDs printed by project CLIs as session links.",
+      "type": "array",
+      "items": {
+        "default": {
+          "type": "invalid-entry-stripped"
+        },
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "Config variant. This client understands \"regex\": matches turn output and builds a URL from named capture groups. Entries with other variants are preserved but skipped at runtime.",
+                "type": "string",
+                "const": "regex"
+              },
+              "pattern": {
+                "description": "Regex matched against turn output (tool results and assistant text)",
+                "type": "string"
+              },
+              "url": {
+                "description": "Link target. {name} placeholders are filled from named regex capture groups, e.g. (?<id>...) -> {id}. Values are URL-encoded; the origin must be literal in the template. The scheme must be https, http, or a recognized editor or workspace deep-link scheme: vscode, vscode-insiders, cursor, windsurf, zed, jetbrains, idea, slack, linear, notion, figma.",
+                "type": "string"
+              },
+              "label": {
+                "description": "Badge text. {name} placeholders filled from named capture groups; defaults to the full match.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "pattern",
+              "url"
+            ],
+            "additionalProperties": {}
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "description": "Config variant discriminator for entries this client does not understand; the entry is preserved as-is and skipped at runtime.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": {}
+          }
+        ]
+      }
+    },
+    "gcpAuthRefresh": {
+      "description": "Command to refresh GCP authentication (e.g., gcloud auth application-default login)",
+      "type": "string"
+    },
+    "inputNeededNotifEnabled": {
+      "description": "Push to mobile when a permission prompt or question is waiting",
+      "type": "boolean"
+    },
+    "isolatePeerMachines": {
+      "description": "Require explicit approval before SendMessage can reach a peer session on another machine via Remote Control",
+      "type": "boolean"
+    },
+    "pluginSuggestionMarketplaces": {
+      "description": "Marketplace names whose plugins may surface as contextual install suggestions (relevance-based tips). No marketplace-declared suggestions surface without this allowlist; the built-in first-party frontend-design tip is unaffected. Only honored when set in managed settings (policy scope); the key is ignored in user, project, and local settings. A name only takes effect when the marketplace is registered on the machine AND its registered source is also declared in managed settings, either as the extraKnownMarketplaces entry for that name or as an entry of strictKnownMarketplaces. A marketplace registered from a different source under an allowlisted name is ignored. The official marketplace is exempt from the source requirement: allowlisting its name alone suffices, since that name can only register from the official Anthropic source.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "policyHelper": {
+      "description": "Executable that computes managed settings at startup. Honored only from admin-controlled policy sources.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Absolute path to the helper executable",
+          "type": "string"
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 9007199254740991
+        },
+        "refreshIntervalMs": {
+          "anyOf": [
+            {
+              "type": "number",
+              "const": 0
+            },
+            {
+              "type": "integer",
+              "minimum": 60000,
+              "maximum": 9007199254740991
+            }
+          ]
+        }
+      },
+      "required": [
+        "path"
+      ]
+    },
+    "preferredNotifChannel": {
+      "description": "Preferred OS notification channel",
+      "type": "string",
+      "enum": [
+        "auto",
+        "iterm2",
+        "iterm2_with_bell",
+        "terminal_bell",
+        "kitty",
+        "ghostty",
+        "notifications_disabled"
+      ]
+    },
+    "promptSuggestionEnabled": {
+      "description": "When false, prompt suggestions are disabled. When absent or true, prompt suggestions are enabled.",
+      "type": "boolean"
+    },
+    "proxyAuthHelper": {
+      "description": "Shell command that outputs a Proxy-Authorization header value (EAP)",
+      "type": "string"
+    },
+    "remote": {
+      "description": "Cloud session configuration",
+      "type": "object",
+      "properties": {
+        "defaultEnvironmentId": {
+          "description": "Default environment ID to use for cloud sessions",
+          "type": "string"
+        }
+      }
+    },
+    "remoteControlAtStartup": {
+      "description": "Start Remote Control bridge automatically each session",
+      "type": "boolean"
+    },
+    "requiredMaximumVersion": {
+      "description": "Maximum Claude Code version allowed to start. If the running version is newer, Claude Code exits at startup with instructions to install an approved version. Only enforced from managed (policy) settings.",
+      "type": "string"
+    },
+    "requiredMinimumVersion": {
+      "description": "Minimum Claude Code version required to start. If the running version is older, Claude Code exits at startup with instructions to update. Only enforced from managed (policy) settings.",
+      "type": "string"
+    },
+    "showMessageTimestamps": {
+      "description": "Stamp each assistant message with its arrival time",
+      "type": "boolean"
+    },
+    "skillListingBudgetFraction": {
+      "description": "Fraction of the context window (in characters) reserved for the skill listing sent to Claude (default: 0.01 = 1%). When the listing exceeds this, descriptions are shortened to fit. Raise to opt in to higher per-turn context cost.",
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 1
+    },
+    "skillListingMaxDescChars": {
+      "description": "Per-skill description character cap in the skill listing sent to Claude (default: 1536). Descriptions longer than this are truncated. Raise to opt in to higher per-turn context cost.",
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991
+    },
+    "sshConfigs": {
+      "description": "SSH connection configurations for remote environments. Typically set in managed settings by enterprise administrators to pre-configure SSH connections for team members.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for this SSH config. Used to match configs across settings sources.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name for the SSH connection",
+            "type": "string"
+          },
+          "sshHost": {
+            "description": "SSH host in format \"user@hostname\" or \"hostname\", or a host alias from ~/.ssh/config",
+            "type": "string"
+          },
+          "sshPort": {
+            "description": "SSH port (default: 22)",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "sshIdentityFile": {
+            "description": "Path to SSH identity file (private key)",
+            "type": "string"
+          },
+          "startDirectory": {
+            "description": "Default working directory on the remote host. Supports tilde expansion (e.g. ~/projects). If not specified, defaults to the remote user home directory. Can be overridden by the [dir] positional argument in `claude ssh <config> [dir]`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sshHost"
+        ]
+      }
+    },
+    "switchModelsOnFlag": {
+      "description": "When safety measures flag a message, automatically switch to a different model to keep chatting. When off, your session will pause instead.",
+      "type": "boolean"
+    },
+    "syntaxHighlightingDisabled": {
+      "description": "Whether to disable syntax highlighting in diffs",
+      "type": "boolean"
+    },
+    "terminalTitleFromRename": {
+      "description": "Whether /rename updates the terminal tab title (defaults to true). Set to false to keep auto-generated topic titles.",
+      "type": "boolean"
+    },
+    "theme": {
+      "description": "Color theme for the UI",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "auto",
+            "dark",
+            "light",
+            "light-daltonized",
+            "dark-daltonized",
+            "light-ansi",
+            "dark-ansi"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^custom:.*"
+        }
+      ]
+    },
+    "todoFeatureEnabled": {
+      "description": "Enable the todo / task tracking panel",
+      "type": "boolean"
+    },
+    "ultracode": {
+      "description": "Enable ultracode for the session: xhigh effort plus standing dynamic-workflow orchestration. Session-scoped — typically provided via --settings or the apply_flag_settings control request; interactive toggles never persist it. Requires workflows to be enabled and an xhigh-capable model.",
+      "type": "boolean"
+    },
+    "verbose": {
+      "description": "Show full tool output instead of truncated summaries",
+      "type": "boolean"
+    },
+    "voice": {
+      "description": "Voice mode settings (hold-to-talk / tap-to-toggle dictation)",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "'hold' (default): hold to talk. 'tap': tap to start, tap to stop+submit.",
+          "type": "string",
+          "enum": [
+            "hold",
+            "tap"
+          ]
+        },
+        "autoSubmit": {
+          "description": "Submit the prompt when hold-to-talk is released (hold mode only)",
+          "type": "boolean"
+        }
+      }
+    },
+    "wheelScrollAccelerationEnabled": {
+      "description": "Ramp mouse-wheel scroll speed during fast scrolls (fullscreen mode only)",
+      "type": "boolean"
+    },
+    "workflowKeywordTriggerEnabled": {
+      "description": "Enable the \"ultracode\" keyword trigger: including the keyword in a prompt opts that turn into the Workflow tool. Set to false to disable the trigger. Default: true.",
+      "type": "boolean"
+    },
+    "awaySummaryEnabled": {
+      "description": "Show a one-line session recap when returning to the terminal after being idle (default: true).",
+      "type": "boolean"
     }
   },
   "title": "Claude Code Settings"

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -2908,11 +2908,13 @@
           "type": "string"
         },
         "timeoutMs": {
+          "description": "Maximum time in milliseconds to wait for the policy helper to produce settings before giving up.",
           "type": "integer",
           "minimum": 1000,
           "maximum": 9007199254740991
         },
         "refreshIntervalMs": {
+          "description": "How often in milliseconds to re-run the policy helper to refresh managed settings. Use 0 to run only once at startup.",
           "anyOf": [
             {
               "type": "number",
@@ -3073,6 +3075,7 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enable voice dictation input.",
           "type": "boolean"
         },
         "mode": {

--- a/src/test/claude-code-settings/notif-channel-ghostty.json
+++ b/src/test/claude-code-settings/notif-channel-ghostty.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "preferredNotifChannel": "ghostty"
+}

--- a/src/test/claude-code-settings/notif-channel-iterm2-bell.json
+++ b/src/test/claude-code-settings/notif-channel-iterm2-bell.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "preferredNotifChannel": "iterm2_with_bell"
+}

--- a/src/test/claude-code-settings/notif-channel-kitty.json
+++ b/src/test/claude-code-settings/notif-channel-kitty.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "preferredNotifChannel": "kitty"
+}

--- a/src/test/claude-code-settings/v2177-enum-coverage.json
+++ b/src/test/claude-code-settings/v2177-enum-coverage.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "daemonColdStart": "ask",
+  "defaultView": "transcript",
+  "editorMode": "vim",
+  "preferredNotifChannel": "iterm2",
+  "voice": {
+    "autoSubmit": true,
+    "enabled": false,
+    "mode": "tap"
+  }
+}

--- a/src/test/claude-code-settings/v2177-new-properties.json
+++ b/src/test/claude-code-settings/v2177-new-properties.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-settings.json",
+  "advisorModel": "claude-opus-4-8",
+  "agentPushNotifEnabled": true,
+  "allowAllClaudeAiMcps": true,
+  "autoCompactEnabled": true,
+  "autoCompactWindow": 200000,
+  "autoDreamEnabled": true,
+  "autoScrollEnabled": false,
+  "autoUploadSessions": false,
+  "awaySummaryEnabled": false,
+  "claudeMd": "# Managed policy\nFollow organization guidelines.",
+  "daemonColdStart": "transient",
+  "defaultView": "chat",
+  "disableAgentView": true,
+  "disableArtifact": true,
+  "disableAutoMode": "disable",
+  "disableBundledSkills": true,
+  "disableRemoteControl": true,
+  "disableWorkflows": false,
+  "editorMode": "normal",
+  "enableWorkflows": true,
+  "enforceAvailableModels": true,
+  "fallbackModel": ["claude-sonnet-4-6", "claude-haiku-4-5"],
+  "fileCheckpointingEnabled": true,
+  "footerLinksRegexes": [
+    {
+      "label": "#{num}",
+      "pattern": "#(?<num>\\d+)",
+      "type": "regex",
+      "url": "https://github.com/example/repo/issues/{num}"
+    }
+  ],
+  "gcpAuthRefresh": "gcloud auth print-access-token",
+  "inputNeededNotifEnabled": true,
+  "isolatePeerMachines": false,
+  "pluginSuggestionMarketplaces": ["acme-plugins"],
+  "policyHelper": {
+    "path": "/opt/claude/policy-helper.sh",
+    "refreshIntervalMs": 60000,
+    "timeoutMs": 5000
+  },
+  "preferredNotifChannel": "auto",
+  "promptSuggestionEnabled": true,
+  "proxyAuthHelper": "/usr/local/bin/proxy-auth",
+  "remote": {
+    "defaultEnvironmentId": "env-prod-1"
+  },
+  "remoteControlAtStartup": false,
+  "requiredMaximumVersion": "3.0.0",
+  "requiredMinimumVersion": "2.0.0",
+  "showMessageTimestamps": true,
+  "skillListingBudgetFraction": 0.05,
+  "skillListingMaxDescChars": 2048,
+  "sshConfigs": [
+    {
+      "id": "home",
+      "name": "Home server",
+      "sshHost": "user@host.example",
+      "sshIdentityFile": "~/.ssh/id_ed25519",
+      "sshPort": 22,
+      "startDirectory": "~/projects"
+    }
+  ],
+  "switchModelsOnFlag": true,
+  "syntaxHighlightingDisabled": false,
+  "todoFeatureEnabled": true,
+  "ultracode": true,
+  "voice": {
+    "autoSubmit": false,
+    "enabled": true,
+    "mode": "hold"
+  },
+  "wheelScrollAccelerationEnabled": true,
+  "workflowKeywordTriggerEnabled": true
+}


### PR DESCRIPTION
## What

Expands `src/schemas/json/claude-code-settings.json` from 84 to 134 top-level properties, closing a ~42-property gap against the authoritative schema bundled with the official Claude Code VS Code extension (v2.1.177), and adds `awaySummaryEnabled`.

## Why

Editors that resolve `settings.json` completion/validation through SchemaStore were missing IntelliSense and validation for the newer settings keys. This syncs SchemaStore to the upstream source of truth.

## Notes

- `$id` is unchanged (`https://json.schemastore.org/claude-code-settings.json`); declares draft-07, consistent with the existing file.
- `additionalProperties: true` is retained — this change only *adds* property definitions, so the existing `src/test/claude-code-settings/` fixtures continue to validate.
- Preserves 5 legacy-only keys already present in SchemaStore but absent from the bundled schema (`autoMode`, `voiceEnabled`, `skippedMarketplaces`, `skippedPlugins`, `useAutoModeDuringPlan`). Left intact; maintainers may deprecate them separately.
- `awaySummaryEnabled` (boolean, default true) is defined from the official settings reference docs — it is absent from both the bundled schema and the prior SchemaStore copy.
- All 33 `$ref`s resolve against `$defs`; no draft-2020-12-only keywords introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
