### PR TITLE
Add Italian sicurezza-lavoro dataset schemas (ATECO 2007, Province, HACCP regional, D.Lgs 81/08)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6,7 +6,7 @@
       "name": "Italian ATECO 2007 Dataset Entry",
       "description": "Schema for a single ATECO 2007 entry enriched with workplace-safety classification (D.Lgs 81/08, Accordo Stato-Regioni 21/12/2011). See https://github.com/tutor-sicurezza/italian-ateco-database",
       "fileMatch": ["ateco/*.json", "ateco-2007-*.json", "**/*.ateco.json"],
-      "url": "https://json.schemastore.org/italian-ateco-2007.json"
+      "url": "https://www.schemastore.org/italian-ateco-2007.json"
     },
     {
       "name": "Italian Provincia Dataset Entry",
@@ -16,7 +16,7 @@
         "provincie/*.json",
         "**/*.provincia.json"
       ],
-      "url": "https://json.schemastore.org/italian-province.json"
+      "url": "https://www.schemastore.org/italian-province.json"
     },
     {
       "name": "Italian HACCP Regional Regulation Entry",
@@ -26,7 +26,7 @@
         "haccp-regionale-*.json",
         "**/*.haccp-regione.json"
       ],
-      "url": "https://json.schemastore.org/italian-haccp-regional.json"
+      "url": "https://www.schemastore.org/italian-haccp-regional.json"
     },
     {
       "name": "D.Lgs 81/08 Articolo Entry",
@@ -36,7 +36,7 @@
         "tus/*.json",
         "**/*.tus-articolo.json"
       ],
