### PR TITLE
Add lychee and Gitleaks config schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3497,6 +3497,12 @@
       }
     },
     {
+      "name": "Gitleaks",
+      "description": "Gitleaks configuration file",
+      "fileMatch": ["gitleaks.toml", ".gitleaks.toml"],
+      "url": "https://www.schemastore.org/gitleaks.json"
+    },
+    {
       "name": "Gitea Issue Template configuration",
       "description": "YAML configuring Gitea Issue Templates",
       "fileMatch": [
@@ -7790,6 +7796,12 @@
       "description": "Husky can prevent bad `git commit`, `git push` and more \ud83d\udc36 woof!",
       "fileMatch": [".huskyrc", ".huskyrc.json"],
       "url": "https://www.schemastore.org/huskyrc.json"
+    },
+    {
+      "name": "lychee",
+      "description": "lychee link checker configuration file",
+      "fileMatch": ["lychee.toml", ".lychee.toml"],
+      "url": "https://www.schemastore.org/lychee.json"
     },
     {
       "name": "lint-staged (.lintstagedrc)",

--- a/src/negative_test/gitleaks/invalid-config.toml
+++ b/src/negative_test/gitleaks/invalid-config.toml
@@ -1,0 +1,18 @@
+#:schema ../../schemas/json/gitleaks.json
+
+[extend]
+path = "common_config.toml"
+useDefault = true
+
+[[rules]]
+description = "missing id"
+regex = '''secret'''
+secretGroup = -1
+entropy = -0.1
+skipReport = "yes"
+
+[[rules.allowlists]]
+regexTarget = "column"
+
+[[allowlists]]
+condition = "XOR"

--- a/src/negative_test/lychee/invalid-config.toml
+++ b/src/negative_test/lychee/invalid-config.toml
@@ -1,0 +1,13 @@
+#:schema ../../schemas/json/lychee.json
+
+verbose = "loud"
+format = "md"
+mode = "sparkles"
+threads = 0
+max_concurrency = 0
+include_fragments = true
+method = []
+accept = [{ code = 200 }]
+
+[hosts."example.com"]
+unknown = true

--- a/src/schemas/json/gitleaks.json
+++ b/src/schemas/json/gitleaks.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/gitleaks.json",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "Gitleaks configuration",
+  "description": "Configuration for Gitleaks secret detection rules and allowlists.\nhttps://github.com/gitleaks/gitleaks#configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "description": "Optional schema URL for editor integrations.",
+      "type": "string"
+    },
+    "title": {
+      "description": "Configuration title.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Configuration description.",
+      "type": "string"
+    },
+    "minVersion": {
+      "description": "Minimum Gitleaks version required to use this configuration.",
+      "type": "string"
+    },
+    "extend": {
+      "$ref": "#/definitions/extend"
+    },
+    "rules": {
+      "description": "Detection rules.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/rule"
+      }
+    },
+    "allowlist": {
+      "$ref": "#/definitions/globalAllowlist",
+      "description": "Deprecated global allowlist form. Prefer [[allowlists]]."
+    },
+    "allowlists": {
+      "description": "Global or targeted allowlists.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/globalAllowlist"
+      }
+    }
+  },
+  "definitions": {
+    "extend": {
+      "description": "Configuration inheritance options.",
+      "type": "object",
+      "additionalProperties": false,
+      "not": {
+        "description": "useDefault and path cannot be used at the same time.",
+        "required": ["path", "useDefault"],
+        "properties": {
+          "path": {},
+          "useDefault": {
+            "const": true
+          }
+        }
+      },
+      "properties": {
+        "path": {
+          "description": "Path to a configuration file to extend.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL to a configuration file to extend.",
+          "type": "string"
+        },
+        "useDefault": {
+          "description": "Extend the default Gitleaks configuration.",
+          "type": "boolean"
+        },
+        "disabledRules": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Inherited rule IDs to disable."
+        }
+      }
+    },
+    "rule": {
+      "description": "A detection rule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "description": "Unique rule identifier.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "description": "Human-readable rule description.",
+          "type": "string"
+        },
+        "regex": {
+          "description": "Go regular expression used to detect secrets.",
+          "type": "string"
+        },
+        "secretGroup": {
+          "description": "Regex capture group used as the secret and for entropy checks.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "entropy": {
+          "description": "Minimum Shannon entropy required for the configured secret group.",
+          "type": "number",
+          "minimum": 0
+        },
+        "path": {
+          "description": "Go regular expression used to match paths.",
+          "type": "string"
+        },
+        "keywords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Keywords used for pre-regex filtering."
+        },
+        "tags": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Metadata tags."
+        },
+        "skipReport": {
+          "description": "Do not include this rule in reports.",
+          "type": "boolean"
+        },
+        "allowlist": {
+          "$ref": "#/definitions/ruleAllowlist",
+          "description": "Deprecated rule allowlist form. Prefer [[rules.allowlists]]."
+        },
+        "allowlists": {
+          "description": "Rule-specific allowlists.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ruleAllowlist"
+          }
+        },
+        "required": {
+          "description": "Auxiliary rules required for a composite rule match.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/requiredRule"
+          }
+        }
+      }
+    },
+    "requiredRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "description": "Required rule ID.",
+          "type": "string",
+          "minLength": 1
+        },
+        "withinLines": {
+          "description": "Maximum line distance between the primary finding and required finding.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "withinColumns": {
+          "description": "Maximum column distance between the primary finding and required finding.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "globalAllowlist": {
+      "description": "A global or targeted allowlist for commits, paths, regexes, or stopwords.",
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["commits"],
+          "properties": {
+            "commits": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["paths"],
+          "properties": {
+            "paths": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["regexes"],
+          "properties": {
+            "regexes": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["stopwords"],
+          "properties": {
+            "stopwords": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["targetRules"],
+          "properties": {
+            "targetRules": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "targetRules": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Rule IDs this common allowlist applies to."
+        },
+        "description": {
+          "description": "Human-readable allowlist description.",
+          "type": "string"
+        },
+        "condition": {
+          "description": "Whether any criterion or all criteria must match.",
+          "type": "string",
+          "enum": ["AND", "OR", "and", "or", "&&", "||"]
+        },
+        "commits": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Commit SHAs to allow."
+        },
+        "paths": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Path regular expressions to allow."
+        },
+        "regexTarget": {
+          "description": "Finding field tested by regexes.",
+          "type": "string",
+          "enum": ["secret", "match", "line"]
+        },
+        "regexes": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Content regular expressions to allow."
+        },
+        "stopwords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Stopwords matched against the extracted secret."
+        }
+      }
+    },
+    "ruleAllowlist": {
+      "description": "An allowlist for commits, paths, regexes, or stopwords.",
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["commits"],
+          "properties": {
+            "commits": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["paths"],
+          "properties": {
+            "paths": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["regexes"],
+          "properties": {
+            "regexes": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["stopwords"],
+          "properties": {
+            "stopwords": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable allowlist description.",
+          "type": "string"
+        },
+        "condition": {
+          "description": "Whether any criterion or all criteria must match.",
+          "type": "string",
+          "enum": ["AND", "OR", "and", "or", "&&", "||"]
+        },
+        "commits": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Commit SHAs to allow."
+        },
+        "paths": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Path regular expressions to allow."
+        },
+        "regexTarget": {
+          "description": "Finding field tested by regexes.",
+          "type": "string",
+          "enum": ["secret", "match", "line"]
+        },
+        "regexes": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Content regular expressions to allow."
+        },
+        "stopwords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Stopwords matched against the extracted secret."
+        }
+      }
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/schemas/json/lychee.json
+++ b/src/schemas/json/lychee.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/lychee.json",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "lychee configuration",
+  "description": "Configuration for lychee, the fast asynchronous link checker.\nhttps://lychee.cli.rs/guides/config/",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "files_from": {
+      "description": "Read input filenames from the given file or stdin if the path is '-'.",
+      "type": "string"
+    },
+    "verbose": {
+      "description": "Program log level.",
+      "type": "string",
+      "enum": ["error", "warn", "info", "debug", "trace"]
+    },
+    "no_progress": {
+      "description": "Do not show the interactive progress bar.",
+      "type": "boolean"
+    },
+    "host_stats": {
+      "description": "Show per-host statistics at the end of the run.",
+      "type": "boolean"
+    },
+    "extensions": {
+      "$ref": "#/definitions/stringArray",
+      "description": "File extensions to check."
+    },
+    "default_extension": {
+      "description": "File extension used to parse input sources without a recognized file type.",
+      "type": "string"
+    },
+    "cache": {
+      "description": "Enable link caching.",
+      "type": "boolean"
+    },
+    "max_cache_age": {
+      "description": "Discard cached requests older than this duration, such as '2d' or '12h'.",
+      "type": "string"
+    },
+    "cache_exclude_status": {
+      "$ref": "#/definitions/statusSelector",
+      "description": "Status codes or ranges ignored from the cache."
+    },
+    "dump": {
+      "description": "Extract links without checking them.",
+      "type": "boolean"
+    },
+    "dump_inputs": {
+      "description": "Dump inputs instead of extracting or checking links.",
+      "type": "boolean"
+    },
+    "archive": {
+      "description": "Web archive to use for suggestions.",
+      "type": "string",
+      "enum": ["wayback"]
+    },
+    "suggest": {
+      "description": "Suggest link replacements for broken links.",
+      "type": "boolean"
+    },
+    "max_redirects": {
+      "description": "Maximum number of allowed redirects.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "max_retries": {
+      "description": "Maximum number of retries per request.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "min_tls": {
+      "description": "Minimum accepted TLS version.",
+      "type": "string",
+      "enum": ["TLSv1_0", "TLSv1_1", "TLSv1_2", "TLSv1_3"]
+    },
+    "max_concurrency": {
+      "description": "Maximum number of concurrent network requests.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "host_concurrency": {
+      "description": "Default maximum concurrent requests per host.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "host_request_interval": {
+      "description": "Default minimum interval between requests to the same host, such as '50ms' or '1s'.",
+      "type": "string"
+    },
+    "threads": {
+      "description": "Number of threads to utilize.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "user_agent": {
+      "description": "User agent sent with each request.",
+      "type": "string"
+    },
+    "insecure": {
+      "description": "Proceed for server connections considered insecure.",
+      "type": "boolean"
+    },
+    "scheme": {
+      "$ref": "#/definitions/stringArray",
+      "description": "URL schemes to check, such as http, https, file, and mailto."
+    },
+    "offline": {
+      "description": "Only check local files and block network requests.",
+      "type": "boolean"
+    },
+    "include": {
+      "$ref": "#/definitions/stringArray",
+      "description": "URLs to check, with preference over excludes. Values are regular expressions."
+    },
+    "exclude": {
+      "$ref": "#/definitions/stringArray",
+      "description": "URLs and mail addresses excluded from checking. Values are regular expressions."
+    },
+    "exclude_path": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Paths excluded from checking. Values are regular expressions."
+    },
+    "exclude_all_private": {
+      "description": "Exclude all private, link-local, and loopback IP ranges.",
+      "type": "boolean"
+    },
+    "exclude_private": {
+      "description": "Exclude private IP address ranges.",
+      "type": "boolean"
+    },
+    "exclude_link_local": {
+      "description": "Exclude link-local IP address ranges.",
+      "type": "boolean"
+    },
+    "exclude_loopback": {
+      "description": "Exclude loopback IP address ranges and localhost.",
+      "type": "boolean"
+    },
+    "include_mail": {
+      "description": "Check email addresses.",
+      "type": "boolean"
+    },
+    "remap": {
+      "$ref": "#/definitions/stringArray",
+      "description": "URI remapping rules."
+    },
+    "fallback_extensions": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Fallback extensions to apply when a URL does not specify one."
+    },
+    "index_files": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Index file names used to resolve directory links."
+    },
+    "header": {
+      "$ref": "#/definitions/stringMap",
+      "description": "Custom request headers applied to all requests."
+    },
+    "accept": {
+      "$ref": "#/definitions/statusSelector",
+      "description": "Accepted status codes or ranges for valid links."
+    },
+    "accept_timeouts": {
+      "description": "Accept timed out requests.",
+      "type": "boolean"
+    },
+    "include_fragments": {
+      "description": "Fragment checking mode.",
+      "type": "string",
+      "enum": ["none", "anchor-only", "text-only", "full"]
+    },
+    "timeout": {
+      "description": "Website timeout in seconds from connect to response finished.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "retry_wait_time": {
+      "description": "Minimum wait time in seconds between retries.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "method": {
+      "$ref": "#/definitions/methods",
+      "description": "Request method or ordered list of fallback methods."
+    },
+    "base_url": {
+      "description": "Base URL or absolute path used to resolve relative URLs in local files.",
+      "type": "string"
+    },
+    "root_dir": {
+      "description": "Root directory used when checking absolute local links.",
+      "type": "string"
+    },
+    "basic_auth": {
+      "$ref": "#/definitions/stringArray",
+      "description": "HTTP basic auth selectors in the form 'example.com user:password'."
+    },
+    "github_token": {
+      "description": "GitHub API token used to avoid rate limiting on github.com links.",
+      "type": "string"
+    },
+    "skip_missing": {
+      "description": "Skip missing input files.",
+      "type": "boolean"
+    },
+    "no_ignore": {
+      "description": "Do not skip files ignored by ignore files.",
+      "type": "boolean"
+    },
+    "hidden": {
+      "description": "Do not skip hidden directories and files.",
+      "type": "boolean"
+    },
+    "include_verbatim": {
+      "description": "Check links inside code and preformatted blocks.",
+      "type": "boolean"
+    },
+    "glob_ignore_case": {
+      "description": "Ignore case when expanding filesystem path glob inputs.",
+      "type": "boolean"
+    },
+    "output": {
+      "description": "Output file for the status report.",
+      "type": "string"
+    },
+    "mode": {
+      "description": "Output display mode.",
+      "type": "string",
+      "enum": ["plain", "color", "emoji", "task"]
+    },
+    "format": {
+      "description": "Output format for the final status report.",
+      "type": "string",
+      "enum": ["compact", "detailed", "json", "junit", "markdown"]
+    },
+    "generate": {
+      "description": "Generate special output instead of checking links.",
+      "type": "string",
+      "enum": [
+        "man",
+        "complete-bash",
+        "complete-elvish",
+        "complete-fish",
+        "complete-powershell",
+        "complete-zsh"
+      ]
+    },
+    "require_https": {
+      "description": "Treat HTTP links as errors when HTTPS is available.",
+      "type": "boolean"
+    },
+    "cookie_jar": {
+      "description": "File used to read and write cookies.",
+      "type": "string"
+    },
+    "include_wikilinks": {
+      "description": "Check WikiLinks in Markdown files.",
+      "type": "boolean"
+    },
+    "preprocess": {
+      "description": "Command used to preprocess input files.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "type": "string"
+        }
+      }
+    },
+    "hosts": {
+      "description": "Host-specific rate limiting and header overrides.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/hostConfig"
+      }
+    }
+  },
+  "definitions": {
+    "statusSelector": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 999
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 999
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "methods": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "hostConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "concurrency": {
+          "description": "Maximum concurrent requests allowed for this host.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "request_interval": {
+          "description": "Minimum interval between requests to this host.",
+          "type": "string"
+        },
+        "headers": {
+          "$ref": "#/definitions/stringMap",
+          "description": "Custom request headers for this host."
+        }
+      }
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/gitleaks/gitleaks.toml
+++ b/src/test/gitleaks/gitleaks.toml
@@ -1,0 +1,63 @@
+#:schema ../../schemas/json/gitleaks.json
+
+title = "gitleaks config"
+description = "Example Gitleaks configuration"
+minVersion = "v8.25.0"
+
+[extend]
+useDefault = true
+disabledRules = ["generic-api-key"]
+
+[[rules]]
+id = "awesome-rule-1"
+description = "awesome rule 1"
+regex = '''one-go-style-regex-for-this-rule'''
+secretGroup = 3
+entropy = 3.5
+path = '''a-file-path-regex'''
+keywords = ["auth", "password", "token"]
+tags = ["tag", "another tag"]
+
+[[rules.allowlists]]
+description = "ignore commit A"
+condition = "OR"
+commits = ["commit-A", "commit-B"]
+paths = ['''go\.mod''', '''go\.sum''']
+stopwords = ['''client''', '''endpoint''']
+
+[[rules.allowlists]]
+condition = "AND"
+regexTarget = "match"
+regexes = ['''(?i)parseur[il]''']
+paths = ['''package-lock\.json''']
+
+[[rules.required]]
+id = "auxiliary-rule"
+withinLines = 4
+withinColumns = 3
+
+[[rules]]
+id = "auxiliary-rule"
+description = "Auxiliary rule"
+regex = '''username\s*=\s*"([^"]+)"'''
+skipReport = true
+
+[[rules]]
+id = "gitlab-pat"
+
+[[rules.allowlists]]
+regexTarget = "line"
+regexes = ['''MY-glpat-''']
+
+[[allowlists]]
+description = "global allow list"
+commits = ["commit-A", "commit-B", "commit-C"]
+paths = ['''gitleaks\.toml''', '''(.*?)(jpg|gif|doc)''']
+regexTarget = "match"
+regexes = ['''219-09-9999''', '''078-05-1120''']
+stopwords = ['''client''', '''endpoint''']
+
+[[allowlists]]
+targetRules = ["awesome-rule-1", "auxiliary-rule"]
+description = "Test assets"
+paths = ['''tests/expected/._\.json$''']

