### PR TITLE
Add Aurora Agile Meta-Framework 2.0 schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -552,12 +552,13 @@
       "name": "Aurora Agile Meta-Framework",
       "description": "Yaml for Aurora Agile Meta-Framework",
       "fileMatch": ["*.aurora.yaml", "*.aurora.yml"],
-      "url": "https://www.schemastore.org/aurora-1.3.json",
+      "url": "https://www.schemastore.org/aurora-2.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/aurora-1.0.json",
         "1.1": "https://www.schemastore.org/aurora-1.1.json",
         "1.2": "https://www.schemastore.org/aurora-1.2.json",
-        "1.3": "https://www.schemastore.org/aurora-1.3.json"
+        "1.3": "https://www.schemastore.org/aurora-1.3.json",
+        "2.0": "https://www.schemastore.org/aurora-2.0.json"
       }
     },
     {

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -11,6 +11,7 @@
     "aurora-1.1.json",
     "aurora-1.2.json",
     "aurora-1.3.json",
+    "aurora-2.0.json",
     "azure-deviceupdate-update-manifest-4.json",
     "azure-deviceupdate-update-manifest-5.json",
     "azure-deviceupdate-import-manifest-4.0.json",

--- a/src/schemas/json/aurora-2.0.json
+++ b/src/schemas/json/aurora-2.0.json
@@ -6,10 +6,7 @@
   "definitions": {
     "propertyDefinition": {
       "type": "object",
-      "required": [
-        "name",
-        "type"
-      ],
+      "required": ["name", "type"],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -25,9 +22,7 @@
         "type": {
           "type": "string",
           "description": "The type of property",
-          "examples": [
-            "varchar"
-          ],
+          "examples": ["varchar"],
           "enum": [
             "array",
             "bigint",
@@ -59,9 +54,7 @@
         "arrayOptions": {
           "type": "object",
           "description": "Options to define array property",
-          "required": [
-            "type"
-          ],
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
@@ -123,10 +116,7 @@
         "index": {
           "type": "string",
           "description": "Define an index on this property: 'index' for a regular index or 'unique' for a uniqueness constraint",
-          "enum": [
-            "index",
-            "unique"
-          ]
+          "enum": ["index", "unique"]
         },
         "indexFields": {
           "type": "array",
@@ -144,14 +134,7 @@
         "indexUsing": {
           "type": "string",
           "description": "Index access method/algorithm used by the database engine (Btree, GIN, HASH, etc.)",
-          "enum": [
-            "Btree",
-            "GIN",
-            "HASH",
-            "spgist",
-            "GiST",
-            "BRIN"
-          ]
+          "enum": ["Btree", "GIN", "HASH", "spgist", "GiST", "BRIN"]
         },
         "isI18n": {
           "type": "boolean",
@@ -183,12 +166,7 @@
           "description": "Default value for property"
         },
         "example": {
-          "type": [
-            "number",
-            "string",
-            "boolean",
-            "array"
-          ],
+          "type": ["number", "string", "boolean", "array"],
           "description": "Example value for property, this value will be used in swagger documentation"
         },
         "decimals": {
@@ -221,11 +199,7 @@
     },
     "additionalApisDefinition": {
       "type": "object",
-      "required": [
-        "path",
-        "resolverType",
-        "httpMethod"
-      ],
+      "required": ["path", "resolverType", "httpMethod"],
       "properties": {
         "path": {
           "type": "string",
@@ -239,27 +213,14 @@
         "resolverType": {
           "type": "string",
           "description": "Type of resolver, query or mutation",
-          "enum": [
-            "query",
-            "mutation"
-          ],
-          "examples": [
-            "query"
-          ]
+          "enum": ["query", "mutation"],
+          "examples": ["query"]
         },
         "httpMethod": {
           "type": "string",
           "description": "Verb of api rest",
-          "enum": [
-            "get",
-            "post",
-            "put",
-            "delete",
-            "patch"
-          ],
-          "examples": [
-            "post"
-          ]
+          "enum": ["get", "post", "put", "delete", "patch"],
+          "examples": ["post"]
         }
       }
     },
@@ -403,31 +364,18 @@
             "const": "grid-select-element"
           }
         },
-        "required": [
-          "type"
-        ]
+        "required": ["type"]
       },
       "then": {
-        "required": [
-          "displayFields"
-        ]
+        "required": ["displayFields"]
       }
     },
     "excludedOperationDefinition": {
       "type": "array",
       "description": "Operations to be excluded from the module",
       "examples": [
-        [
-          "create",
-          "update",
-          "delete"
-        ],
-        [
-          "create",
-          "update",
-          "delete",
-          "findById"
-        ]
+        ["create", "update", "delete"],
+        ["create", "update", "delete", "findById"]
       ],
       "items": {
         "enum": [
@@ -460,10 +408,7 @@
           "type": "string",
           "description": "Grammatical gender to be used in the front application",
           "default": "masculine",
-          "enum": [
-            "masculine",
-            "feminine"
-          ]
+          "enum": ["masculine", "feminine"]
         },
         "iconModule": {
           "type": "string",
@@ -512,28 +457,18 @@
           "type": "string",
           "description": "Outline icon to be used in the front application",
           "minLength": 2,
-          "examples": [
-            "lucideTag",
-            "lucideOctagonPause",
-            "heroArchiveBoxXMark"
-          ]
+          "examples": ["lucideTag", "lucideOctagonPause", "heroArchiveBoxXMark"]
         },
         "solidIcon": {
           "type": "string",
           "description": "Solid icon to be used in the front application",
           "minLength": 2,
-          "examples": [
-            "heroAcademicCapSolid",
-            "heroArchiveBoxSolid"
-          ]
+          "examples": ["heroAcademicCapSolid", "heroArchiveBoxSolid"]
         },
         "detailMode": {
           "type": "string",
           "description": "Detail view mode for the front application, define detail in a dialog or in a separated view",
-          "enum": [
-            "view",
-            "dialog"
-          ]
+          "enum": ["view", "dialog"]
         },
         "embedSupport": {
           "type": "boolean",
@@ -610,61 +545,43 @@
     "boundedContextName": {
       "type": "string",
       "description": "The name of the package, singular in kebab case",
-      "examples": [
-        "iam",
-        "queue-manager"
-      ],
+      "examples": ["iam", "queue-manager"],
       "minLength": 2
     },
     "moduleName": {
       "type": "string",
       "description": "The name of the module, singular in kebab case",
-      "examples": [
-        "account",
-        "job-registry"
-      ],
+      "examples": ["account", "job-registry"],
       "minLength": 2
     },
     "moduleNames": {
       "type": "string",
       "description": "The name of the module, plural in kebab case",
-      "examples": [
-        "accounts",
-        "jobs-registry"
-      ],
+      "examples": ["accounts", "jobs-registry"],
       "minLength": 2
     },
     "aggregateName": {
       "type": "string",
       "description": "The name of the aggregateName, singular in pascal case, is composed of the boundedContextName plus the moduleName",
-      "examples": [
-        "IamAccount",
-        "QueueManagerJobRegistry"
-      ],
+      "examples": ["IamAccount", "QueueManagerJobRegistry"],
       "minLength": 2
     },
     "hasOAuth": {
       "type": "boolean",
       "description": "Enabled authentication for this module",
-      "examples": [
-        false
-      ],
+      "examples": [false],
       "default": false
     },
     "hasTenant": {
       "type": "boolean",
       "description": "Enabled tenant for this module",
-      "examples": [
-        false
-      ],
+      "examples": [false],
       "default": false
     },
     "hasAuditing": {
       "type": "boolean",
       "description": "Enabled auditing for this module",
-      "examples": [
-        false
-      ],
+      "examples": [false],
       "default": false
     },
     "description": {

--- a/src/schemas/json/aurora-2.0.json
+++ b/src/schemas/json/aurora-2.0.json
@@ -1,0 +1,713 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/aurora-2.0.json",
+  "$comment": "https://docs.aurorajs.dev/",
+  "additionalProperties": false,
+  "definitions": {
+    "propertyDefinition": {
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of property, in camelCase",
+          "minLength": 2
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the property",
+          "minLength": 2
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of property",
+          "examples": [
+            "varchar"
+          ],
+          "enum": [
+            "array",
+            "bigint",
+            "blob.long",
+            "blob.medium",
+            "blob.tiny",
+            "blob",
+            "boolean",
+            "char",
+            "date",
+            "dateTime",
+            "decimal",
+            "encrypted",
+            "enum",
+            "float",
+            "id",
+            "int",
+            "json",
+            "jsonb",
+            "manyToMany",
+            "password",
+            "relationship",
+            "smallint",
+            "text",
+            "timestamp",
+            "varchar"
+          ]
+        },
+        "arrayOptions": {
+          "type": "object",
+          "description": "Options to define array property",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of each array element",
+              "enum": [
+                "char",
+                "date",
+                "dateTime",
+                "decimal",
+                "enum",
+                "id",
+                "int",
+                "timestamp",
+                "varchar"
+              ]
+            },
+            "length": {
+              "type": "number",
+              "description": "Set max length to property",
+              "minimum": 1
+            },
+            "maxLength": {
+              "type": "number",
+              "description": "Set max length to property",
+              "minimum": 1
+            },
+            "enumOptions": {
+              "type": "array",
+              "description": "Values for enum type",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "length": {
+          "type": "number",
+          "description": "Set max length to property",
+          "minimum": 1
+        },
+        "maxLength": {
+          "type": "number",
+          "description": "Set max length to property",
+          "minimum": 1
+        },
+        "nullable": {
+          "type": "boolean",
+          "description": "Set property to nullable"
+        },
+        "unsigned": {
+          "type": "boolean",
+          "description": "Set property as unsigned"
+        },
+        "primaryKey": {
+          "type": "boolean",
+          "description": "Set property to primary key"
+        },
+        "index": {
+          "type": "string",
+          "description": "Define an index on this property: 'index' for a regular index or 'unique' for a uniqueness constraint",
+          "enum": [
+            "index",
+            "unique"
+          ]
+        },
+        "indexFields": {
+          "type": "array",
+          "description": "Fields to do composite unique index",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "indexName": {
+          "type": "string",
+          "description": "The name of index, if there are various indexes with the same name, they will be grouped",
+          "minLength": 2
+        },
+        "indexUsing": {
+          "type": "string",
+          "description": "Index access method/algorithm used by the database engine (Btree, GIN, HASH, etc.)",
+          "enum": [
+            "Btree",
+            "GIN",
+            "HASH",
+            "spgist",
+            "GiST",
+            "BRIN"
+          ]
+        },
+        "isI18n": {
+          "type": "boolean",
+          "description": "Set property as i18n, this property will be used to translate the entity in the translation table"
+        },
+        "enumOptions": {
+          "type": "array",
+          "description": "Values for enum type",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "defaultValue": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array"
+            }
+          ],
+          "description": "Default value for property"
+        },
+        "example": {
+          "type": [
+            "number",
+            "string",
+            "boolean",
+            "array"
+          ],
+          "description": "Example value for property, this value will be used in swagger documentation"
+        },
+        "decimals": {
+          "type": "array",
+          "description": "Total digits of the number and length of the decimal places in the back of the number, example: [10, 2].",
+          "items": {
+            "type": "number",
+            "minimum": 1
+          }
+        },
+        "autoIncrement": {
+          "type": "boolean",
+          "description": "Set number property as auto increment"
+        },
+        "readonly": {
+          "type": "boolean",
+          "description": "Set property as read only"
+        },
+        "applyTimezone": {
+          "type": "boolean",
+          "description": "Apply timezone to date property, by default is true"
+        },
+        "relationship": {
+          "$ref": "#/definitions/relationshipDefinition"
+        },
+        "widget": {
+          "$ref": "#/definitions/widgetDefinition"
+        }
+      }
+    },
+    "additionalApisDefinition": {
+      "type": "object",
+      "required": [
+        "path",
+        "resolverType",
+        "httpMethod"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to access api",
+          "minLength": 2,
+          "examples": [
+            "auditing/side-effect/rollback",
+            "iam/account/check-unique-username"
+          ]
+        },
+        "resolverType": {
+          "type": "string",
+          "description": "Type of resolver, query or mutation",
+          "enum": [
+            "query",
+            "mutation"
+          ],
+          "examples": [
+            "query"
+          ]
+        },
+        "httpMethod": {
+          "type": "string",
+          "description": "Verb of api rest",
+          "enum": [
+            "get",
+            "post",
+            "put",
+            "delete",
+            "patch"
+          ],
+          "examples": [
+            "post"
+          ]
+        }
+      }
+    },
+    "relationshipDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Relationship definition for this property",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of relationship",
+          "enum": [
+            "many-to-many",
+            "many-to-one",
+            "none",
+            "one-to-many",
+            "one-to-one"
+          ]
+        },
+        "singularName": {
+          "type": "string",
+          "description": "Singular name of the property referred to in the relationship, only for one-to-many and many-to-many relationship, example: book",
+          "minLength": 2
+        },
+        "aggregateName": {
+          "type": "string",
+          "description": "Aggregate referring to this relationship, example: LibraryAuthor",
+          "minLength": 2
+        },
+        "modulePath": {
+          "type": "string",
+          "description": "Path to the module that refers to this relationship, example: library/author",
+          "minLength": 2
+        },
+        "key": {
+          "type": "string",
+          "description": "Property key that refers to this relationship, only for many-to-one relationship, example: id",
+          "minLength": 2
+        },
+        "field": {
+          "type": "string",
+          "description": "Field to obtain the relationship data, example: author",
+          "minLength": 2
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the relationship field",
+          "minLength": 2
+        },
+        "avoidConstraint": {
+          "type": "boolean",
+          "description": "Avoid constraint rules for this relationship"
+        },
+        "packageName": {
+          "type": "string",
+          "description": "Path to packageName where is the relationship, example: @aurora-ts/core",
+          "minLength": 2
+        },
+        "isDenormalized": {
+          "type": "boolean",
+          "description": "Set many-to-many relationship as denormalized, creating a field to store the selected ids"
+        },
+        "pivot": {
+          "$ref": "#/definitions/pivotTableDefinition"
+        }
+      }
+    },
+    "widgetDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "UI widget that will be rendered for this property",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of widget",
+          "enum": [
+            "async-multiple-search-select",
+            "async-search-select",
+            "color-picker",
+            "grid-elements-manager",
+            "grid-select-element",
+            "grid-select-multiple-elements",
+            "multiple-search-select",
+            "multiple-select",
+            "search-select",
+            "select"
+          ]
+        },
+        "className": {
+          "type": "string",
+          "description": "CSS class for widget",
+          "minLength": 2
+        },
+        "detailSort": {
+          "type": "number",
+          "description": "Web component order on detail view",
+          "minimum": 1
+        },
+        "isDetailHidden": {
+          "type": "boolean",
+          "description": "Set hidden widget on detail view"
+        },
+        "listSort": {
+          "type": "number",
+          "description": "Web component order on list view",
+          "minimum": 1
+        },
+        "isListHidden": {
+          "type": "boolean",
+          "description": "Set hidden widget on list view"
+        },
+        "displayFields": {
+          "type": "array",
+          "description": "Fields to display in the grid-select-element widget",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "tab": {
+          "type": "string",
+          "description": "Name of the tab where the field will be placed, enabling a tab-based form layout",
+          "minLength": 1
+        },
+        "group": {
+          "type": "string",
+          "description": "Name of the group that groups fields into a section within the form, either inside a tab or standalone",
+          "minLength": 1
+        },
+        "span": {
+          "type": "integer",
+          "description": "Per-property column span override on the form's 12-column grid. Integer 1-12. When omitted, the codegen picks a default by type (and by maxLength for varchar)",
+          "minimum": 1,
+          "maximum": 12
+        }
+      },
+      "if": {
+        "properties": {
+          "type": {
+            "const": "grid-select-element"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "then": {
+        "required": [
+          "displayFields"
+        ]
+      }
+    },
+    "excludedOperationDefinition": {
+      "type": "array",
+      "description": "Operations to be excluded from the module",
+      "examples": [
+        [
+          "create",
+          "update",
+          "delete"
+        ],
+        [
+          "create",
+          "update",
+          "delete",
+          "findById"
+        ]
+      ],
+      "items": {
+        "enum": [
+          "count",
+          "create",
+          "createBatch",
+          "deleteById",
+          "delete",
+          "findById",
+          "find",
+          "get",
+          "max",
+          "min",
+          "paginate",
+          "getRaw",
+          "sum",
+          "updateAndIncrement",
+          "updateById",
+          "update",
+          "upsert"
+        ]
+      }
+    },
+    "frontDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Appearance properties for front application",
+      "properties": {
+        "gender": {
+          "type": "string",
+          "description": "Grammatical gender to be used in the front application",
+          "default": "masculine",
+          "enum": [
+            "masculine",
+            "feminine"
+          ]
+        },
+        "iconModule": {
+          "type": "string",
+          "description": "Icon library to be used in the front application",
+          "default": "@ng-icons/lucide",
+          "enum": [
+            "@ng-icons/bootstrap-icons",
+            "@ng-icons/heroicons",
+            "@ng-icons/ionicons",
+            "@ng-icons/material-icons",
+            "@ng-icons/material-file-icons",
+            "@ng-icons/css.gg",
+            "@ng-icons/feather-icons",
+            "@ng-icons/jam-icons",
+            "@ng-icons/octicons",
+            "@ng-icons/radix-icons",
+            "@ng-icons/tabler-icons",
+            "@ng-icons/akar-icons",
+            "@ng-icons/iconoir",
+            "@ng-icons/cryptocurrency-icons",
+            "@ng-icons/simple-icons",
+            "@ng-icons/typicons",
+            "@ng-icons/dripicons",
+            "@ng-icons/ux-aspects",
+            "@ng-icons/circum-icons",
+            "@ng-icons/remixicon",
+            "@ng-icons/font-awesome",
+            "@ng-icons/iconsax",
+            "@ng-icons/tdesign-icons",
+            "@ng-icons/phosphor-icons",
+            "@ng-icons/lets-icons",
+            "@ng-icons/huge-icons",
+            "@ng-icons/devicon",
+            "@ng-icons/game-icons",
+            "@ng-icons/solar-icons",
+            "@ng-icons/svgl",
+            "@ng-icons/material-symbols",
+            "@ng-icons/mynaui",
+            "@ng-icons/boxicons",
+            "@ng-icons/mono-icons",
+            "@ng-icons/lucide",
+            "@ng-icons/coolicons"
+          ]
+        },
+        "outlineIcon": {
+          "type": "string",
+          "description": "Outline icon to be used in the front application",
+          "minLength": 2,
+          "examples": [
+            "lucideTag",
+            "lucideOctagonPause",
+            "heroArchiveBoxXMark"
+          ]
+        },
+        "solidIcon": {
+          "type": "string",
+          "description": "Solid icon to be used in the front application",
+          "minLength": 2,
+          "examples": [
+            "heroAcademicCapSolid",
+            "heroArchiveBoxSolid"
+          ]
+        },
+        "detailMode": {
+          "type": "string",
+          "description": "Detail view mode for the front application, define detail in a dialog or in a separated view",
+          "enum": [
+            "view",
+            "dialog"
+          ]
+        },
+        "embedSupport": {
+          "type": "boolean",
+          "description": "When true, the module generates embed-mode artifacts (form-embed component, embed columns config, list mode embed). Required when another module references this one via widget.type: grid-elements-manager. Default: false."
+        },
+        "displayField": {
+          "type": "string",
+          "description": "Human-readable display label for this aggregate. Accepts either an identifier (a single property name, e.g. 'name', 'email') or an interpolation template with {fieldName} placeholders (e.g. '{code} - {name}', 'Plan: {planId}'). Codegen substitutes placeholders with the corresponding property reference at emit time; segments that are not valid JS identifiers inside braces are emitted as literal text. Defaults to 'name' when unset. Used for list-component delete confirmation toasts and FK column display rendering.",
+          "minLength": 1
+        }
+      }
+    },
+    "pivotTableDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Relationship pivot table definition for this relationship",
+      "properties": {
+        "boundedContextName": {
+          "type": "string",
+          "description": "The name of the package, singular in kebab-case",
+          "minLength": 2
+        },
+        "moduleName": {
+          "type": "string",
+          "description": "The name of the module, singular in kebab-case",
+          "minLength": 2
+        },
+        "moduleNames": {
+          "type": "string",
+          "description": "The name of the module, plural in kebab-case",
+          "minLength": 2
+        },
+        "aggregateName": {
+          "type": "string",
+          "description": "The name of the aggregateName, singular in PascalCase",
+          "minLength": 2
+        },
+        "hasOAuth": {
+          "type": "boolean",
+          "description": "Enabled authentication for this pivot table",
+          "default": false
+        },
+        "hasAuditing": {
+          "type": "boolean",
+          "description": "Enabled auditing for pivot table",
+          "default": false
+        },
+        "aggregateProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/propertyDefinition"
+          }
+        },
+        "excludedFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludedOperations": {
+          "$ref": "#/definitions/excludedOperationDefinition"
+        }
+      }
+    }
+  },
+  "description": "Aurora module definition: describes a bounded context module with its aggregate, properties, relationships and front configuration",
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version",
+      "default": "0.0.1",
+      "minLength": 2
+    },
+    "boundedContextName": {
+      "type": "string",
+      "description": "The name of the package, singular in kebab case",
+      "examples": [
+        "iam",
+        "queue-manager"
+      ],
+      "minLength": 2
+    },
+    "moduleName": {
+      "type": "string",
+      "description": "The name of the module, singular in kebab case",
+      "examples": [
+        "account",
+        "job-registry"
+      ],
+      "minLength": 2
+    },
+    "moduleNames": {
+      "type": "string",
+      "description": "The name of the module, plural in kebab case",
+      "examples": [
+        "accounts",
+        "jobs-registry"
+      ],
+      "minLength": 2
+    },
+    "aggregateName": {
+      "type": "string",
+      "description": "The name of the aggregateName, singular in pascal case, is composed of the boundedContextName plus the moduleName",
+      "examples": [
+        "IamAccount",
+        "QueueManagerJobRegistry"
+      ],
+      "minLength": 2
+    },
+    "hasOAuth": {
+      "type": "boolean",
+      "description": "Enabled authentication for this module",
+      "examples": [
+        false
+      ],
+      "default": false
+    },
+    "hasTenant": {
+      "type": "boolean",
+      "description": "Enabled tenant for this module",
+      "examples": [
+        false
+      ],
+      "default": false
+    },
+    "hasAuditing": {
+      "type": "boolean",
+      "description": "Enabled auditing for this module",
+      "examples": [
+        false
+      ],
+      "default": false
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the module and its function and interaction with the other modules in the package",
+      "minLength": 2
+    },
+    "front": {
+      "$ref": "#/definitions/frontDefinition"
+    },
+    "aggregateProperties": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/propertyDefinition"
+      }
+    },
+    "additionalApis": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/additionalApisDefinition"
+      }
+    },
+    "excludedFiles": {
+      "type": "array",
+      "description": "Files to be excluded from the module",
+      "examples": [
+        "src/@api/iam/account/resolvers/iam-create-accounts.resolver.ts",
+        "src/@api/iam/account/resolvers/iam-create-accounts.resolver.spec.ts"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "excludedOperations": {
+      "$ref": "#/definitions/excludedOperationDefinition"
+    }
+  },
+  "required": [
+    "boundedContextName",
+    "moduleName",
+    "moduleNames",
+    "aggregateName"
+  ],
+  "title": "Aurora Agile Meta Framework",
+  "type": "object"
+}

