### PR TITLE
feat(ryl): update schema to v0.17.0

### DIFF
--- a/src/schemas/json/ryl.json
+++ b/src/schemas/json/ryl.json
@@ -131,6 +131,100 @@
       "enum": ["unix", "dos", "platform"],
       "type": "string"
     },
+    "OutputDestination": {
+      "additionalProperties": false,
+      "description": "Where one format's output goes. An absent `path` means the format's default stream\n(stderr for the console formats, stdout for `junit`/`gitlab`); `\"-\"` means stdout; any\nother value is a file path.",
+      "properties": {
+        "path": {
+          "type": ["string", "null"]
+        }
+      },
+      "type": "object"
+    },
+    "OutputTable": {
+      "additionalProperties": false,
+      "description": "Output targets (ryl-only; TOML). Each format present is rendered to its destination,\nso several formats produce several outputs in one run (e.g. console plus a report\nfile). A CLI `--format` overrides this table wholesale. yamllint has no equivalent;\nsee `docs/output-formats.md`.",
+      "properties": {
+        "auto": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Auto-detected console format (GitHub annotations in CI, otherwise colored/plain)."
+        },
+        "colored": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Plain text with ANSI colors."
+        },
+        "github": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "GitHub Actions workflow commands."
+        },
+        "gitlab": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "`GitLab` Code Quality JSON report."
+        },
+        "junit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "`JUnit` XML test report."
+        },
+        "parsable": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "One `path:line:col: [level] message (rule)` line per diagnostic."
+        },
+        "standard": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OutputDestination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Plain text grouped per file."
+        }
+      },
+      "type": "object"
+    },
     "PerLineIgnore": {
       "additionalProperties": false,
       "description": "A single `per-line-ignores` entry. Suppresses `rules` on source lines matching\n`regex` (the whole physical line, unanchored) within files matching `path` (a\nglob). All present fields must match (logical AND); at least one of `regex`/`path`\nis required (validated in `validate_toml_config`), so an entry can't disable a rule\nglobally.",
@@ -1847,6 +1941,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "description": "JSON Schema root for `ryl` TOML configuration.",
   "properties": {
     "files": {
@@ -1907,6 +2002,17 @@
         }
       ],
       "description": "Behaviour for YAML embedded in markdown (front matter and fenced blocks)."
+    },
+    "output": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OutputTable"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Output targets: which format goes to which destination (file/stdout/stderr)."
     },
     "per-file-ignores": {
       "additionalProperties": {

--- a/src/test/ryl/01-valid.toml
+++ b/src/test/ryl/01-valid.toml
@@ -1,6 +1,8 @@
 #:schema ../../schemas/json/ryl.json
-yaml-files = ["*.yaml", "*.yml"]
 ignore = ["vendor/**"]
+
+[files]
+yaml = ["*.yaml", "*.yml"]
 
 [per-file-ignores]
 "**/values.yaml" = ["document-start"]


### PR DESCRIPTION
Syncs SchemaStore's `ryl.json` with the schema released in `ryl` v0.17.0.

## Changes

- Updates `src/schemas/json/ryl.json`
- Adds or refreshes the catalog entry for `ryl.toml` / `.ryl.toml`
- Adds positive and negative TOML tests under `src/test/ryl` and `src/negative_test/ryl`

## Validation

- `node cli.js check --schema-name=ryl.json`

## Source

- Schema source: https://github.com/owenlamont/ryl/blob/50a1abec1f9107b60d4e24d4a1f23628dd3ce7da/ryl.toml.schema.json
- Release workflow: https://github.com/owenlamont/ryl/blob/50a1abec1f9107b60d4e24d4a1f23628dd3ce7da/.github/workflows/sync-schemastore.yml