### PR TITLE
Allowed `bundleDependencies` and `bundledDependencies` simultaneously in `package.json`

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -799,7 +799,7 @@
       ]
     },
     "bundledDependencies": {
-      "description": "DEPRECATED: This field is honored, but \"bundleDependencies\" is the correct field name.",
+      "description": "DEPRECATED: This field is honored, but \"bundleDependencies\" is the correct field name. Ignored if \"bundleDependencies\" is also present.",
       "oneOf": [
         {
           "type": "array",
@@ -1325,38 +1325,5 @@
       "additionalProperties": false
     }
   },
-  "anyOf": [
-    {
-      "type": "object",
-      "not": {
-        "required": [
-          "bundledDependencies",
-          "bundleDependencies"
-        ]
-      }
-    },
-    {
-      "type": "object",
-      "not": {
-        "required": [
-          "bundleDependencies"
-        ]
-      },
-      "required": [
-        "bundledDependencies"
-      ]
-    },
-    {
-      "type": "object",
-      "not": {
-        "required": [
-          "bundledDependencies"
-        ]
-      },
-      "required": [
-        "bundleDependencies"
-      ]
-    }
-  ],
   "$id": "https://json.schemastore.org/package.json"
 }

--- a/src/test/package/bundleDependencies.json
+++ b/src/test/package/bundleDependencies.json
@@ -1,0 +1,4 @@
+{
+  "bundleDependencies": ["abc"],
+  "bundledDependencies": ["def"]
+}


### PR DESCRIPTION
Currently, the `package.json` schema disallows `bundleDependencies` and `bundleDependencies` to be simultaneously present. The following sample demonstrates this is incorrect behavior:

```json
{
  "name": "test",
  "version": "0.0.0",
  "license": "Apache 2.0",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "bundledDependencies": [
    "@npm/abc"
  ],
  "bundleDependencies": [
    "@npm/def"
  ]
}
```

Running `npm i` (with npm v11) in the same directory creates the following `package-lock.json` file:

```json
{
  "name": "test",
  "version": "0.0.0",
  "lockfileVersion": 3,
  "requires": true,
  "packages": {
    "": {
      "name": "test",
      "version": "0.0.0",
      "bundleDependencies": [
        "@npm/def"
      ],
      "license": "Apache 2.0"
    }
  }
}
```

This not only shows that npm is able to handle both properties, but it also prioritizes `bundleDependencies` over its deprecated predecessor. Note that `npm pkg fix` also doesn't change `package.json`.