### PR TITLE
Add EMILIA action-risk manifest (externally hosted)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "EMILIA action-risk manifest",
+      "description": "Machine actions that require pre-execution human-authorization receipts, and their assurance tiers, consumed by EMILIA Gate and @emilia-protocol/require-receipt\nhttps://github.com/emiliaprotocol/emilia-protocol/tree/main/packages/gate",
+      "fileMatch": ["action-risk-manifest.json", "*.ep-manifest.json"],
+      "url": "https://www.emiliaprotocol.ai/schemas/ep-action-risk-manifest.schema.json"
+    },
+    {
       "name": "Specpin spec file",
       "description": "Specpin business-spec file (.specs/*.spec.json): rules, descriptions, and acceptance criteria pinned to UI elements",
       "fileMatch": ["**/.specs/*.spec.json"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4,7 +4,7 @@
   "schemas": [
     {
       "name": "EMILIA action-risk manifest",
-      "description": "Machine actions that require pre-execution human-authorization receipts, and their assurance tiers, consumed by EMILIA Gate and @emilia-protocol/require-receipt\nhttps://github.com/emiliaprotocol/emilia-protocol/tree/main/packages/gate",
+      "description": "Machine actions that require pre-execution human-authorization receipts, and their assurance tiers, consumed by EMILIA Gate and @emilia-protocol/require-receipt",
       "fileMatch": ["action-risk-manifest.json", "*.ep-manifest.json"],
       "url": "https://www.emiliaprotocol.ai/schemas/ep-action-risk-manifest.schema.json"
     },


### PR DESCRIPTION
Adds a catalog entry for the EMILIA action-risk manifest, following the self-hosted/remote/external instructions in CONTRIBUTING.

**What the file is:** `action-risk-manifest.json` declares which machine actions (AI-agent tool calls, deploys, payments) require a pre-execution human-authorization receipt and at which assurance tier. It is hand-authored by deployers of the Apache-2.0 [EMILIA Gate](https://github.com/emiliaprotocol/emilia-protocol/tree/main/packages/gate) policy-enforcement point, so editor validation/autocomplete is genuinely useful.

**Schema:** hosted at a stable URL on the project's domain (https://www.emiliaprotocol.ai/schemas/ep-action-risk-manifest.schema.json), draft-07, mirrors the runtime validator exactly. Verified with ajv: the project's reference manifest validates; a manifest with `receipt_required: true` but no `action_type` is rejected (matching the runtime).

**fileMatch:** `action-risk-manifest.json` (the documented filename, also used by the project's Helm chart mount) and `*.ep-manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)