### PR TITLE
Update tox JSON Schema to 4.56.0

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -531,8 +531,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "type": "object",
       "$ref": "#/properties/env_run_base",
+      "type": "object",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -619,10 +619,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "name"
-      ],
+      "required": ["replace", "name"],
       "additionalProperties": false
     },
     "replace_ref": {
@@ -664,9 +661,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_posargs": {
@@ -689,9 +684,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_glob": {
@@ -724,10 +717,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "pattern"
-      ],
+      "required": ["replace", "pattern"],
       "additionalProperties": false
     },
     "replace_if": {
@@ -749,11 +739,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "condition",
-        "then"
-      ],
+      "required": ["replace", "condition", "then"],
       "additionalProperties": false
     },
     "replace_object": {
@@ -778,9 +764,7 @@
     },
     "factor_range_dict": {
       "type": "object",
-      "required": [
-        "prefix"
-      ],
+      "required": ["prefix"],
       "properties": {
         "prefix": {
           "type": "string"
@@ -800,9 +784,7 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": [
-          "prefix"
-        ]
+        "required": ["prefix"]
       },
       "additionalProperties": {
         "type": "array",
@@ -835,9 +817,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "product"
-          ],
+          "required": ["product"],
           "properties": {
             "product": {
               "type": "array",

--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -504,7 +504,7 @@
         },
         "virtualenv_spec": {
           "type": "string",
-          "description": "PEP 440 version spec for virtualenv (e.g. virtualenv<20.22.0). When set, tox bootstraps this version in an isolated environment and runs it via subprocess, enabling Python versions incompatible with the installed virtualenv."
+          "description": "PEP 440 version spec for virtualenv (e.g. virtualenv<20.22.0). When set, tox bootstraps this version in an isolated environment and runs it via subprocess, enabling Python versions incompatible with the installed virtualenv. Left empty it is derived automatically: tox pins an older virtualenv only when the installed one can no longer create the targeted Python version."
         },
         "skip_install": {
           "type": "boolean",
@@ -531,8 +531,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "$ref": "#/properties/env_run_base",
       "type": "object",
+      "$ref": "#/properties/env_run_base",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -619,7 +619,10 @@
           "type": "string"
         }
       },
-      "required": ["replace", "name"],
+      "required": [
+        "replace",
+        "name"
+      ],
       "additionalProperties": false
     },
     "replace_ref": {
@@ -661,7 +664,9 @@
           "type": "string"
         }
       },
-      "required": ["replace"],
+      "required": [
+        "replace"
+      ],
       "additionalProperties": false
     },
     "replace_posargs": {
@@ -684,7 +689,9 @@
           "type": "string"
         }
       },
-      "required": ["replace"],
+      "required": [
+        "replace"
+      ],
       "additionalProperties": false
     },
     "replace_glob": {
@@ -717,7 +724,10 @@
           "type": "string"
         }
       },
-      "required": ["replace", "pattern"],
+      "required": [
+        "replace",
+        "pattern"
+      ],
       "additionalProperties": false
     },
     "replace_if": {
@@ -739,7 +749,11 @@
           "type": "string"
         }
       },
-      "required": ["replace", "condition", "then"],
+      "required": [
+        "replace",
+        "condition",
+        "then"
+      ],
       "additionalProperties": false
     },
     "replace_object": {
@@ -764,7 +778,9 @@
     },
     "factor_range_dict": {
       "type": "object",
-      "required": ["prefix"],
+      "required": [
+        "prefix"
+      ],
       "properties": {
         "prefix": {
           "type": "string"
@@ -784,7 +800,9 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": ["prefix"]
+        "required": [
+          "prefix"
+        ]
       },
       "additionalProperties": {
         "type": "array",
@@ -817,7 +835,9 @@
         },
         {
           "type": "object",
-          "required": ["product"],
+          "required": [
+            "product"
+          ],
           "properties": {
             "product": {
               "type": "array",


### PR DESCRIPTION
Updates tox's JSON Schema to [f3a626a016c96206a5306ccd73f08eb0e83e4abc](https://github.com/tox-dev/tox/commit/f3a626a016c96206a5306ccd73f08eb0e83e4abc) (release 4.56.0).