--- a/src/test/lychee/lychee.toml
+++ b/src/test/lychee/lychee.toml
@@ -1,0 +1,71 @@
+#:schema ../../schemas/json/lychee.json
+
+verbose = "info"
+format = "detailed"
+mode = "emoji"
+no_progress = false
+output = ".config.dummy.report.md"
+host_stats = true
+dump = true
+dump_inputs = true
+
+cache = true
+max_cache_age = "2d"
+cache_exclude_status = "500.."
+
+cookie_jar = "cookie-jar"
+threads = 2
+max_redirects = 10
+max_retries = 2
+max_concurrency = 14
+default_extension = "md"
+github_token = "secret"
+index_files = ["index.html"]
+preprocess = { command = "preprocess.sh" }
+
+user_agent = "curl/7.83.1"
+timeout = 20
+retry_wait_time = 2
+accept = ["200", "429"]
+insecure = false
+scheme = ["https"]
+require_https = false
+method = ["head", "get"]
+header = { "accept" = "text/html", "x-custom-header" = "value" }
+remap = ["https://example.com http://example.invalid"]
+fallback_extensions = ["md", "html"]
+base_url = "https://example.com"
+root_dir = "/dist"
+basic_auth = ["example.com user:pwd"]
+include_fragments = "full"
+min_tls = "TLSv1_3"
+
+skip_missing = false
+hidden = true
+no_ignore = true
+include_verbatim = false
+glob_ignore_case = false
+exclude = ['^https://example\.com/home$', '^https?://example\.com']
+exclude_path = ["\\.txt$", "(^|/)test/"]
+extensions = ["md", "txt", "html"]
+include = ['gist\.github\.com.*']
+exclude_all_private = false
+exclude_private = false
+exclude_link_local = false
+exclude_loopback = false
+include_mail = true
+include_wikilinks = true
+offline = true
+
+files_from = "fixtures/empty-file.txt"
+generate = "man"
+archive = "wayback"
+suggest = true
+
+host_concurrency = 5
+host_request_interval = "50ms"
+
+[hosts."blog.example.com"]
+concurrency = 5
+request_interval = "0"
+headers = { "A" = "B" }


### PR DESCRIPTION
## Summary
- add a JSON Schema for lychee TOML configuration with Tombi TOML v1.0.0 metadata
- add a JSON Schema for Gitleaks TOML configuration with Tombi TOML v1.0.0 metadata
- register common lychee and Gitleaks config filenames in the SchemaStore catalog
- add positive and negative TOML fixtures for both schemas

## Validation
- `node ./cli.js check --schema-name=lychee.json`
- `node ./cli.js check --schema-name=gitleaks.json`
- validated `gitleaks.json` with Ajv + smol-toml against 60 local/upstream Gitleaks TOML files under `C:\Repos`, `F:\Repos`, and upstream `config/gitleaks.toml`
- checked local lychee TOML files under `C:\Repos` and `F:\Repos`; they intentionally fail the strict current lychee schema because they contain non-lychee metadata keys, removed `cache_file`, and the older boolean `include_fragments` value