### PR TITLE
Add Gitleaks config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3497,6 +3497,12 @@
       }
     },
     {
+      "name": "Gitleaks",
+      "description": "Gitleaks configuration file",
+      "fileMatch": ["gitleaks.toml", ".gitleaks.toml"],
+      "url": "https://www.schemastore.org/gitleaks.json"
+    },
+    {
       "name": "Gitea Issue Template configuration",
       "description": "YAML configuring Gitea Issue Templates",
       "fileMatch": [

--- a/src/negative_test/gitleaks/invalid-config.toml
+++ b/src/negative_test/gitleaks/invalid-config.toml
@@ -1,0 +1,27 @@
+#:schema ../../schemas/json/gitleaks.json
+
+[extend]
+path = "common_config.toml"
+useDefault = true
+
+[[rules]]
+description = "missing id"
+regex = '''secret'''
+secretGroup = -1
+entropy = -0.1
+skipReport = "yes"
+
+[[rules.allowlists]]
+regexTarget = "column"
+
+[rules.allowlist]
+paths = ['''deprecated-only''']
+
+[[allowlists]]
+condition = "XOR"
+
+[[allowlists]]
+targetRules = ["missing-criteria"]
+
+[allowlist]
+paths = ['''deprecated-only''']

--- a/src/schemas/json/gitleaks.json
+++ b/src/schemas/json/gitleaks.json
@@ -1,0 +1,338 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/gitleaks.json",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "Gitleaks configuration",
+  "description": "Configuration for Gitleaks secret detection rules and allowlists.\nhttps://github.com/gitleaks/gitleaks#configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "not": {
+    "description": "[allowlist] is deprecated and cannot be used alongside [[allowlists]].",
+    "required": ["allowlist", "allowlists"],
+    "properties": {
+      "allowlist": {},
+      "allowlists": {}
+    }
+  },
+  "properties": {
+    "$schema": {
+      "description": "Optional schema URL for editor integrations.",
+      "type": "string"
+    },
+    "title": {
+      "description": "Configuration title.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Configuration description.",
+      "type": "string"
+    },
+    "minVersion": {
+      "description": "Minimum Gitleaks version required to use this configuration.",
+      "type": "string"
+    },
+    "extend": {
+      "$ref": "#/definitions/extend"
+    },
+    "rules": {
+      "description": "Detection rules.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/rule"
+      }
+    },
+    "allowlist": {
+      "$ref": "#/definitions/globalAllowlist",
+      "description": "Deprecated global allowlist form. Prefer [[allowlists]]."
+    },
+    "allowlists": {
+      "description": "Global or targeted allowlists.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/globalAllowlist"
+      }
+    }
+  },
+  "definitions": {
+    "extend": {
+      "description": "Configuration inheritance options.",
+      "type": "object",
+      "additionalProperties": false,
+      "not": {
+        "description": "useDefault and path cannot be used at the same time.",
+        "required": ["path", "useDefault"],
+        "properties": {
+          "path": {},
+          "useDefault": {
+            "const": true
+          }
+        }
+      },
+      "properties": {
+        "path": {
+          "description": "Path to a configuration file to extend.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL to a configuration file to extend.",
+          "type": "string"
+        },
+        "useDefault": {
+          "description": "Extend the default Gitleaks configuration.",
+          "type": "boolean"
+        },
+        "disabledRules": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Inherited rule IDs to disable."
+        }
+      }
+    },
+    "rule": {
+      "description": "A detection rule.",
+      "type": "object",
+      "additionalProperties": false,
+      "not": {
+        "description": "[rules.allowlist] is deprecated and cannot be used alongside [[rules.allowlists]].",
+        "required": ["allowlist", "allowlists"],
+        "properties": {
+          "allowlist": {},
+          "allowlists": {}
+        }
+      },
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "description": "Unique rule identifier.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "description": "Human-readable rule description.",
+          "type": "string"
+        },
+        "regex": {
+          "description": "Go regular expression used to detect secrets.",
+          "type": "string"
+        },
+        "secretGroup": {
+          "description": "Regex capture group used as the secret and for entropy checks.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "entropy": {
+          "description": "Minimum Shannon entropy required for the configured secret group.",
+          "type": "number",
+          "minimum": 0
+        },
+        "path": {
+          "description": "Go regular expression used to match paths.",
+          "type": "string"
+        },
+        "keywords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Keywords used for pre-regex filtering."
+        },
+        "tags": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Metadata tags."
+        },
+        "skipReport": {
+          "description": "Do not include this rule in reports.",
+          "type": "boolean"
+        },
+        "allowlist": {
+          "$ref": "#/definitions/ruleAllowlist",
+          "description": "Deprecated rule allowlist form. Prefer [[rules.allowlists]]."
+        },
+        "allowlists": {
+          "description": "Rule-specific allowlists.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ruleAllowlist"
+          }
+        },
+        "required": {
+          "description": "Auxiliary rules required for a composite rule match.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/requiredRule"
+          }
+        }
+      }
+    },
+    "requiredRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "description": "Required rule ID.",
+          "type": "string",
+          "minLength": 1
+        },
+        "withinLines": {
+          "description": "Maximum line distance between the primary finding and required finding.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "withinColumns": {
+          "description": "Maximum column distance between the primary finding and required finding.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "globalAllowlist": {
+      "description": "A global or targeted allowlist for commits, paths, regexes, or stopwords.",
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["commits"],
+          "properties": {
+            "commits": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["paths"],
+          "properties": {
+            "paths": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["regexes"],
+          "properties": {
+            "regexes": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["stopwords"],
+          "properties": {
+            "stopwords": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "targetRules": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Rule IDs this common allowlist applies to."
+        },
+        "description": {
+          "description": "Human-readable allowlist description.",
+          "type": "string"
+        },
+        "condition": {
+          "description": "Whether any criterion or all criteria must match.",
+          "type": "string",
+          "enum": ["AND", "OR", "and", "or", "&&", "||"]
+        },
+        "commits": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Commit SHAs to allow."
+        },
+        "paths": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Path regular expressions to allow."
+        },
+        "regexTarget": {
+          "description": "Finding field tested by regexes.",
+          "type": "string",
+          "enum": ["secret", "match", "line"]
+        },
+        "regexes": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Content regular expressions to allow."
+        },
+        "stopwords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Stopwords matched against the extracted secret."
+        }
+      }
+    },
+    "ruleAllowlist": {
+      "description": "An allowlist for commits, paths, regexes, or stopwords.",
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["commits"],
+          "properties": {
+            "commits": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["paths"],
+          "properties": {
+            "paths": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["regexes"],
+          "properties": {
+            "regexes": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        },
+        {
+          "required": ["stopwords"],
+          "properties": {
+            "stopwords": {
+              "$ref": "#/definitions/stringArray"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable allowlist description.",
+          "type": "string"
+        },
+        "condition": {
+          "description": "Whether any criterion or all criteria must match.",
+          "type": "string",
+          "enum": ["AND", "OR", "and", "or", "&&", "||"]
+        },
+        "commits": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Commit SHAs to allow."
+        },
+        "paths": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Path regular expressions to allow."
+        },
+        "regexTarget": {
+          "description": "Finding field tested by regexes.",
+          "type": "string",
+          "enum": ["secret", "match", "line"]
+        },
+        "regexes": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Content regular expressions to allow."
+        },
+        "stopwords": {
+          "$ref": "#/definitions/stringArray",
+          "description": "Stopwords matched against the extracted secret."
+        }
+      }
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/gitleaks/gitleaks.toml
+++ b/src/test/gitleaks/gitleaks.toml
@@ -1,0 +1,63 @@
+#:schema ../../schemas/json/gitleaks.json
+
+title = "gitleaks config"
+description = "Example Gitleaks configuration"
+minVersion = "v8.25.0"
+
+[extend]
+useDefault = true
+disabledRules = ["generic-api-key"]
+
+[[rules]]
+id = "awesome-rule-1"
+description = "awesome rule 1"
+regex = '''one-go-style-regex-for-this-rule'''
+secretGroup = 3
+entropy = 3.5
+path = '''a-file-path-regex'''
+keywords = ["auth", "password", "token"]
+tags = ["tag", "another tag"]
+
+[[rules.allowlists]]
+description = "ignore commit A"
+condition = "OR"
+commits = ["commit-A", "commit-B"]
+paths = ['''go\.mod''', '''go\.sum''']
+stopwords = ['''client''', '''endpoint''']
+
+[[rules.allowlists]]
+condition = "AND"
+regexTarget = "match"
+regexes = ['''(?i)parseur[il]''']
+paths = ['''package-lock\.json''']
+
+[[rules.required]]
+id = "auxiliary-rule"
+withinLines = 4
+withinColumns = 3
+
+[[rules]]
+id = "auxiliary-rule"
+description = "Auxiliary rule"
+regex = '''username\s*=\s*"([^"]+)"'''
+skipReport = true
+
+[[rules]]
+id = "gitlab-pat"
+
+[[rules.allowlists]]
+regexTarget = "line"
+regexes = ['''MY-glpat-''']
+
+[[allowlists]]
+description = "global allow list"
+commits = ["commit-A", "commit-B", "commit-C"]
+paths = ['''gitleaks\.toml''', '''(.*?)(jpg|gif|doc)''']
+regexTarget = "match"
+regexes = ['''219-09-9999''', '''078-05-1120''']
+stopwords = ['''client''', '''endpoint''']
+
+[[allowlists]]
+targetRules = ["awesome-rule-1", "auxiliary-rule"]
+description = "Test assets"
+paths = ['''tests/expected/._\.json$''']


### PR DESCRIPTION
## Summary
- add a JSON Schema for Gitleaks TOML configuration
- register `gitleaks.toml` and `.gitleaks.toml` in the SchemaStore catalog
- add positive and negative TOML fixtures

## Notes
- The schema includes `x-tombi-toml-version: "v1.0.0"`.
- The schema covers extend config, rules, composite required rules, global/rule allowlists, deprecated singular allowlist forms, targeted allowlists, and current Gitleaks validation constraints that are practical in JSON Schema.

## Validation
- `node ./cli.js check --schema-name=gitleaks.json`
- validated with Ajv + smol-toml against 60 local/upstream Gitleaks TOML files under `C:\Repos`, `F:\Repos`, and upstream `config/gitleaks.toml`
- `git diff --check`