### PR TITLE
Add Secure SDLC Evidence Bundle schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6557,6 +6557,12 @@
       }
     },
     {
+      "name": "Secure SDLC Evidence Bundle",
+      "description": "Auditable release-readiness evidence bundle produced by the Secure SDLC Evidence Collector",
+      "fileMatch": ["**/*.evidence-bundle.json"],
+      "url": "https://www.schemastore.org/evidence-bundle.json"
+    },
+    {
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
       "fileMatch": ["*.sdf.yml"],

--- a/src/negative_test/evidence-bundle/missing-required-field.json
+++ b/src/negative_test/evidence-bundle/missing-required-field.json
@@ -1,0 +1,757 @@
+{
+  "application": {
+    "environment": "production",
+    "name": "payments-api",
+    "owner_team": null,
+    "repository": "acme/payments-api"
+  },
+  "bundle_id": "bundle-20260629-payments-api-2026.04.10-6f45cb54",
+  "bundle_version": "1.0.0",
+  "control_evaluations": [
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.7",
+      "control_name": "Review and/or analyze human-readable code (SAST)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["sast-cfcf7a634b32"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.7 is met by evidence ['sast-cfcf7a634b32']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.4",
+      "control_name": "Reuse existing, well-secured software (SCA)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["sca-54e49b31bec7"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.4 is met by evidence ['sca-54e49b31bec7']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "ORG-SECRETS-SCAN",
+      "control_name": "Repository-wide secrets scanning",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["secrets-3bc6ef3a7a0a"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-SECRETS-SCAN is met by evidence ['secrets-3bc6ef3a7a0a']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PS.3",
+      "control_name": "Archive and protect each software release (SBOM)",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sbom-8f24db8264b4",
+        "att-eeab3847be8e",
+        "att-4fdd0c6e65a1"
+      ],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PS.3 is met by evidence ['sbom-8f24db8264b4', 'att-eeab3847be8e', 'att-4fdd0c6e65a1']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.8",
+      "control_name": "Test executable code to identify vulnerabilities",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["test-3ba115181f49"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.8 is met by evidence ['test-3ba115181f49']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-CODE-REVIEW",
+      "control_name": "Code review by eligible reviewers",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-61dda6456f8e", "att-b0fcf22e94ec"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-CODE-REVIEW is met by evidence ['att-61dda6456f8e', 'att-b0fcf22e94ec']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PW.1",
+      "control_name": "Design software to meet security requirements (threat model)",
+      "criticality": "medium",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-361af230e38f"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.1 is met by evidence ['att-361af230e38f']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-RELEASE-APPROVAL",
+      "control_name": "Formal release approval",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-2cfa2bc287a7"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-RELEASE-APPROVAL is met by evidence ['att-2cfa2bc287a7']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-REL-ROLLBACK",
+      "control_name": "Rollback plan exists and was approved",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-790592cda958"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-REL-ROLLBACK is met by evidence ['att-790592cda958']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PS.2",
+      "control_name": "Provide a mechanism to verify software release integrity",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-4fdd0c6e65a1", "att-eeab3847be8e"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PS.2 is met by evidence ['att-4fdd0c6e65a1', 'att-eeab3847be8e']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SAMM-DESIGN-TA-1",
+      "control_name": "Threat Assessment (Design / Threat Assessment 1)",
+      "criticality": "medium",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-361af230e38f"],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-DESIGN-TA-1 is met by evidence ['att-361af230e38f']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SAMM-IMPL-SB-2",
+      "control_name": "Secure Build (Implementation / Secure Build 2)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sbom-8f24db8264b4",
+        "att-4fdd0c6e65a1",
+        "att-eeab3847be8e"
+      ],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-IMPL-SB-2 is met by evidence ['sbom-8f24db8264b4', 'att-4fdd0c6e65a1', 'att-eeab3847be8e']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SAMM-VERIF-ST-1",
+      "control_name": "Security Testing (Verification / Security Testing 1)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sast-cfcf7a634b32",
+        "sca-54e49b31bec7",
+        "dast-f6a61122d5a3"
+      ],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-VERIF-ST-1 is met by evidence ['sast-cfcf7a634b32', 'sca-54e49b31bec7', 'dast-f6a61122d5a3']."
+    }
+  ],
+  "evidence": [
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "gitleaks",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.048359Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "secrets-3bc6ef3a7a0a",
+      "evidence_type": "secrets_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 0,
+        "medium": 0
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "gitleaks",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\gitleaks.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:3ccb3d37a2b3a6ee3a3146a6bedd8238addb4e138f0492555803a4c4b7fd534b",
+        "size_bytes": 286
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "gitleaks",
+        "uri": null,
+        "version": "8.18.4"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "gitleaks reported 0 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.050934Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "test-3ba115181f49",
+      "evidence_type": "test_result",
+      "findings_count": {
+        "errors": 0,
+        "failures": 0,
+        "skipped": 1,
+        "total": 42
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "payments-api-suite",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\junit.xml",
+        "artifact_uri": null,
+        "content_type": "application/xml",
+        "integrity_hash": "sha256:fa65f270998190cd0014fe7f09b3e4c7e69b898913702d3bd48b3eab2cf87e43",
+        "size_bytes": 896
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "junit-xml",
+        "name": "junit",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "42 tests executed, 0 failures, 0 errors, 1 skipped, duration 8.42s",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.054968Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "sbom-8f24db8264b4",
+      "evidence_type": "sbom",
+      "findings_count": {
+        "components": 3
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {
+        "cisa_2025_conformant": false,
+        "cisa_2025_minimum_elements": {
+          "author": true,
+          "component_name": true,
+          "dependency_relationships": false,
+          "generation_context": false,
+          "hash": false,
+          "license": false,
+          "supplier": false,
+          "timestamp": true,
+          "tool": true,
+          "unique_identifier": true,
+          "version": true
+        },
+        "serial_number": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+      },
+      "producer": "cyclonedx",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\sbom.cdx.json",
+        "artifact_uri": null,
+        "content_type": "application/vnd.cyclonedx+json",
+        "integrity_hash": "sha256:84088064a42486df71ca5567ce4857b6b6ecf1a5445f76166c19c83057ed977e",
+        "size_bytes": 863
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sbom",
+        "name": "cyclonedx",
+        "uri": null,
+        "version": "1.5"
+      },
+      "status": "generated",
+      "subject_ref": "pkg:generic/acme/payments-api@2026.04.10",
+      "subject_type": "artifact",
+      "summary": "CYCLONEDX SBOM with 3 components (spec 1.5)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "semgrep",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.059049Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "sast-cfcf7a634b32",
+      "evidence_type": "sast_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 1,
+        "medium": 1
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "semgrep",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\semgrep.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:7b0a9f4e140945d4bec39ffb4f2340366336e1d74c639bccf2d33dcf74f969ef",
+        "size_bytes": 1170
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "semgrep",
+        "uri": null,
+        "version": "1.70.0"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "semgrep reported 2 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "trivy",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.065457Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": ["CVE-2024-12345"],
+      "evidence_id": "sca-54e49b31bec7",
+      "evidence_type": "sca_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 0,
+        "medium": 1
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "trivy",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\trivy.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:acab632c4fa3302c2c6acba37a5c4f36630b7993df1fd14bb94ebe165da25c5d",
+        "size_bytes": 459
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "trivy",
+        "uri": null,
+        "version": "0.52.0"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "trivy reported 1 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.067684Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "dast-f6a61122d5a3",
+      "evidence_type": "dast_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 2,
+        "low": 1,
+        "medium": 0
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {
+        "targets": ["http./sample_release"]
+      },
+      "producer": "OWASP ZAP",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\zap-baseline.json",
+        "artifact_uri": null,
+        "content_type": "application/json",
+        "integrity_hash": "sha256:c5bb8ca639728d37dd4fee2a629e39de4e0510b307e560d1b1f77d4c5d9067db",
+        "size_bytes": 819
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "dast",
+        "name": "OWASP ZAP",
+        "uri": null,
+        "version": "2.14.0"
+      },
+      "status": "passed",
+      "subject_ref": "http./sample_release",
+      "subject_type": "application",
+      "summary": "OWASP ZAP DAST reported 3 findings across 1 target(s); high/critical=0",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.073794Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-eeab3847be8e",
+      "evidence_type": "artifact_attestation",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:50:00Z",
+      "manual": true,
+      "metadata": {
+        "attestation_bundle": "artifacts/payments-api-2026.04.10.attestation.jsonl",
+        "builder_id": "https://github.com/acme/payments-api/.github/workflows/release.yml",
+        "builder_version": "v1.0.0",
+        "predicate_type": "https://slsa.dev/provenance/v1"
+      },
+      "producer": "cosign-attestation",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\artifact_attestation.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:2d98bd13086735eb367c62290df3989ec04443030bf590f7762e122ec9c140cd",
+        "size_bytes": 526
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "artifact",
+      "summary": "SLSA build provenance attestation generated for the release artifact",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.078039Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-4fdd0c6e65a1",
+      "evidence_type": "artifact_signature",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:45:00Z",
+      "manual": true,
+      "metadata": {
+        "algorithm": "ecdsa-p256-sha256",
+        "issuer": "https://token.actions.githubusercontent.com",
+        "signature_bundle": "artifacts/payments-api-2026.04.10.sig"
+      },
+      "producer": "cosign",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\artifact_signature.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:3fe2f1b0ebf3ba4b1f03e5778b04d99b7d555fc4dd3de66e04dbb5e7d794c2ab",
+        "size_bytes": 406
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "artifact",
+      "summary": "Artifact signed with cosign using keyless OIDC flow",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.084051Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-61dda6456f8e",
+      "evidence_type": "code_review",
+      "findings_count": {},
+      "generated_at": "2026-04-10T11:45:00Z",
+      "manual": true,
+      "metadata": {
+        "last_approval_after_last_commit": true,
+        "reviewers": ["alice@example.com", "bob@example.com"],
+        "reviewers_approved": 2,
+        "reviewers_required": 2
+      },
+      "producer": "github-pull-request",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\code_review.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:5df9fdb7e6774c36d1c40c0292fca75bb1af831161e6b9b6344c46067174ec40",
+        "size_bytes": 394
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "PR-184",
+      "subject_type": "pull_request",
+      "summary": "PR-184 approved by 2 reviewers after last commit",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.092101Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-b0fcf22e94ec",
+      "evidence_type": "pr_metadata",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:00:00Z",
+      "manual": true,
+      "metadata": {
+        "author": "alice",
+        "base": "main",
+        "head": "feature/refund",
+        "html_url": "https://github.com/acme/payments-api/pull/184",
+        "last_approval_after_last_commit": true,
+        "merged": true,
+        "number": 184,
+        "reviewers_approved": 2,
+        "reviewers_required": 2,
+        "title": "Refactor refund service"
+      },
+      "producer": "github-pull-request-export",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\pr_metadata.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:d610fdcc08aff91fe6ba8029a6b83fc50838dcb54e3b8a75a1486c15ac833840",
+        "size_bytes": 543
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "PR-184",
+      "subject_type": "pull_request",
+      "summary": "Exported PR-184 metadata: 2 approvals after last commit, CI green",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.096274Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-2cfa2bc287a7",
+      "evidence_type": "release_approval",
+      "findings_count": {},
+      "generated_at": "2026-04-10T13:00:00Z",
+      "manual": true,
+      "metadata": {
+        "approver": "releases@example.com",
+        "change_ticket": "CHG-1234"
+      },
+      "producer": "Change Advisory Board",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\release_approval.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:35641e1d797d269ed57a32ff62b20524b0f3f54e81af8d7fbbdcf2201fb05a95",
+        "size_bytes": 310
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "release",
+      "summary": "Release 2026.04.10 formally approved by CAB",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.102402Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-790592cda958",
+      "evidence_type": "rollback_plan",
+      "findings_count": {},
+      "generated_at": "2026-04-10T10:30:00Z",
+      "manual": true,
+      "metadata": {
+        "link": "https://runbooks.example.com/payments-api/rollback/2026-04-10"
+      },
+      "producer": "Release Manager",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\rollback_plan.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:9b7aced1f6f379dcec6fabe176ccef7f64f5dc7de1d02c566c3e0aa9ea321099",
+        "size_bytes": 330
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "release",
+      "summary": "Documented rollback plan in runbook with 15 min MTTR target",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.108413Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-361af230e38f",
+      "evidence_type": "threat_model",
+      "findings_count": {},
+      "generated_at": "2026-03-22T09:00:00Z",
+      "manual": true,
+      "metadata": {
+        "link": "https://wiki.example.com/appsec/payments-api/threat-model",
+        "model_version": "2026.1",
+        "scope": "refund-flow"
+      },
+      "producer": "AppSec Team",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\threat_model.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:f6d5ec38328ef7dd319e39f78e2fc53cc78dede302c0d85dfb25fb1b870acce6",
+        "size_bytes": 366
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "completed",
+      "subject_ref": "payments-api",
+      "subject_type": "application",
+      "summary": "Threat model updated for payments-api refund flow",
+      "vulnerability_intelligence": null
+    }
+  ],
+  "exceptions": [],
+  "gaps": [],
+  "generated_at": "2026-06-29T14:24:22.117753Z",
+  "release": {
+    "artifact_digest": null,
+    "branch": "main",
+    "build_id": null,
+    "commit_sha": "abcdef1234567890",
+    "pipeline_run_id": null,
+    "release_id": "2026.04.10",
+    "tag": null
+  }
+}

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -360,6 +360,7 @@
     "*.cryproj"
   ],
   "highSchemaVersion": [
+    "evidence-bundle.json",
     // JSON schema 2019-09 and 2020-12 are not well supported by many IDEs and should not be used
     "jsone.json",
     "pgrls.json",

--- a/src/schemas/json/evidence-bundle.json
+++ b/src/schemas/json/evidence-bundle.json
@@ -1,0 +1,1167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.schemastore.org/evidence-bundle.json",
+  "$defs": {
+    "Application": {
+      "additionalProperties": false,
+      "description": "Product or service under evaluation.",
+      "properties": {
+        "environment": {
+          "default": "production",
+          "maxLength": 50,
+          "minLength": 1,
+          "title": "Environment",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "owner_team": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Owner Team"
+        },
+        "repository": {
+          "maxLength": 300,
+          "minLength": 1,
+          "title": "Repository",
+          "type": "string"
+        }
+      },
+      "required": ["name", "repository"],
+      "title": "Application",
+      "type": "object"
+    },
+    "ConfidenceLevel": {
+      "description": "Confidence of an evidence or an evaluation.\n\nManual attestations default to `medium` at best; automated signals from\ntrusted sources can reach `high`. `low` signals data that is inconsistent\nor derived from weakly authenticated sources.",
+      "enum": ["high", "medium", "low"],
+      "title": "ConfidenceLevel",
+      "type": "string"
+    },
+    "ControlCriticality": {
+      "description": "Criticality of a control, driving release gate impact.\n\n- `critical`: missing evidence forces `release_status = not_ready`.\n- `high`: missing evidence forces `release_status = conditional` (at best).\n- `medium`: missing evidence downgrades to `conditional` when paired with\n  any other gap; otherwise tolerated.\n- `low`: advisory; never blocks the release by itself.",
+      "enum": ["critical", "high", "medium", "low"],
+      "title": "ControlCriticality",
+      "type": "string"
+    },
+    "ControlEvaluation": {
+      "additionalProperties": false,
+      "description": "Outcome of evaluating a control against the collected evidence set.",
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/ConfidenceLevel",
+          "default": "medium"
+        },
+        "control_id": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Control Id",
+          "type": "string"
+        },
+        "control_name": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Control Name",
+          "type": "string"
+        },
+        "criticality": {
+          "$ref": "#/$defs/ControlCriticality"
+        },
+        "evaluated_at": {
+          "format": "date-time",
+          "title": "Evaluated At",
+          "type": "string"
+        },
+        "evaluation_status": {
+          "$ref": "#/$defs/ControlEvaluationStatus"
+        },
+        "evidence_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Refs",
+          "type": "array"
+        },
+        "exception_refs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Exception Refs",
+          "type": "array"
+        },
+        "framework": {
+          "$ref": "#/$defs/ControlFramework"
+        },
+        "missing_recommended_evidence_types": {
+          "items": {
+            "$ref": "#/$defs/EvidenceType"
+          },
+          "title": "Missing Recommended Evidence Types",
+          "type": "array"
+        },
+        "missing_required_evidence_types": {
+          "items": {
+            "$ref": "#/$defs/EvidenceType"
+          },
+          "title": "Missing Required Evidence Types",
+          "type": "array"
+        },
+        "rationale": {
+          "maxLength": 2000,
+          "minLength": 1,
+          "title": "Rationale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "control_id",
+        "framework",
+        "control_name",
+        "evaluation_status",
+        "criticality",
+        "rationale"
+      ],
+      "title": "ControlEvaluation",
+      "type": "object"
+    },
+    "ControlEvaluationStatus": {
+      "description": "Outcome of evaluating a control against collected evidence.",
+      "enum": ["met", "partial", "missing", "waived", "not_applicable"],
+      "title": "ControlEvaluationStatus",
+      "type": "string"
+    },
+    "ControlFramework": {
+      "description": "Compliance / governance frameworks referenced by controls.",
+      "enum": ["NIST_SSDF", "OWASP_SAMM", "ORG_INTERNAL"],
+      "title": "ControlFramework",
+      "type": "string"
+    },
+    "EvidenceClassification": {
+      "additionalProperties": false,
+      "description": "How the ``evidence_type`` of a record was decided.\n\nPromotes the implicit confidence signal previously visible only in\n``evaluation.rationale`` text to a first-class bundle field so\ndownstream consumers can weight or filter evidence by classification\nconfidence without parsing free-form prose. The taxonomy is small on\npurpose: any new ``reason`` value MUST be documented in\n``docs/limitations.md`` so reviewers know what to expect.",
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/ConfidenceLevel"
+        },
+        "driver_name": {
+          "anyOf": [
+            {
+              "maxLength": 120,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Driver Name"
+        },
+        "reason": {
+          "maxLength": 60,
+          "minLength": 1,
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": ["confidence", "reason"],
+      "title": "EvidenceClassification",
+      "type": "object"
+    },
+    "EvidenceException": {
+      "additionalProperties": false,
+      "description": "Formal, time-bound waiver that allows a control to pass without\nits required evidence being present.\n\nExceptions must have an approver, a written justification, and an\nexpiration date. The engine refuses expired or unscoped exceptions.",
+      "properties": {
+        "approved_at": {
+          "format": "date-time",
+          "title": "Approved At",
+          "type": "string"
+        },
+        "approver": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Approver",
+          "type": "string"
+        },
+        "control_id": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Control Id",
+          "type": "string"
+        },
+        "exception_id": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Exception Id",
+          "type": "string"
+        },
+        "expires_at": {
+          "format": "date-time",
+          "title": "Expires At",
+          "type": "string"
+        },
+        "justification": {
+          "maxLength": 2000,
+          "minLength": 10,
+          "title": "Justification",
+          "type": "string"
+        },
+        "reference": {
+          "anyOf": [
+            {
+              "maxLength": 300,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ticket or document where the waiver was recorded.",
+          "title": "Reference"
+        },
+        "scope": {
+          "$ref": "#/$defs/ExceptionScope"
+        }
+      },
+      "required": [
+        "exception_id",
+        "control_id",
+        "approver",
+        "approved_at",
+        "expires_at",
+        "justification"
+      ],
+      "title": "EvidenceException",
+      "type": "object"
+    },
+    "EvidenceSource": {
+      "additionalProperties": false,
+      "description": "Origin system that produced an evidence artifact.",
+      "properties": {
+        "kind": {
+          "maxLength": 60,
+          "minLength": 1,
+          "title": "Kind",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uri"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "maxLength": 60,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": ["name", "kind"],
+      "title": "EvidenceSource",
+      "type": "object"
+    },
+    "EvidenceStatus": {
+      "description": "Operational status of an evidence artifact.\n\n`passed`/`failed` apply to evaluative evidence (scans, tests). `generated`\napplies to artifacts that exist without a pass/fail verdict (SBOM). `missing`\nis used by the evaluation engine when an expected evidence is not found.\n`invalid` marks artifacts that were present but failed parsing/validation.",
+      "enum": [
+        "passed",
+        "failed",
+        "completed",
+        "generated",
+        "missing",
+        "invalid",
+        "unknown"
+      ],
+      "title": "EvidenceStatus",
+      "type": "string"
+    },
+    "EvidenceType": {
+      "description": "Canonical evidence types supported by the MVP.\n\nExtending this enum requires updating control definitions that reference\nthe new type. Unknown evidence should be rejected at the parser boundary.",
+      "enum": [
+        "sast_scan",
+        "sca_scan",
+        "secrets_scan",
+        "dast_scan",
+        "sbom",
+        "test_result",
+        "code_review",
+        "pr_metadata",
+        "workflow_run",
+        "threat_model",
+        "release_approval",
+        "rollback_plan",
+        "artifact_signature",
+        "artifact_attestation",
+        "generic_attestation",
+        "model_card",
+        "prompt_injection_test_result",
+        "ai_safety_eval",
+        "mcp_tool_inventory",
+        "ai_training_data_lineage"
+      ],
+      "title": "EvidenceType",
+      "type": "string"
+    },
+    "ExceptionScope": {
+      "additionalProperties": false,
+      "description": "Scope to which an exception applies.",
+      "properties": {
+        "application": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Application"
+        },
+        "release_id": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Release Id"
+        }
+      },
+      "title": "ExceptionScope",
+      "type": "object"
+    },
+    "Gap": {
+      "additionalProperties": false,
+      "description": "A concrete missing or weak evidence that impacts release readiness.",
+      "properties": {
+        "control_id": {
+          "title": "Control Id",
+          "type": "string"
+        },
+        "criticality": {
+          "$ref": "#/$defs/ControlCriticality"
+        },
+        "description": {
+          "maxLength": 1000,
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "evidence_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvidenceType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "remediation": {
+          "anyOf": [
+            {
+              "maxLength": 1000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Remediation"
+        }
+      },
+      "required": ["control_id", "criticality", "description"],
+      "title": "Gap",
+      "type": "object"
+    },
+    "NormalizedEvidence": {
+      "additionalProperties": false,
+      "description": "Canonical evidence record after normalization.\n\nEvery evaluation must reference normalized evidence via `evidence_id`.",
+      "properties": {
+        "classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EvidenceClassification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional classification provenance for the evidence_type. Populated by parsers that apply a heuristic (currently the SARIF normalizer); absent when the evidence type is self-evident from the format (SBOM, JUnit, ZAP)."
+        },
+        "collected_at": {
+          "format": "date-time",
+          "title": "Collected At",
+          "type": "string"
+        },
+        "commit_sha": {
+          "maxLength": 64,
+          "minLength": 7,
+          "title": "Commit Sha",
+          "type": "string"
+        },
+        "confidence": {
+          "$ref": "#/$defs/ConfidenceLevel",
+          "default": "medium"
+        },
+        "cve_ids": {
+          "description": "Distinct CVE identifiers extracted from the underlying scanner output. Populated by parsers that can correlate findings to CVEs (SARIF results with security/cve tags, CycloneDX vulnerabilities block). Used by the optional EPSS/KEV enrichment step. Empty when the parser cannot derive CVEs or when the evidence type does not correspond to vulnerability data (test_result, code_review, etc).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Cve Ids",
+          "type": "array"
+        },
+        "evidence_id": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Evidence Id",
+          "type": "string"
+        },
+        "evidence_type": {
+          "$ref": "#/$defs/EvidenceType"
+        },
+        "findings_count": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Aggregated findings counters keyed by severity, e.g. {high: 0}.",
+          "title": "Findings Count",
+          "type": "object"
+        },
+        "generated_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Generated At"
+        },
+        "manual": {
+          "default": false,
+          "description": "True when the evidence was provided via manual attestation.",
+          "title": "Manual",
+          "type": "boolean"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "title": "Metadata",
+          "type": "object"
+        },
+        "producer": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Producer",
+          "type": "string"
+        },
+        "raw": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawEvidenceRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reachability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Reachability"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional reachability annotation (§3.2). Populated externally (CodeQL reachability, Endor Labs, Semgrep Pro, manual review). The collector preserves the upstream verdict; it does not compute reachability itself."
+        },
+        "release_id": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Release Id",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/EvidenceSource"
+        },
+        "status": {
+          "$ref": "#/$defs/EvidenceStatus"
+        },
+        "subject_ref": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Subject Ref",
+          "type": "string"
+        },
+        "subject_type": {
+          "$ref": "#/$defs/SubjectType"
+        },
+        "summary": {
+          "anyOf": [
+            {
+              "maxLength": 1000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Summary"
+        },
+        "vulnerability_intelligence": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VulnerabilityIntelligence"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional EPSS/KEV enrichment summary for the CVEs in ``cve_ids``. Stays ``None`` unless the user opted into enrichment via the ``run --enrich`` flag or the standalone ``sdlc-evidence enrich`` command. The bundle remains schema-compatible with pre-enrichment consumers when this field is absent."
+        }
+      },
+      "required": [
+        "evidence_id",
+        "evidence_type",
+        "source",
+        "producer",
+        "subject_type",
+        "subject_ref",
+        "status",
+        "release_id",
+        "commit_sha"
+      ],
+      "title": "NormalizedEvidence",
+      "type": "object"
+    },
+    "RawEvidenceRef": {
+      "additionalProperties": false,
+      "description": "Reference to a raw (non-normalized) artifact stored alongside the bundle.",
+      "properties": {
+        "artifact_path": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Artifact Path"
+        },
+        "artifact_uri": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Artifact Uri"
+        },
+        "content_type": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Content Type"
+        },
+        "integrity_hash": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Hex digest with algorithm prefix, e.g. sha256:abcd...",
+          "title": "Integrity Hash"
+        },
+        "size_bytes": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Size Bytes"
+        }
+      },
+      "title": "RawEvidenceRef",
+      "type": "object"
+    },
+    "Reachability": {
+      "additionalProperties": false,
+      "description": "Optional reachability annotation for an SCA / dependency finding (§3.2).\n\nRecords whether the vulnerable code path is reachable from the\napplication entry points. Source = whichever tool produced the\nsignal (CodeQL reachability, Endor Labs, Semgrep Pro, or a manual\nreview). The collector **does not** re-derive reachability; it\nonly stores the upstream verdict so consumers can filter findings\nby reachable / not_reachable / unknown.",
+      "properties": {
+        "evidence_ref": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Evidence Ref"
+        },
+        "method": {
+          "default": "manual_review",
+          "maxLength": 30,
+          "minLength": 1,
+          "title": "Method",
+          "type": "string"
+        },
+        "source": {
+          "maxLength": 60,
+          "minLength": 1,
+          "title": "Source",
+          "type": "string"
+        },
+        "status": {
+          "maxLength": 20,
+          "minLength": 1,
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": ["status", "source"],
+      "title": "Reachability",
+      "type": "object"
+    },
+    "ReleaseContext": {
+      "additionalProperties": false,
+      "description": "Release candidate context that anchors every evidence collected.",
+      "properties": {
+        "artifact_digest": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Content digest of the published artifact, e.g. sha256:...",
+          "title": "Artifact Digest"
+        },
+        "branch": {
+          "default": "main",
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Branch",
+          "type": "string"
+        },
+        "build_id": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Build Id"
+        },
+        "commit_sha": {
+          "maxLength": 64,
+          "minLength": 7,
+          "title": "Commit Sha",
+          "type": "string"
+        },
+        "pipeline_run_id": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Pipeline Run Id"
+        },
+        "release_id": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Release Id",
+          "type": "string"
+        },
+        "tag": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tag"
+        }
+      },
+      "required": ["release_id", "commit_sha"],
+      "title": "ReleaseContext",
+      "type": "object"
+    },
+    "ReleaseStatus": {
+      "description": "Overall release readiness verdict computed from control evaluations.",
+      "enum": ["ready", "conditional", "not_ready"],
+      "title": "ReleaseStatus",
+      "type": "string"
+    },
+    "RiskAssessment": {
+      "additionalProperties": false,
+      "description": "Risk-weighted verdict rationale (T6.6, opt-in).\n\nPopulated when the run was invoked with ``--risk-mode epss-weighted``.\n``None`` when the default presence-based verdict is in effect, which\npreserves byte-stability for pre-T6.6 bundles.",
+      "properties": {
+        "base_release_status": {
+          "$ref": "#/$defs/ReleaseStatus"
+        },
+        "epss_percentile_threshold": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epss Percentile Threshold",
+          "type": "number"
+        },
+        "exploitable_cve_count": {
+          "minimum": 0,
+          "title": "Exploitable Cve Count",
+          "type": "integer"
+        },
+        "high_epss_cve_count": {
+          "minimum": 0,
+          "title": "High Epss Cve Count",
+          "type": "integer"
+        },
+        "kev_blocks": {
+          "default": true,
+          "title": "Kev Blocks",
+          "type": "boolean"
+        },
+        "kev_cve_count": {
+          "minimum": 0,
+          "title": "Kev Cve Count",
+          "type": "integer"
+        },
+        "kev_ransomware_cve_count": {
+          "minimum": 0,
+          "title": "Kev Ransomware Cve Count",
+          "type": "integer"
+        },
+        "mode": {
+          "maxLength": 40,
+          "minLength": 1,
+          "title": "Mode",
+          "type": "string"
+        },
+        "rationale": {
+          "default": "",
+          "maxLength": 400,
+          "title": "Rationale",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mode",
+        "epss_percentile_threshold",
+        "exploitable_cve_count",
+        "kev_cve_count",
+        "kev_ransomware_cve_count",
+        "high_epss_cve_count",
+        "base_release_status"
+      ],
+      "title": "RiskAssessment",
+      "type": "object"
+    },
+    "SubjectType": {
+      "description": "Subject an evidence is attached to.",
+      "enum": [
+        "repository",
+        "commit",
+        "pull_request",
+        "workflow_run",
+        "build",
+        "artifact",
+        "release",
+        "application",
+        "ai_model",
+        "ai_agent",
+        "ai_dataset"
+      ],
+      "title": "SubjectType",
+      "type": "string"
+    },
+    "Summary": {
+      "additionalProperties": false,
+      "description": "Aggregated verdict and scores for the bundle.",
+      "properties": {
+        "confidence_score": {
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Confidence Score",
+          "type": "integer"
+        },
+        "controls_met": {
+          "minimum": 0,
+          "title": "Controls Met",
+          "type": "integer"
+        },
+        "controls_missing": {
+          "minimum": 0,
+          "title": "Controls Missing",
+          "type": "integer"
+        },
+        "controls_not_applicable": {
+          "minimum": 0,
+          "title": "Controls Not Applicable",
+          "type": "integer"
+        },
+        "controls_partial": {
+          "minimum": 0,
+          "title": "Controls Partial",
+          "type": "integer"
+        },
+        "controls_waived": {
+          "minimum": 0,
+          "title": "Controls Waived",
+          "type": "integer"
+        },
+        "evidence_coverage_score": {
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Evidence Coverage Score",
+          "type": "integer"
+        },
+        "missing_critical_evidence": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Missing Critical Evidence",
+          "type": "array"
+        },
+        "release_status": {
+          "$ref": "#/$defs/ReleaseStatus"
+        },
+        "risk_assessment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RiskAssessment"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "total_controls": {
+          "minimum": 0,
+          "title": "Total Controls",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "evidence_coverage_score",
+        "confidence_score",
+        "release_status",
+        "total_controls",
+        "controls_met",
+        "controls_partial",
+        "controls_missing",
+        "controls_waived",
+        "controls_not_applicable"
+      ],
+      "title": "Summary",
+      "type": "object"
+    },
+    "TopRiskCve": {
+      "additionalProperties": false,
+      "description": "A single CVE selected for top-risk listing in vulnerability intelligence.\n\nKept small on purpose: only the fields a maintainer needs to decide\nwhether to patch *this week* vs *batch later*. Full CVE detail lives\nin the raw scanner artefacts referenced by ``raw.artifact_path``.",
+      "properties": {
+        "cve_id": {
+          "maxLength": 30,
+          "minLength": 1,
+          "title": "Cve Id",
+          "type": "string"
+        },
+        "epss_percentile": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epss Percentile",
+          "type": "number"
+        },
+        "epss_score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epss Score",
+          "type": "number"
+        },
+        "in_kev": {
+          "default": false,
+          "title": "In Kev",
+          "type": "boolean"
+        },
+        "known_ransomware": {
+          "default": false,
+          "title": "Known Ransomware",
+          "type": "boolean"
+        }
+      },
+      "required": ["cve_id", "epss_score", "epss_percentile"],
+      "title": "TopRiskCve",
+      "type": "object"
+    },
+    "VulnerabilityIntelligence": {
+      "additionalProperties": false,
+      "description": "EPSS + CISA KEV enrichment aggregated for a single evidence record.\n\nComputed by the optional ``enrich`` step (CLI flag ``--enrich`` on\n``run``, or the standalone ``sdlc-evidence enrich`` command). When the\nenrichment step is skipped the field stays ``None`` and the bundle\nbehaves exactly like it did pre-enrichment, so consumers that never\nopt in are unaffected.\n\nSource feeds:\n\n* EPSS — https://epss.cyentia.com/ (FIRST.org, public CSV, refreshed\n  daily). ``epss_score`` is the probability of exploitation in the\n  next 30 days; ``epss_percentile`` is the position within the day's\n  distribution.\n* CISA KEV — https://www.cisa.gov/known-exploited-vulnerabilities-catalog\n  (JSON catalog of vulnerabilities confirmed exploited in the wild).",
+      "properties": {
+        "cve_count": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Cve Count",
+          "type": "integer"
+        },
+        "cves_in_kev_count": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Cves In Kev Count",
+          "type": "integer"
+        },
+        "cves_known_ransomware_count": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Cves Known Ransomware Count",
+          "type": "integer"
+        },
+        "enriched_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp at which enrichment ran; volatile, stripped before structural hash.",
+          "title": "Enriched At"
+        },
+        "epss_feed_date": {
+          "anyOf": [
+            {
+              "maxLength": 20,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "YYYY-MM-DD date stamped on the EPSS feed used for enrichment.",
+          "title": "Epss Feed Date"
+        },
+        "epss_model_version": {
+          "anyOf": [
+            {
+              "maxLength": 40,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "EPSS model version stamped on the feed header (e.g. 'v2026.01.04'). EPSS scores are not comparable across model versions, so recording it keeps day-to-day score deltas honest. None when enrichment is skipped or the feed header omits it.",
+          "title": "Epss Model Version"
+        },
+        "kev_feed_date": {
+          "anyOf": [
+            {
+              "maxLength": 20,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "YYYY-MM-DD date stamped on the CISA KEV catalog used for enrichment.",
+          "title": "Kev Feed Date"
+        },
+        "max_epss_percentile": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Epss Percentile"
+        },
+        "max_epss_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Epss Score"
+        },
+        "top_risk_cves": {
+          "description": "Up to N CVEs sorted by EPSS percentile (highest first).",
+          "items": {
+            "$ref": "#/$defs/TopRiskCve"
+          },
+          "title": "Top Risk Cves",
+          "type": "array"
+        }
+      },
+      "title": "VulnerabilityIntelligence",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Top-level, serializable container produced by the collector.",
+  "properties": {
+    "application": {
+      "$ref": "#/$defs/Application"
+    },
+    "bundle_id": {
+      "maxLength": 200,
+      "minLength": 1,
+      "title": "Bundle Id",
+      "type": "string"
+    },
+    "bundle_version": {
+      "default": "1.0.0",
+      "title": "Bundle Version",
+      "type": "string"
+    },
+    "control_evaluations": {
+      "items": {
+        "$ref": "#/$defs/ControlEvaluation"
+      },
+      "title": "Control Evaluations",
+      "type": "array"
+    },
+    "evidence": {
+      "items": {
+        "$ref": "#/$defs/NormalizedEvidence"
+      },
+      "title": "Evidence",
+      "type": "array"
+    },
+    "exceptions": {
+      "items": {
+        "$ref": "#/$defs/EvidenceException"
+      },
+      "title": "Exceptions",
+      "type": "array"
+    },
+    "gaps": {
+      "items": {
+        "$ref": "#/$defs/Gap"
+      },
+      "title": "Gaps",
+      "type": "array"
+    },
+    "generated_at": {
+      "format": "date-time",
+      "title": "Generated At",
+      "type": "string"
+    },
+    "release": {
+      "$ref": "#/$defs/ReleaseContext"
+    },
+    "summary": {
+      "$ref": "#/$defs/Summary"
+    }
+  },
+  "required": ["bundle_id", "application", "release", "summary"],
+  "title": "EvidenceBundle",
+  "type": "object"
+}

--- a/src/test/evidence-bundle/sample-bundle.json
+++ b/src/test/evidence-bundle/sample-bundle.json
@@ -1,0 +1,770 @@
+{
+  "application": {
+    "environment": "production",
+    "name": "payments-api",
+    "owner_team": null,
+    "repository": "acme/payments-api"
+  },
+  "bundle_id": "bundle-20260629-payments-api-2026.04.10-6f45cb54",
+  "bundle_version": "1.0.0",
+  "control_evaluations": [
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.7",
+      "control_name": "Review and/or analyze human-readable code (SAST)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["sast-cfcf7a634b32"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.7 is met by evidence ['sast-cfcf7a634b32']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.4",
+      "control_name": "Reuse existing, well-secured software (SCA)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["sca-54e49b31bec7"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.4 is met by evidence ['sca-54e49b31bec7']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "ORG-SECRETS-SCAN",
+      "control_name": "Repository-wide secrets scanning",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["secrets-3bc6ef3a7a0a"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-SECRETS-SCAN is met by evidence ['secrets-3bc6ef3a7a0a']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PS.3",
+      "control_name": "Archive and protect each software release (SBOM)",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sbom-8f24db8264b4",
+        "att-eeab3847be8e",
+        "att-4fdd0c6e65a1"
+      ],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PS.3 is met by evidence ['sbom-8f24db8264b4', 'att-eeab3847be8e', 'att-4fdd0c6e65a1']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SSDF-PW.8",
+      "control_name": "Test executable code to identify vulnerabilities",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["test-3ba115181f49"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.8 is met by evidence ['test-3ba115181f49']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-CODE-REVIEW",
+      "control_name": "Code review by eligible reviewers",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-61dda6456f8e", "att-b0fcf22e94ec"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-CODE-REVIEW is met by evidence ['att-61dda6456f8e', 'att-b0fcf22e94ec']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PW.1",
+      "control_name": "Design software to meet security requirements (threat model)",
+      "criticality": "medium",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-361af230e38f"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PW.1 is met by evidence ['att-361af230e38f']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-RELEASE-APPROVAL",
+      "control_name": "Formal release approval",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-2cfa2bc287a7"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-RELEASE-APPROVAL is met by evidence ['att-2cfa2bc287a7']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "ORG-REL-ROLLBACK",
+      "control_name": "Rollback plan exists and was approved",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-790592cda958"],
+      "exception_refs": [],
+      "framework": "ORG_INTERNAL",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control ORG-REL-ROLLBACK is met by evidence ['att-790592cda958']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SSDF-PS.2",
+      "control_name": "Provide a mechanism to verify software release integrity",
+      "criticality": "critical",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-4fdd0c6e65a1", "att-eeab3847be8e"],
+      "exception_refs": [],
+      "framework": "NIST_SSDF",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SSDF-PS.2 is met by evidence ['att-4fdd0c6e65a1', 'att-eeab3847be8e']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SAMM-DESIGN-TA-1",
+      "control_name": "Threat Assessment (Design / Threat Assessment 1)",
+      "criticality": "medium",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": ["att-361af230e38f"],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-DESIGN-TA-1 is met by evidence ['att-361af230e38f']."
+    },
+    {
+      "confidence": "low",
+      "control_id": "SAMM-IMPL-SB-2",
+      "control_name": "Secure Build (Implementation / Secure Build 2)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sbom-8f24db8264b4",
+        "att-4fdd0c6e65a1",
+        "att-eeab3847be8e"
+      ],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-IMPL-SB-2 is met by evidence ['sbom-8f24db8264b4', 'att-4fdd0c6e65a1', 'att-eeab3847be8e']."
+    },
+    {
+      "confidence": "high",
+      "control_id": "SAMM-VERIF-ST-1",
+      "control_name": "Security Testing (Verification / Security Testing 1)",
+      "criticality": "high",
+      "evaluated_at": "2026-06-29T14:24:22.117753Z",
+      "evaluation_status": "met",
+      "evidence_refs": [
+        "sast-cfcf7a634b32",
+        "sca-54e49b31bec7",
+        "dast-f6a61122d5a3"
+      ],
+      "exception_refs": [],
+      "framework": "OWASP_SAMM",
+      "missing_recommended_evidence_types": [],
+      "missing_required_evidence_types": [],
+      "rationale": "Control SAMM-VERIF-ST-1 is met by evidence ['sast-cfcf7a634b32', 'sca-54e49b31bec7', 'dast-f6a61122d5a3']."
+    }
+  ],
+  "evidence": [
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "gitleaks",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.048359Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "secrets-3bc6ef3a7a0a",
+      "evidence_type": "secrets_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 0,
+        "medium": 0
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "gitleaks",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\gitleaks.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:3ccb3d37a2b3a6ee3a3146a6bedd8238addb4e138f0492555803a4c4b7fd534b",
+        "size_bytes": 286
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "gitleaks",
+        "uri": null,
+        "version": "8.18.4"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "gitleaks reported 0 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.050934Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "test-3ba115181f49",
+      "evidence_type": "test_result",
+      "findings_count": {
+        "errors": 0,
+        "failures": 0,
+        "skipped": 1,
+        "total": 42
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "payments-api-suite",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\junit.xml",
+        "artifact_uri": null,
+        "content_type": "application/xml",
+        "integrity_hash": "sha256:fa65f270998190cd0014fe7f09b3e4c7e69b898913702d3bd48b3eab2cf87e43",
+        "size_bytes": 896
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "junit-xml",
+        "name": "junit",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "42 tests executed, 0 failures, 0 errors, 1 skipped, duration 8.42s",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.054968Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "sbom-8f24db8264b4",
+      "evidence_type": "sbom",
+      "findings_count": {
+        "components": 3
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {
+        "cisa_2025_conformant": false,
+        "cisa_2025_minimum_elements": {
+          "author": true,
+          "component_name": true,
+          "dependency_relationships": false,
+          "generation_context": false,
+          "hash": false,
+          "license": false,
+          "supplier": false,
+          "timestamp": true,
+          "tool": true,
+          "unique_identifier": true,
+          "version": true
+        },
+        "serial_number": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+      },
+      "producer": "cyclonedx",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\sbom.cdx.json",
+        "artifact_uri": null,
+        "content_type": "application/vnd.cyclonedx+json",
+        "integrity_hash": "sha256:84088064a42486df71ca5567ce4857b6b6ecf1a5445f76166c19c83057ed977e",
+        "size_bytes": 863
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sbom",
+        "name": "cyclonedx",
+        "uri": null,
+        "version": "1.5"
+      },
+      "status": "generated",
+      "subject_ref": "pkg:generic/acme/payments-api@2026.04.10",
+      "subject_type": "artifact",
+      "summary": "CYCLONEDX SBOM with 3 components (spec 1.5)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "semgrep",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.059049Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "sast-cfcf7a634b32",
+      "evidence_type": "sast_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 1,
+        "medium": 1
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "semgrep",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\semgrep.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:7b0a9f4e140945d4bec39ffb4f2340366336e1d74c639bccf2d33dcf74f969ef",
+        "size_bytes": 1170
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "semgrep",
+        "uri": null,
+        "version": "1.70.0"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "semgrep reported 2 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": {
+        "confidence": "high",
+        "driver_name": "trivy",
+        "reason": "driver_match"
+      },
+      "collected_at": "2026-06-29T14:24:22.065457Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": ["CVE-2024-12345"],
+      "evidence_id": "sca-54e49b31bec7",
+      "evidence_type": "sca_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 0,
+        "low": 0,
+        "medium": 1
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {},
+      "producer": "trivy",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\trivy.sarif",
+        "artifact_uri": null,
+        "content_type": "application/sarif+json",
+        "integrity_hash": "sha256:acab632c4fa3302c2c6acba37a5c4f36630b7993df1fd14bb94ebe165da25c5d",
+        "size_bytes": 459
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "sarif",
+        "name": "trivy",
+        "uri": null,
+        "version": "0.52.0"
+      },
+      "status": "passed",
+      "subject_ref": "abcdef1234567890",
+      "subject_type": "commit",
+      "summary": "trivy reported 1 findings (high/critical=0)",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.067684Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "high",
+      "cve_ids": [],
+      "evidence_id": "dast-f6a61122d5a3",
+      "evidence_type": "dast_scan",
+      "findings_count": {
+        "critical": 0,
+        "high": 0,
+        "info": 2,
+        "low": 1,
+        "medium": 0
+      },
+      "generated_at": null,
+      "manual": false,
+      "metadata": {
+        "targets": ["http./sample_release"]
+      },
+      "producer": "OWASP ZAP",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\artifacts\\zap-baseline.json",
+        "artifact_uri": null,
+        "content_type": "application/json",
+        "integrity_hash": "sha256:c5bb8ca639728d37dd4fee2a629e39de4e0510b307e560d1b1f77d4c5d9067db",
+        "size_bytes": 819
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "dast",
+        "name": "OWASP ZAP",
+        "uri": null,
+        "version": "2.14.0"
+      },
+      "status": "passed",
+      "subject_ref": "http./sample_release",
+      "subject_type": "application",
+      "summary": "OWASP ZAP DAST reported 3 findings across 1 target(s); high/critical=0",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.073794Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-eeab3847be8e",
+      "evidence_type": "artifact_attestation",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:50:00Z",
+      "manual": true,
+      "metadata": {
+        "attestation_bundle": "artifacts/payments-api-2026.04.10.attestation.jsonl",
+        "builder_id": "https://github.com/acme/payments-api/.github/workflows/release.yml",
+        "builder_version": "v1.0.0",
+        "predicate_type": "https://slsa.dev/provenance/v1"
+      },
+      "producer": "cosign-attestation",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\artifact_attestation.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:2d98bd13086735eb367c62290df3989ec04443030bf590f7762e122ec9c140cd",
+        "size_bytes": 526
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "artifact",
+      "summary": "SLSA build provenance attestation generated for the release artifact",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.078039Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-4fdd0c6e65a1",
+      "evidence_type": "artifact_signature",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:45:00Z",
+      "manual": true,
+      "metadata": {
+        "algorithm": "ecdsa-p256-sha256",
+        "issuer": "https://token.actions.githubusercontent.com",
+        "signature_bundle": "artifacts/payments-api-2026.04.10.sig"
+      },
+      "producer": "cosign",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\artifact_signature.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:3fe2f1b0ebf3ba4b1f03e5778b04d99b7d555fc4dd3de66e04dbb5e7d794c2ab",
+        "size_bytes": 406
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "artifact",
+      "summary": "Artifact signed with cosign using keyless OIDC flow",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.084051Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-61dda6456f8e",
+      "evidence_type": "code_review",
+      "findings_count": {},
+      "generated_at": "2026-04-10T11:45:00Z",
+      "manual": true,
+      "metadata": {
+        "last_approval_after_last_commit": true,
+        "reviewers": ["alice@example.com", "bob@example.com"],
+        "reviewers_approved": 2,
+        "reviewers_required": 2
+      },
+      "producer": "github-pull-request",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\code_review.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:5df9fdb7e6774c36d1c40c0292fca75bb1af831161e6b9b6344c46067174ec40",
+        "size_bytes": 394
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "PR-184",
+      "subject_type": "pull_request",
+      "summary": "PR-184 approved by 2 reviewers after last commit",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.092101Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-b0fcf22e94ec",
+      "evidence_type": "pr_metadata",
+      "findings_count": {},
+      "generated_at": "2026-04-10T12:00:00Z",
+      "manual": true,
+      "metadata": {
+        "author": "alice",
+        "base": "main",
+        "head": "feature/refund",
+        "html_url": "https://github.com/acme/payments-api/pull/184",
+        "last_approval_after_last_commit": true,
+        "merged": true,
+        "number": 184,
+        "reviewers_approved": 2,
+        "reviewers_required": 2,
+        "title": "Refactor refund service"
+      },
+      "producer": "github-pull-request-export",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\pr_metadata.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:d610fdcc08aff91fe6ba8029a6b83fc50838dcb54e3b8a75a1486c15ac833840",
+        "size_bytes": 543
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "PR-184",
+      "subject_type": "pull_request",
+      "summary": "Exported PR-184 metadata: 2 approvals after last commit, CI green",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.096274Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-2cfa2bc287a7",
+      "evidence_type": "release_approval",
+      "findings_count": {},
+      "generated_at": "2026-04-10T13:00:00Z",
+      "manual": true,
+      "metadata": {
+        "approver": "releases@example.com",
+        "change_ticket": "CHG-1234"
+      },
+      "producer": "Change Advisory Board",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\release_approval.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:35641e1d797d269ed57a32ff62b20524b0f3f54e81af8d7fbbdcf2201fb05a95",
+        "size_bytes": 310
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "release",
+      "summary": "Release 2026.04.10 formally approved by CAB",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.102402Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-790592cda958",
+      "evidence_type": "rollback_plan",
+      "findings_count": {},
+      "generated_at": "2026-04-10T10:30:00Z",
+      "manual": true,
+      "metadata": {
+        "link": "https://runbooks.example.com/payments-api/rollback/2026-04-10"
+      },
+      "producer": "Release Manager",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\rollback_plan.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:9b7aced1f6f379dcec6fabe176ccef7f64f5dc7de1d02c566c3e0aa9ea321099",
+        "size_bytes": 330
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "passed",
+      "subject_ref": "payments-api:2026.04.10",
+      "subject_type": "release",
+      "summary": "Documented rollback plan in runbook with 15 min MTTR target",
+      "vulnerability_intelligence": null
+    },
+    {
+      "classification": null,
+      "collected_at": "2026-06-29T14:24:22.108413Z",
+      "commit_sha": "abcdef1234567890",
+      "confidence": "medium",
+      "cve_ids": [],
+      "evidence_id": "att-361af230e38f",
+      "evidence_type": "threat_model",
+      "findings_count": {},
+      "generated_at": "2026-03-22T09:00:00Z",
+      "manual": true,
+      "metadata": {
+        "link": "https://wiki.example.com/appsec/payments-api/threat-model",
+        "model_version": "2026.1",
+        "scope": "refund-flow"
+      },
+      "producer": "AppSec Team",
+      "raw": {
+        "artifact_path": "examples\\sample_release\\attestations\\threat_model.yaml",
+        "artifact_uri": null,
+        "content_type": "application/yaml",
+        "integrity_hash": "sha256:f6d5ec38328ef7dd319e39f78e2fc53cc78dede302c0d85dfb25fb1b870acce6",
+        "size_bytes": 366
+      },
+      "reachability": null,
+      "release_id": "2026.04.10",
+      "source": {
+        "kind": "attestation",
+        "name": "manual-attestation",
+        "uri": null,
+        "version": null
+      },
+      "status": "completed",
+      "subject_ref": "payments-api",
+      "subject_type": "application",
+      "summary": "Threat model updated for payments-api refund flow",
+      "vulnerability_intelligence": null
+    }
+  ],
+  "exceptions": [],
+  "gaps": [],
+  "generated_at": "2026-06-29T14:24:22.117753Z",
+  "release": {
+    "artifact_digest": null,
+    "branch": "main",
+    "build_id": null,
+    "commit_sha": "abcdef1234567890",
+    "pipeline_run_id": null,
+    "release_id": "2026.04.10",
+    "tag": null
+  },
+  "summary": {
+    "confidence_score": 59,
+    "controls_met": 13,
+    "controls_missing": 0,
+    "controls_not_applicable": 0,
+    "controls_partial": 0,
+    "controls_waived": 0,
+    "evidence_coverage_score": 100,
+    "missing_critical_evidence": [],
+    "release_status": "ready",
+    "risk_assessment": null,
+    "total_controls": 13
+  }
+}


### PR DESCRIPTION
Adds a JSON Schema for the **Secure SDLC Evidence Bundle** — the auditable, deterministic release-readiness evidence document produced by the [Secure SDLC Evidence Collector](https://github.com/lucashgrifoni/Secure-SDLC-Evidence-Collector) (open source; on PyPI as `secure-sdlc-evidence-collector`).

The bundle normalizes scanner/attestation output (SARIF, CycloneDX/SPDX SBOMs, OpenVEX, in-toto/SLSA, OSV, …) and evaluates it against control catalogs. Editors validating these bundles is the goal of this entry.

- Schema: `src/schemas/json/evidence-bundle.json` (generated from the project's Pydantic v2 models; same contract published at `https://lucashgrifoni.github.io/Secure-SDLC-Evidence-Collector/docs/evidence-bundle.schema.json`).
- `fileMatch`: `**/*.evidence-bundle.json` (intentionally specific — the tool's bare `bundle.json` default is too generic to claim).
- Draft 2020-12 (the project's native dialect); registered in `highSchemaVersion`.
- Positive test: a real bundle generated by the tool. Negative test: a bundle missing a required field.

`node ./cli.js check --schema-name=evidence-bundle.json` passes locally; prettier clean.