### PR TITLE
feat: add Falco runtime security rules JSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3242,12 +3242,9 @@
       "url": "https://gitlab.com/fdroid/fdroiddata/-/raw/master/schemas/metadata.json"
     },
     {
-      "description": "Falco runtime security rules file (https://falco.org/docs/rules/)",
-      "fileMatch": [
-        "falco_rules.yaml",
-        "falco_rules.local.yaml"
-      ],
       "name": "Falco Rules",
+      "description": "Falco runtime security rules file (https://falco.org/docs/rules/)",
+      "fileMatch": ["falco_rules.yaml", "falco_rules.local.yaml"],
       "url": "https://json.schemastore.org/falco-rules.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3242,6 +3242,15 @@
       "url": "https://gitlab.com/fdroid/fdroiddata/-/raw/master/schemas/metadata.json"
     },
     {
+      "description": "Falco runtime security rules file (https://falco.org/docs/rules/)",
+      "fileMatch": [
+        "falco_rules.yaml",
+        "falco_rules.local.yaml"
+      ],
+      "name": "Falco Rules",
+      "url": "https://json.schemastore.org/falco-rules.json"
+    },
+    {
       "name": ".ffizer.yaml",
       "description": "ffizer template configuration files",
       "fileMatch": [".ffizer.yaml"],

--- a/src/schemas/json/falco-rules.json
+++ b/src/schemas/json/falco-rules.json
@@ -1,0 +1,241 @@
+{
+  "$id": "https://json.schemastore.org/falco-rules.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Falco Rules",
+  "description": "Schema for Falco security rules files (https://falco.org/docs/rules/)",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/FalcoRule"
+  },
+  "definitions": {
+    "FalcoRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required_engine_version": {
+          "type": "string",
+          "description": "Minimum required Falco engine version"
+        },
+        "required_plugin_versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequiredPluginVersion"
+          },
+          "description": "List of required plugin versions"
+        },
+        "macro": {
+          "type": "string",
+          "description": "Name of the macro"
+        },
+        "condition": {
+          "type": "string",
+          "description": "Filter condition expression"
+        },
+        "list": {
+          "type": "string",
+          "description": "Name of the list"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Item"
+          },
+          "description": "List items (strings or integers)"
+        },
+        "rule": {
+          "type": "string",
+          "description": "Name of the rule"
+        },
+        "desc": {
+          "type": "string",
+          "description": "Human-readable description of the rule"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the rule is enabled"
+        },
+        "output": {
+          "type": "string",
+          "description": "Output message template when the rule matches"
+        },
+        "append": {
+          "type": "boolean",
+          "description": "Whether to append to an existing rule, macro, or list"
+        },
+        "priority": {
+          "$ref": "#/definitions/Priority",
+          "description": "Severity priority of the rule"
+        },
+        "capture": {
+          "type": "boolean",
+          "description": "Whether to capture matching events"
+        },
+        "capture_duration": {
+          "type": "integer",
+          "description": "Duration in seconds for capture mode"
+        },
+        "source": {
+          "type": "string",
+          "description": "Event source the rule applies to (e.g. syscall)"
+        },
+        "exceptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Exception"
+          },
+          "description": "List of exception definitions for the rule"
+        },
+        "override": {
+          "$ref": "#/definitions/Override",
+          "description": "Fields to override when extending a rule"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags associated with the rule"
+        },
+        "warn_evttypes": {
+          "type": "boolean",
+          "description": "Whether to warn if the rule does not specify event types"
+        },
+        "skip-if-unknown-filter": {
+          "type": "boolean",
+          "description": "Whether to skip loading the rule if a filter field is unknown"
+        }
+      },
+      "required": [],
+      "title": "FalcoRule"
+    },
+    "Item": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "title": "Item"
+    },
+    "Exception": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the exception"
+        },
+        "fields": {},
+        "comps": {},
+        "values": {}
+      },
+      "required": ["name"],
+      "title": "Exception"
+    },
+    "Priority": {
+      "type": "string",
+      "enum": [
+        "EMERGENCY",
+        "ALERT",
+        "CRITICAL",
+        "ERROR",
+        "WARNING",
+        "NOTICE",
+        "INFO",
+        "INFORMATIONAL",
+        "DEBUG"
+      ],
+      "title": "Priority"
+    },
+    "OverriddenItem": {
+      "type": "string",
+      "enum": ["append", "replace"],
+      "title": "OverriddenItem"
+    },
+    "Override": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "items": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "desc": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "condition": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "output": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "priority": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "enabled": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "exceptions": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "capture": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "capture_duration": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "tags": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "warn_evttypes": {
+          "$ref": "#/definitions/OverriddenItem"
+        },
+        "skip-if-unknown-filter": {
+          "$ref": "#/definitions/OverriddenItem"
+        }
+      },
+      "minProperties": 1,
+      "title": "Override"
+    },
+    "RequiredPluginVersion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Plugin name"
+        },
+        "version": {
+          "type": "string",
+          "description": "Minimum required plugin version"
+        },
+        "alternatives": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Alternative"
+          },
+          "description": "Alternative plugins that can satisfy this requirement"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "RequiredPluginVersion"
+    },
+    "Alternative": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Alternative plugin name"
+        },
+        "version": {
+          "type": "string",
+          "description": "Alternative plugin version"
+        }
+      },
+      "required": ["name", "version"],
+      "title": "Alternative"
+    }
+  }
+}

