### PR TITLE
Add modelparams.dev schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4846,6 +4846,12 @@
       "url": "https://www.mock-server.com/schema/expectations.json"
     },
     {
+      "name": "modelparams.dev Model",
+      "description": "Model Parameters Convention entry for one model variant in the modelparams.dev catalog. Documentation: https://modelparams.dev",
+      "fileMatch": [],
+      "url": "https://www.schemastore.org/modelparams.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],

--- a/src/negative_test/modelparams/missing-auth-type.yaml
+++ b/src/negative_test/modelparams/missing-auth-type.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../schemas/json/modelparams.json
+provider: anthropic
+model: claude-sonnet-4-5
+params:
+  - path: 1invalid
+    label: Broken path
+    description: This path starts with a digit and should be rejected.
+    group: reasoning
+    type: boolean

--- a/src/schemas/json/modelparams.json
+++ b/src/schemas/json/modelparams.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/modelparams.json",
+  "$ref": "#/definitions/Model",
+  "title": "modelparams.dev Model",
+  "description": "Schema for a single AI model variant entry in the modelparams.dev catalog. Documentation: https://github.com/mnfst/modelparams.dev/blob/main/docs/model-parameters-schema.md",
+  "definitions": {
+    "Model": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "authType": {
+          "type": "string",
+          "enum": ["api_key", "subscription"]
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)*$"
+                  },
+                  "label": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500
+                  },
+                  "group": {
+                    "type": "string",
+                    "enum": [
+                      "generation_length",
+                      "sampling",
+                      "reasoning",
+                      "tooling",
+                      "output_format",
+                      "observability",
+                      "provider_metadata"
+                    ]
+                  },
+                  "applicability": {
+                    "type": "object",
+                    "properties": {
+                      "only": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0/additionalProperties/anyOf/0"
+                                  },
+                                  "minItems": 1
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "not": {
+                                      "anyOf": [
+                                        {
+                                          "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0/additionalProperties/anyOf/0"
+                                        },
+                                        {
+                                          "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0/additionalProperties/anyOf/1"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "required": ["not"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "propertyNames": {
+                              "pattern": "^[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)*$"
+                            }
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0"
+                            },
+                            "minItems": 1
+                          }
+                        ]
+                      },
+                      "except": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0"
+                          },
+                          {
+                            "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/1"
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string",
+                    "const": "boolean"
+                  },
+                  "default": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["path", "label", "description", "group", "type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/path"
+                  },
+                  "label": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/label"
+                  },
+                  "description": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/description"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/group"
+                  },
+                  "applicability": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability"
+                  },
+                  "type": {
+                    "type": "string",
+                    "const": "enum"
+                  },
+                  "default": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0/additionalProperties/anyOf/0"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability/properties/only/anyOf/0/additionalProperties/anyOf/0"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "path",
+                  "label",
+                  "description",
+                  "group",
+                  "type",
+                  "values"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/path"
+                  },
+                  "label": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/label"
+                  },
+                  "description": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/description"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/group"
+                  },
+                  "applicability": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability"
+                  },
+                  "type": {
+                    "type": "string",
+                    "const": "integer"
+                  },
+                  "default": {
+                    "type": "integer"
+                  },
+                  "range": {
+                    "type": "object",
+                    "properties": {
+                      "min": {
+                        "type": "number"
+                      },
+                      "max": {
+                        "type": "number"
+                      },
+                      "step": {
+                        "type": "number",
+                        "exclusiveMinimum": 0
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["path", "label", "description", "group", "type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/path"
+                  },
+                  "label": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/label"
+                  },
+                  "description": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/description"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/group"
+                  },
+                  "applicability": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability"
+                  },
+                  "type": {
+                    "type": "string",
+                    "const": "number"
+                  },
+                  "default": {
+                    "type": "number"
+                  },
+                  "range": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/2/properties/range"
+                  }
+                },
+                "required": ["path", "label", "description", "group", "type"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/path"
+                  },
+                  "label": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/label"
+                  },
+                  "description": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/description"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/group"
+                  },
+                  "applicability": {
+                    "$ref": "#/definitions/Model/properties/params/items/anyOf/0/properties/applicability"
+                  },
+                  "type": {
+                    "type": "string",
+                    "const": "string"
+                  },
+                  "default": {
+                    "type": "string"
+                  }
+                },
+                "required": ["path", "label", "description", "group", "type"],
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      },
+      "required": ["provider", "authType", "model", "params"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/test/modelparams/modelparams.yaml
+++ b/src/test/modelparams/modelparams.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../schemas/json/modelparams.json
+provider: anthropic
+authType: api_key
+model: claude-sonnet-4-5
+params:
+  - path: max_tokens
+    label: Max tokens
+    description: Maximum number of output tokens the model may generate.
+    group: generation_length
+    type: integer
+    default: 4096
+    range:
+      min: 1
+  - path: thinking.type
+    label: Thinking mode
+    description: Controls whether Claude uses extended reasoning for the response.
+    group: reasoning
+    type: enum
+    values:
+      - enabled
+      - disabled
+    applicability:
+      except:
+        thinking.budget_tokens:
+          not: null


### PR DESCRIPTION
## Summary
- add a SchemaStore-hosted JSON Schema for a single modelparams.dev Model Parameters Convention entry
- register it in the JSON schema catalog with an empty `fileMatch` to avoid broad filename matches
- add positive and negative YAML fixtures for the modelparams source-entry shape

## Context
Manifest recently published modelparams.dev as an open source catalog for LLM model parameter metadata. The catalog stores one YAML/JSON entry per provider/auth/model variant, and this SchemaStore entry makes those source files easier to edit with standard JSON/YAML language-server validation.

## Notes
The schema was sourced from `https://modelparams.dev/api/v1/schema.json`, with the `$id` adjusted to the SchemaStore URL and the generated union shorthand normalized for Ajv strict mode.

## Validation
- `node ./cli.js check --schema-name=modelparams.json`
- `git diff --check`
