### PR TITLE
tsconfig: Add minLength validation to path in project reference

### DIFF
--- a/src/schemas/json/jsconfig.json
+++ b/src/schemas/json/jsconfig.json
@@ -1238,6 +1238,7 @@
             "properties": {
               "path": {
                 "type": "string",
+                "minLength": 1,
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }
             }

--- a/src/schemas/json/tsconfig.json
+++ b/src/schemas/json/tsconfig.json
@@ -1366,6 +1366,7 @@
             "properties": {
               "path": {
                 "type": "string",
+                "minLength": 1,
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }
             }


### PR DESCRIPTION
An empty string works in ts6, but will not in ts7 aka tsgo.
(and is quite a bad idea even in older versions)

ref https://github.com/microsoft/typescript-go/issues/4484

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
