### PR TITLE
Add Trading Strategy Protocol (TSP) schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "Trading Strategy Protocol (TSP)",
+      "description": "Open declarative protocol for signals-only equities & crypto trading strategies\nhttps://b1dz.com/spec/tsp/v0.1/tsp.schema.json",
+      "fileMatch": ["**/*.tsp.json"],
+      "url": "https://www.schemastore.org/tradingstrategyprotocol.json"
+    },
+    {
       "name": "Specpin spec file",
       "description": "Specpin business-spec file (.specs/*.spec.json): rules, descriptions, and acceptance criteria pinned to UI elements",
       "fileMatch": ["**/.specs/*.spec.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4,7 +4,7 @@
   "schemas": [
     {
       "name": "Trading Strategy Protocol (TSP)",
-      "description": "Open declarative protocol for signals-only equities & crypto trading strategies\nhttps://b1dz.com/spec/tsp/v0.1/tsp.schema.json",
+      "description": "Open declarative protocol for signals-only equities and crypto trading strategies",
       "fileMatch": ["**/*.tsp.json"],
       "url": "https://www.schemastore.org/tradingstrategyprotocol.json"
     },

--- a/src/negative_test/tradingstrategyprotocol/missing-definition.tsp.json
+++ b/src/negative_test/tradingstrategyprotocol/missing-definition.tsp.json
@@ -1,0 +1,5 @@
+{
+  "id": "incomplete",
+  "name": "Missing the definition body",
+  "tsp": "0.1"
+}

--- a/src/schemas/json/tradingstrategyprotocol.json
+++ b/src/schemas/json/tradingstrategyprotocol.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://www.schemastore.org/tradingstrategyprotocol.json",
-  "$defs": {
+  "definitions": {
     "templateDefinition": {
       "type": "object",
       "required": ["kind", "template"],
@@ -25,12 +25,12 @@
         "kind": { "const": "rules" },
         "indicators": {
           "type": "object",
-          "additionalProperties": { "$ref": "#/$defs/indicator" }
+          "additionalProperties": { "$ref": "#/definitions/indicator" }
         },
         "rules": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/rule" }
+          "items": { "$ref": "#/definitions/rule" }
         }
       }
     },
@@ -77,8 +77,8 @@
       "required": ["when", "signal"],
       "additionalProperties": false,
       "properties": {
-        "when": { "$ref": "#/$defs/condition" },
-        "signal": { "$ref": "#/$defs/signal" }
+        "when": { "$ref": "#/definitions/condition" },
+        "signal": { "$ref": "#/definitions/signal" }
       }
     },
     "signal": {
@@ -101,23 +101,23 @@
       "maxProperties": 1,
       "additionalProperties": false,
       "properties": {
-        "gt": { "$ref": "#/$defs/operandPair" },
-        "gte": { "$ref": "#/$defs/operandPair" },
-        "lt": { "$ref": "#/$defs/operandPair" },
-        "lte": { "$ref": "#/$defs/operandPair" },
-        "eq": { "$ref": "#/$defs/operandPair" },
-        "neq": { "$ref": "#/$defs/operandPair" }
+        "gt": { "$ref": "#/definitions/operandPair" },
+        "gte": { "$ref": "#/definitions/operandPair" },
+        "lt": { "$ref": "#/definitions/operandPair" },
+        "lte": { "$ref": "#/definitions/operandPair" },
+        "eq": { "$ref": "#/definitions/operandPair" },
+        "neq": { "$ref": "#/definitions/operandPair" }
       }
     },
     "operandPair": {
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
-      "items": { "$ref": "#/$defs/operand" }
+      "items": { "$ref": "#/definitions/operand" }
     },
     "condition": {
       "oneOf": [
-        { "$ref": "#/$defs/comparison" },
+        { "$ref": "#/definitions/comparison" },
         {
           "type": "object",
           "required": ["and"],
@@ -126,7 +126,7 @@
             "and": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/condition" }
+              "items": { "$ref": "#/definitions/condition" }
             }
           }
         },
@@ -138,7 +138,7 @@
             "or": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/condition" }
+              "items": { "$ref": "#/definitions/condition" }
             }
           }
         },
