### PR TITLE
Add DebtLens config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1734,6 +1734,12 @@
       "url": "https://salsa.debian.org/debian/debian-json-schemas/-/raw/main/schemas/debian-upstream-metadata/debian-upstream-metadata-latest.json"
     },
     {
+      "name": "DebtLens",
+      "description": "Configuration file for the DebtLens maintainability scanner",
+      "fileMatch": ["debtlens.config.json", ".debtlensrc.json"],
+      "url": "https://raw.githubusercontent.com/ColumbusLabs/DebtLens/main/schema/debtlens.config.schema.json"
+    },
+    {
       "name": "Deck config",
       "description": "Deck is a tool for creating presentation using Markdown and Google Slides",
       "fileMatch": [


### PR DESCRIPTION
Adds the DebtLens maintainability scanner configuration schema to the JSON Schema Store catalog.\n\nSchema URL: https://raw.githubusercontent.com/ColumbusLabs/DebtLens/main/schema/debtlens.config.schema.json\n\nFile matches:\n- debtlens.config.json\n- .debtlensrc.json\n\nDebtLens project: https://github.com/ColumbusLabs/DebtLens