### PR TITLE
Support `aube` as a package manager in `package.json` schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -826,7 +826,7 @@
       "type": "string",
       "oneOf": [
         {
-          "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
+          "pattern": "(npm|pnpm|yarn|bun|aube)@\\d+\\.\\d+\\.\\d+(-.+)?"
         },
         {
           "const": "bun"


### PR DESCRIPTION
This PR updates the `package.json` schema to support **[aube](https://aube.jdx.dev)** as a valid package manager.