### PR TITLE
Add AI Harness schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -332,6 +332,18 @@
       "url": "https://www.schemastore.org/actionlint.json"
     },
     {
+      "name": "AI Harness config",
+      "description": "Repository bootstrap-intent marker for ai-harness, including context directory, resolved AI coding targets, and posture",
+      "fileMatch": [".aih-config.json"],
+      "url": "https://www.schemastore.org/aih-config.json"
+    },
+    {
+      "name": "AI Harness org policy",
+      "description": "Repository governance policy for ai-harness command guardrails, MCP policy, and trust gates",
+      "fileMatch": ["aih-org-policy.json"],
+      "url": "https://www.schemastore.org/aih-org-policy.json"
+    },
+    {
       "name": "AIConfig",
       "description": "AIConfig that is used to store generative AI prompts, models and model parameters",
       "fileMatch": [

--- a/src/schemas/json/aih-config.json
+++ b/src/schemas/json/aih-config.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/aih-config.json",
+  "title": "AI Harness config",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "contextDir": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9._\\-/]+$"
+    },
+    "targets": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "posture": {
+      "type": "string",
+      "enum": ["vibe", "team", "enterprise"]
+    },
+    "adopt": {
+      "type": "object",
+      "properties": {
+        "acknowledged": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": ["schemaVersion", "contextDir"]
+}

--- a/src/schemas/json/aih-org-policy.json
+++ b/src/schemas/json/aih-org-policy.json
@@ -1,0 +1,253 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/aih-org-policy.json",
+  "title": "AI Harness org policy",
+  "type": "object",
+  "properties": {
+    "schemaVersion": {
+      "type": "number",
+      "const": 1
+    },
+    "minimumPosture": {
+      "type": "string",
+      "enum": ["vibe", "team", "enterprise"]
+    },
+    "references": {
+      "type": "object",
+      "properties": {
+        "repoContract": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["repoContract"]
+    },
+    "command": {
+      "type": "object",
+      "properties": {
+        "deny": {
+          "type": "object",
+          "properties": {
+            "add": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": ["pattern"]
+              }
+            },
+            "remove": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ask": {
+          "type": "object",
+          "properties": {
+            "add": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pattern": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": ["pattern"]
+              }
+            },
+            "remove": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "riskGates": {
+      "type": "object",
+      "properties": {
+        "add": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "pathPatterns": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "commandPatterns": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["name", "description"]
+          }
+        },
+        "override": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "pathPatterns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "commandPatterns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "licenses": {
+      "type": "object",
+      "properties": {
+        "disposition": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["auto-approve", "alert", "fail", "block"]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "mcp": {
+      "type": "object",
+      "properties": {
+        "allowedServers": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "allowManagedOnly": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "trust": {
+      "type": "object",
+      "properties": {
+        "approvedSources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "owner": {
+                "type": "string",
+                "minLength": 1
+              },
+              "repo": {
+                "type": "string",
+                "minLength": 1
+              },
+              "pinnedSha": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{40}$"
+              },
+              "reason": {
+                "type": "string"
+              }
+            },
+            "required": ["owner", "repo"],
+            "additionalProperties": false
+          }
+        },
+        "requireSignedSource": {
+          "default": false,
+          "type": "boolean"
+        },
+        "requiredDetectors": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["skillspector", "cisco", "mcp-scanner"]
+          }
+        },
+        "requiredChecks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "internalScopes": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["schemaVersion", "minimumPosture", "references"],
+  "additionalProperties": false
+}

--- a/src/test/aih-config/aih-config.json
+++ b/src/test/aih-config/aih-config.json
@@ -1,0 +1,4 @@
+{
+  "contextDir": "ai-coding",
+  "schemaVersion": 1
+}

--- a/src/test/aih-org-policy/aih-org-policy.json
+++ b/src/test/aih-org-policy/aih-org-policy.json
@@ -1,0 +1,26 @@
+{
+  "command": {
+    "deny": {
+      "add": [
+        {
+          "pattern": "curl * | sh",
+          "reason": "Pipe-to-shell installers need separate review."
+        }
+      ]
+    }
+  },
+  "mcp": {
+    "allowManagedOnly": true,
+    "allowedServers": ["code-review-graph", "github"]
+  },
+  "minimumPosture": "enterprise",
+  "references": {
+    "repoContract": "ai-coding/project.json"
+  },
+  "schemaVersion": 1,
+  "trust": {
+    "internalScopes": ["@acme"],
+    "requireSignedSource": true,
+    "requiredDetectors": ["skillspector", "cisco"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds hosted SchemaStore entries for AI Harness configuration files:

- `aih-config.json` for `.aih-config.json`
- `aih-org-policy.json` for `aih-org-policy.json`

Both schemas are generated from the project source schemas and adapted to SchemaStore draft-07 conventions with positive examples under `src/test`.

## Validation

- `node ./cli.js check --schema-name=aih-config.json`
- `node ./cli.js check --schema-name=aih-org-policy.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src\schemas\json\aih-config.json src\schemas\json\aih-org-policy.json src\api\json\catalog.json src\test\aih-config\aih-config.json src\test\aih-org-policy\aih-org-policy.json`
- `npm run typecheck`
- `npm run eslint`

Note: `npm run prettier` across the entire repository reports existing baseline formatting warnings in thousands of unrelated files in my checkout, so I validated formatting for the files changed by this PR.
