### PR TITLE
Migrated `stylintrc.json` from draft-04 to draft-07

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -259,7 +259,6 @@
     "stale.json",
     "staticwebapp.config.json",
     "stylelintrc.json",
-    "stylintrc.json",
     "taurus.json",
     "template.json",
     "templatesources.json",

--- a/src/schemas/json/stylintrc.json
+++ b/src/schemas/json/stylintrc.json
@@ -1,55 +1,111 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/stylintrc.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/stylintrc.json",
   "properties": {
     "blocks": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"]
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "@block keyword preference",
-      "description": "Expect the @block keyword when defining block variables.",
-      "default": false,
-      "enum": [false, "never", "always"]
+      "description": "Expect the @block keyword when defining block variables."
     },
     "brackets": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Brackets preference",
-      "description": "Expect {} when declaring a selector.",
-      "default": "never",
-      "enum": [false, "never", "always"]
+      "description": "Expect {} when declaring a selector."
     },
     "colons": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Colon preference",
-      "description": "Expect : when declaring a property.",
-      "default": "always",
-      "enum": [false, "never", "always"]
+      "description": "Expect : when declaring a property."
     },
     "colors": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "always",
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Colors preference",
-      "description": "Enforce variables when defining hex values",
-      "default": "always",
-      "enum": [false, "always"]
+      "description": "Enforce variables when defining hex values"
     },
     "commaSpace": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "CommaSpace preference",
-      "description": "Enforce or disallow spaces after commas.",
-      "default": "always",
-      "enum": [false, "never", "always"]
+      "description": "Enforce or disallow spaces after commas."
     },
     "commentSpace": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "CommentSpace preference",
-      "description": "Enforce or disallow spaces after line comments ('// comment' vs '//comment').",
-      "default": "always",
-      "enum": [false, "never", "always"]
+      "description": "Enforce or disallow spaces after line comments ('// comment' vs '//comment')."
     },
     "cssLiteral": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "never",
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "CssLiteral preference",
-      "description": "By default Stylint ignores @css blocks. If set to true however, it will throw a warning if @css is used.",
-      "default": "never",
-      "enum": [false, "never"]
+      "description": "By default Stylint ignores @css blocks. If set to true however, it will throw a warning if @css is used."
     },
     "customProperties": {
       "type": "array",
@@ -58,10 +114,17 @@
       "items": {}
     },
     "depthLimit": {
-      "type": ["boolean", "integer"],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer"
+        }
+      ],
       "title": "Max selector depth preference",
-      "description": "Sets the max selector depth. If set to 4, max selector depth will be 4 indents. Pseudo selectors like &:first-child or &:hover won't count towards the limit. Set to false if you don't want to check for this",
-      "default": false
+      "description": "Sets the max selector depth. If set to 4, max selector depth will be 4 indents. Pseudo selectors like &:first-child or &:hover won't count towards the limit. Set to false if you don't want to check for this"
     },
     "duplicates": {
       "type": "boolean",
@@ -70,11 +133,19 @@
       "default": true
     },
     "efficient": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Property efficiency preference",
-      "description": "Check for places where properties can be written more efficiently. (Example: prefer margin 0 over margin 0 0)",
-      "default": "always",
-      "enum": [false, "never", "always"]
+      "description": "Check for places where properties can be written more efficiently. (Example: prefer margin 0 over margin 0 0)"
     },
     "exclude": {
       "type": "array",
@@ -83,11 +154,19 @@
       "items": {}
     },
     "extendPref": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["@extend", "@extends"]
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "Extend(s) preference",
-      "description": "Pass in either @extend or @extends to enforce one, or false to enforce neither.",
-      "default": false,
-      "enum": [false, "@extend", "@extends"]
+      "description": "Pass in either @extend or @extends to enforce one, or false to enforce neither."
     },
     "globalDupe": {
       "type": "boolean",
@@ -102,29 +181,58 @@
       "default": true
     },
     "indentPref": {
-      "type": ["boolean", "integer"],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer"
+        }
+      ],
       "title": "IndentPref preference.",
-      "description": "Number of spaces to indent.",
-      "default": false
+      "description": "Number of spaces to indent."
     },
     "leadingZero": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "LeadingZero preference",
-      "description": "Enforce or disallow unnecessary leading zeroes on decimal points.",
-      "default": "never",
-      "enum": [false, "never", "always"]
+      "description": "Enforce or disallow unnecessary leading zeroes on decimal points."
     },
     "maxErrors": {
-      "type": ["boolean", "integer"],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer"
+        }
+      ],
       "title": "Max number of errors preference",
-      "description": "Set 'max' number of Errors.",
-      "default": false
+      "description": "Set 'max' number of Errors."
     },
     "maxWarnings": {
-      "type": ["boolean", "integer"],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer"
+        }
+      ],
       "title": "Max number of warnings preference",
-      "description": "Set 'max' number of Warnings.",
-      "default": false
+      "description": "Set 'max' number of Warnings."
     },
     "mixed": {
       "type": "boolean",
@@ -139,17 +247,19 @@
       "items": {}
     },
     "namingConvention": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["lowercase-dash", "lowercase_underscore", "camelCase", "BEM"]
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "Naming Convention",
-      "description": "Enforce a particular naming convention when declaring classes, ids, and variables. Throws a warning if you don't follow the convention.",
-      "default": false,
-      "enum": [
-        false,
-        "lowercase-dash",
-        "lowercase_underscore",
-        "camelCase",
-        "BEM"
-      ]
+      "description": "Enforce a particular naming convention when declaring classes, ids, and variables. Throws a warning if you don't follow the convention."
     },
     "namingConventionStrict": {
       "type": "boolean",
@@ -158,11 +268,19 @@
       "default": false
     },
     "none": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "None preference.",
