### PR TITLE
Fixed dead schema `$ref` in problem_package_generators.json

### DIFF
--- a/src/schemas/json/problem_package_generators.json
+++ b/src/schemas/json/problem_package_generators.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/generators_yaml_schema.json"
 }

--- a/src/schemas/json/problem_package_generators.json
+++ b/src/schemas/json/problem_package_generators.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/master/support/schemas/generators_yaml_schema.json"
+  "$ref": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/generators_yaml_schema.json"
 }


### PR DESCRIPTION
- `$ref` is no longer dead and now matches what's in `src/api/json/catalog.json`
- Updated schema version to match the new `$ref`