### PR TITLE
Add remote schemas for Nextflow module files by nf-core

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5028,6 +5028,12 @@
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json"
     },
     {
+      "name": "nf-core subworkflow meta.yml",
+      "description": "Metadata file for an nf-core Nextflow subworkflow",
+      "fileMatch": ["**/subworkflows/nf-core/**/meta.yml"],
+      "url": "https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json"
+    },
+    {
       "name": "nFPM",
       "description": "nFPM configuration file",
       "fileMatch": ["nfpm.yaml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5012,19 +5012,13 @@
     {
       "name": "nf-core module environment.yml",
       "description": "Conda environment file for an nf-core Nextflow module",
-      "fileMatch": [
-        "**/modules/nf-core/**/environment.yml",
-        "**/modules/local/**/environment.yml"
-      ],
+      "fileMatch": ["**/modules/nf-core/**/environment.yml"],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json"
     },
     {
       "name": "nf-core module meta.yml",
       "description": "Metadata file for an nf-core Nextflow module",
-      "fileMatch": [
-        "**/modules/nf-core/**/meta.yml",
-        "**/modules/local/**/meta.yml"
-      ],
+      "fileMatch": ["**/modules/nf-core/**/meta.yml"],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5010,6 +5010,24 @@
       "url": "https://nexte.st/schemas/user-config.json"
     },
     {
+      "name": "nf-core module environment.yml",
+      "description": "Conda environment file for an nf-core Nextflow module",
+      "fileMatch": [
+        "**/modules/nf-core/**/environment.yml",
+        "**/modules/local/**/environment.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json"
+    },
+    {
+      "name": "nf-core module meta.yml",
+      "description": "Metadata file for an nf-core Nextflow module",
+      "fileMatch": [
+        "**/modules/nf-core/**/meta.yml",
+        "**/modules/local/**/meta.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json"
+    },
+    {
       "name": "nFPM",
       "description": "nFPM configuration file",
       "fileMatch": ["nfpm.yaml"],


### PR DESCRIPTION
This adds a schemas for the meta.yml and the environment.yml files of [nf-core](https://nf-co.re/)-flavored Nextflow modules, e.g. https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/environment.yml and https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/meta.yml

Same for the meta.yml of nf-core subworkflows.