### PR TITLE
Tighten Codex hooks root schema

### DIFF
--- a/src/negative_test/codex-hooks/unknown-root-metadata.json
+++ b/src/negative_test/codex-hooks/unknown-root-metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/codex-hooks.json",
+  "description": "Project-level Codex hooks",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/stop.py",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schemas/json/codex-hooks.json
+++ b/src/schemas/json/codex-hooks.json
@@ -5,16 +5,8 @@
   "description": "Configuration for OpenAI Codex lifecycle hooks.\nhttps://developers.openai.com/codex/hooks",
   "type": "object",
   "required": ["hooks"],
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "JSON Schema reference for Codex hooks configuration."
-    },
-    "description": {
-      "type": "string",
-      "description": "Human-readable description of the hooks file."
-    },
     "hooks": {
       "type": "object",
       "description": "Hook event registrations grouped by Codex lifecycle event.",

--- a/src/test/codex-hooks/hooks.json
+++ b/src/test/codex-hooks/hooks.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/codex-hooks.json",
-  "description": "Project-level Codex hooks",
   "hooks": {
     "PermissionRequest": [
       {


### PR DESCRIPTION
## Summary

Updates the Codex hooks schema to match Codex's stricter root object parsing.

Codex now warns when `hooks.json` contains top-level metadata keys such as `$schema` or `description`; the file is expected to start with the `hooks` configuration object. This PR:

- removes root `$schema` and `description` from the positive fixture
- changes the root object to `additionalProperties: false`
- adds a negative fixture that rejects top-level `$schema` / `description` metadata

Nested matcher groups and hook handlers remain permissive, matching the existing schema behavior for forward-compatible hook options.

## Validation

- `node .\cli.js check --schema-name=codex-hooks.json`
- `npm run prettier -- --cache --ignore-unknown .\src\schemas\json\codex-hooks.json .\src\test\codex-hooks\hooks.json .\src\negative_test\codex-hooks\invalid-event-shape.json .\src\negative_test\codex-hooks\missing-command.json .\src\negative_test\codex-hooks\unknown-root-metadata.json`
