### PR TITLE
feat: add JSON schema for commit-check configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2263,6 +2263,12 @@
       "url": "https://www.schemastore.org/coffeelint.json"
     },
     {
+      "name": "commit-check",
+      "description": "Configuration for commit-check, a commit message, branch naming, and push linter",
+      "fileMatch": ["cchk.toml", "commit-check.toml", "**/.github/cchk.toml", "**/.github/commit-check.toml"],
+      "url": "https://www.schemastore.org/commit-check.json"
+    },
+    {
       "name": "committed.toml",
       "description": "committed configuration file",
       "fileMatch": ["committed.toml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2265,7 +2265,12 @@
     {
       "name": "commit-check",
       "description": "Configuration for commit-check, a commit message, branch naming, and push linter",
-      "fileMatch": ["cchk.toml", "commit-check.toml", "**/.github/cchk.toml", "**/.github/commit-check.toml"],
+      "fileMatch": [
+        "cchk.toml",
+        "commit-check.toml",
+        "**/.github/cchk.toml",
+        "**/.github/commit-check.toml"
+      ],
       "url": "https://www.schemastore.org/commit-check.json"
     },
     {

--- a/src/negative_test/commit-check/minimum-violation.toml
+++ b/src/negative_test/commit-check/minimum-violation.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/commit-check.json
+[commit]
+subject_max_length = -1  # should be >= 1
+subject_min_length = 0  # should be >= 1

--- a/src/negative_test/commit-check/minimum-violation.toml
+++ b/src/negative_test/commit-check/minimum-violation.toml
@@ -1,4 +1,4 @@
 #:schema ../../schemas/json/commit-check.json
 [commit]
-subject_max_length = -1  # should be >= 1
+subject_max_length = -1 # should be >= 1
 subject_min_length = 0  # should be >= 1

--- a/src/negative_test/commit-check/type-error.toml
+++ b/src/negative_test/commit-check/type-error.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/commit-check.json
+[commit]
+conventional_commits = "yes"  # should be boolean, not string
+subject_max_length = "eighty"  # should be integer, not string
+allow_commit_types = "feat,fix,docs"  # should be array, not string

--- a/src/negative_test/commit-check/type-error.toml
+++ b/src/negative_test/commit-check/type-error.toml
@@ -1,5 +1,5 @@
 #:schema ../../schemas/json/commit-check.json
 [commit]
-conventional_commits = "yes"  # should be boolean, not string
-subject_max_length = "eighty"  # should be integer, not string
-allow_commit_types = "feat,fix,docs"  # should be array, not string
+conventional_commits = "yes"         # should be boolean, not string
+subject_max_length = "eighty"        # should be integer, not string
+allow_commit_types = "feat,fix,docs" # should be array, not string

--- a/src/schemas/json/commit-check.json
+++ b/src/schemas/json/commit-check.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://www.schemastore.org/commit-check.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/commit-check.json",
   "title": "commit-check",
   "description": "Configuration for commit-check, a commit message, branch naming, and push linter\nhttps://github.com/commit-check/commit-check",
   "type": "object",
@@ -49,7 +49,18 @@
         "allow_commit_types": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"],
+          "default": [
+            "feat",
+            "fix",
+            "docs",
+            "style",
+            "refactor",
+            "test",
+            "chore",
+            "perf",
+            "build",
+            "ci"
+          ],
           "description": "Allowed commit types when conventional_commits is true."
         },
         "allow_merge_commits": {
@@ -109,7 +120,15 @@
         "allow_branch_types": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"],
+          "default": [
+            "feature",
+            "bugfix",
+            "hotfix",
+            "release",
+            "chore",
+            "feat",
+            "fix"
+          ],
           "description": "Allowed branch types when conventional_branch is true."
         },
         "allow_branch_names": {

--- a/src/schemas/json/commit-check.json
+++ b/src/schemas/json/commit-check.json
@@ -1,0 +1,147 @@
+{
+  "$id": "https://www.schemastore.org/commit-check.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "commit-check",
+  "description": "Configuration for commit-check, a commit message, branch naming, and push linter\nhttps://github.com/commit-check/commit-check",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "inherit_from": {
+      "type": "string",
+      "description": "Inherit configuration from a parent file. Supports github: shorthand (e.g., github:owner/repo:path/to/cchk.toml), HTTPS URL, or local file path.\nhttps://github.com/commit-check/commit-check/blob/main/docs/configuration.rst#organization-level-configuration-inherit_from"
+    },
+    "commit": {
+      "type": "object",
+      "title": "Commit rules",
+      "description": "Settings for commit message validation.\nhttps://github.com/commit-check/commit-check/blob/main/docs/configuration.rst",
+      "additionalProperties": true,
+      "properties": {
+        "conventional_commits": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enforce Conventional Commits specification.\nhttps://www.conventionalcommits.org"
+        },
+        "message_pattern": {
+          "type": "string",
+          "default": "",
+          "description": "Custom regex pattern for commit message validation. When set (non-empty), this replaces the auto-generated Conventional Commits regex entirely. Useful for enforcing custom formats such as JIRA smart commits (e.g., ^PROJ-\\\\d+: .+)."
+        },
+        "subject_capitalized": {
+          "type": "boolean",
+          "default": true,
+          "description": "Subject must start with a capital letter."
+        },
+        "subject_imperative": {
+          "type": "boolean",
+          "default": true,
+          "description": "Subject must be in imperative mood.\nhttps://github.com/commit-check/commit-check/blob/main/commit_check/imperatives.py"
+        },
+        "subject_max_length": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum length of the subject line. No limit by default."
+        },
+        "subject_min_length": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum length of the subject line. No limit by default."
+        },
+        "allow_commit_types": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"],
+          "description": "Allowed commit types when conventional_commits is true."
+        },
+        "allow_merge_commits": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow merge commits."
+        },
+        "allow_revert_commits": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow revert commits."
+        },
+        "allow_empty_commits": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow empty commits."
+        },
+        "allow_fixup_commits": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow fixup commits (e.g., fixup! <commit message>)."
+        },
+        "allow_wip_commits": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow work-in-progress commits (e.g., WIP: <commit message>)."
+        },
+        "require_body": {
+          "type": "boolean",
+          "default": false,
+          "description": "Require a body in the commit message."
+        },
+        "require_signed_off_by": {
+          "type": "boolean",
+          "default": false,
+          "description": "Require Signed-off-by line in the commit message footer."
+        },
+        "ignore_authors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "List of commit authors or co-authors (Co-authored-by: lines) to bypass all commit checks. Useful for bots (e.g., dependabot[bot], coderabbitai[bot])."
+        }
+      }
+    },
+    "branch": {
+      "type": "object",
+      "title": "Branch rules",
+      "description": "Settings for branch naming validation.\nhttps://conventional-branch.github.io/",
+      "additionalProperties": true,
+      "properties": {
+        "conventional_branch": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enforce Conventional Branch specification.\nhttps://conventional-branch.github.io/"
+        },
+        "allow_branch_types": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"],
+          "description": "Allowed branch types when conventional_branch is true."
+        },
+        "allow_branch_names": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Additional standalone branch names allowed when conventional_branch is true (e.g., [\"develop\", \"staging\"]). By default, master, main, HEAD, and PR-* are always allowed."
+        },
+        "require_rebase_target": {
+          "type": "string",
+          "description": "Target branch for rebase requirement. If not set, no rebase validation is performed."
+        },
+        "ignore_authors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "List of authors to bypass branch checks."
+        }
+      }
+    },
+    "push": {
+      "type": "object",
+      "title": "Push rules",
+      "description": "Settings for push validation (pre-push hook).\nhttps://github.com/commit-check/commit-check",
+      "additionalProperties": true,
+      "properties": {
+        "allow_force_push": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow force pushes. Set to false to block force pushes when used as a pre-push hook or with --no-force-push."
+        }
+      }
+    }
+  }
+}