-      "url": "https://json.schemastore.org/dlgs-81-08-articolo.json"
+      "url": "https://www.schemastore.org/dlgs-81-08-articolo.json"
     },
     {
       "name": "SigmaCV CV",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5,11 +5,7 @@
     {
       "name": "Italian ATECO 2007 Dataset Entry",
       "description": "Schema for a single ATECO 2007 entry enriched with workplace-safety classification (D.Lgs 81/08, Accordo Stato-Regioni 21/12/2011). See https://github.com/tutor-sicurezza/italian-ateco-database",
-      "fileMatch": [
-        "ateco/*.json",
-        "ateco-2007-*.json",
-        "**/*.ateco.json"
-      ],
+      "fileMatch": ["ateco/*.json", "ateco-2007-*.json", "**/*.ateco.json"],
       "url": "https://json.schemastore.org/italian-ateco-2007.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,46 @@
   "version": 1,
   "schemas": [
     {
+      "name": "Italian ATECO 2007 Dataset Entry",
+      "description": "Schema for a single ATECO 2007 entry enriched with workplace-safety classification (D.Lgs 81/08, Accordo Stato-Regioni 21/12/2011). See https://github.com/tutor-sicurezza/italian-ateco-database",
+      "fileMatch": [
+        "ateco/*.json",
+        "ateco-2007-*.json",
+        "**/*.ateco.json"
+      ],
+      "url": "https://json.schemastore.org/italian-ateco-2007.json"
+    },
+    {
+      "name": "Italian Provincia Dataset Entry",
+      "description": "Schema for a single Italian provincia (sigla, regione, ISTAT code, prevailing ATECO sectors). See https://github.com/tutor-sicurezza/italian-province-regioni-dataset",
+      "fileMatch": [
+        "province/*.json",
+        "provincie/*.json",
+        "**/*.provincia.json"
+      ],
+      "url": "https://json.schemastore.org/italian-province.json"
+    },
+    {
+      "name": "Italian HACCP Regional Regulation Entry",
+      "description": "Schema for regional HACCP food-safety operator training requirements (Reg. CE 852/2004 + regional adaptation). See https://github.com/tutor-sicurezza/haccp-italia-normativa-regionale",
+      "fileMatch": [
+        "haccp/regioni/*.json",
+        "haccp-regionale-*.json",
+        "**/*.haccp-regione.json"
+      ],
+      "url": "https://json.schemastore.org/italian-haccp-regional.json"
+    },
+    {
+      "name": "D.Lgs 81/08 Articolo Entry",
+      "description": "Schema for a single article of D.Lgs 81/08 (Italian Testo Unico on workplace health and safety) including metadata and associated penalties. See https://github.com/tutor-sicurezza/dlgs-81-08-testo-unico",
+      "fileMatch": [
+        "dlgs-81-08/*.json",
+        "tus/*.json",
+        "**/*.tus-articolo.json"
+      ],
+      "url": "https://json.schemastore.org/dlgs-81-08-articolo.json"
+    },
+    {
       "name": "SigmaCV CV",
       "description": "SigmaCV canonical academic-CV object \u2014 open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information",
       "fileMatch": ["**/*.sigmacv.json"],

--- a/src/schemas/json/dlgs-81-08-articolo.json
+++ b/src/schemas/json/dlgs-81-08-articolo.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/dlgs-81-08-articolo.json",
+  "title": "D.Lgs 81/08 Articolo Entry",
+  "description": "Schema for a single article (articolo) of D.Lgs 81/08, the Italian Testo Unico on workplace health and safety (Testo Unico sulla Sicurezza sul Lavoro, TUS).",
+  "type": "object",
+  "required": ["numero", "titolo"],
+  "additionalProperties": true,
+  "properties": {
+    "numero": {
+      "type": "string",
+      "title": "Numero articolo",
+      "description": "Article number, including any letter suffix for inserted articles (e.g., '37', '28-bis', '300')."
+    },
+    "titolo": {
+      "type": "string",
+      "title": "Titolo articolo",
+      "description": "Official title of the article."
+    },
+    "materia": {
+      "type": "string",
+      "title": "Materia",
+      "description": "Subject area of the article (e.g., 'Formazione dei lavoratori', 'Valutazione dei rischi', 'Sorveglianza sanitaria')."
+    },
+    "titoloSezione": {
+      "type": "string",
+      "title": "Titolo del Titolo del TUS",
+      "description": "Name of the parent Titolo of the Testo Unico containing the article (e.g., 'Titolo I - Principi comuni')."
+    },
+    "contenutoSommario": {
+      "type": "string",
+      "title": "Sommario del contenuto",
+      "description": "Concise summary of the article's normative content."
+    },
+    "articoliCorrelati": {
+      "type": "array",
+      "title": "Articoli correlati",
+      "description": "Related TUS articles referenced or cross-cited.",
+      "items": { "type": "string" }
+    },
+    "sanzioniAssociate": {
+      "type": "array",
+      "title": "Sanzioni associate",
+      "description": "Penalties associated with violation of the article.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "soggetto": {
+            "type": "string",
+            "description": "Subject liable for the penalty (e.g., 'datore di lavoro', 'dirigente', 'preposto', 'lavoratore')."
+          },
+          "tipo": {
+            "type": "string",
+            "description": "Penalty type (e.g., 'ammenda', 'arresto', 'arresto o ammenda')."
+          },
+          "importoMinimoEuro": {
+            "type": "number",
+            "description": "Minimum monetary penalty in euro, where applicable.",
+            "minimum": 0
+          },
+          "importoMassimoEuro": {
+            "type": "number",
+            "description": "Maximum monetary penalty in euro, where applicable.",
+            "minimum": 0
+          },
+          "arrestoMesiMin": {
+            "type": "number",
+            "description": "Minimum arresto duration in months, where applicable.",
+            "minimum": 0
+          },
+          "arrestoMesiMax": {
+            "type": "number",
+            "description": "Maximum arresto duration in months, where applicable.",
+            "minimum": 0
+          },
+          "riferimentoArticoloSanzione": {
+            "type": "string",
+            "description": "Article of D.Lgs 81/08 that establishes the penalty (e.g., 'art. 55')."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/italian-ateco-2007.json
+++ b/src/schemas/json/italian-ateco-2007.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/italian-ateco-2007.json",
+  "title": "Italian ATECO 2007 Dataset Entry",
+  "description": "Schema for a single ATECO 2007 (Italian economic activity classification) entry enriched with workplace-safety metadata per D.Lgs 81/08 and Accordo Stato-Regioni 21/12/2011.",
+  "type": "object",
+  "required": ["codice", "slug", "settore", "rischioAteco"],
+  "additionalProperties": true,
+  "properties": {
+    "codice": {
+      "type": "string",
+      "title": "Codice ATECO 2007",
+      "description": "ATECO 2007 code in the standard ISTAT format (e.g., '10.71.10', '47.11.10'). May include subcategory digits.",
+      "pattern": "^[0-9]{2}(\\.[0-9]{1,2}){0,3}$"
+    },
+    "slug": {
+      "type": "string",
+      "title": "URL-safe slug",
+      "description": "Lowercase, hyphen-separated identifier suitable for URLs and filenames.",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+    "settore": {
+      "type": "string",
+      "title": "Settore (sector name)",
+      "description": "Human-readable Italian sector or activity name corresponding to the ATECO code."
+    },
+    "rischioAteco": {
+      "type": "string",
+      "title": "Livello di rischio",
+      "description": "Workplace-safety risk classification per Accordo Stato-Regioni 21/12/2011 (Allegato II, Tabella 1).",
+      "enum": ["basso", "medio", "alto"]
+    },
+    "corsiObbligatori": {
+      "type": "array",
+      "title": "Corsi formativi obbligatori",
+      "description": "Mandatory training courses applicable to workers in this ATECO sector under D.Lgs 81/08.",
+      "items": {
+        "type": "object",
+        "required": ["nome"],
+        "additionalProperties": true,
+        "properties": {
+          "nome": {
+            "type": "string",
+            "description": "Course name (e.g., 'Formazione generale lavoratori', 'RSPP Datore di Lavoro Rischio Alto')."
+          },
+          "durataOre": {
+            "type": "number",
+            "description": "Duration in hours of the training course.",
+            "minimum": 0
+          },
+          "validitaAnni": {
+            "type": "number",
+            "description": "Validity period of the certification in years before refresher training is required.",
+            "minimum": 0
+          },
+          "riferimentoNormativo": {
+            "type": "string",
+            "description": "Legal reference for the training requirement (e.g., 'Accordo Stato-Regioni 21/12/2011')."
+          }
+        }
+      }
+    },
+    "leggiApplicabili": {
+      "type": "array",
+      "title": "Leggi applicabili",
+      "description": "List of Italian laws, decrees, or regulations applicable to this ATECO sector.",
+      "items": {
+        "type": "object",
+        "required": ["riferimento"],
+        "additionalProperties": true,
+        "properties": {
+          "riferimento": {
+            "type": "string",
+            "description": "Normative reference (e.g., 'D.Lgs 81/08', 'Reg. CE 852/2004')."
+          },
+          "titolo": {
+            "type": "string",
+            "description": "Title or short description of the legal instrument."
+          },
+          "articoli": {
+            "type": "array",
+            "description": "Specific article numbers within the referenced law.",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "title": "Keywords",
+      "description": "Search keywords associated with this sector entry.",
+      "items": { "type": "string" }
+    },
+    "descrizione": {
+      "type": "string",
+      "title": "Descrizione estesa",
+      "description": "Extended description of the sector and its workplace-safety implications."
+    },
+    "descrizioneBreve": {
+      "type": "string",
+      "title": "Descrizione breve",
+      "description": "Short one-line summary of the sector."
+    }
+  }
+}

--- a/src/schemas/json/italian-haccp-regional.json
+++ b/src/schemas/json/italian-haccp-regional.json
@@ -41,7 +41,14 @@
       "description": "Training delivery modes permitted by the regional regulation.",
       "items": {
         "type": "string",
-        "enum": ["aula", "fad-sincrona", "fad-asincrona", "e-learning", "blended", "videoconferenza"]
+        "enum": [
+          "aula",
+          "fad-sincrona",
+          "fad-asincrona",
+          "e-learning",
+          "blended",
+          "videoconferenza"
+        ]
       }
     },
     "categorieOperatori": {

--- a/src/schemas/json/italian-haccp-regional.json
+++ b/src/schemas/json/italian-haccp-regional.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/italian-haccp-regional.json",
+  "title": "Italian HACCP Regional Regulation Entry",
+  "description": "Schema for HACCP food-safety operator training requirements per Italian region (Reg. CE 852/2004 + regional adaptation).",
+  "type": "object",
+  "required": ["regione", "riferimentoNormativo"],
+  "additionalProperties": true,
+  "properties": {
+    "regione": {
+      "type": "string",
+      "title": "Regione",
+      "description": "Name of the Italian region whose HACCP regulation is described."
+    },
+    "riferimentoNormativo": {
+      "type": "string",
+      "title": "Riferimento normativo",
+      "description": "Regional law, decree, or deliberation establishing HACCP training requirements (e.g., 'D.G.R. Lombardia n. X/1105/2013')."
+    },
+    "durataOreBase": {
+      "type": "number",
+      "title": "Durata ore corso base",
+      "description": "Required duration in hours for the base HACCP training course.",
+      "minimum": 0
+    },
+    "durataOreAggiornamento": {
+      "type": "number",
+      "title": "Durata ore corso aggiornamento",
+      "description": "Required duration in hours for the periodic refresher (aggiornamento) HACCP course.",
+      "minimum": 0
+    },
+    "validitaAnni": {
+      "type": "number",
+      "title": "Validità in anni",
+      "description": "Validity period of the HACCP certification in years before refresher training is required.",
+      "minimum": 0
+    },
+    "modalitaAmmesse": {
+      "type": "array",
+      "title": "Modalità formative ammesse",
+      "description": "Training delivery modes permitted by the regional regulation.",
+      "items": {
+        "type": "string",
+        "enum": ["aula", "fad-sincrona", "fad-asincrona", "e-learning", "blended", "videoconferenza"]
+      }
+    },
+    "categorieOperatori": {
+      "type": "array",
+      "title": "Categorie di operatori",
+      "description": "Operator categories addressed by the regulation (e.g., 'responsabile industria alimentare', 'addetto manipolazione alimenti').",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/src/schemas/json/italian-province.json
+++ b/src/schemas/json/italian-province.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/italian-province.json",
+  "title": "Italian Provincia Dataset Entry",
+  "description": "Schema for a single Italian provincia entry, including ISTAT code, sigla, regione, and prevailing ATECO sectors.",
+  "type": "object",
+  "required": ["slug", "sigla", "regione"],
+  "additionalProperties": true,
+  "properties": {
+    "slug": {
+      "type": "string",
+      "title": "URL-safe slug",
+      "description": "Lowercase, hyphen-separated identifier for the provincia (e.g., 'milano', 'reggio-emilia').",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+    "nome": {
+      "type": "string",
+      "title": "Nome",
+      "description": "Official name of the provincia."
+    },
+    "sigla": {
+      "type": "string",
+      "title": "Sigla automobilistica",
+      "description": "Two-letter Italian vehicle registration code for the provincia (e.g., 'MI', 'RE', 'TO').",
+      "pattern": "^[A-Z]{2}$"
+    },
+    "regione": {
+      "type": "string",
+      "title": "Regione",
+      "description": "Italian region to which the provincia belongs."
+    },
+    "capoluogo": {
+      "type": "boolean",
+      "title": "Capoluogo di regione",
+      "description": "True if this provincia is the capital of its region."
+    },
+    "codiceISTAT": {
+      "type": "string",
+      "title": "Codice ISTAT",
+      "description": "ISTAT numeric code for the provincia.",
+      "pattern": "^[0-9]{3}$"
+    },
+    "ATECOPrevalenti": {
+      "type": "array",
+      "title": "ATECO prevalenti",
+      "description": "List of prevailing ATECO 2007 sector codes for the provincia, ordered by economic relevance.",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9]{2}(\\.[0-9]{1,2}){0,3}$"
+      }
+    }
+  }
+}

--- a/src/test/dlgs-81-08-articolo/esempio-articolo-37.json
+++ b/src/test/dlgs-81-08-articolo/esempio-articolo-37.json
@@ -1,19 +1,19 @@
 {
-  "numero": "37",
-  "titolo": "Formazione dei lavoratori e dei loro rappresentanti",
-  "materia": "Formazione dei lavoratori",
-  "titoloSezione": "Titolo I - Principi comuni",
-  "contenutoSommario": "Disciplina gli obblighi formativi del datore di lavoro nei confronti dei lavoratori, dirigenti, preposti e RLS, con riferimento all'Accordo Stato-Regioni 21/12/2011.",
   "articoliCorrelati": ["36", "73", "168"],
+  "contenutoSommario": "Disciplina gli obblighi formativi del datore di lavoro nei confronti dei lavoratori, dirigenti, preposti e RLS, con riferimento all'Accordo Stato-Regioni 21/12/2011.",
+  "materia": "Formazione dei lavoratori",
+  "numero": "37",
   "sanzioniAssociate": [
     {
-      "soggetto": "datore di lavoro",
-      "tipo": "arresto o ammenda",
-      "arrestoMesiMin": 2,
       "arrestoMesiMax": 4,
-      "importoMinimoEuro": 1474.21,
+      "arrestoMesiMin": 2,
       "importoMassimoEuro": 6388.23,
-      "riferimentoArticoloSanzione": "art. 55, comma 5, lett. c)"
+      "importoMinimoEuro": 1474.21,
+      "riferimentoArticoloSanzione": "art. 55, comma 5, lett. c)",
+      "soggetto": "datore di lavoro",
+      "tipo": "arresto o ammenda"
     }
-  ]
+  ],
+  "titolo": "Formazione dei lavoratori e dei loro rappresentanti",
+  "titoloSezione": "Titolo I - Principi comuni"
 }

--- a/src/test/dlgs-81-08-articolo/esempio-articolo-37.json
+++ b/src/test/dlgs-81-08-articolo/esempio-articolo-37.json
@@ -1,0 +1,19 @@
+{
+  "numero": "37",
+  "titolo": "Formazione dei lavoratori e dei loro rappresentanti",
+  "materia": "Formazione dei lavoratori",
+  "titoloSezione": "Titolo I - Principi comuni",
+  "contenutoSommario": "Disciplina gli obblighi formativi del datore di lavoro nei confronti dei lavoratori, dirigenti, preposti e RLS, con riferimento all'Accordo Stato-Regioni 21/12/2011.",
+  "articoliCorrelati": ["36", "73", "168"],
+  "sanzioniAssociate": [
+    {
+      "soggetto": "datore di lavoro",
+      "tipo": "arresto o ammenda",
+      "arrestoMesiMin": 2,
+      "arrestoMesiMax": 4,
+      "importoMinimoEuro": 1474.21,
+      "importoMassimoEuro": 6388.23,
+      "riferimentoArticoloSanzione": "art. 55, comma 5, lett. c)"
+    }
+  ]
+}

--- a/src/test/italian-ateco-2007/esempio-panetteria.json
+++ b/src/test/italian-ateco-2007/esempio-panetteria.json
@@ -1,34 +1,34 @@
 {
   "codice": "10.71.10",
-  "slug": "produzione-prodotti-panetteria-freschi",
-  "settore": "Produzione di prodotti di panetteria freschi",
-  "rischioAteco": "medio",
-  "descrizioneBreve": "Panetterie e produzione di pane fresco.",
-  "descrizione": "Attività di produzione e vendita di pane, pizza e prodotti da forno freschi.",
-  "keywords": ["panetteria", "pane", "forno", "alimentare"],
   "corsiObbligatori": [
     {
-      "nome": "Formazione generale lavoratori",
       "durataOre": 4,
-      "validitaAnni": 5,
-      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011"
+      "nome": "Formazione generale lavoratori",
+      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011",
+      "validitaAnni": 5
     },
     {
-      "nome": "Formazione specifica rischio medio",
       "durataOre": 8,
-      "validitaAnni": 5,
-      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011"
+      "nome": "Formazione specifica rischio medio",
+      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011",
+      "validitaAnni": 5
     }
   ],
+  "descrizione": "Attività di produzione e vendita di pane, pizza e prodotti da forno freschi.",
+  "descrizioneBreve": "Panetterie e produzione di pane fresco.",
+  "keywords": ["panetteria", "pane", "forno", "alimentare"],
   "leggiApplicabili": [
     {
+      "articoli": ["28", "36", "37"],
       "riferimento": "D.Lgs 81/08",
-      "titolo": "Testo Unico sulla Sicurezza sul Lavoro",
-      "articoli": ["28", "36", "37"]
+      "titolo": "Testo Unico sulla Sicurezza sul Lavoro"
     },
     {
       "riferimento": "Reg. CE 852/2004",
       "titolo": "Igiene dei prodotti alimentari"
     }
-  ]
+  ],
+  "rischioAteco": "medio",
+  "settore": "Produzione di prodotti di panetteria freschi",
+  "slug": "produzione-prodotti-panetteria-freschi"
 }

--- a/src/test/italian-ateco-2007/esempio-panetteria.json
+++ b/src/test/italian-ateco-2007/esempio-panetteria.json
@@ -1,0 +1,34 @@
+{
+  "codice": "10.71.10",
+  "slug": "produzione-prodotti-panetteria-freschi",
+  "settore": "Produzione di prodotti di panetteria freschi",
+  "rischioAteco": "medio",
+  "descrizioneBreve": "Panetterie e produzione di pane fresco.",
+  "descrizione": "Attività di produzione e vendita di pane, pizza e prodotti da forno freschi.",
+  "keywords": ["panetteria", "pane", "forno", "alimentare"],
+  "corsiObbligatori": [
+    {
+      "nome": "Formazione generale lavoratori",
+      "durataOre": 4,
+      "validitaAnni": 5,
+      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011"
+    },
+    {
+      "nome": "Formazione specifica rischio medio",
+      "durataOre": 8,
+      "validitaAnni": 5,
+      "riferimentoNormativo": "Accordo Stato-Regioni 21/12/2011"
+    }
+  ],
+  "leggiApplicabili": [
+    {
+      "riferimento": "D.Lgs 81/08",
+      "titolo": "Testo Unico sulla Sicurezza sul Lavoro",
+      "articoli": ["28", "36", "37"]
+    },
+    {
+      "riferimento": "Reg. CE 852/2004",
+      "titolo": "Igiene dei prodotti alimentari"
+    }
+  ]
+}

--- a/src/test/italian-haccp-regional/esempio-lombardia.json
+++ b/src/test/italian-haccp-regional/esempio-lombardia.json
@@ -1,12 +1,12 @@
 {
-  "regione": "Lombardia",
-  "riferimentoNormativo": "D.G.R. Lombardia n. X/1105/2013",
-  "durataOreBase": 12,
-  "durataOreAggiornamento": 6,
-  "validitaAnni": 3,
-  "modalitaAmmesse": ["aula", "fad-sincrona", "e-learning", "blended"],
   "categorieOperatori": [
     "responsabile industria alimentare",
     "addetto manipolazione alimenti"
-  ]
+  ],
+  "durataOreAggiornamento": 6,
+  "durataOreBase": 12,
+  "modalitaAmmesse": ["aula", "fad-sincrona", "e-learning", "blended"],
+  "regione": "Lombardia",
+  "riferimentoNormativo": "D.G.R. Lombardia n. X/1105/2013",
+  "validitaAnni": 3
 }

--- a/src/test/italian-haccp-regional/esempio-lombardia.json
+++ b/src/test/italian-haccp-regional/esempio-lombardia.json
@@ -1,0 +1,12 @@
+{
+  "regione": "Lombardia",
+  "riferimentoNormativo": "D.G.R. Lombardia n. X/1105/2013",
+  "durataOreBase": 12,
+  "durataOreAggiornamento": 6,
+  "validitaAnni": 3,
+  "modalitaAmmesse": ["aula", "fad-sincrona", "e-learning", "blended"],
+  "categorieOperatori": [
+    "responsabile industria alimentare",
+    "addetto manipolazione alimenti"
+  ]
+}

--- a/src/test/italian-province/esempio-milano.json
+++ b/src/test/italian-province/esempio-milano.json
@@ -1,0 +1,9 @@
+{
+  "slug": "milano",
+  "nome": "Milano",
+  "sigla": "MI",
+  "regione": "Lombardia",
+  "capoluogo": true,
+  "codiceISTAT": "015",
+  "ATECOPrevalenti": ["64.19", "62.01", "47.11.10", "10.71.10"]
+}

--- a/src/test/italian-province/esempio-milano.json
+++ b/src/test/italian-province/esempio-milano.json
@@ -1,9 +1,9 @@
 {
-  "slug": "milano",
-  "nome": "Milano",
-  "sigla": "MI",
-  "regione": "Lombardia",
+  "ATECOPrevalenti": ["64.19", "62.01", "47.11.10", "10.71.10"],
   "capoluogo": true,
   "codiceISTAT": "015",
-  "ATECOPrevalenti": ["64.19", "62.01", "47.11.10", "10.71.10"]
+  "nome": "Milano",
+  "regione": "Lombardia",
+  "sigla": "MI",
+  "slug": "milano"
 }


### PR DESCRIPTION
## Summary

This PR adds 4 JSON Schema definitions for Italian datasets related to workplace safety (D.Lgs 81/08, Italian Testo Unico sulla Sicurezza sul Lavoro):

- **italian-ateco-2007.json** — ATECO 2007 economic activity codes enriched with workplace-safety risk classification (per Accordo Stato-Regioni 21/12/2011).
- **italian-province.json** — Italian provincie with sigla, regione, ISTAT code, prevailing ATECO sectors.
- **italian-haccp-regional.json** — Regional HACCP regulations for food-safety operator training (Reg. CE 852/2004 + regional adaptation).
- **dlgs-81-08-articolo.json** — Single article of D.Lgs 81/08 with metadata and associated penalties.

Each schema is associated with public open-data repositories maintained by the contributor:

- https://github.com/tutor-sicurezza/italian-ateco-database
- https://github.com/tutor-sicurezza/italian-province-regioni-dataset
- https://github.com/tutor-sicurezza/haccp-italia-normativa-regionale
- https://github.com/tutor-sicurezza/dlgs-81-08-testo-unico

## Why

Italian developers building legal-tech, compliance, training-management, or HR-tech tools frequently need ATECO and workplace-safety reference data. Publishing canonical JSON Schemas through SchemaStore enables IDE autocomplete, validation, and discoverability for the Italian developer community.

## Changes

- 4 new schemas under `src/schemas/json/` (JSON Schema Draft-07).
- 4 corresponding catalog entries in `src/api/json/catalog.json` with scoped `fileMatch` patterns (no overly generic globs).
- 4 positive test fixtures under `src/test/<schema>/`.

## License

Schemas are contributed under the SchemaStore repository license (Apache-2.0).