### PR TITLE
Add Spotlight Ruleset

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6922,6 +6922,19 @@
       "url": "https://www.schemastore.org/sponge-mixins.json"
     },
     {
+      "name": "Spotlight Ruleset",
+      "description": "Spotlight (Spectral-compatible) ruleset for linting OpenAPI, AsyncAPI, Arazzo, APIs.json and other JSON/YAML API descriptions.",
+      "fileMatch": [
+        "*.spotlight.json",
+        "*.spotlight.yaml",
+        "*.spotlight.yml",
+        "spotlight-ruleset.json",
+        "spotlight-ruleset.yaml",
+        "spotlight-ruleset.yml"
+      ],
+      "url": "https://api-commons.github.io/spotlight-spec/schema/v1/spotlight-ruleset.schema.json"
+    },
+    {
       "name": ".sprite files",
       "description": "image sprite generation files",
       "fileMatch": ["*.sprite"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6923,7 +6923,7 @@
     },
     {
       "name": "Spotlight Ruleset",
-      "description": "Spotlight (Spectral-compatible) ruleset for linting OpenAPI, AsyncAPI, Arazzo, APIs.json and other JSON/YAML API descriptions.",
+      "description": "Spotlight (Spectral-compatible) ruleset for linting OpenAPI, AsyncAPI, Arazzo, APIs.json and other JSON/YAML API descriptions",
       "fileMatch": [
         "*.spotlight.json",
         "*.spotlight.yaml",


### PR DESCRIPTION
Adds a catalog entry for the **Spotlight Ruleset** schema.

Spotlight is an open, Spectral-compatible ruleset format for linting JSON/YAML API descriptions (OpenAPI, AsyncAPI, Arazzo, APIs.json, and more). The schema is a self-contained JSON Schema 2020-12 bundle with full `description`/`title`/`examples` annotations.

- **Schema URL (external, hosted by us):** https://api-commons.github.io/spotlight-spec/schema/v1/spotlight-ruleset.schema.json
- **Source:** https://github.com/api-commons/spotlight-spec
- **fileMatch:** Spotlight-specific globs (`*.spotlight.{json,yaml,yml}`, `spotlight-ruleset.{json,yaml,yml}`) — deliberately narrow to avoid false positives; no conflicts with existing entries.

Checklist:
- [x] Entry added alphabetically in `src/api/json/catalog.json`
- [x] `prettier --check` passes
- [x] Schema URL resolves (HTTP 200) and is valid JSON Schema 2020-12
- [x] No `fileMatch` conflicts with existing entries