### PR TITLE
added support for github actions parallel steps

### DIFF
--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -168,6 +168,46 @@
                 "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsworking-directory",
                 "description": "Specifies the working directory where the command is run.",
                 "type": "string"
+              },
+              "background": {
+                "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsbackground",
+                "description": "Runs a step asynchronously so the job continues to the next step without waiting for it to finish. You can use background on steps that use run or uses.",
+                "type": "boolean"
+              },
+              "wait": {
+                "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswait",
+                "description": "Pauses the job until one or more background steps complete. Provide a single step id as a string, or multiple step ids as an array.",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                ]
+              },
+              "wait-all": {
+                "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswait-all",
+                "description": "Pauses the job until all active background steps complete. The wait-all keyword takes no arguments.",
+                "type": ["boolean", "null"]
+              },
+              "cancel": {
+                "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscancel",
+                "description": "Gracefully terminates a running background step. The cancel keyword targets a single background step by its id.",
+                "type": "string"
+              },
+              "parallel": {
+                "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsparallel",
+                "description": "Runs a group of steps concurrently, then waits for all of them to finish before continuing.",
+                "type": "array",
+                "items": {
+                  "type": "object"
+                },
+                "minItems": 1
               }
             },
             "oneOf": [
@@ -176,6 +216,18 @@
               },
               {
                 "required": ["uses"]
+              },
+              {
+                "required": ["wait"]
+              },
+              {
+                "required": ["wait-all"]
+              },
+              {
+                "required": ["cancel"]
+              },
+              {
+                "required": ["parallel"]
               }
             ],
             "additionalProperties": false

--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -488,6 +488,18 @@
         },
         {
           "required": ["run"]
+        },
+        {
+          "required": ["wait"]
+        },
+        {
+          "required": ["wait-all"]
+        },
+        {
+          "required": ["cancel"]
+        },
+        {
+          "required": ["parallel"]
         }
       ],
       "properties": {
@@ -566,6 +578,46 @@
               "$ref": "#/definitions/expressionSyntax"
             }
           ]
+        },
+        "background": {
+          "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsbackground",
+          "description": "Runs a step asynchronously so the job continues to the next step without waiting for it to finish. You can use background on steps that use run or uses. To reference a background step from wait or cancel, give it an id. A maximum of 10 background steps can run concurrently in a single job.",
+          "type": "boolean"
+        },
+        "wait": {
+          "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswait",
+          "description": "Pauses the job until one or more background steps complete. Provide a single step id as a string, or multiple step ids as an array. After a wait step completes, the outputs of the referenced background steps become available to subsequent steps.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "wait-all": {
+          "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswait-all",
+          "description": "Pauses the job until all active background steps complete. The wait-all keyword takes no arguments.",
+          "type": ["boolean", "null"]
+        },
+        "cancel": {
+          "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscancel",
+          "description": "Gracefully terminates a running background step. The runner sends the step's process a termination signal (SIGTERM) so it can clean up. The cancel keyword targets a single background step by its id.",
+          "type": "string"
+        },
+        "parallel": {
+          "$comment": "https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsparallel",
+          "description": "Runs a group of steps concurrently, then waits for all of them to finish before continuing. Every step in the group runs as a background step, with an implicit wait at the end of the group.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/step"
+          },
+          "minItems": 1
         }
       }
     },

--- a/src/test/github-action/parallel-steps.json
+++ b/src/test/github-action/parallel-steps.json
@@ -1,22 +1,21 @@
 {
-  "name": "Test parallel steps",
   "description": "Test composite action with parallel step features",
   "inputs": {
     "target": {
+      "default": "all",
       "description": "Build target",
-      "required": false,
-      "default": "all"
+      "required": false
     }
   },
+  "name": "Test parallel steps",
   "runs": {
-    "using": "composite",
     "steps": [
       {
-        "name": "Start server",
+        "background": true,
         "id": "server",
+        "name": "Start server",
         "run": "npm start",
-        "shell": "bash",
-        "background": true
+        "shell": "bash"
       },
       {
         "name": "Run tests",
@@ -27,39 +26,39 @@
         "wait": "server"
       },
       {
-        "name": "Build frontend",
+        "background": true,
         "id": "build-frontend",
+        "name": "Build frontend",
         "run": "npm run build:frontend",
-        "shell": "bash",
-        "background": true
+        "shell": "bash"
       },
       {
-        "name": "Build backend",
+        "background": true,
         "id": "build-backend",
+        "name": "Build backend",
         "run": "npm run build:backend",
-        "shell": "bash",
-        "background": true
+        "shell": "bash"
       },
       {
         "wait": ["build-frontend", "build-backend"]
       },
       {
-        "name": "Start database",
+        "background": true,
         "id": "db",
+        "name": "Start database",
         "run": "docker run -d postgres:15",
-        "shell": "bash",
-        "background": true
+        "shell": "bash"
       },
       {
         "name": "Wait for all",
         "wait-all": true
       },
       {
-        "name": "Start monitor",
+        "background": true,
         "id": "monitor",
+        "name": "Start monitor",
         "run": "./scripts/monitor.sh",
-        "shell": "bash",
-        "background": true
+        "shell": "bash"
       },
       {
         "name": "Main task",
@@ -93,6 +92,7 @@
           }
         ]
       }
-    ]
+    ],
+    "using": "composite"
   }
 }