@@ -146,7 +146,7 @@
           "type": "object",
           "required": ["not"],
           "additionalProperties": false,
-          "properties": { "not": { "$ref": "#/$defs/condition" } }
+          "properties": { "not": { "$ref": "#/definitions/condition" } }
         }
       ]
     }
@@ -177,8 +177,8 @@
     },
     "definition": {
       "oneOf": [
-        { "$ref": "#/$defs/templateDefinition" },
-        { "$ref": "#/$defs/rulesDefinition" }
+        { "$ref": "#/definitions/templateDefinition" },
+        { "$ref": "#/definitions/rulesDefinition" }
       ]
     }
   }

--- a/src/schemas/json/tradingstrategyprotocol.json
+++ b/src/schemas/json/tradingstrategyprotocol.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.schemastore.org/tradingstrategyprotocol.json",
+  "$defs": {
+    "templateDefinition": {
+      "type": "object",
+      "required": ["kind", "template"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "template" },
+        "template": {
+          "enum": ["mean-reversion", "breakout", "trend-continuation"]
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": { "type": "number" }
+        }
+      }
+    },
+    "rulesDefinition": {
+      "type": "object",
+      "required": ["kind", "rules"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "rules" },
+        "indicators": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/indicator" }
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/rule" }
+        }
+      }
+    },
+    "indicator": {
+      "type": "object",
+      "required": ["fn"],
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "fn": { "const": "rsi" },
+            "period": { "type": "number" }
+          }
+        },
+        {
+          "required": ["period"],
+          "additionalProperties": false,
+          "properties": {
+            "fn": { "const": "ema" },
+            "period": { "type": "number" }
+          }
+        },
+        {
+          "required": ["period"],
+          "additionalProperties": false,
+          "properties": {
+            "fn": { "const": "sma" },
+            "period": { "type": "number" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "fn": { "const": "macdHist" },
+            "fast": { "type": "number" },
+            "slow": { "type": "number" },
+            "signal": { "type": "number" }
+          }
+        }
+      ]
+    },
+    "rule": {
+      "type": "object",
+      "required": ["when", "signal"],
+      "additionalProperties": false,
+      "properties": {
+        "when": { "$ref": "#/$defs/condition" },
+        "signal": { "$ref": "#/$defs/signal" }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "required": ["side"],
+      "additionalProperties": false,
+      "properties": {
+        "side": { "enum": ["buy", "sell"] },
+        "strength": { "type": "number", "minimum": 0, "maximum": 1 },
+        "reason": { "type": "string" }
+      }
+    },
+    "operand": {
+      "description": "A numeric literal, the keyword \"price\" (current mid), or a declared indicator name.",
+      "oneOf": [{ "type": "number" }, { "type": "string", "minLength": 1 }]
+    },
+    "comparison": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "gt": { "$ref": "#/$defs/operandPair" },
+        "gte": { "$ref": "#/$defs/operandPair" },
+        "lt": { "$ref": "#/$defs/operandPair" },
+        "lte": { "$ref": "#/$defs/operandPair" },
+        "eq": { "$ref": "#/$defs/operandPair" },
+        "neq": { "$ref": "#/$defs/operandPair" }
+      }
+    },
+    "operandPair": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "$ref": "#/$defs/operand" }
+    },
+    "condition": {
+      "oneOf": [
+        { "$ref": "#/$defs/comparison" },
+        {
+          "type": "object",
+          "required": ["and"],
+          "additionalProperties": false,
+          "properties": {
+            "and": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/condition" }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["or"],
+          "additionalProperties": false,
+          "properties": {
+            "or": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/condition" }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["not"],
+          "additionalProperties": false,
+          "properties": { "not": { "$ref": "#/$defs/condition" } }
+        }
+      ]
+    }
+  },
+  "title": "Trading Strategy Protocol (TSP) v0.1",
+  "description": "An open, vendor-neutral, declarative JSON protocol for signals-only equities & crypto trading strategies. A TSP document reads a market-data stream and emits buy/sell signals; it executes no code, so user-authored strategies are safe to run and publish.",
+  "type": "object",
+  "required": ["tsp", "id", "name", "definition"],
+  "additionalProperties": false,
+  "properties": {
+    "tsp": {
+      "description": "Protocol version.",
+      "const": "0.1"
+    },
+    "id": {
+      "description": "Stable slug for the strategy.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "author": { "type": "string" },
+    "description": { "type": "string" },
+    "assetClasses": {
+      "type": "array",
+      "items": { "enum": ["crypto", "equity"] },
+      "uniqueItems": true
+    },
+    "definition": {
+      "oneOf": [
+        { "$ref": "#/$defs/templateDefinition" },
+        { "$ref": "#/$defs/rulesDefinition" }
+      ]
+    }
+  }
+}

--- a/src/test/tradingstrategyprotocol/rules-rsi-dip.tsp.json
+++ b/src/test/tradingstrategyprotocol/rules-rsi-dip.tsp.json
@@ -1,0 +1,28 @@
+{
+  "assetClasses": ["crypto", "equity"],
+  "author": "b1dz",
+  "definition": {
+    "indicators": {
+      "emaFast": { "fn": "ema", "period": 12 },
+      "emaSlow": { "fn": "ema", "period": 26 },
+      "rsi14": { "fn": "rsi", "period": 14 }
+    },
+    "kind": "rules",
+    "rules": [
+      {
+        "signal": { "reason": "RSI oversold", "side": "buy", "strength": 0.8 },
+        "when": { "lt": ["rsi14", 30] }
+      },
+      {
+        "signal": { "side": "sell" },
+        "when": {
+          "and": [{ "gt": ["rsi14", 70] }, { "lt": ["emaFast", "emaSlow"] }]
+        }
+      }
+    ]
+  },
+  "description": "Buy deep RSI dips, sell the bounce.",
+  "id": "rsi-dip",
+  "name": "RSI Dip Buyer",
+  "tsp": "0.1"
+}

--- a/src/test/tradingstrategyprotocol/template-breakout.tsp.json
+++ b/src/test/tradingstrategyprotocol/template-breakout.tsp.json
@@ -1,0 +1,10 @@
+{
+  "definition": {
+    "kind": "template",
+    "params": { "lookback": 10 },
+    "template": "breakout"
+  },
+  "id": "fast-breakout",
+  "name": "Fast Breakout",
+  "tsp": "0.1"
+}


### PR DESCRIPTION
Adds a schema for **TSP — Trading Strategy Protocol v0.1**, an open, vendor-neutral, declarative JSON protocol for *signals-only* equities & crypto trading strategies.

A TSP document describes a trading strategy as **data, not code**: it names indicators and boolean rules over them and emits buy/sell signals. Because nothing is executable, user-authored strategies are safe to validate, share, and publish. It fills a gap not covered by existing standards — Pine Script is a proprietary DSL, QuantConnect/Backtrader are code, and FIX/FIXML cover order messaging rather than strategy logic.

- Canonical spec & reference implementation: https://b1dz.com/spec/tsp/v0.1/tsp.schema.json (served), spec doc in the b1dz.com repo.
- **`fileMatch`:** `**/*.tsp.json` (the `.tsp.json` double extension is strategy-specific and unlikely to collide).

### Checklist
- [x] Schema added at `src/schemas/json/tradingstrategyprotocol.json` (draft 2020-12; compiles under ajv strict mode).
- [x] Catalog entry added (`name`, `description` with docs URL, `fileMatch`, `url`).
- [x] Positive tests in `src/test/tradingstrategyprotocol/` (a `rules` doc and a `template` doc).
- [x] Negative test in `src/negative_test/tradingstrategyprotocol/`.
- [x] Formatted with the repo's Prettier config (`prettier-plugin-sort-json`).