### PR TITLE
Add Slang Server configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10445,6 +10445,5 @@
       "fileMatch": ["**/.slang/server.json", "**/.slang/local/server.json"],
       "url": "https://raw.githubusercontent.com/hudson-trading/slang-server/refs/heads/main/clients/vscode/resources/config.schema.json"
     }
-
   ]
 }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10438,6 +10438,13 @@
       "versions": {
         "1.27": "https://www.schemastore.org/podman-desktop-extension-1.27.json"
       }
+    },
+    {
+      "name": "Slang Server Configuration",
+      "description": "Configuration file for the slang-server SystemVerilog language server. Documentation: https://hudson-trading.github.io/slang-server",
+      "fileMatch": ["**/.slang/server.json", "**/.slang/local/server.json"],
+      "url": "https://raw.githubusercontent.com/hudson-trading/slang-server/refs/heads/main/clients/vscode/resources/config.schema.json"
     }
+
   ]
 }


### PR DESCRIPTION
This PR adds the schema for the [Slang Server](https://github.com/hudson-trading/slang-server) SystemVerilog language server configuration files:

- `./.slang/server.json`
- `./.slang/local/server.json`
- `~/.slang/server.json`

The schema is remotely hosted in the Slang Server repository: [https://github.com/hudson-trading/slang-server/blob/main/clients/vscode/resources/config.schema.json](https://github.com/hudson-trading/slang-server/blob/main/clients/vscode/resources/config.schema.json)