### PR TITLE
fix(youtrack-app): drop trailing colon from permissions property name

### DIFF
--- a/src/negative_test/youtrack-app/empty-permissions-list.json
+++ b/src/negative_test/youtrack-app/empty-permissions-list.json
@@ -6,7 +6,7 @@
       "indexPath": "index.html",
       "key": "test",
       "name": "test",
-      "permissions:": []
+      "permissions": []
     }
   ]
 }

--- a/src/schemas/json/youtrack-app.json
+++ b/src/schemas/json/youtrack-app.json
@@ -245,7 +245,7 @@
             "$ref": "#/definitions/icon",
             "description": "The relative path to the file with the icon for the widget inside the app package."
           },
-          "permissions:": {
+          "permissions": {
             "type": "array",
             "minItems": 1,
             "uniqueItems": true,


### PR DESCRIPTION
## Summary
- Fix typo in widget `permissions` property name: `"permissions:"` → `"permissions"`
- The trailing colon caused the schema to not match the actual YouTrack app manifest format
- Also fixes the same typo in the negative test file

Fixes: [JT-95513](https://youtrack.jetbrains.com/issue/JT-95513)