-      "description": "If 'always' check for places where none used instead of 0. If 'never' check for places where 0 could be used instead of none.",
-      "default": "never",
-      "enum": [false, "always", "never"]
+      "description": "If 'always' check for places where none used instead of 0. If 'never' check for places where 0 could be used instead of none."
     },
     "noImportant": {
       "type": "boolean",
@@ -171,32 +289,64 @@
       "default": true
     },
     "parenSpace": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"]
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "ParenSpace preference.",
-      "description": "Enforce or disallow use of extra spaces inside parens.",
-      "default": false,
-      "enum": [false, "always", "never"]
+      "description": "Enforce or disallow use of extra spaces inside parens."
     },
     "placeholders": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Placeholders preference",
-      "description": "Enforce extending placeholder vars when using @extend(s) (prefer @extends $placeholder over $extends .some-class)",
-      "default": "always",
-      "enum": [false, "always", "never"]
+      "description": "Enforce extending placeholder vars when using @extend(s) (prefer @extends $placeholder over $extends .some-class)"
     },
     "prefixVarsWithDollar": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "always"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "PrefixVarsWithDollar preference",
-      "description": "Enforce use of $ when defining a variable. In Stylus using a $ when defining a variable is optional, but is a good idea if you want to prevent ambiguity. Not including the $ sets up situations where you wonder: 'Is this a variable or a value?' For instance: padding $default is easier to understand than padding default.",
-      "default": "always",
-      "enum": [false, "always", "never"]
+      "description": "Enforce use of $ when defining a variable. In Stylus using a $ when defining a variable is optional, but is a good idea if you want to prevent ambiguity. Not including the $ sets up situations where you wonder: 'Is this a variable or a value?' For instance: padding $default is easier to understand than padding default."
     },
     "quotePref": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["single", "double"]
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "Quote style preference",
-      "description": "Enforce consistent quotation style.",
-      "default": false,
-      "enum": [false, "single", "double"]
+      "description": "Enforce consistent quotation style."
     },
     "reporterOptions": {
       "type": "object",
@@ -213,9 +363,16 @@
           }
         },
         "columnSplitter": {
-          "type": ["boolean", "string"],
-          "title": "ColumnSplitter schema.",
-          "default": "  "
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "default": "  "
+            }
+          ],
+          "title": "ColumnSplitter schema."
         },
         "showHeaders": {
           "title": "ShowHeaders schema.",
@@ -229,37 +386,79 @@
       }
     },
     "semicolons": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"],
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "Semicolon preference",
-      "description": "Enforce or disallow semicolons",
-      "default": "never",
-      "enum": [false, "always", "never"]
+      "description": "Enforce or disallow semicolons"
     },
     "sortOrder": {
-      "type": ["boolean", "string", "array"],
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string",
+          "default": "alphabetical"
+        },
+        {
+          "type": "array"
+        }
+      ],
       "title": "Property sorting order preference",
-      "description": "Enforce a particular sort order when declaring properties. Throws a warning if you don't follow the order.",
-      "default": "alphabetical"
+      "description": "Enforce a particular sort order when declaring properties. Throws a warning if you don't follow the order."
     },
     "stackedProperties": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["never", "always"]
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "One-liners preference",
-      "description": "Enforce putting properties on new lines.",
-      "enum": [false, "always", "never"]
+      "description": "Enforce putting properties on new lines."
     },
     "trailingWhitespace": {
-      "type": ["string", "boolean"],
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "never",
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "TrailingWhitespace preference",
-      "description": "An explanation about the purpose of this instance.",
-      "default": "never",
-      "enum": [false, "never"]
+      "description": "An explanation about the purpose of this instance."
     },
     "universal": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false,
+          "default": false
+        }
+      ],
       "title": "Universal preference",
-      "description": "Looks for instances of the inefficient * selector. Lots of resets use this, for good reason (resetting box model), but past that you really don't need this selector, and you should avoid it if possible.",
-      "default": false,
-      "enum": [false, "never"]
+      "description": "Looks for instances of the inefficient * selector. Lots of resets use this, for good reason (resetting box model), but past that you really don't need this selector, and you should avoid it if possible."
     },
     "valid": {
       "type": "boolean",
@@ -268,17 +467,32 @@
       "default": true
     },
     "zeroUnits": {
-      "type": ["boolean", "string"],
+      "oneOf": [
+        {
+          "type": "string",
+          "const": "never",
+          "default": "never"
+        },
+        {
+          "type": "boolean",
+          "const": false
+        }
+      ],
       "title": "ZeroUnits preference",
-      "description": "Looks for instances of 0px. You don't need the px. Checks all units, not just px.",
-      "default": "never",
-      "enum": [false, "never"]
+      "description": "Looks for instances of 0px. You don't need the px. Checks all units, not just px."
     },
     "zIndexNormalize": {
-      "type": ["boolean", "integer"],
+      "oneOf": [
+        {
+          "type": "boolean",
+          "default": false
+        },
+        {
+          "type": "integer"
+        }
+      ],
       "title": "ZIndexNormalize preference",
-      "description": "Enforce some (very) basic z-index sanity. Any number passed in will be used as the base for your z-index values. Throws an error if your value is not normalized.",
-      "default": false
+      "description": "Enforce some (very) basic z-index sanity. Any number passed in will be used as the base for your z-index values. Throws an error if your value is not normalized."
     }
   },
   "title": "JSON schema for Stylint configuration files",


### PR DESCRIPTION
- Migrated `stylintrc.json` from draft-04 to draft-06, which draft-07 is backwards compatible with
- Migrated from type unions to a stricter equivalent using `oneOf`
- Enabled strict validation
