### PR TITLE
Add GitResume

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3621,6 +3621,17 @@
       "url": "https://gitpod.io/schemas/gitpod-schema.json"
     },
     {
+      "name": "GitResume",
+      "description": "GitResume resume-as-code definition file",
+      "fileMatch": [
+        "gitresume.yaml",
+        "gitresume.yml",
+        "*.gitresume.yaml",
+        "*.gitresume.yml"
+      ],
+      "url": "https://gitresume.co/schema/resume.schema.json"
+    },
+    {
       "name": "Ansible Execution Environment",
       "description": "Ansible execution-environment.yml file",
       "fileMatch": ["**/execution-environment.yml"],


### PR DESCRIPTION
Registers GitResume resume files in the catalog as a self-hosted schema, per [How to add a JSON Schema that's self-hosted/remote/external](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal). Catalog entry only, no local schema file.

[GitResume](https://gitresume.co) is a resume-as-code platform: users describe their resume in `gitresume.yaml` in a GitHub repo, and every push builds a hosted PDF/HTML resume. The schema is maintained and served by us at https://gitresume.co/schema/resume.schema.json (public, CORS-enabled).

Notes:
- `fileMatch` uses the distinctive `gitresume.yaml` name plus `*.gitresume.yaml` variants, so there is no overlap with existing entries (`resume.yaml` belongs to JSON Resume, `cv.yaml` to CodeCV).
- `node ./cli.js check` passes locally; prettier clean.