### PR TITLE
Update Codex hooks schema

### DIFF
--- a/src/negative_test/codex-hooks/fractional-timeout.json
+++ b/src/negative_test/codex-hooks/fractional-timeout.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/stop.py",
+            "timeout": 0.5,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/schemas/json/codex-hooks.json
+++ b/src/schemas/json/codex-hooks.json
@@ -31,9 +31,25 @@
           "$ref": "#/definitions/matcherGroups",
           "description": "Runs after supported tool calls. The matcher filters tool names and aliases."
         },
+        "PreCompact": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs before conversation compaction. The matcher filters the compaction trigger, such as manual or auto."
+        },
+        "PostCompact": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs after conversation compaction. The matcher filters the compaction trigger, such as manual or auto."
+        },
         "UserPromptSubmit": {
           "$ref": "#/definitions/matcherGroups",
           "description": "Runs before a user prompt is submitted. Codex currently ignores matcher for this event."
+        },
+        "SubagentStart": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs when a subagent starts. The matcher filters the subagent type."
+        },
+        "SubagentStop": {
+          "$ref": "#/definitions/matcherGroups",
+          "description": "Runs when a subagent stops. The matcher filters the subagent type."
         },
         "Stop": {
           "$ref": "#/definitions/matcherGroups",
@@ -96,8 +112,13 @@
           "description": "Command to execute.",
           "minLength": 1
         },
+        "commandWindows": {
+          "type": "string",
+          "description": "Optional Windows-only command override.",
+          "minLength": 1
+        },
         "timeout": {
-          "type": "number",
+          "type": "integer",
           "description": "Timeout in seconds. Codex uses 600 seconds when omitted.",
           "minimum": 0
         },

--- a/src/test/codex-hooks/hooks.json
+++ b/src/test/codex-hooks/hooks.json
@@ -12,6 +12,17 @@
         "matcher": "Bash|apply_patch"
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/post_compact.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
     "PostToolUse": [
       {
         "hooks": [
@@ -23,6 +34,30 @@
           }
         ],
         "matcher": "mcp__filesystem__.*"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/pre_compact.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "bash .codex/hooks/pre_tool_use.sh",
+            "commandWindows": "pwsh -NoLogo -NoProfile -File .codex/hooks/pre_tool_use.ps1",
+            "statusMessage": "Checking tool input",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|Edit|Write"
       }
     ],
     "SessionStart": [
@@ -46,6 +81,28 @@
             "type": "command"
           }
         ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/subagent_start.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "reviewer|tester"
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "python3 .codex/hooks/subagent_stop.py",
+            "type": "command"
+          }
+        ],
+        "matcher": "reviewer|tester"
       }
     ],
     "UserPromptSubmit": [


### PR DESCRIPTION
## Changes

- Add the current Codex hook events documented by OpenAI: `PreCompact`, `PostCompact`, `SubagentStart`, and `SubagentStop`.
- Add `commandWindows`, the optional Windows-only command override for command hook handlers.
- Tighten `timeout` from any number to a non-negative integer to match Codex's parser.
- Expand the positive fixture to cover the new events and add a negative fixture for fractional timeouts.

## References

- https://developers.openai.com/codex/hooks
- https://github.com/openai/codex/blob/main/codex-rs/config/src/hook_config.rs

## Validation

- `npm ci`
- `node .\cli.js check --schema-name=codex-hooks.json`
- `npx prettier --check src/schemas/json/codex-hooks.json src/test/codex-hooks/hooks.json src/negative_test/codex-hooks/fractional-timeout.json`