### PR TITLE
Implement localized Web Manifest members

### DIFF
--- a/src/schemas/json/web-manifest-app-info.json
+++ b/src/schemas/json/web-manifest-app-info.json
@@ -1,5 +1,35 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "manifest_screenshot_resource": {
+      "allOf": [
+        {
+          "$ref": "web-manifest.json#/definitions/manifest_image_resource"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "description": "The label member is a string that serves as the accessible name of the screenshot.",
+              "type": "string"
+            },
+            "label_localized": {
+              "$ref": "web-manifest.json#/definitions/localized_text_map",
+              "description": "A language map containing localized values for the screenshot label."
+            },
+            "platform": {
+              "description": "The distribution platform for which the screenshot applies.",
+              "type": "string"
+            },
+            "form_factor": {
+              "description": "The screen shape of a broad class of devices for which the screenshot applies.",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  },
   "id": "https://json.schemastore.org/web-manifest-app-info.json",
   "properties": {
     "categories": {
@@ -13,6 +43,10 @@
       "description": "Description of the purpose of the web application",
       "type": "string"
     },
+    "description_localized": {
+      "$ref": "web-manifest.json#/definitions/localized_text_map",
+      "description": "A language map containing localized values for the web application description."
+    },
     "iarc_rating_id": {
       "description": "Represents an ID value of the IARC rating of the web application. It is intended to be used to determine which ages the web application is appropriate for.",
       "type": "string"
@@ -21,7 +55,7 @@
       "description": "The screenshots member is an array of image objects represent the web application in common usage scenarios.",
       "type": "array",
       "items": {
-        "$ref": "web-manifest.json#/definitions/manifest_image_resource"
+        "$ref": "#/definitions/manifest_screenshot_resource"
       }
     }
   },

--- a/src/schemas/json/web-manifest.json
+++ b/src/schemas/json/web-manifest.json
@@ -49,6 +49,52 @@
       },
       "required": ["src"]
     },
+    "localized_text_object": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The localized string.",
+          "type": "string"
+        },
+        "dir": {
+          "description": "The text direction for the localized string.",
+          "enum": ["ltr", "rtl", "auto"]
+        },
+        "lang": {
+          "description": "A language tag for the localized string.",
+          "type": "string"
+        }
+      },
+      "required": ["value"]
+    },
+    "localized_text_value": {
+      "description": "A localized value for a text member. It may be a string or an object with value, dir, and lang members.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/localized_text_object"
+        }
+      ]
+    },
+    "localized_text_map": {
+      "description": "A language map whose keys are language tags and whose values are localized text values.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/localized_text_value"
+      }
+    },
+    "localized_image_resource_map": {
+      "description": "A language map whose keys are language tags and whose values are arrays of image resources.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/manifest_image_resource"
+        }
+      }
+    },
     "external_application_resource": {
       "type": "object",
       "properties": {
@@ -95,13 +141,25 @@
           "description": "The name member of a shortcut item is a string that represents the name of the shortcut as it is usually displayed to the user in a context menu.",
           "type": "string"
         },
+        "name_localized": {
+          "$ref": "#/definitions/localized_text_map",
+          "description": "A language map containing localized values for the shortcut name."
+        },
         "short_name": {
           "description": "The short_name member of a shortcut item is a string that represents a short version of the name of the shortcut. It is intended to be used where there is insufficient space to display the full name of the shortcut.",
           "type": "string"
         },
+        "short_name_localized": {
+          "$ref": "#/definitions/localized_text_map",
+          "description": "A language map containing localized values for the shortcut short_name."
+        },
         "description": {
           "description": "The description member of a shortcut item is a string that allows the developer to describe the purpose of the shortcut.",
           "type": "string"
+        },
+        "description_localized": {
+          "$ref": "#/definitions/localized_text_map",
+          "description": "A language map containing localized values for the shortcut description."
         },
         "url": {
           "description": "The url member of a shortcut item is a URL within scope of a processed manifest that opens when the associated shortcut is activated.",
@@ -113,6 +171,10 @@
           "items": {
             "$ref": "#/definitions/manifest_image_resource"
           }
+        },
+        "icons_localized": {
+          "$ref": "#/definitions/localized_image_resource_map",
+          "description": "A language map containing localized icon resources for the shortcut."
         }
       },
       "required": ["name", "url"]
