### PR TITLE
feat(hugo): update permalinks array form and module.mounts

### DIFF
--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -480,12 +480,14 @@
             "default": false
           },
           "lang": {
-            "description": "The language code\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "description": "DEPRECATED. Deprecated in v0.153.0. Use `sites` instead.\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "deprecated": true
           },
           "includeFiles": {
-            "description": "The included files\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "description": "DEPRECATED. Deprecated in v0.153.0. Use `files` instead.\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "deprecated": true,
             "oneOf": [
               {
                 "type": "string"
@@ -500,7 +502,8 @@
             ]
           },
           "excludeFiles": {
-            "description": "The excluded files\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "description": "DEPRECATED. Deprecated in v0.153.0. Use `files` instead.\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "deprecated": true,
             "oneOf": [
               {
                 "type": "string"
@@ -513,6 +516,67 @@
                 }
               }
             ]
+          },
+          "files": {
+            "description": "A glob slice defining the files to include or exclude\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sites": {
+            "description": "A map to define sites matrix and sites complements for the mount\nhttps://gohugo.io/hugo-modules/configuration/#module-configuration-mounts",
+            "type": "object",
+            "properties": {
+              "matrix": {
+                "description": "The sites matrix\nhttps://gohugo.io/quick-reference/glossary/#sites-matrix",
+                "type": "object",
+                "properties": {
+                  "languages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "versions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "complements": {
+                "description": "The sites complements\nhttps://gohugo.io/quick-reference/glossary/#sites-complements",
+                "type": "object",
+                "properties": {
+                  "languages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "versions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "additionalProperties": false
@@ -3326,22 +3390,92 @@
     },
     "permalinks": {
       "title": "permalink options",
-      "description": "The permalink options\nhttps://gohugo.io/content-management/urls/#permalinks",
-      "type": "object",
-      "properties": {
-        "_merge": {
-          "$ref": "#/definitions/mergeType"
+      "description": "The permalink options\nhttps://gohugo.io/configuration/permalinks/",
+      "oneOf": [
+        {
+          "description": "Map form: define URL patterns per page kind (page, section, term)\nhttps://gohugo.io/configuration/permalinks/#map-form",
+          "type": "object",
+          "properties": {
+            "_merge": {
+              "$ref": "#/definitions/mergeType"
+            },
+            "page": {
+              "$ref": "#/definitions/permalinkConfiguration"
+            },
+            "section": {
+              "$ref": "#/definitions/permalinkConfiguration"
+            },
+            "term": {
+              "$ref": "#/definitions/permalinkConfiguration"
+            }
+          }
         },
-        "page": {
-          "$ref": "#/definitions/permalinkConfiguration"
-        },
-        "section": {
-          "$ref": "#/definitions/permalinkConfiguration"
-        },
-        "term": {
-          "$ref": "#/definitions/permalinkConfiguration"
+        {
+          "description": "Array form: define permalink entries with page matchers support\nhttps://gohugo.io/configuration/permalinks/#array-form",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["pattern"],
+            "properties": {
+              "pattern": {
+                "description": "The URL pattern to apply\nhttps://gohugo.io/configuration/permalinks/",
+                "$ref": "#/definitions/permalinkDefinition"
+              },
+              "target": {
+                "description": "Optional page matcher. If omitted, the pattern applies to all pages\nhttps://gohugo.io/configuration/permalinks/",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "A glob pattern matching the page's logical path\nhttps://gohugo.io/configuration/permalinks/#path",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "kind": {
+                    "description": "A glob pattern matching the page kind\nhttps://gohugo.io/configuration/permalinks/#kind",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "environment": {
+                    "description": "A glob pattern matching the environment\nhttps://gohugo.io/configuration/permalinks/#environment",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sites": {
+                    "description": "A sites matrix matching any combination of content dimensions including language, version, and role\nhttps://gohugo.io/quick-reference/glossary/#sites-matrix",
+                    "type": "object",
+                    "properties": {
+                      "matrix": {
+                        "description": "The sites matrix\nhttps://gohugo.io/quick-reference/glossary/#sites-matrix",
+                        "type": "object",
+                        "properties": {
+                          "languages": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "roles": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "versions": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
-      }
+      ]
     },
     "pluralizeListTitles": {
       "description": "Pluralize/leave titles in lists\nhttps://gohugo.io/getting-started/configuration/#pluralizelisttitles",

--- a/src/schemas/json/hugo.json
+++ b/src/schemas/json/hugo.json
@@ -3418,8 +3418,8 @@
             "required": ["pattern"],
             "properties": {
               "pattern": {
-                "description": "The URL pattern to apply\nhttps://gohugo.io/configuration/permalinks/",
-                "$ref": "#/definitions/permalinkDefinition"
+                "$ref": "#/definitions/permalinkDefinition",
+                "description": "The URL pattern to apply\nhttps://gohugo.io/configuration/permalinks/"
               },
               "target": {
                 "description": "Optional page matcher. If omitted, the pattern applies to all pages\nhttps://gohugo.io/configuration/permalinks/",

--- a/src/test/hugo/example-6.yaml
+++ b/src/test/hugo/example-6.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=../../schemas/json/hugo.json
+
+# 1. permalinks array form (new in 0.161.0)
+permalinks:
+  - pattern: /artikel/
+    target:
+      path: '{/articles}'
+      sites:
+        matrix:
+          languages:
+          - de
+  - pattern: /artikel/:year/:month/:slug/
+    target:
+      path: '{/articles/**}'
+      sites:
+        matrix:
+          languages:
+          - de
+
+# 2. module.mounts files/sites (new in 0.153.0)
+module:
+  mounts:
+    - source: content
+      target: content
+      files:
+        - "! docs/*"
+    - source: assets
+      target: assets
+      sites:
+        matrix:
+          languages:
+            - en

--- a/src/test/hugo/example-6.yaml
+++ b/src/test/hugo/example-6.yaml
@@ -8,14 +8,14 @@ permalinks:
       sites:
         matrix:
           languages:
-          - de
+            - de
   - pattern: /artikel/:year/:month/:slug/
     target:
       path: '{/articles/**}'
       sites:
         matrix:
           languages:
-          - de
+            - de
 
 # 2. module.mounts files/sites (new in 0.153.0)
 module:
@@ -23,7 +23,7 @@ module:
     - source: content
       target: content
       files:
-        - "! docs/*"
+        - '! docs/*'
     - source: assets
       target: assets
       sites:


### PR DESCRIPTION
Adds schema support for two Hugo features:

- `permalinks` array form (v0.161.0): `permalinks` with `pattern` and optional `target` page matcher
- `module.mounts`: new `files` and `sites` fields (v0.153.0); deprecates `includeFiles`, `excludeFiles`, `lang`

Refs:
- https://gohugo.io/configuration/permalinks/#array-form
- https://gohugo.io/configuration/module/#files
- https://gohugo.io/configuration/module/#sites