--- a/src/test/commit-check/valid-full.toml
+++ b/src/test/commit-check/valid-full.toml
@@ -1,0 +1,26 @@
+#:schema ../../schemas/json/commit-check.json
+[commit]
+conventional_commits = true
+subject_capitalized = true
+subject_imperative = true
+subject_max_length = 80
+subject_min_length = 5
+allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"]
+allow_merge_commits = true
+allow_revert_commits = true
+allow_empty_commits = false
+allow_fixup_commits = true
+allow_wip_commits = false
+require_body = false
+require_signed_off_by = false
+ignore_authors = ["dependabot[bot]", "pre-commit-ci[bot]"]
+
+[branch]
+conventional_branch = true
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+allow_branch_names = ["develop", "staging"]
+require_rebase_target = "main"
+ignore_authors = ["dependabot[bot]"]
+
+[push]
+allow_force_push = false

--- a/src/test/commit-check/valid-full.toml
+++ b/src/test/commit-check/valid-full.toml
@@ -5,7 +5,18 @@ subject_capitalized = true
 subject_imperative = true
 subject_max_length = 80
 subject_min_length = 5
-allow_commit_types = ["feat", "fix", "docs", "style", "refactor", "test", "chore", "perf", "build", "ci"]
+allow_commit_types = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "test",
+  "chore",
+  "perf",
+  "build",
+  "ci",
+]
 allow_merge_commits = true
 allow_revert_commits = true
 allow_empty_commits = false