--- a/src/test/aurora-2.0/author.aurora.yaml
+++ b/src/test/aurora-2.0/author.aurora.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-2.0.json
+version: 0.0.1
+boundedContextName: library
+moduleName: author
+moduleNames: authors
+aggregateName: LibraryAuthor
+hasOAuth: true
+hasTenant: false
+hasAuditing: false
+description: Authors that belong to the library bounded context
+front:
+  gender: masculine
+  iconModule: '@ng-icons/lucide'
+  outlineIcon: lucideUser
+  embedSupport: true
+  displayField: name
+aggregateProperties:
+  - name: id
+    type: id
+    primaryKey: true
+    nullable: false
+  - name: rowId
+    type: bigint
+    index: unique
+    autoIncrement: true
+    nullable: false
+  - name: name
+    type: varchar
+    maxLength: 50
+    nullable: false
+    widget:
+      type: select
+      listSort: 1
+      detailSort: 1
+  - name: books
+    type: relationship
+    nullable: true
+    relationship:
+      type: one-to-many
+      singularName: book
+      aggregateName: LibraryBook
+      modulePath: library/book
+    widget:
+      type: grid-elements-manager
+  - name: createdAt
+    type: timestamp
+    nullable: true
+  - name: updatedAt
+    type: timestamp
+    nullable: true
+  - name: deletedAt
+    type: timestamp
+    nullable: true
+additionalApis: []