--- a/src/test/github-action/parallel-steps.json
+++ b/src/test/github-action/parallel-steps.json
@@ -1,0 +1,98 @@
+{
+  "name": "Test parallel steps",
+  "description": "Test composite action with parallel step features",
+  "inputs": {
+    "target": {
+      "description": "Build target",
+      "required": false,
+      "default": "all"
+    }
+  },
+  "runs": {
+    "using": "composite",
+    "steps": [
+      {
+        "name": "Start server",
+        "id": "server",
+        "run": "npm start",
+        "shell": "bash",
+        "background": true
+      },
+      {
+        "name": "Run tests",
+        "run": "npm test",
+        "shell": "bash"
+      },
+      {
+        "wait": "server"
+      },
+      {
+        "name": "Build frontend",
+        "id": "build-frontend",
+        "run": "npm run build:frontend",
+        "shell": "bash",
+        "background": true
+      },
+      {
+        "name": "Build backend",
+        "id": "build-backend",
+        "run": "npm run build:backend",
+        "shell": "bash",
+        "background": true
+      },
+      {
+        "wait": ["build-frontend", "build-backend"]
+      },
+      {
+        "name": "Start database",
+        "id": "db",
+        "run": "docker run -d postgres:15",
+        "shell": "bash",
+        "background": true
+      },
+      {
+        "name": "Wait for all",
+        "wait-all": true
+      },
+      {
+        "name": "Start monitor",
+        "id": "monitor",
+        "run": "./scripts/monitor.sh",
+        "shell": "bash",
+        "background": true
+      },
+      {
+        "name": "Main task",
+        "run": "npm test",
+        "shell": "bash"
+      },
+      {
+        "cancel": "monitor"
+      },
+      {
+        "parallel": [
+          {
+            "name": "Build A",
+            "run": "npm run build:a",
+            "shell": "bash"
+          },
+          {
+            "name": "Build B",
+            "run": "npm run build:b",
+            "shell": "bash"
+          }
+        ]
+      },
+      {
+        "parallel": [
+          {
+            "uses": "actions/setup-node@v4"
+          },
+          {
+            "uses": "actions/setup-python@v5"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/github-workflow/parallel-steps.yaml
+++ b/src/test/github-workflow/parallel-steps.yaml
@@ -1,0 +1,112 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
+name: Test parallel steps
+on:
+  - push
+jobs:
+  background-step:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start server
+        id: server
+        run: npm start
+        background: true
+      - name: Run tests against the server
+        run: npm test
+      - name: Wait for the server step to finish
+        wait: server
+
+  background-with-uses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        background: true
+        id: checkout
+      - run: echo "other work"
+      - wait: checkout
+
+  wait-multiple:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build frontend
+        id: build-frontend
+        run: npm run build:frontend
+        background: true
+      - name: Build backend
+        id: build-backend
+        run: npm run build:backend
+        background: true
+      - name: Run linter while builds run
+        run: npm run lint
+      - name: Wait for both builds to finish
+        wait:
+          - build-frontend
+          - build-backend
+      - name: Run tests
+        run: npm test
+
+  wait-all-step:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start database
+        id: db
+        run: docker run -d postgres:15
+        background: true
+      - name: Start cache
+        id: cache
+        run: docker run -d redis:7
+        background: true
+      - name: Run integration tests
+        run: npm run test:integration
+      - name: Wait for all services to stop
+        wait-all:
+
+  cancel-step:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start long-running monitor
+        id: monitor
+        run: ./scripts/monitor.sh
+        background: true
+      - name: Run the main task
+        run: npm test
+      - name: Stop the monitor
+        cancel: monitor
+
+  parallel-group:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - parallel:
+          - name: Build frontend
+            run: npm run build:frontend
+          - name: Build backend
+            run: npm run build:backend
+          - name: Build docs
+            run: npm run build:docs
+      - name: Run tests after all builds complete
+        run: npm test
+
+  parallel-group-with-uses:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - uses: actions/setup-node@v4
+          - uses: actions/setup-python@v5
+      - run: echo "both set up"
+
+  combined:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Start server
+        id: server
+        run: npm start
+        background: true
+      - parallel:
+          - name: Build A
+            run: npm run build:a
+          - name: Build B
+            run: npm run build:b
+      - name: Run tests
+        run: npm test
+      - cancel: server


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Github recently added support for parallel steps: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

This PR adds the 5 new keywords that were introduced:
- [background: true](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsbackground)
- [wait](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepswait) / [wait-all](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepswait-all)
- [cancel](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepscancel)
- [parallel](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel)