@@ -17,7 +28,15 @@ ignore_authors = ["dependabot[bot]", "pre-commit-ci[bot]"]
 
 [branch]
 conventional_branch = true
-allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+allow_branch_types = [
+  "feature",
+  "bugfix",
+  "hotfix",
+  "release",
+  "chore",
+  "feat",
+  "fix",
+]
 allow_branch_names = ["develop", "staging"]
 require_rebase_target = "main"
 ignore_authors = ["dependabot[bot]"]

--- a/src/test/commit-check/valid-inherit.toml
+++ b/src/test/commit-check/valid-inherit.toml
@@ -1,0 +1,9 @@
+#:schema ../../schemas/json/commit-check.json
+inherit_from = "github:my-org/.github:cchk.toml"
+
+[commit]
+subject_max_length = 72
+
+[branch]
+conventional_branch = true
+allow_branch_types = ["feature", "bugfix", "hotfix"]

--- a/src/test/commit-check/valid-minimal.toml
+++ b/src/test/commit-check/valid-minimal.toml
@@ -1,0 +1,6 @@
+#:schema ../../schemas/json/commit-check.json
+[commit]
+conventional_commits = true
+subject_capitalized = false
+subject_imperative = false
+allow_commit_types = ["feat", "fix", "docs", "chore"]


### PR DESCRIPTION
## Summary

Add JSON Schema for [commit-check](https://github.com/commit-check/commit-check), a commit message, branch naming, and push linter.

## Details

commit-check uses TOML configuration files (`cchk.toml` or `commit-check.toml`, also under `.github/`). This schema provides autocompletion and validation in IDEs (VS Code with Even Better TOML, PyCharm, etc.).

### Schema coverage

| Section | Fields |
|---------|--------|
| `[commit]` | conventional_commits, message_pattern, subject_capitalized, subject_imperative, subject_max_length, subject_min_length, allow_commit_types, allow_merge_commits, allow_revert_commits, allow_empty_commits, allow_fixup_commits, allow_wip_commits, require_body, require_signed_off_by, ignore_authors |
| `[branch]` | conventional_branch, allow_branch_types, allow_branch_names, require_rebase_target, ignore_authors |
| `[push]` | allow_force_push |
| Top-level | inherit_from |
