### PR TITLE
Add hassette.toml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3975,6 +3975,12 @@
       "url": "https://hazelcast.com/schema/config/hazelcast-config-5.7.json"
     },
     {
+      "name": "hassette.toml",
+      "description": "Configuration file for Hassette, an async Python framework for Home Assistant automations",
+      "fileMatch": ["hassette.toml"],
+      "url": "https://raw.githubusercontent.com/NodeJSmith/hassette/main/hassette.schema.json"
+    },
+    {
       "name": "Home Assistant Integration Manifest",
       "description": "Home Assistant integration manifest file. Documentation: https://developers.home-assistant.io/docs/creating_integration_manifest/",
       "fileMatch": [


### PR DESCRIPTION
Add a catalog entry for [hassette.toml](https://github.com/NodeJSmith/hassette), the configuration file for [Hassette](https://hassette.readthedocs.io/) — an async Python framework for building Home Assistant automations.

The schema is hosted in the hassette repository at [`hassette.schema.json`](https://raw.githubusercontent.com/NodeJSmith/hassette/main/hassette.schema.json), generated from the Pydantic settings model that backs the configuration. CI enforces schema freshness on every PR, so the external URL always serves the current version.

`fileMatch` is `["hassette.toml"]` — a single, project-specific filename with no risk of false positives.