### PR TITLE
Add Specpin spec file schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "Specpin spec file",
+      "description": "Specpin business-spec file (.specs/*.spec.json): rules, descriptions, and acceptance criteria pinned to UI elements",
+      "fileMatch": ["**/.specs/*.spec.json"],
+      "url": "https://specpin.ohnice.app/schema/v1.json"
+    },
+    {
       "name": "Burnless SRE config",
       "description": "Burnless sre.yaml \u2014 SLOs, error budgets, runbooks, on-call, and dashboards as code",
       "fileMatch": ["sre.yaml", "sre.yml"],


### PR DESCRIPTION
Adds a catalog entry for **Specpin** spec files.

[Specpin](https://specpin.ohnice.app) pins business specifications (rules, descriptions, acceptance criteria) onto elements of a running web UI. Specs live as JSON in a repo's `.specs/` directory as `*.spec.json` files.

- **Schema**: https://specpin.ohnice.app/schema/v1.json (self-hosted, JSON Schema draft 2020-12)
- **fileMatch**: `**/.specs/*.spec.json`: scoped to the `.specs/` directory and the `.spec.json` suffix, so no generic-pattern false positives.
- The schema compiles cleanly under Ajv strict mode.
