### PR TITLE
Update prek schema to v0.4.7

### DIFF
--- a/src/schemas/json/prek.json
+++ b/src/schemas/json/prek.json
@@ -5,9 +5,9 @@
   "description": "The configuration file for prek, a git hook manager written in Rust.",
   "type": "object",
   "properties": {
-    "auto_update": {
-      "$ref": "#/definitions/AutoUpdateOptions",
-      "description": "Default settings for `prek auto-update` in this project."
+    "update": {
+      "$ref": "#/definitions/UpdateOptions",
+      "description": "Default settings for `prek update` in this project."
     },
     "repos": {
       "type": "array",
@@ -106,6 +106,13 @@
       },
       "uniqueItems": true
     },
+    "default_env": {
+      "description": "Default runtime environment variables for hooks.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "files": {
       "$ref": "#/definitions/FilePattern",
       "description": "Global file include pattern."
@@ -125,14 +132,18 @@
     "orphan": {
       "description": "Set to true to isolate this project from parent configurations in workspace mode.\nWhen true, files in this project are \"consumed\" by this project and will not be processed\nby parent projects.\nWhen false (default), files in subprojects are processed by both the subproject and\nany parent projects that contain them.",
       "type": "boolean"
+    },
+    "auto_update": {
+      "$ref": "#/definitions/UpdateOptions",
+      "description": "Compatibility alias for `update`. Prefer `update` in new configs."
     }
   },
   "required": ["repos"],
   "additionalProperties": true,
   "x-tombi-toml-version": "v1.1.0",
   "definitions": {
-    "AutoUpdateOptions": {
-      "description": "Controls how `prek auto-update` selects eligible releases.",
+    "UpdateOptions": {
+      "description": "Controls how `prek update` selects eligible releases.",
       "type": "object",
       "properties": {
         "cooldown_days": {


### PR DESCRIPTION
Update prek schema to v0.4.7, which renames `auto_update` to `update` and adds `default_env`.