@@ -141,6 +203,10 @@
         "$ref": "#/definitions/manifest_image_resource"
       }
     },
+    "icons_localized": {
+      "$ref": "#/definitions/localized_image_resource_map",
+      "description": "A language map containing localized icon resources for the web application."
+    },
     "lang": {
       "description": "The primary language for the values of the manifest.",
       "type": "string"
@@ -148,6 +214,10 @@
     "name": {
       "description": "The name of the web application.",
       "type": "string"
+    },
+    "name_localized": {
+      "$ref": "#/definitions/localized_text_map",
+      "description": "A language map containing localized values for the web application name."
     },
     "orientation": {
       "description": "The orientation member is a string that serves as the default orientation for all  top-level browsing contexts of the web application.",
@@ -204,6 +274,10 @@
     "short_name": {
       "description": "A string that represents a short version of the name of the web application.",
       "type": "string"
+    },
+    "short_name_localized": {
+      "$ref": "#/definitions/localized_text_map",
+      "description": "A language map containing localized values for the web application short_name."
     },
     "shortcuts": {
       "description": "Array of shortcut items that provide access to key tasks within a web application.",

--- a/src/test/web-manifest-app-info/Localized members.json
+++ b/src/test/web-manifest-app-info/Localized members.json
@@ -1,0 +1,22 @@
+{
+  "description": "A precise color tool.",
+  "description_localized": {
+    "de": {
+      "lang": "de-DE",
+      "value": "Ein Farbwerkzeug."
+    },
+    "fr": "Un outil de couleur precis."
+  },
+  "screenshots": [
+    {
+      "form_factor": "wide",
+      "label": "Palette view",
+      "label_localized": {
+        "fr": "Vue palette"
+      },
+      "platform": "windows",
+      "sizes": "1280x720",
+      "src": "screenshots/palette-en.png"
+    }
+  ]
+}

--- a/src/test/web-manifest/Localized members.json
+++ b/src/test/web-manifest/Localized members.json
@@ -1,0 +1,70 @@
+{
+  "dir": "ltr",
+  "icons": [
+    {
+      "sizes": "64x64",
+      "src": "icons/en.png"
+    }
+  ],
+  "icons_localized": {
+    "fr": [
+      {
+        "sizes": "64x64",
+        "src": "icons/fr.png"
+      }
+    ]
+  },
+  "lang": "en-US",
+  "name": "Color Picker",
+  "name_localized": {
+    "de": "Farbwaehler",
+    "en-GB": {
+      "dir": "ltr",
+      "value": "Colour Picker"
+    },
+    "fr": {
+      "lang": "fr-CA",
+      "value": "Selecteur de Couleur"
+    }
+  },
+  "short_name": "Picker",
+  "short_name_localized": {
+    "de": {
+      "lang": "de",
+      "value": "Picker"
+    }
+  },
+  "shortcuts": [
+    {
+      "description": "Open a saved color palette.",
+      "description_localized": {
+        "fr": "Ouvrir une palette de couleurs."
+      },
+      "icons": [
+        {
+          "sizes": "48x48",
+          "src": "icons/palette.png"
+        }
+      ],
+      "icons_localized": {
+        "fr": [
+          {
+            "sizes": "48x48",
+            "src": "icons/palette-fr.png"
+          }
+        ]
+      },
+      "name": "Open palette",
+      "name_localized": {
+        "fr": "Ouvrir la palette"
+      },
+      "short_name": "Palette",
+      "short_name_localized": {
+        "fr": {
+          "value": "Palette"
+        }
+      },
+      "url": "/palette"
+    }
+  ]
+}


### PR DESCRIPTION
Implement additional Web Manifest `*_localized` members, following the addition to the official W3C spec:

- https://developer.chrome.com/blog/manifest-localization
- https://www.w3.org/TR/appmanifest/#x_localized-members

