### PR TITLE
feat: add Feature Forge Flow Definition schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3243,6 +3243,12 @@
       "url": "https://www.schemastore.org/fabric.mod.json"
     },
     {
+      "name": "Feature Forge Flow Definition",
+      "description": "Feature Forge flow definition file — declares a slash command, orchestrator config, and named deterministic routines",
+      "fileMatch": ["**/src/flows/*/flow.json"],
+      "url": "https://raw.githubusercontent.com/misiekhardcore/feature-forge/main/src/flows/flow-schema.json"
+    },
+    {
       "name": "F-Droid Data metadata",
       "description": "F-Droid Data app metadata files",
       "fileMatch": ["**/metadata/*.yml"],


### PR DESCRIPTION
Adds a catalog entry for [Feature Forge](https://github.com/misiekhardcore/feature-forge) flow definition files.

**Schema URL**: `https://raw.githubusercontent.com/misiekhardcore/feature-forge/main/src/flows/flow-schema.json`
**File match**: `**/src/flows/*/flow.json`
**Schema spec**: JSON Schema draft 2020-12

The schema validates flow definition files used by the Feature Forge autonomous software engineering platform. Each flow file declares a slash command, orchestrator configuration, and named deterministic routines.