--- a/src/test/aurora-2.0/book.aurora.yaml
+++ b/src/test/aurora-2.0/book.aurora.yaml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-2.0.json
+version: 0.0.1
+boundedContextName: library
+moduleName: book
+moduleNames: books
+aggregateName: LibraryBook
+hasOAuth: true
+hasTenant: false
+hasAuditing: false
+front:
+  gender: masculine
+  iconModule: '@ng-icons/lucide'
+  outlineIcon: lucideBook
+  detailMode: dialog
+  displayField: '{title}'
+aggregateProperties:
+  - name: id
+    type: id
+    primaryKey: true
+    nullable: false
+  - name: rowId
+    type: bigint
+    index: unique
+    autoIncrement: true
+    nullable: false
+  - name: title
+    description: The title of the book
+    type: varchar
+    maxLength: 50
+    nullable: false
+    isI18n: true
+    widget:
+      type: select
+      span: 6
+      tab: general
+      group: main
+  - name: publishedAt
+    type: date
+    nullable: false
+    applyTimezone: false
+  - name: price
+    type: int
+    maxLength: 10
+    nullable: false
+    unsigned: true
+  - name: tags
+    type: array
+    nullable: true
+    arrayOptions:
+      type: varchar
+      maxLength: 32
+  - name: authorId
+    type: id
+    nullable: false
+    relationship:
+      type: many-to-one
+      aggregateName: LibraryAuthor
+      modulePath: library/author
+      key: id
+      field: author
+      avoidConstraint: true
+    widget:
+      type: async-search-select
+  - name: authorName
+    type: varchar
+    maxLength: 50
+    nullable: false
+    readonly: true
+  - name: createdAt
+    type: timestamp
+    nullable: true
+  - name: updatedAt
+    type: timestamp
+    nullable: true
+  - name: deletedAt
+    type: timestamp
+    nullable: true
+excludedOperations:
+  - delete
+  - deleteById

