### PR TITLE
add attribution.sessionUrl property

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -1058,6 +1058,10 @@
         "pr": {
           "type": "string",
           "description": "Attribution for pull request descriptions. Empty string hides pull request attribution"
+        },
+        "sessionUrl": {
+          "type": "boolean",
+          "description": "Whether to append the claude.ai session link to commits and pull requests in web and Remote Control sessions. Set to false to omit it (default: true)."
         }
       }
     },

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -9,7 +9,8 @@
   "apiKeyHelper": "/usr/local/bin/claude-auth-helper",
   "attribution": {
     "commit": "Generated with AI\n\nCo-Authored-By: AI <ai@example.com>",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "autoMemoryDirectory": "~/.claude/custom-memory",
   "autoMemoryEnabled": false,


### PR DESCRIPTION
## Change

Add the `attribution.sessionUrl` boolean property to the `claude-code-settings` schema, and extend the `modern-complete-config` positive test to cover it.

## Why

Claude Code **v2.1.183 (2026-06-19)** introduced this setting:

> Added `attribution.sessionUrl` setting to omit the claude.ai session link from commits and PRs in web and Remote Control sessions

(see the [Claude Code changelog](https://code.claude.com/docs/en/changelog) and [attribution settings](https://code.claude.com/docs/en/settings#attribution-settings))

The schema's `attribution` object declares `"additionalProperties": false`, so configs that set `attribution.sessionUrl` currently get a false "unknown property" warning in editors/language servers. This adds the missing property so valid configs validate cleanly.

## Details

- `src/schemas/json/claude-code-settings.json`: add `sessionUrl` (boolean) alongside the existing `commit` / `pr` properties.
- `src/test/claude-code-settings/modern-complete-config.json`: add `"sessionUrl": false` to the existing `attribution` block (this file is the "modern/complete" positive test that already exercises `attribution`), following the existing test convention rather than adding a separate file.

Both files validated as JSON.