### PR TITLE
WebExtension Manifest Version 3 for `web_accessible_resources`

### DIFF
--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -75,21 +75,36 @@
         }
       },
       "web_accessible_resources": {
-        "description": "Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.\n\nWith the web_accessible_resources key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.\n\nNote that content scripts don't need to be listed as web accessible resources.\n\nIf an extension wants to use webRequest or declarativeNetRequest to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the web_accessible_resources key.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources",
         "type": "array",
+        "description": "Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.\n\nWith the web_accessible_resources key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.\n\nNote that content scripts don't need to be listed as web accessible resources.\n\nIf an extension wants to use webRequest or declarativeNetRequest to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the web_accessible_resources key.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources",
         "items": {
           "type": "object",
-          "properties": {
-            "extension_ids": { "$ref": "#/definitions/scripts", "default": [] },
-            "matches": { "$ref": "#/definitions/scripts", "default": [] },
-            "resources": { "$ref": "#/definitions/scripts" },
-            "use_dynamic_url": { "type": "boolean", "default": false }
-          },
           "required": ["resources"],
           "anyOf": [
             { "required": ["matches"] },
             { "required": ["extension_ids"] }
-          ]
+          ],
+          "properties": {
+            "extension_ids": {
+              "$ref": "#/definitions/scripts",
+              "default": [],
+              "description": "A list of extension IDs specifying the extensions that can access the resources. \"*\" matches all extensions.\nDefaults to `[]`, meaning that other extensions cannot access the resource."
+            },
+            "matches": {
+              "$ref": "#/definitions/scripts",
+              "default": [],
+              "description": "A list of URL match patterns specifying the pages that can access the resources. Only the origin is used to match URLs. However:\n- In Firefox and Safari, any path can be included.\n- In Chrome, the path must be set to `/*`.\nOrigins include subdomain matching.\nDefaults to `[]`, meaning that other websites cannot access the resource."
+            },
+            "resources": {
+              "$ref": "#/definitions/scripts",
+              "description": "An array of resources to be exposed. Resources are specified as strings and may contain `*` for wildcard matches. For example, `\"/images/*\"` exposes everything in the extension's `/images` directory recursively, while `\"*.png\"` exposes all PNG files."
+            },
+            "use_dynamic_url": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether resources to be accessible through the dynamic ID. The dynamic ID is generated per session and regenerated on browser restart or extension reload."
+            }
+          }
         }
       }
     },

--- a/src/schemas/json/webextension.json
+++ b/src/schemas/json/webextension.json
@@ -27,6 +27,10 @@
             "default": true
           }
         }
+      },
+      "web_accessible_resources": {
+        "$ref": "#/definitions/scripts",
+        "description": "Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.\n\nWith the web_accessible_resources key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.\n\nNote that content scripts don't need to be listed as web accessible resources.\n\nIf an extension wants to use webRequest or declarativeNetRequest to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the web_accessible_resources key.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"
       }
     },
     "definitions": {
@@ -68,6 +72,24 @@
         "items": {
           "$ref": "#/definitions/match_pattern",
           "description": "Use the host_permissions key to request access for the APIs in your extension that read or modify host data, such as cookies, webRequest, and tabs. This key is an array of strings, and each string is a request for a permission. Users can grant or revoke host permissions on an ad hoc basis. Therefore., most browsers treat host_permissions as optional.\n\nThe extra privileges include:\nXMLHttpRequest and fetch access to those origins without cross-origin restrictions (though not for requests from content scripts, as was the case in Manifest V2).\nthe ability to read tab-specific metadata without the \"tabs\" permission, such as the url, title, and favIconUrl properties of tabs.Tab objects.\nthe ability to inject scripts programmatically (using tabs.executeScript()) into pages served from those origins.\nthe ability to receive events from the webRequest API for these hosts.\nthe ability to access cookies for that host using the cookies API, as long as the \"cookies\" API permission is also included.\nbypassing tracking protection for extension pages where a host is specified as a full domain or with wildcards.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions"
+        }
+      },
+      "web_accessible_resources": {
+        "description": "Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.\n\nWith the web_accessible_resources key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.\n\nNote that content scripts don't need to be listed as web accessible resources.\n\nIf an extension wants to use webRequest or declarativeNetRequest to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the web_accessible_resources key.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "extension_ids": { "$ref": "#/definitions/scripts", "default": [] },
+            "matches": { "$ref": "#/definitions/scripts", "default": [] },
+            "resources": { "$ref": "#/definitions/scripts" },
+            "use_dynamic_url": { "type": "boolean", "default": false }
+          },
+          "required": ["resources"],
+          "anyOf": [
+            { "required": ["matches"] },
+            { "required": ["extension_ids"] }
+          ]
         }
       }
     },
@@ -1084,10 +1106,6 @@
     "version_name": {
       "description": "In addition to the version field, which is used for update purposes, version_name can be set to a descriptive version string and will be used for display purposes if present.\n\nIf no version_name is present, the version field will be used for display purposes as well.https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name",
       "type": "string"
-    },
-    "web_accessible_resources": {
-      "$ref": "#/definitions/scripts",
-      "description": "Sometimes you want to package resources—for example, images, HTML, CSS, or JavaScript—with your extension and make them available to web pages and other extensions.\n\nWith the web_accessible_resources key, you list all the packaged resources that you want to make available to web pages. You specify them as paths relative to the manifest.json file.\n\nNote that content scripts don't need to be listed as web accessible resources.\n\nIf an extension wants to use webRequest or declarativeNetRequest to redirect a public URL (e.g., HTTPS) to a page that's packaged in the extension, then the extension must list the page in the web_accessible_resources key.\n\nhttps://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources"
     }
   },
   "definitions": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

I was getting error when using Manifest V3 to define `web_accessible_resources`. Apparently, the syntax for V2 and V3 are different:
- In V2: [an array of string](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#manifest_v2_syntax)
- In V3: [an array of object](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources#manifest_v3_syntax)

I followed the changes in this PR: #4357 and apply `web_accessible_resources` V2 and V3.