### PR TITLE
feat(mypy): add num_workers for parallel type checking

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -607,6 +607,11 @@
       "default": 0,
       "type": "integer"
     },
+    "num_workers": {
+      "description": "Use the specified number of worker processes to type check in parallel. This is an experimental feature added in mypy 2.0, equivalent to the --num-workers (-n) command line flag. A value of 0 disables parallel checking.",
+      "default": 0,
+      "type": "integer"
+    },
     "show_error_codes": {
       "type": "boolean",
       "default": true,

--- a/src/test/pyproject/mypy-01.toml
+++ b/src/test/pyproject/mypy-01.toml
@@ -5,6 +5,7 @@
 python_version = "2.7"
 warn_return_any = true
 warn_unused_configs = true
+num_workers = 4
 exclude = [
   '^file1\.py$',  # TOML literal string (single-quotes, no escaping necessary)
   "^file2\\.py$", # TOML basic string (double-quotes, backslash and other characters need escaping)


### PR DESCRIPTION
Closes #5826.

mypy 2.0 added experimental parallel type checking via the `num_workers` config option (the `--num-workers` / `-n` CLI flag), but the schema's `additionalProperties: false` rejects it, so editors like Even Better TOML flag `num_workers` as an unexpected property. This adds it to the global options block in partial-mypy.json. It's a global-only option, so it's intentionally not added to the per-module overrides section. The entry matches the existing `verbosity` style (plain description, integer type, default 0) and I extended the existing mypy-01.toml positive test with `num_workers = 4` rather than adding a new fixture.

Worth flagging for maintainers: the schema looks broadly stale relative to mypy 2.0/2.1, since it was last generated before 2.0 shipped in May. `native_parser` was exposed in the same 2.0 release (python/mypy#21387) and is also missing here. I kept this PR scoped to the reported issue, but a fuller regeneration pass against the current docs would be worthwhile as a follow-up if someone wants to pick it up.

Validation: `node cli.js check --schema-name=pyproject.json` passes, and prettier is clean on both files.