### PR TITLE
Support custom wheel target options for hatchling

### DIFF
--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -637,9 +637,11 @@
           "default": false
         }
       },
-      "allOf": [{
-        "$ref": "#/definitions/Target"
-      }]
+      "allOf": [
+        {
+          "$ref": "#/definitions/Target"
+        }
+      ]
     },
     "BuildTargets": {
       "title": "BuildTargets",

--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -556,8 +556,93 @@
         }
       }
     },
-    "CustomTargets": {
-      "title": "CustomTargets",
+    "WheelTarget": {
+      "title": "WheelTarget",
+      "description": "Wheel build targets",
+      "x-taplo": {
+        "links": {
+          "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "core-metadata-version": {
+          "title": "Core metadata version",
+          "description": "The version of core metadata to use",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "string",
+          "default": "2.1"
+        },
+        "shared-data": {
+          "title": "Shared data",
+          "description": "A mapping similar to the forced inclusion option corresponding to data that will be installed globally in a given Python environment, usually under sys.prefix",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "extra-metadata": {
+          "title": "Extra metadata",
+          "description": "A mapping similar to the forced inclusion option corresponding to extra metadata that will be shipped in a directory named extra_metadata",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "strict-naming": {
+          "title": "Strict naming",
+          "description": "Whether or not file names should contain the normalized version of the project name",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "boolean",
+          "default": true
+        },
+        "macos-max-compat": {
+          "title": "Broad MacOS compatibility",
+          "description": "Whether or not on macOS, when build hooks have set the infer_tag build data, the wheel name should signal broad support rather than specific versions for newer SDK versions.",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "boolean",
+          "default": true
+        },
+        "broad-selection": {
+          "title": "Broad file selection",
+          "description": "Whether or not to suppress the error when one has not defined any file selection options and all heuristics have failed to determine what to ship",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration"
+            }
+          },
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "allOf": [{
+        "$ref": "#/definitions/Target"
+      }]
+    },
+    "BuildTargets": {
+      "title": "BuildTargets",
       "description": "Build targets",
       "x-taplo": {
         "links": {
@@ -565,6 +650,11 @@
         }
       },
       "type": "object",
+      "properties": {
+        "wheel": {
+          "$ref": "#/definitions/WheelTarget"
+        }
+      },
       "additionalProperties": {
         "$ref": "#/definitions/Target"
       },
@@ -751,7 +841,7 @@
           "type": "boolean"
         },
         "targets": {
-          "$ref": "#/definitions/CustomTargets"
+          "$ref": "#/definitions/BuildTargets"
         },
         "hooks": {
           "$ref": "#/definitions/BuildHooks"

--- a/src/test/hatch/wheel-no-strict-naming.toml
+++ b/src/test/hatch/wheel-no-strict-naming.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/hatch.json
+[build.targets.wheel]
+strict-naming = false

--- a/src/test/hatch/wheel-shared-data.toml
+++ b/src/test/hatch/wheel-shared-data.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/hatch.json
+[build.targets.wheel]
+shared-data = { "a" = "b" }


### PR DESCRIPTION
I noticed that some more obscure (but documented) options for [hatchling](https://hatch.pypa.io/1.9/config/build/) were not available. I added those for wheel build configuration from <https://hatch.pypa.io/1.9/plugins/builder/wheel/#configuration>.

Please let me know if anything is off; I have read the contribution guidelines but I have not submitted schemas here before.