### PR TITLE
Add GAMA config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3407,6 +3407,12 @@
       }
     },
     {
+      "name": "GAMA",
+      "description": "GAMA configuration file",
+      "fileMatch": ["**/gama/config.yaml", ".gama.yaml"],
+      "url": "https://www.schemastore.org/gama.json"
+    },
+    {
       "name": "Gaspar",
       "description": "Configuration for Gaspar",
       "fileMatch": ["gaspar.config.json"],

--- a/src/negative_test/gama/invalid-config.yaml
+++ b/src/negative_test/gama/invalid-config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../schemas/json/gama.json
+github:
+  token: ''
+keys:
+  quit: ''
+settings:
+  live_mode:
+    enabled: 'true'
+    interval: fifteen-seconds

--- a/src/negative_test/gama/invalid-config.yaml
+++ b/src/negative_test/gama/invalid-config.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=../../schemas/json/gama.json
 github:
-  token: ''
+  token: 123
 keys:
-  quit: ''
+  quit: false
 settings:
   live_mode:
     enabled: 'true'

--- a/src/schemas/json/gama.json
+++ b/src/schemas/json/gama.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/gama.json",
+  "title": "GAMA configuration",
+  "description": "Configuration for GAMA, a terminal user interface for GitHub Actions.\nhttps://github.com/termkit/gama#configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "github": {
+      "description": "GitHub connection settings.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "token": {
+          "description": "GitHub token. Environment variables are usually preferred for secrets.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "keys": {
+      "description": "Keyboard shortcuts.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "switch_tab_right": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "switch_tab_left": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "quit": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "refresh": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "enter": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "live_mode": {
+          "$ref": "#/definitions/keyBinding"
+        },
+        "tab": {
+          "$ref": "#/definitions/keyBinding"
+        }
+      }
+    },
+    "settings": {
+      "description": "Runtime settings.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "live_mode": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "description": "Whether live mode is enabled by default.",
+              "type": "boolean"
+            },
+            "interval": {
+              "description": "Refresh interval as a Go duration string, such as 15s or 1m.",
+              "type": "string",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "keyBinding": {
+      "description": "Keyboard shortcut, such as ctrl+c, shift+right, enter, or tab.",
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/src/schemas/json/gama.json
+++ b/src/schemas/json/gama.json
@@ -13,8 +13,7 @@
       "properties": {
         "token": {
           "description": "GitHub token. Environment variables are usually preferred for secrets.",
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         }
       }
     },
@@ -60,9 +59,9 @@
               "type": "boolean"
             },
             "interval": {
-              "description": "Refresh interval as a Go duration string, such as 15s or 1m.",
+              "description": "Refresh interval as a Go duration string, such as 15s, 1m, 1m30s, or 1.5s.",
               "type": "string",
-              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
+              "pattern": "^[+-]?([0-9]+(\\.[0-9]+)?(ns|us|ms|s|m|h))+$"
             }
           }
         }
@@ -72,8 +71,7 @@
   "definitions": {
     "keyBinding": {
       "description": "Keyboard shortcut, such as ctrl+c, shift+right, enter, or tab.",
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     }
   }
 }

--- a/src/test/gama/config.yaml
+++ b/src/test/gama/config.yaml
@@ -12,4 +12,4 @@ keys:
 settings:
   live_mode:
     enabled: true
-    interval: 15s
+    interval: 1m30s

--- a/src/test/gama/config.yaml
+++ b/src/test/gama/config.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../schemas/json/gama.json
+github:
+  token: ghp_example
+keys:
+  switch_tab_right: shift+right
+  switch_tab_left: shift+left
+  quit: ctrl+c
+  refresh: ctrl+r
+  enter: enter
+  live_mode: ctrl+l
+  tab: tab
+settings:
+  live_mode:
+    enabled: true
+    interval: 15s


### PR DESCRIPTION
## Summary
- add a JSON Schema for GAMA's YAML configuration
- register GAMA's current and legacy config paths in the SchemaStore catalog
- add positive and negative YAML fixtures

## Validation
- node ./cli.js check --schema-name=gama.json