### PR TITLE
Add act3 config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10390,6 +10390,12 @@
       "url": "https://raw.githubusercontent.com/ton-blockchain/acton/master/crates/acton-config/schemas/acton.schema.json"
     },
     {
+      "name": "act3",
+      "description": "act3 configuration file",
+      "fileMatch": ["**/act3/act3.yml"],
+      "url": "https://www.schemastore.org/act3.json"
+    },
+    {
       "name": "memnex",
       "description": "Open specification for portable meeting outputs \u2014 transcripts, summaries, action items, and decisions. https://memnex.org",
       "fileMatch": ["*.memnex.json", "meeting-output.json"],

--- a/src/negative_test/act3/invalid-workflow.yml
+++ b/src/negative_test/act3/invalid-workflow.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../schemas/json/act3.json
+workflows:
+  - id: ''
+    repo: dhth
+    name: ''
+    key: ''
+    url: http://example.com/runs/{{runNumber}}

--- a/src/schemas/json/act3.json
+++ b/src/schemas/json/act3.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/act3.json",
+  "title": "act3 configuration",
+  "description": "Configuration for act3, a terminal user interface for tracking GitHub Actions workflow runs.\nhttps://github.com/dhth/act3#usage",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "workflows": {
+      "description": "GitHub Actions workflows to track.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/workflow"
+      }
+    }
+  },
+  "definitions": {
+    "workflow": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "repo", "name"],
+      "properties": {
+        "id": {
+          "description": "GitHub Actions workflow ID.",
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "description": "GitHub repository in owner/name form.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "name": {
+          "description": "Display name for the workflow.",
+          "type": "string",
+          "minLength": 1
+        },
+        "key": {
+          "description": "Optional key used to disambiguate workflows with the same name.",
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "description": "Optional HTTPS URL template associated with the workflow.",
+          "type": "string",
+          "pattern": "^https://"
+        }
+      }
+    }
+  }
+}

--- a/src/test/act3/act3.yml
+++ b/src/test/act3/act3.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../schemas/json/act3.json
+workflows:
+  - id: W_kwDOLkC0eM4FaKV_
+    repo: dhth/act3
+    name: build
+  - id: W_kwDOLb3Pms4FRxjX
+    repo: dhth/cueitup
+    name: release
+    key: cueitup-release
+    url: https://example.com/runs/{{runNumber}}


### PR DESCRIPTION
## Summary
- add a JSON Schema for act3's YAML configuration
- register the default act3 config path in the SchemaStore catalog
- add positive and negative YAML fixtures

## Validation
- node ./cli.js check --schema-name=act3.json