### PR TITLE
Add models CLI config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4908,7 +4908,6 @@
     {
       "name": "models CLI",
       "description": "models CLI configuration file",
-      "fileMatch": ["**/models/config.toml"],
       "url": "https://www.schemastore.org/modelsdev.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4906,6 +4906,12 @@
       "url": "https://www.schemastore.org/modelparams.json"
     },
     {
+      "name": "models CLI",
+      "description": "models CLI configuration file",
+      "fileMatch": ["**/models/config.toml"],
+      "url": "https://www.schemastore.org/modelsdev.json"
+    },
+    {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
       "fileMatch": ["monospace.yml"],

--- a/src/negative_test/modelsdev/invalid-config.toml
+++ b/src/negative_test/modelsdev/invalid-config.toml
@@ -1,0 +1,18 @@
+#:schema ../../schemas/json/modelsdev.json
+
+config_version = -1
+
+[agents]
+tracked = ["codex", "codex"]
+
+[[agents.custom]]
+name = ""
+repo = "not-a-repo"
+agent_type = "desktop"
+version_command = ["models", ""]
+
+[display]
+default_tab = "unknown"
+
+[aliases]
+agents = ""

--- a/src/schemas/json/modelsdev.json
+++ b/src/schemas/json/modelsdev.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/modelsdev.json",
+  "title": "models configuration",
+  "description": "Configuration for models, a terminal user interface and CLI for browsing AI models, benchmarks, coding agents, and provider statuses.\nhttps://github.com/reyamira/models/wiki/Configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "config_version": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tracked": { "$ref": "#/definitions/stringSet" },
+        "excluded": { "$ref": "#/definitions/stringSet" },
+        "custom": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/customAgent"
+          }
+        }
+      }
+    },
+    "cache": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "github_ttl_seconds": {
+          "description": "GitHub cache time-to-live in seconds.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "display": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "default_tab": {
+          "type": "string",
+          "enum": ["models", "agents", "benchmarks", "status"]
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tracked": { "$ref": "#/definitions/stringSet" }
+      }
+    },
+    "aliases": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "agents": {
+          "type": "string",
+          "minLength": 1
+        },
+        "benchmarks": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "benchmarks": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "columns": {
+          "description": "Visible benchmark metric columns keyed by data-source id.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/stringSet"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "stringSet": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "customAgent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "repo"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "description": "GitHub repository in owner/name form.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "agent_type": {
+          "type": "string",
+          "enum": ["cli", "ide"]
+        },
+        "binary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version_command": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/modelsdev.json
+++ b/src/schemas/json/modelsdev.json
@@ -41,7 +41,7 @@
       "properties": {
         "default_tab": {
           "type": "string",
-          "enum": ["models", "agents", "benchmarks", "status"]
+          "pattern": "^([Mm][Oo][Dd][Ee][Ll][Ss]|[Aa][Gg][Ee][Nn][Tt][Ss]|[Bb][Ee][Nn][Cc][Hh][Mm][Aa][Rr][Kk][Ss]|[Ss][Tt][Aa][Tt][Uu][Ss])$"
         }
       }
     },

--- a/src/test/modelsdev/config.toml
+++ b/src/test/modelsdev/config.toml
@@ -17,7 +17,7 @@ version_command = ["example-agent", "--version"]
 github_ttl_seconds = 3600
 
 [display]
-default_tab = "benchmarks"
+default_tab = "Benchmarks"
 
 [status]
 tracked = ["openai", "anthropic"]

--- a/src/test/modelsdev/config.toml
+++ b/src/test/modelsdev/config.toml
@@ -1,0 +1,34 @@
+#:schema ../../schemas/json/modelsdev.json
+
+config_version = 1
+
+[agents]
+tracked = ["claude-code", "codex", "gemini-cli", "opencode"]
+excluded = ["cursor"]
+
+[[agents.custom]]
+name = "Example Agent"
+repo = "example/agent"
+agent_type = "cli"
+binary = "example-agent"
+version_command = ["example-agent", "--version"]
+
+[cache]
+github_ttl_seconds = 3600
+
+[display]
+default_tab = "benchmarks"
+
+[status]
+tracked = ["openai", "anthropic"]
+
+[aliases]
+agents = "agents"
+benchmarks = "benchmarks"
+status = "mstatus"
+
+[benchmarks.columns]
+aa = ["model", "speed", "quality"]
+epoch = ["model", "score"]
+arena = ["rank", "model"]
+llmstats = ["model", "context"]


### PR DESCRIPTION
## Summary
- add a JSON Schema for the models CLI TOML configuration
- register the default models config path in the SchemaStore catalog
- add positive and negative TOML fixtures

## Validation
- node ./cli.js check --schema-name=modelsdev.json