### PR TITLE
Add TunnelHub sqlTables configuration

### DIFF
--- a/src/schemas/json/tunnelhub.json
+++ b/src/schemas/json/tunnelhub.json
@@ -84,6 +84,16 @@
             }
           }
         },
+        "sqlTables": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": ["enabled"],
+          "type": "object"
+        },
         "stsAccess": {
           "additionalProperties": false,
           "properties": {
@@ -100,6 +110,39 @@
           "type": "object"
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "type": "object",
+            "properties": {
+              "sqlTables": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                },
+                "required": ["enabled"]
+              }
+            },
+            "required": ["sqlTables"]
+          },
+          "then": {
+            "properties": {
+              "runInVpc": {
+                "const": true
+              },
+              "runtime": {
+                "const": "nodejs24.x"
+              },
+              "runtimeEngine": {
+                "enum": ["LAMBDA", "ECS_FARGATE"]
+              }
+            },
+            "required": ["runtimeEngine", "runtime", "runInVpc"]
+          }
+        }
+      ],
       "required": ["runtimeEngine", "entrypoint", "runtime", "memorySize"],
       "type": "object"
     },

--- a/src/test/tunnelhub/tunnelhub.yml
+++ b/src/test/tunnelhub/tunnelhub.yml
@@ -12,3 +12,6 @@ configuration:
   runtime: nodejs24.x
   memorySize: 512
   timeout: 900
+  runInVpc: true
+  sqlTables:
+    enabled: true


### PR DESCRIPTION
## Summary
- add configuration.sqlTables.enabled to the TunnelHub schema
- require nodejs24.x and runInVpc when SQL Tables are enabled
- update the TunnelHub fixture with SQL Tables enabled

## Validation
- node cli.js check --schema-name=tunnelhub.json
- npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/tunnelhub.json src/test/tunnelhub/tunnelhub.yml

Note: npm run prettier currently reports an unrelated existing formatting issue in src/test/sourcery_yaml_schema/.sourcery-init.yaml.