### PR TITLE
paper-plugin: allow booleans for permission default

### DIFF
--- a/src/schemas/json/paper-plugin.json
+++ b/src/schemas/json/paper-plugin.json
@@ -12,7 +12,7 @@
       "pattern": "^(?!io\\.papermc\\.)([a-zA-Z_$][a-zA-Z\\d_$]*\\.)*[a-zA-Z_$][a-zA-Z\\d_$]*$"
     },
     "perm-default": {
-      "enum": ["true", "false", "op", "not op"]
+      "enum": ["true", true, "false", false, "op", "not op"]
     },
     "permission": {
       "type": "object",


### PR DESCRIPTION
This is allowed since [Paper uses `toString` on the object](https://github.com/PaperMC/Paper/blob/0ae1b4239e9559516917f86bfcac404a091c710c/paper-api/src/main/java/org/bukkit/permissions/Permission.java#L299), converting the boolean to String before looking up the enumeration of possible string values.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