--- a/src/test/aurora-2.0/country.aurora.yaml
+++ b/src/test/aurora-2.0/country.aurora.yaml
@@ -1,0 +1,203 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-2.0.json
+version: 0.0.1
+boundedContextName: common
+moduleName: country
+moduleNames: countries
+aggregateName: CommonCountry
+hasOAuth: true
+hasTenant: false
+hasAuditing: true
+front:
+  gender: feminine
+  iconModule: '@ng-icons/material-icons'
+  solidIcon: matFlag
+  outlineIcon: matFlagOutline
+  detailMode: view
+aggregateProperties:
+  - name: id
+    type: id
+    primaryKey: true
+    nullable: false
+  - name: rowId
+    type: bigint
+    index: unique
+    autoIncrement: true
+    nullable: false
+  - name: iso3166Alpha2
+    type: char
+    length: 2
+    nullable: false
+    index: index
+    indexUsing: Btree
+  - name: iso3166Alpha3
+    type: char
+    length: 3
+    nullable: false
+    index: index
+  - name: iso3166Numeric
+    type: char
+    length: 3
+    nullable: false
+    index: index
+  - name: customCode
+    type: varchar
+    maxLength: 64
+    nullable: true
+    index: index
+  - name: prefix
+    type: varchar
+    maxLength: 5
+    nullable: true
+  - name: image
+    type: varchar
+    maxLength: 1022
+    nullable: true
+  - name: sort
+    type: smallint
+    unsigned: true
+    nullable: true
+  - name: administrativeAreas
+    type: json
+    nullable: true
+  - name: latitude
+    type: decimal
+    decimals:
+      - 16
+      - 14
+    nullable: true
+  - name: longitude
+    type: decimal
+    decimals:
+      - 17
+      - 14
+    nullable: true
+  - name: zoom
+    type: smallint
+    unsigned: true
+    nullable: true
+  - name: mapType
+    type: enum
+    enumOptions:
+      - ROADMAP
+      - SATELLITE
+      - HYBRID
+      - TERRAIN
+    nullable: true
+    defaultValue: ROADMAP
+    example: CommonCountryMapType.TERRAIN
+  - name: langs
+    type: manyToMany
+    nullable: true
+    relationship:
+      type: many-to-many
+      singularName: lang
+      aggregateName: CommonLang
+      modulePath: common/lang
+      field: langs
+      isDenormalized: true
+      pivot:
+        boundedContextName: common
+        moduleName: country-lang
+        moduleNames: countries-langs
+        aggregateName: CommonCountryLang
+    widget:
+      type: grid-select-multiple-elements
+      displayFields:
+        - name
+  - name: availableLangs
+    type: json
+    nullable: true
+  - name: createdAt
+    type: timestamp
+    nullable: true
+  - name: updatedAt
+    type: timestamp
+    nullable: true
+  - name: deletedAt
+    type: timestamp
+    nullable: true
+  - name: id
+    isI18n: true
+    type: id
+    primaryKey: true
+    nullable: false
+  - name: rowId
+    isI18n: true
+    type: bigint
+    index: unique
+    autoIncrement: true
+    nullable: false
+  - name: countryId
+    isI18n: true
+    type: id
+    nullable: false
+    relationship:
+      type: many-to-one
+      aggregateName: CommonCountry
+      modulePath: common/country
+      key: id
+      field: country
+    index: unique
+    indexFields:
+      - countryId
+      - langId
+    indexName: uniqueCountryIdLangId
+  - name: langId
+    isI18n: true
+    type: id
+    nullable: false
+    relationship:
+      type: many-to-one
+      aggregateName: CommonLang
+      modulePath: common/lang
+      key: id
+      field: lang
+      avoidConstraint: true
+    index: unique
+    indexFields:
+      - countryId
+      - langId
+    indexName: uniqueCountryIdLangId
+  - name: name
+    isI18n: true
+    type: varchar
+    maxLength: 128
+    nullable: false
+    index: index
+  - name: slug
+    isI18n: true
+    type: varchar
+    maxLength: 128
+    nullable: false
+    index: index
+  - name: administrativeAreaLevel1
+    isI18n: true
+    type: varchar
+    maxLength: 64
+    nullable: true
+  - name: administrativeAreaLevel2
+    isI18n: true
+    type: varchar
+    maxLength: 64
+    nullable: true
+  - name: administrativeAreaLevel3
+    isI18n: true
+    type: varchar
+    maxLength: 64
+    nullable: true
+  - name: createdAt
+    isI18n: true
+    type: timestamp
+    nullable: true
+  - name: updatedAt
+    isI18n: true
+    type: timestamp
+    nullable: true
+  - name: deletedAt
+    isI18n: true
+    type: timestamp
+    nullable: true
+additionalApis:
+  - path: common/country/administrative-areas
+    resolverType: query
+    httpMethod: post

