### PR TITLE
Add Codex plugin manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2008,6 +2008,12 @@
       "url": "https://www.schemastore.org/codex-hooks.json"
     },
     {
+      "name": "Codex Plugin Manifest",
+      "description": "OpenAI Codex plugin manifest file",
+      "fileMatch": ["**/.codex-plugin/plugin.json"],
+      "url": "https://www.schemastore.org/codex-plugin-manifest.json"
+    },
+    {
       "name": "Codex Skill Metadata",
       "description": "OpenAI Codex skill metadata file",
       "fileMatch": ["**/agents/openai.yaml"],

--- a/src/negative_test/codex-plugin-manifest/invalid-logo-dark-type.json
+++ b/src/negative_test/codex-plugin-manifest/invalid-logo-dark-type.json
@@ -1,0 +1,18 @@
+{
+  "author": {
+    "name": "OpenAI"
+  },
+  "description": "Bad plugin",
+  "interface": {
+    "capabilities": ["Interactive"],
+    "category": "Productivity",
+    "defaultPrompt": "Use $bad-plugin.",
+    "developerName": "OpenAI",
+    "displayName": "Bad Plugin",
+    "logoDark": false,
+    "longDescription": "A plugin manifest with an invalid dark logo value.",
+    "shortDescription": "Bad dark logo"
+  },
+  "name": "bad-plugin",
+  "version": "1.0.0"
+}

--- a/src/negative_test/codex-plugin-manifest/remote-logo-url-dark.json
+++ b/src/negative_test/codex-plugin-manifest/remote-logo-url-dark.json
@@ -1,0 +1,18 @@
+{
+  "author": {
+    "name": "OpenAI"
+  },
+  "description": "Bad plugin",
+  "interface": {
+    "capabilities": ["Interactive"],
+    "category": "Productivity",
+    "defaultPrompt": "Use $bad-plugin.",
+    "developerName": "OpenAI",
+    "displayName": "Bad Plugin",
+    "logoUrlDark": "https://example.com/logo-dark.png",
+    "longDescription": "Remote catalog dark logo fields are not local plugin manifest fields.",
+    "shortDescription": "Wrong dark logo field"
+  },
+  "name": "bad-plugin",
+  "version": "1.0.0"
+}

--- a/src/negative_test/codex-plugin-manifest/unsupported-hooks-field.json
+++ b/src/negative_test/codex-plugin-manifest/unsupported-hooks-field.json
@@ -1,0 +1,18 @@
+{
+  "author": {
+    "name": "OpenAI"
+  },
+  "description": "Bad plugin",
+  "hooks": "./hooks.json",
+  "interface": {
+    "capabilities": ["Interactive"],
+    "category": "Productivity",
+    "defaultPrompt": "Use $bad-plugin.",
+    "developerName": "OpenAI",
+    "displayName": "Bad Plugin",
+    "longDescription": "The bundled validator rejects unsupported top-level hooks.",
+    "shortDescription": "Unsupported field"
+  },
+  "name": "bad-plugin",
+  "version": "1.0.0"
+}

--- a/src/schemas/json/codex-plugin-manifest.json
+++ b/src/schemas/json/codex-plugin-manifest.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/codex-plugin-manifest.json",
+  "$comment": "Sources: https://github.com/openai/codex/blob/main/codex-rs/plugin/src/manifest.rs and https://github.com/openai/codex/blob/main/codex-rs/skills/src/assets/samples/plugin-creator/scripts/validate_plugin.py",
+  "title": "Codex plugin manifest",
+  "description": "Manifest for an OpenAI Codex plugin.",
+  "type": "object",
+  "required": ["name", "version", "description", "author", "interface"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional plugin identifier."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Plugin identifier."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$",
+      "description": "Strict semantic version."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Brief plugin description."
+    },
+    "skills": {
+      "$ref": "#/definitions/relativePath",
+      "description": "Relative path to skill directories or files."
+    },
+    "apps": {
+      "$ref": "#/definitions/relativePath",
+      "description": "Relative path to the app manifest."
+    },
+    "mcpServers": {
+      "description": "Relative path to an MCP manifest or inline MCP server configuration.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/relativePath"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        }
+      ]
+    },
+    "interface": {
+      "$ref": "#/definitions/pluginInterface"
+    },
+    "author": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "$ref": "#/definitions/httpsUrl"
+        }
+      }
+    },
+    "homepage": {
+      "$ref": "#/definitions/httpsUrl",
+      "description": "Plugin documentation URL."
+    },
+    "repository": {
+      "$ref": "#/definitions/httpsUrl",
+      "description": "Plugin source repository URL."
+    },
+    "license": {
+      "type": "string",
+      "minLength": 1
+    },
+    "keywords": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "definitions": {
+    "httpsUrl": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://",
+      "minLength": 1
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "pattern": "^(?:[A-Za-z]:|/|\\\\\\\\)"
+      }
+    },
+    "assetPath": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Package-relative asset path."
+    },
+    "defaultPrompt": {
+      "description": "Starter prompt shown by Codex clients.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "pluginInterface": {
+      "type": "object",
+      "required": [
+        "displayName",
+        "shortDescription",
+        "longDescription",
+        "developerName",
+        "category",
+        "capabilities"
+      ],
+      "anyOf": [
+        {
+          "properties": {
+            "defaultPrompt": true
+          },
+          "required": ["defaultPrompt"]
+        },
+        {
+          "properties": {
+            "default_prompt": true
+          },
+          "required": ["default_prompt"]
+        }
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "shortDescription": {
+          "type": "string",
+          "minLength": 1
+        },
+        "longDescription": {
+          "type": "string",
+          "minLength": 1
+        },
+        "developerName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "websiteURL": {
+          "$ref": "#/definitions/httpsUrl"
+        },
+        "privacyPolicyURL": {
+          "$ref": "#/definitions/httpsUrl"
+        },
+        "termsOfServiceURL": {
+          "$ref": "#/definitions/httpsUrl"
+        },
+        "defaultPrompt": {
+          "$ref": "#/definitions/defaultPrompt"
+        },
+        "default_prompt": {
+          "$ref": "#/definitions/defaultPrompt"
+        },
+        "brandColor": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "composerIcon": {
+          "$ref": "#/definitions/assetPath"
+        },
+        "logo": {
+          "$ref": "#/definitions/assetPath"
+        },
+        "logoDark": {
+          "$ref": "#/definitions/assetPath",
+          "description": "Optional package-relative logo asset used in dark mode."
+        },
+        "screenshots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/assetPath"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/codex-plugin-manifest/inline-mcp.json
+++ b/src/test/codex-plugin-manifest/inline-mcp.json
@@ -1,0 +1,23 @@
+{
+  "author": {
+    "name": "OpenAI"
+  },
+  "description": "Plugin with inline MCP configuration",
+  "interface": {
+    "capabilities": ["Interactive"],
+    "category": "Productivity",
+    "default_prompt": "Use $inline-mcp-plugin to inspect the counter.",
+    "developerName": "OpenAI",
+    "displayName": "Inline MCP Plugin",
+    "longDescription": "A plugin manifest with inline MCP server configuration.",
+    "shortDescription": "Uses inline MCP server config"
+  },
+  "mcpServers": {
+    "counter": {
+      "type": "http",
+      "url": "https://sample.example/counter/mcp"
+    }
+  },
+  "name": "inline-mcp-plugin",
+  "version": "0.1.0"
+}

--- a/src/test/codex-plugin-manifest/plugin.json
+++ b/src/test/codex-plugin-manifest/plugin.json
@@ -1,0 +1,37 @@
+{
+  "apps": "./.app.json",
+  "author": {
+    "email": "plugins@example.com",
+    "name": "OpenAI",
+    "url": "https://openai.com"
+  },
+  "description": "Demo Codex plugin",
+  "homepage": "https://example.com/plugin",
+  "interface": {
+    "brandColor": "#3B82F6",
+    "capabilities": ["Interactive", "Write"],
+    "category": "Productivity",
+    "composerIcon": "./assets/icon.png",
+    "defaultPrompt": [
+      "Summarize my inbox.",
+      "Find open bugs and draft tickets."
+    ],
+    "developerName": "OpenAI",
+    "displayName": "Demo Plugin",
+    "logo": "./assets/logo.png",
+    "logoDark": "./assets/logo-dark.png",
+    "longDescription": "A demo plugin manifest used to validate the Codex plugin schema.",
+    "privacyPolicyURL": "https://example.com/privacy",
+    "screenshots": ["./assets/screenshot.png"],
+    "shortDescription": "Demo plugin for Codex",
+    "termsOfServiceURL": "https://example.com/terms",
+    "websiteURL": "https://example.com/plugin"
+  },
+  "keywords": ["demo", "codex"],
+  "license": "MIT",
+  "mcpServers": "./.mcp.json",
+  "name": "demo-plugin",
+  "repository": "https://github.com/example/demo-plugin",
+  "skills": "./skills",
+  "version": "1.2.0"
+}


### PR DESCRIPTION
## Summary

Adds a SchemaStore schema for Codex plugin manifests at `.codex-plugin/plugin.json`.

This is the correct schema surface for OpenAI Codex PR #29488, which added dark-mode plugin logo metadata. The existing `codex-skill-metadata.json` schema covers `agents/openai.yaml` skill metadata; that skill metadata surface still does not expose plugin `interface.logoDark`.

This schema includes:

- `interface.logoDark` for local package-relative dark-mode logo assets
- local plugin interface fields from the Codex plugin manifest validator
- negative fixtures for invalid `logoDark` values
- negative fixtures showing that app-server/remote-catalog fields such as `logoUrlDark` are not accepted in local `plugin.json`
- a negative fixture for unsupported top-level `hooks`, matching the bundled validator's accepted manifest keys

## Sources

- https://github.com/openai/codex/pull/29488
- https://github.com/openai/codex/blob/main/codex-rs/plugin/src/manifest.rs
- https://github.com/openai/codex/blob/main/codex-rs/core-plugins/src/manifest.rs
- https://github.com/openai/codex/blob/main/codex-rs/skills/src/assets/samples/plugin-creator/scripts/validate_plugin.py
- https://github.com/openai/codex/blob/main/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md

## Validation

- `node .\cli.js check --schema-name=codex-plugin-manifest.json`
- `npm run prettier -- --cache --ignore-unknown .\src\schemas\json\codex-plugin-manifest.json .\src\api\json\catalog.json .\src\test\codex-plugin-manifest\plugin.json .\src\test\codex-plugin-manifest\inline-mcp.json .\src\negative_test\codex-plugin-manifest\invalid-logo-dark-type.json .\src\negative_test\codex-plugin-manifest\remote-logo-url-dark.json .\src\negative_test\codex-plugin-manifest\unsupported-hooks-field.json`
