### PR TITLE
Add abtop config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -235,6 +235,12 @@
       }
     },
     {
+      "name": "abtop",
+      "description": "abtop configuration file",
+      "fileMatch": ["**/abtop/config.toml"],
+      "url": "https://www.schemastore.org/abtop.json"
+    },
+    {
       "name": "ABCInventoryModuleData",
       "description": "ABCInventoryModuleData defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module",
       "fileMatch": ["abc-inventory-module-data-*.json"],

--- a/src/negative_test/abtop/invalid-config.toml
+++ b/src/negative_test/abtop/invalid-config.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/abtop.json
+
+theme = "unknown"
+hidden_agents = ["codex"]
+show_tokens = "false"

--- a/src/schemas/json/abtop.json
+++ b/src/schemas/json/abtop.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/abtop.json",
+  "title": "abtop configuration",
+  "description": "Configuration for abtop, a terminal dashboard for coding agent activity.\nhttps://github.com/graykode/abtop#configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "theme": {
+      "description": "Color theme used by abtop.",
+      "type": "string",
+      "enum": [
+        "btop",
+        "dracula",
+        "catppuccin",
+        "tokyo-night",
+        "gruvbox",
+        "nord",
+        "light",
+        "white",
+        "high-contrast",
+        "protanopia",
+        "deuteranopia",
+        "tritanopia"
+      ]
+    },
+    "hidden_agents": {
+      "description": "Agent names to hide from the dashboard.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "claude_config_dirs": {
+      "description": "Additional Claude configuration directories to scan.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "language": {
+      "description": "Interface language. Leave empty or omit to auto-detect.",
+      "type": "string",
+      "enum": ["", "en", "zh"]
+    },
+    "show_context": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_quota": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_tokens": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_projects": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_ports": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_sessions": {
+      "$ref": "#/definitions/displayToggle"
+    },
+    "show_mcp": {
+      "$ref": "#/definitions/displayToggle"
+    }
+  },
+  "definitions": {
+    "displayToggle": {
+      "description": "Whether to show a dashboard section.",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/schemas/json/abtop.json
+++ b/src/schemas/json/abtop.json
@@ -41,9 +41,9 @@
       }
     },
     "language": {
-      "description": "Interface language. Leave empty or omit to auto-detect.",
+      "description": "Interface language. Leave empty or omit to auto-detect. Values beginning with zh use Simplified Chinese; other values use English.",
       "type": "string",
-      "enum": ["", "en", "zh"]
+      "pattern": "^(|en|zh.*)$"
     },
     "show_context": {
       "$ref": "#/definitions/displayToggle"

--- a/src/test/abtop/config.toml
+++ b/src/test/abtop/config.toml
@@ -3,7 +3,7 @@
 theme = "btop"
 hidden_agents = ["codex"]
 claude_config_dirs = ["~/.claude-personal", "~/.claude-work-team"]
-language = "zh"
+language = "zh-CN"
 show_context = true
 show_quota = true
 show_tokens = false

--- a/src/test/abtop/config.toml
+++ b/src/test/abtop/config.toml
@@ -1,0 +1,13 @@
+#:schema ../../schemas/json/abtop.json
+
+theme = "btop"
+hidden_agents = ["codex"]
+claude_config_dirs = ["~/.claude-personal", "~/.claude-work-team"]
+language = "zh"
+show_context = true
+show_quota = true
+show_tokens = false
+show_projects = true
+show_ports = true
+show_sessions = true
+show_mcp = false


### PR DESCRIPTION
## Summary
- add a JSON Schema for abtop's TOML configuration
- register the default abtop config path in the SchemaStore catalog
- add positive and negative TOML fixtures

## Validation
- node ./cli.js check --schema-name=abtop.json