### PR TITLE
claude-code: add missing settings

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -94,6 +94,7 @@
     "disableAutoMode": "enabled",
     "disableBypassPermissionsMode": "enabled"
   },
+  "preferredNotifChannel": "slack",
   "skillOverrides": {
     "test-skill": "invalid-mode"
   },
@@ -102,6 +103,7 @@
     "verbs": ["Analyzing"]
   },
   "teammateMode": "split",
+  "theme": "midnight",
   "tui": "mini",
   "viewMode": "list",
   "worktree": {

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -2719,6 +2719,66 @@
       "type": "boolean",
       "description": "(Windows managed settings only) When true, Claude Code on WSL reads managed settings from the Windows policy chain in addition to /etc/claude-code, with Windows sources taking priority. Only honored when set in the HKLM registry key or C:\\Program Files\\ClaudeCode\\managed-settings.json, both of which require Windows admin to write. For HKCU policy to also apply on WSL, the flag must additionally be set in HKCU itself. Has no effect on native Windows. See https://code.claude.com/docs/en/settings#available-settings"
     },
+    "theme": {
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "auto",
+            "dark",
+            "light",
+            "light-daltonized",
+            "dark-daltonized",
+            "light-ansi",
+            "dark-ansi"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^custom:",
+          "description": "Custom theme defined in ~/.claude/themes/"
+        }
+      ],
+      "description": "Color theme for the UI. Built-in: auto, dark, light, the daltonized variants (deuteranopia-friendly), and the ansi variants (16-color terminals). \"auto\" detects light/dark from the terminal background. Use a \"custom:<name>\" value for a custom theme. See https://code.claude.com/docs/en/settings#available-settings",
+      "default": "dark"
+    },
+    "preferredNotifChannel": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "iterm2",
+        "iterm2_with_bell",
+        "terminal_bell",
+        "kitty",
+        "ghostty",
+        "notifications_disabled"
+      ],
+      "description": "Preferred OS notification channel for task-complete and permission-prompt notifications. \"auto\" sends a desktop notification in iTerm2, Ghostty, and Kitty and does nothing elsewhere; \"terminal_bell\" rings the bell in any terminal; \"notifications_disabled\" turns them off. See https://code.claude.com/docs/en/settings#available-settings",
+      "default": "auto"
+    },
+    "autoCompactEnabled": {
+      "type": "boolean",
+      "description": "Automatically compact the conversation when context approaches the limit. Also configurable via the DISABLE_AUTO_COMPACT environment variable. See https://code.claude.com/docs/en/settings#available-settings",
+      "default": true
+    },
+    "skipWorkflowUsageWarning": {
+      "type": "boolean",
+      "description": "Whether the user has accepted the multi-agent workflow usage warning. Until set, auto permission mode prompts before running a workflow. Typically managed by the CLI rather than set by hand."
+    },
+    "skipAutoPermissionPrompt": {
+      "type": "boolean",
+      "description": "Whether the user has accepted the auto mode opt-in dialog. Typically managed by the CLI rather than set by hand."
+    },
+    "inputNeededNotifEnabled": {
+      "type": "boolean",
+      "description": "When Remote Control is connected, send a push notification to your phone when a permission prompt or question is waiting for input. Requires Claude Code v2.1.119 or later. See https://code.claude.com/docs/en/settings#available-settings",
+      "default": false
+    },
+    "agentPushNotifEnabled": {
+      "type": "boolean",
+      "description": "When Remote Control is connected, allow Claude to send proactive push notifications to your phone, for example when a long task finishes. Requires Claude Code v2.1.119 or later. See https://code.claude.com/docs/en/settings#available-settings",
+      "default": false
+    },
     "subagentStatusLine": {
       "type": "object",
       "additionalProperties": false,

--- a/src/test/claude-code-settings/enum-coverage.json
+++ b/src/test/claude-code-settings/enum-coverage.json
@@ -92,6 +92,8 @@
       }
     ]
   },
+  "skipAutoPermissionPrompt": true,
+  "skipWorkflowUsageWarning": true,
   "terminalTitleFromRename": true,
   "tui": "fullscreen",
   "viewMode": "verbose"

--- a/src/test/claude-code-settings/notifications.json
+++ b/src/test/claude-code-settings/notifications.json
@@ -1,4 +1,6 @@
 {
+  "agentPushNotifEnabled": true,
+  "inputNeededNotifEnabled": true,
   "preferredNotifChannel": "terminal_bell",
   "theme": "dark-daltonized"
 }

--- a/src/test/claude-code-settings/theme-custom.json
+++ b/src/test/claude-code-settings/theme-custom.json
@@ -1,0 +1,4 @@
+{
+  "preferredNotifChannel": "iterm2_with_bell",
+  "theme": "custom:solarized"
+}

--- a/src/test/claude-code-settings/theme-dark-ansi.json
+++ b/src/test/claude-code-settings/theme-dark-ansi.json
@@ -1,0 +1,4 @@
+{
+  "preferredNotifChannel": "kitty",
+  "theme": "dark-ansi"
+}

--- a/src/test/claude-code-settings/theme-dark.json
+++ b/src/test/claude-code-settings/theme-dark.json
@@ -1,0 +1,4 @@
+{
+  "preferredNotifChannel": "auto",
+  "theme": "dark"
+}

--- a/src/test/claude-code-settings/theme-light-ansi.json
+++ b/src/test/claude-code-settings/theme-light-ansi.json
@@ -1,0 +1,4 @@
+{
+  "preferredNotifChannel": "ghostty",
+  "theme": "light-ansi"
+}

--- a/src/test/claude-code-settings/theme-light-daltonized.json
+++ b/src/test/claude-code-settings/theme-light-daltonized.json
@@ -1,0 +1,4 @@
+{
+  "preferredNotifChannel": "iterm2",
+  "theme": "light-daltonized"
+}

--- a/src/test/claude-code-settings/theme-variations.json
+++ b/src/test/claude-code-settings/theme-variations.json
@@ -1,1 +1,4 @@
-{}
+{
+  "autoCompactEnabled": false,
+  "theme": "auto"
+}


### PR DESCRIPTION
Adds seven settings to `claude-code-settings.json` that Claude Code accepts but the schema did not model: `theme`, `preferredNotifChannel`, `autoCompactEnabled`, `skipWorkflowUsageWarning`, `skipAutoPermissionPrompt`, `inputNeededNotifEnabled`, and `agentPushNotifEnabled`.

The schema sets `additionalProperties: true`, so `ajv` never rejected these keys. 

Types, descriptions, and enum values were extracted from the Claude Code v2.1.179 binary's settings schema. `theme` is modeled as an `anyOf` of a built-in enum (`auto`, `dark`, `light`, the daltonized variants, the ansi variants) and a `^custom:` pattern, matching the CLI's `union([enum(...), string().startsWith("custom:")])`. A bare enum would wrongly reject valid custom themes like `custom:my-theme`.

## Testing

`claude-code-settings.json` is registered with `"strict": true`, so the coverage tool enforces test completeness. Positive fixtures cover every `theme` and `preferredNotifChannel` enum value, the `^custom:` pattern, and a non-default value for each boolean that declares a default. Negative cases (`theme: "midnight"`, `preferredNotifChannel: "slack"`) go in the existing all-`invalid_enum` file to keep negative-test isolation cohesive. Verified locally with `node ./cli.js check`, `node ./cli.js coverage`, and `prettier --check` scoped to this schema.
