### PR TITLE
Add actionlint schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -311,6 +311,12 @@
       "url": "https://acp-protocol.dev/schemas/v1/vars.schema.json"
     },
     {
+      "name": "actionlint",
+      "description": "Configuration file for actionlint",
+      "fileMatch": ["actionlint.yaml", "actionlint.yml"],
+      "url": "https://www.schemastore.org/actionlint.json"
+    },
+    {
       "name": "AIConfig",
       "description": "AIConfig that is used to store generative AI prompts, models and model parameters",
       "fileMatch": [

--- a/src/negative_test/actionlint/invalid-ignore-shape.yaml
+++ b/src/negative_test/actionlint/invalid-ignore-shape.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/actionlint.json
+paths:
+  .github/workflows/*.yaml:
+    ignore: 'shellcheck reported issue in this script: SC2086:.+'

--- a/src/negative_test/actionlint/unknown-path-key.yaml
+++ b/src/negative_test/actionlint/unknown-path-key.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/actionlint.json
+paths:
+  .github/workflows/*.yaml:
+    ignore:
+      - 'label .+ is unknown'
+    severity: warning

--- a/src/negative_test/actionlint/unknown-root-key.yaml
+++ b/src/negative_test/actionlint/unknown-root-key.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/actionlint.json
+self-hosted-runner:
+  labels:
+    - self-hosted
+secrets:
+  - GITHUB_TOKEN

--- a/src/schemas/json/actionlint.json
+++ b/src/schemas/json/actionlint.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/actionlint.json",
+  "$comment": "Sources: https://github.com/rhysd/actionlint/blob/v1.7.12/docs/config.md and https://github.com/rhysd/actionlint/blob/v1.7.12/config.go",
+  "title": "actionlint configuration",
+  "description": "Configuration for actionlint, a static checker for GitHub Actions workflow files.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "self-hosted-runner": {
+      "description": "Configuration for self-hosted runner environments.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "labels": {
+              "description": "Label names added to self-hosted runners. Glob syntax supported by Go's path.Match is available.",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/stringList"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": []
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "config-variables": {
+      "description": "Configuration variables defined in the repository or organization. Null disables strict checking; an empty array means no variable is allowed.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/stringList"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "paths": {
+      "description": "Path-specific configurations keyed by glob patterns relative to the repository root. Path separators are always '/'.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/pathConfig"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "stringList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "pathConfig": {
+      "description": "Configuration applied to files matched by a paths glob.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ignore": {
+              "$ref": "#/definitions/stringList",
+              "description": "Regular expressions for filtering actionlint errors by error message.",
+              "default": []
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/actionlint/actionlint.yaml
+++ b/src/test/actionlint/actionlint.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../schemas/json/actionlint.json
+self-hosted-runner:
+  labels:
+    - linux.2xlarge
+    - windows-latest-xl
+    - linux-multi-gpu
+config-variables:
+  - DEFAULT_RUNNER
+  - JOB_NAME
+  - ENVIRONMENT_STAGE
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'shellcheck reported issue in this script: SC2086:.+'
+  .github/workflows/release.yaml:
+    ignore:
+      - 'the runner of ".+" action is too old to run on GitHub Actions'

--- a/src/test/actionlint/null-values.yaml
+++ b/src/test/actionlint/null-values.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/actionlint.json
+self-hosted-runner:
+  labels:
+config-variables:
+paths:
+  .github/workflows/*.yaml:


### PR DESCRIPTION
## Summary

Adds a SchemaStore schema for actionlint configuration files.

The schema covers the documented/source-backed actionlint config surface:

- `self-hosted-runner.labels`
- `config-variables`
- `paths.<glob>.ignore`

It also adds negative fixtures for common invalid shapes, including unsupported top-level keys such as `secrets`, because actionlint's config struct does not define those keys.

## Sources

- https://github.com/rhysd/actionlint/blob/v1.7.12/docs/config.md
- https://github.com/rhysd/actionlint/blob/v1.7.12/config.go
- https://github.com/rhysd/actionlint/blob/v1.7.12/config_test.go

## Validation

- `node .\cli.js check --schema-name=actionlint.json`
- `npm run prettier -- --cache --ignore-unknown .\src\schemas\json\actionlint.json .\src\api\json\catalog.json .\src\test\actionlint\actionlint.yaml .\src\test\actionlint\null-values.yaml .\src\negative_test\actionlint\invalid-ignore-shape.yaml .\src\negative_test\actionlint\unknown-root-key.yaml .\src\negative_test\actionlint\unknown-path-key.yaml`
