### PR TITLE
Add Nika workflow schema (*.nika.yaml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5096,6 +5096,12 @@
       "url": "https://www.schemastore.org/nodehawkrc.json"
     },
     {
+      "name": "Nika workflow",
+      "description": "Nika workflow language (*.nika.yaml) · the nika: v1 envelope, four verbs, stdlib builtins",
+      "fileMatch": ["*.nika.yaml", "*.nika.yml"],
+      "url": "https://raw.githubusercontent.com/supernovae-st/nika-spec/main/schemas/workflow.schema.json"
+    },
+    {
       "name": "nodemon.json",
       "description": "nodemon.json configuration files",
       "fileMatch": ["nodemon.json"],


### PR DESCRIPTION
Adds a remote catalog entry for the Nika workflow language.

- **What is Nika** · a YAML workflow language for AI workflows (`nika: v1` envelope · four verbs · a closed stdlib). Spec: [supernovae-st/nika-spec](https://github.com/supernovae-st/nika-spec) (Apache-2.0) · reference engine: [supernovae-st/nika](https://github.com/supernovae-st/nika) (Rust, AGPL-3.0, brew-installable).
- **fileMatch** · `*.nika.yaml` / `*.nika.yml` — specific extension, no generic-pattern collision.
- **Schema** · JSON Schema 2020-12, maintained in the spec repo alongside an 83-fixture conformance suite; the URL is the raw main-branch path (same pattern as the Serverless Workflow entry).
- The schema is already used in the wild via `yaml-language-server` modelines; this entry removes the per-file modeline need.