### PR TITLE
Add MSTest testconfig.json schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4924,7 +4924,7 @@
     },
     {
       "name": "MSTest testconfig.json",
-      "description": "Configuration file for MSTest and Microsoft.Testing.Platform.",
+      "description": "Configuration file for MSTest and Microsoft.Testing.Platform",
       "fileMatch": ["testconfig.json", "*.testconfig.json"],
       "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4923,6 +4923,12 @@
       "url": "https://raw.githubusercontent.com/compomics/ms2rescore/main/ms2rescore/package_data/config_schema.json"
     },
     {
+      "name": "MSTest testconfig.json",
+      "description": "Configuration file for MSTest and Microsoft.Testing.Platform.",
+      "fileMatch": ["testconfig.json", "*.testconfig.json"],
+      "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
+    },
+    {
       "name": "Mergify Configuration",
       "description": "Mergify configuration file",
       "fileMatch": [


### PR DESCRIPTION
This registers a self-hosted/external JSON schema for `testconfig.json`, the configuration file consumed by [MSTest](https://github.com/microsoft/testfx) and Microsoft.Testing.Platform.

The schema is hosted in the `microsoft/testfx` repository and this PR only adds a catalog entry pointing at its raw URL (per the [self-hosted/remote/external](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal) instructions).

```json
{
  "name": "MSTest testconfig.json",
  "description": "Configuration file for MSTest and Microsoft.Testing.Platform.",
  "fileMatch": ["testconfig.json", "*.testconfig.json"],
  "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
}
```

- `testconfig.json` is a well-known, fixed filename used by Microsoft.Testing.Platform; `*.testconfig.json` matches the `<AssemblyName>.testconfig.json` form emitted next to the test executable.
- The schema (draft-07) is maintained at https://github.com/microsoft/testfx/blob/main/docs/testconfig.schema.json.

> [!NOTE]
> The schema file is being merged into `microsoft/testfx` `main` in https://github.com/microsoft/testfx/issues/9381. Until that change lands, the `url` above may 404. Please hold merge until the URL resolves; I'll confirm here once it's live.