### PR TITLE
adds underscoreHeadersStrategy

### DIFF
--- a/src/schemas/json/traefik-v3.json
+++ b/src/schemas/json/traefik-v3.json
@@ -1092,6 +1092,9 @@
         },
         "tls": {
           "$ref": "#/$defs/staticTLSConfig"
+        },
+        "underscoreHeadersStrategy": {
+          "type": "string"
         }
       },
       "type": "object"


### PR DESCRIPTION
adds the `underscoreHeadersStrategy` property (new for 3.7.6, 2.11.51)

refs
- https://github.com/traefik/traefik/pull/13262
- [Docs: underscoreHeadersStrategy](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#underscoreheadersstrategy)
- [Security: Headers with Underscores](https://doc.traefik.io/traefik/security/header-underscores/)
