### PR TITLE
Add missing permissions to youtrack-app.json schema

### DIFF
--- a/src/schemas/json/youtrack-app.json
+++ b/src/schemas/json/youtrack-app.json
@@ -107,6 +107,7 @@
         "SHARE_WATCH_FOLDER",
         "READ_WORK_ITEM",
         "UPDATE_WORK_ITEM",
+        "CREATE_WORK_ITEM",
         "CREATE_NOT_OWN_WORK_ITEM",
         "UPDATE_NOT_OWN_WORK_ITEM"
       ]


### PR DESCRIPTION
## Summary
- Add missing `CREATE_WORK_ITEM` permission to the YouTrack app manifest JSON schema's permissions enum
- The other permissions from [JT-95511](https://youtrack.jetbrains.com/issue/JT-95511) were already added in #5590; this PR adds the one that was missed

Resolves: [JT-95511](https://youtrack.jetbrains.com/issue/JT-95511)