--- a/src/schemas/json/falco-rules.json
+++ b/src/schemas/json/falco-rules.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://json.schemastore.org/falco-rules.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/falco-rules.json",
   "title": "Falco Rules",
   "description": "Schema for Falco security rules files (https://falco.org/docs/rules/)",
   "type": "array",

--- a/src/test/falco-rules/falco-rules.yaml
+++ b/src/test/falco-rules/falco-rules.yaml
@@ -1,0 +1,47 @@
+- list: shell_binaries
+  items: [bash, sh, dash, zsh, fish, csh, ksh]
+
+- macro: shell_procs
+  condition: proc.name in (shell_binaries)
+
+- rule: Terminal shell in container
+  desc: A shell was used as the entrypoint/exec point into a container with an attached terminal.
+  condition: >
+    spawned_process and container
+    and shell_procs and proc.tty != 0
+    and container_entrypoint
+    and not user_expected_terminal_shell_in_container_conditions
+  output: A shell was spawned in a container with an attached terminal (evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty exe_flags=%evt.arg.flags %container.info)
+  priority: NOTICE
+  tags: [maturity_stable, container, shell, mitre_execution, T1059]
+
+- rule: Read sensitive file untrusted
+  desc: An attempt to read a file that contains sensitive data, by a process not explicitly allowed to do so.
+  condition: >
+    open_read
+    and sensitive_files
+    and not proc.name in (user_mgmt_binaries)
+    and not read_sensitive_file_binaries
+    and not read_sensitive_file_conditions
+  output: Sensitive file opened for reading by non-trusted program (file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty %container.info)
+  priority: WARNING
+  tags: [maturity_stable, host, container, filesystem, mitre_credential_access, T1555]
+
+- rule: Custom rule with override example
+  desc: Example showing override syntax
+  condition: evt.type = open
+  output: File opened (file=%fd.name %container.info)
+  priority: DEBUG
+  tags: [custom]
+  override:
+    condition: append
+    output: replace
+
+- required_engine_version: "0.36.0"
+
+- required_plugin_versions:
+    - name: cloudtrail
+      version: "0.10.0"
+      alternatives:
+        - name: cloudtrail-v2
+          version: "2.0.0"

--- a/src/test/falco-rules/falco-rules.yaml
+++ b/src/test/falco-rules/falco-rules.yaml
@@ -25,7 +25,15 @@
     and not read_sensitive_file_conditions
   output: Sensitive file opened for reading by non-trusted program (file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty %container.info)
   priority: WARNING
-  tags: [maturity_stable, host, container, filesystem, mitre_credential_access, T1555]
+  tags:
+    [
+      maturity_stable,
+      host,
+      container,
+      filesystem,
+      mitre_credential_access,
+      T1555,
+    ]
 
 - rule: Custom rule with override example
   desc: Example showing override syntax
@@ -37,11 +45,11 @@
     condition: append
     output: replace
 
-- required_engine_version: "0.36.0"
+- required_engine_version: '0.36.0'
 
 - required_plugin_versions:
     - name: cloudtrail
-      version: "0.10.0"
+      version: '0.10.0'
       alternatives:
         - name: cloudtrail-v2
-          version: "2.0.0"
+          version: '2.0.0'


### PR DESCRIPTION
## Summary

Adds a JSON Schema for [Falco](https://falco.org) runtime security rules files, enabling IDE autocompletion and validation.

**Schema file:** `src/schemas/json/falco-rules.json`
**Catalog entry** added with `fileMatch` for `falco_rules.yaml` and `falco_rules.local.yaml`

## What is Falco?

[Falco](https://falco.org) is a CNCF Incubating cloud-native runtime security tool. Users write rules in YAML files that are loaded by Falco to detect suspicious behavior at runtime.

## Schema Coverage

The schema covers all Falco rule file constructs:
- **Rules** — `rule`, `desc`, `condition`, `output`, `priority`, `tags`, `source`, `enabled`, `exceptions`
- **Macros** — `macro`, `condition`, `append`
- **Lists** — `list`, `items`, `append`
- **Metadata** — `required_engine_version`, `required_plugin_versions` (with `alternatives`)
- **Override syntax** — `override` field with `append`/`replace` semantics for extending built-in rules

The schema was derived from the [official Falco engine schema](https://github.com/falcosecurity/falco/blob/master/userspace/engine/rule_json_schema.h) (accessible via `falco --rule-schema`) with added descriptions for each property.

## Related

- Falco GitHub issue requesting SchemaStore integration: https://github.com/falcosecurity/falco/issues/3432
- Falco rules documentation: https://falco.org/docs/rules/