### PR TITLE
Add Manifest Config schema (@angriff36/manifest)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10432,6 +10432,17 @@
       "versions": {
         "1.27": "https://www.schemastore.org/podman-desktop-extension-1.27.json"
       }
+    },
+    {
+      "name": "Manifest Config",
+      "description": "Manifest DSL build configuration (manifest.config.yaml / manifest.config.yml / .manifestrc.yaml) for the @angriff36/manifest CLI.",
+      "fileMatch": [
+        "manifest.config.yaml",
+        "manifest.config.yml",
+        "manifest.config.json",
+        ".manifestrc.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/Angriff36/Manifest/main/docs/spec/config/manifest.config.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Registers the JSON schema for the **Manifest DSL** build configuration file (`manifest.config.yaml` / `manifest.config.yml` / `manifest.config.json` / `.manifestrc.yaml`), used by the [`@angriff36/manifest`](https://github.com/Angriff36/Manifest) CLI.

- **Schema URL:** https://raw.githubusercontent.com/Angriff36/Manifest/main/docs/spec/config/manifest.config.schema.json (served with `Access-Control-Allow-Origin: *`, so editors can fetch it cross-origin)
- **Draft:** draft-07
- **fileMatch:** `manifest.config.yaml`, `manifest.config.yml`, `manifest.config.json`, `.manifestrc.yaml`

This gives editors (VS Code YAML extension, JetBrains) automatic IntelliSense + validation on Manifest config files by filename, with no per-user `yaml.schemas` mapping required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)