--- a/src/test/aurora-2.0/lang.aurora.yaml
+++ b/src/test/aurora-2.0/lang.aurora.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=../../schemas/json/aurora-2.0.json
+version: 0.0.1
+boundedContextName: common
+moduleName: lang
+moduleNames: langs
+aggregateName: CommonLang
+hasOAuth: true
+hasTenant: false
+hasAuditing: true
+front:
+  gender: feminine
+  iconModule: '@ng-icons/material-icons'
+  solidIcon: matLanguage
+  outlineIcon: matLanguageOutline
+aggregateProperties:
+  - name: id
+    type: id
+    primaryKey: true
+    nullable: false
+  - name: rowId
+    type: bigint
+    index: unique
+    autoIncrement: true
+    nullable: false
+  - name: name
+    type: varchar
+    maxLength: 128
+    nullable: false
+    widget:
+      type: select
+      span: 12
+  - name: image
+    type: varchar
+    maxLength: 1022
+    nullable: true
+  - name: iso6392
+    type: char
+    length: 2
+    nullable: false
+    index: index
+  - name: iso6393
+    type: char
+    length: 3
+    nullable: false
+    index: index
+  - name: ietf
+    type: char
+    length: 5
+    nullable: false
+    index: index
+  - name: customCode
+    type: varchar
+    maxLength: 64
+    nullable: true
+    index: index
+  - name: dir
+    type: enum
+    enumOptions:
+      - LTR
+      - RTL
+    nullable: false
+    defaultValue: LTR
+  - name: sort
+    type: smallint
+    unsigned: true
+    nullable: true
+  - name: isActive
+    type: boolean
+    nullable: false
+    defaultValue: true
+  - name: createdAt
+    type: timestamp
+    nullable: true
+  - name: updatedAt
+    type: timestamp
+    nullable: true
+  - name: deletedAt
+    type: timestamp
+    nullable: true


### PR DESCRIPTION
Adds the `aurora-2.0.json` schema for the [Aurora Agile Meta-Framework](https://docs.aurorajs.dev/), the next version after the existing `aurora-1.3.json`.

### Changes
- New schema `src/schemas/json/aurora-2.0.json` (draft-07).
- Positive tests under `src/test/aurora-2.0/` (`author`, `book`, `country`, `lang`), modeled on the existing `aurora-1.3` tests and adapted to the 2.0 schema — notably the `webComponent` → `widget` rename and new fields (`arrayOptions`, `pivot`, `displayField`, `embedSupport`, `indexUsing`, `indexFields`, `span`/`tab`/`group`, etc.).
- Registered `2.0` in the catalog `versions` map and set it as the default `url`.
- Added `aurora-2.0.json` to the `ajvNotStrictMode` coverage list in `schema-validation.jsonc`.

All files validate via `node cli.js check --schema-name=aurora-2.0.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)