### PR TITLE
Add gollama config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3752,6 +3752,12 @@
       "url": "https://golangci-lint.run/jsonschema/custom-gcl.jsonschema.json"
     },
     {
+      "name": "gollama",
+      "description": "gollama configuration file",
+      "fileMatch": ["**/gollama/config.json"],
+      "url": "https://www.schemastore.org/gollama.json"
+    },
+    {
       "name": "go-feature-flag Flag Configuration",
       "description": "go-feature-flag flag configuration file",
       "fileMatch": ["*.goff.yml", "*.goff.yaml", "*.goff.json", "*.goff.toml"],

--- a/src/negative_test/gollama/invalid-config.json
+++ b/src/negative_test/gollama/invalid-config.json
@@ -1,0 +1,5 @@
+{
+  "columns": "Name,Size",
+  "ollama_api_url": 11434,
+  "theme": false
+}

--- a/src/schemas/json/gollama.json
+++ b/src/schemas/json/gollama.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/gollama.json",
+  "title": "gollama configuration",
+  "description": "Configuration for gollama, a terminal user interface for managing Ollama models.\nhttps://github.com/sammcj/gollama#configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "columns": {
+      "description": "Columns to show in the model list.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "ollama_api_key": {
+      "description": "API key sent to Ollama-compatible endpoints.",
+      "type": "string"
+    },
+    "ollama_api_url": {
+      "description": "Ollama API URL.",
+      "type": "string"
+    },
+    "ollama_models_dir": {
+      "description": "Directory containing Ollama model files.",
+      "type": "string"
+    },
+    "log_level": {
+      "description": "Logging level.",
+      "type": "string"
+    },
+    "log_file_path": {
+      "description": "Path to the log file.",
+      "type": "string"
+    },
+    "sort_order": {
+      "description": "Default model sort order.",
+      "type": "string"
+    },
+    "strip_string": {
+      "description": "String to strip from model names for display.",
+      "type": "string"
+    },
+    "editor": {
+      "description": "Editor command used when opening files.",
+      "type": "string"
+    },
+    "theme": {
+      "description": "Theme name.",
+      "type": "string"
+    },
+    "docker_container": {
+      "description": "Docker container name used when managing models through Docker.",
+      "type": "string"
+    }
+  }
+}

--- a/src/test/gollama/config.json
+++ b/src/test/gollama/config.json
@@ -1,0 +1,13 @@
+{
+  "columns": ["Name", "Size", "Quant", "Family", "Modified", "ID"],
+  "docker_container": "ollama",
+  "editor": "code",
+  "log_file_path": "~/.local/state/gollama/gollama.log",
+  "log_level": "info",
+  "ollama_api_key": "example-token",
+  "ollama_api_url": "http://127.0.0.1:11434",
+  "ollama_models_dir": "~/.ollama/models",
+  "sort_order": "modified",
+  "strip_string": "latest",
+  "theme": "dark-neon"
+}


### PR DESCRIPTION
## Summary
- add a JSON Schema for gollama's JSON configuration
- register the default gollama config path in the SchemaStore catalog
- add positive and negative JSON fixtures

## Validation
- node ./cli.js check --schema-name=gollama.json