### PR TITLE
Add lsd configuration schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1035,6 +1035,24 @@
       "url": "https://www.schemastore.org/loki.json"
     },
     {
+      "name": "lsd config",
+      "description": "Configuration for lsd, the next-generation ls command",
+      "fileMatch": ["**/.config/lsd/config.yaml"],
+      "url": "https://www.schemastore.org/lsd-config.json"
+    },
+    {
+      "name": "lsd colors",
+      "description": "Color theme configuration for lsd",
+      "fileMatch": ["**/.config/lsd/colors.yaml"],
+      "url": "https://www.schemastore.org/lsd-colors.json"
+    },
+    {
+      "name": "lsd icons",
+      "description": "Icon theme configuration for lsd",
+      "fileMatch": ["**/.config/lsd/icons.yaml"],
+      "url": "https://www.schemastore.org/lsd-icons.json"
+    },
+    {
       "name": "Azure Pipelines",
       "description": "Azure Pipelines YAML pipelines definition",
       "fileMatch": ["azure-pipelines.yml", "azure-pipelines.yaml"],

--- a/src/negative_test/lsd-colors/invalid-color.yaml
+++ b/src/negative_test/lsd-colors/invalid-color.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-colors.json
+
+user: 300

--- a/src/negative_test/lsd-config/invalid-block.yaml
+++ b/src/negative_test/lsd-config/invalid-block.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-config.json
+
+blocks:
+  - owner

--- a/src/negative_test/lsd-icons/unknown-filetype.yaml
+++ b/src/negative_test/lsd-icons/unknown-filetype.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-icons.json
+
+filetype:
+  directory: D

--- a/src/schemas/json/lsd-colors.json
+++ b/src/schemas/json/lsd-colors.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/lsd-colors.json",
+  "$comment": "Sources: https://github.com/lsd-rs/lsd#customizing-lsd-configuration-and-theming and https://github.com/lsd-rs/lsd/blob/main/src/theme/color.rs",
+  "title": "lsd colors.yaml",
+  "description": "Color theme configuration for lsd.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "user": {
+      "$ref": "#/definitions/color"
+    },
+    "group": {
+      "$ref": "#/definitions/color"
+    },
+    "permission": {
+      "$ref": "#/definitions/permission"
+    },
+    "attributes": {
+      "$ref": "#/definitions/attributes"
+    },
+    "date": {
+      "$ref": "#/definitions/date"
+    },
+    "size": {
+      "$ref": "#/definitions/size"
+    },
+    "inode": {
+      "$ref": "#/definitions/validInvalid"
+    },
+    "links": {
+      "$ref": "#/definitions/validInvalid"
+    },
+    "tree-edge": {
+      "$ref": "#/definitions/color"
+    },
+    "git-status": {
+      "$ref": "#/definitions/gitStatus"
+    }
+  },
+  "definitions": {
+    "color": {
+      "description": "A crossterm color name, hex RGB string, xterm 0-255 color index, or RGB triplet.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
+        }
+      ]
+    },
+    "nullableColor": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/color"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "permission": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "read": {
+          "$ref": "#/definitions/color"
+        },
+        "write": {
+          "$ref": "#/definitions/color"
+        },
+        "exec": {
+          "$ref": "#/definitions/color"
+        },
+        "exec-sticky": {
+          "$ref": "#/definitions/color"
+        },
+        "no-access": {
+          "$ref": "#/definitions/color"
+        },
+        "octal": {
+          "$ref": "#/definitions/color"
+        },
+        "acl": {
+          "$ref": "#/definitions/color"
+        },
+        "context": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "archive": {
+          "$ref": "#/definitions/color"
+        },
+        "read": {
+          "$ref": "#/definitions/color"
+        },
+        "hidden": {
+          "$ref": "#/definitions/color"
+        },
+        "system": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    },
+    "date": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hour-old": {
+          "$ref": "#/definitions/nullableColor"
+        },
+        "day-old": {
+          "$ref": "#/definitions/nullableColor"
+        },
+        "older": {
+          "$ref": "#/definitions/color"
+        },
+        "relative": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/timeColor"
+          }
+        },
+        "absolute": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/timeColor"
+          }
+        }
+      }
+    },
+    "timeColor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["threshold", "color"],
+      "properties": {
+        "threshold": {
+          "description": "Time threshold understood by lsd.",
+          "type": "string"
+        },
+        "color": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    },
+    "size": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "none": {
+          "$ref": "#/definitions/color"
+        },
+        "small": {
+          "$ref": "#/definitions/color"
+        },
+        "medium": {
+          "$ref": "#/definitions/color"
+        },
+        "large": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    },
+    "validInvalid": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "valid": {
+          "$ref": "#/definitions/color"
+        },
+        "invalid": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    },
+    "gitStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/color"
+        },
+        "unmodified": {
+          "$ref": "#/definitions/color"
+        },
+        "ignored": {
+          "$ref": "#/definitions/color"
+        },
+        "new-in-index": {
+          "$ref": "#/definitions/color"
+        },
+        "new-in-workdir": {
+          "$ref": "#/definitions/color"
+        },
+        "typechange": {
+          "$ref": "#/definitions/color"
+        },
+        "deleted": {
+          "$ref": "#/definitions/color"
+        },
+        "renamed": {
+          "$ref": "#/definitions/color"
+        },
+        "modified": {
+          "$ref": "#/definitions/color"
+        },
+        "conflicted": {
+          "$ref": "#/definitions/color"
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/json/lsd-config.json
+++ b/src/schemas/json/lsd-config.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/lsd-config.json",
+  "$comment": "Sources: https://github.com/lsd-rs/lsd#customizing-lsd-configuration-and-theming and https://github.com/lsd-rs/lsd/blob/main/src/config_file.rs",
+  "title": "lsd config.yaml",
+  "description": "Configuration for lsd, the next-generation ls command.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "classic": {
+      "description": "Use classic ls-compatible output defaults.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "blocks": {
+      "description": "Columns and their order when using the long or tree layout.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "permission",
+              "user",
+              "group",
+              "context",
+              "size",
+              "size_value",
+              "date",
+              "name",
+              "inode",
+              "links",
+              "git"
+            ]
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "color": {
+      "description": "Color output settings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "when": {
+              "description": "When to colorize output.",
+              "enum": ["never", "auto", "always", null],
+              "default": "auto"
+            },
+            "theme": {
+              "description": "How to colorize output. Use `custom` to load colors.yaml, `default` for the built-in theme, or a custom theme file path supported by lsd.",
+              "type": ["string", "null"],
+              "default": "default"
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "date": {
+      "description": "Date display format. Built-in values include `date`, `locale`, and `relative`; strftime-style custom formats start with `+`.",
+      "type": ["string", "null"],
+      "default": "date"
+    },
+    "dereference": {
+      "description": "Dereference symbolic links.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "display": {
+      "description": "Which filesystem entries to display.",
+      "enum": [
+        "system-protected",
+        "all",
+        "almost-all",
+        "directory-only",
+        "visible-only",
+        null
+      ]
+    },
+    "icons": {
+      "description": "Icon output settings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "when": {
+              "description": "When to show icons.",
+              "enum": ["always", "auto", "never", null],
+              "default": "auto"
+            },
+            "theme": {
+              "description": "Icon theme to use.",
+              "enum": ["fancy", "unicode", null],
+              "default": "fancy"
+            },
+            "separator": {
+              "description": "Separator between icon and filename.",
+              "type": ["string", "null"],
+              "default": " "
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ignore-globs": {
+      "description": "Glob patterns to ignore when listing.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "indicators": {
+      "description": "Add indicator characters to certain listed files.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "layout": {
+      "description": "Output layout.",
+      "enum": ["grid", "tree", "oneline", null],
+      "default": "grid"
+    },
+    "recursion": {
+      "description": "Recursive listing settings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enable recursion.",
+              "type": ["boolean", "null"],
+              "default": false
+            },
+            "depth": {
+              "description": "Maximum recursion depth.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "size": {
+      "description": "File size display format.",
+      "enum": ["default", "short", "bytes", null],
+      "default": "default"
+    },
+    "permission": {
+      "description": "Permission column format.",
+      "enum": ["rwx", "octal", "attributes", "disable", null]
+    },
+    "sorting": {
+      "description": "Sort settings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "column": {
+              "description": "Column to sort by.",
+              "enum": [
+                "none",
+                "extension",
+                "name",
+                "time",
+                "size",
+                "version",
+                "git-status",
+                null
+              ],
+              "default": "name"
+            },
+            "reverse": {
+              "description": "Reverse sort order.",
+              "type": ["boolean", "null"],
+              "default": false
+            },
+            "dir-grouping": {
+              "description": "Where to group directories.",
+              "enum": ["first", "last", "none", null],
+              "default": "none"
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "no-symlink": {
+      "description": "Omit showing symlink targets.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "total-size": {
+      "description": "Display total directory sizes.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "symlink-arrow": {
+      "description": "Text shown between symlink and target.",
+      "type": ["string", "null"],
+      "default": "⇒"
+    },
+    "hyperlink": {
+      "description": "When to attach hyperlinks to filenames.",
+      "enum": ["always", "auto", "never", null],
+      "default": "never"
+    },
+    "header": {
+      "description": "Display block headers.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "literal": {
+      "description": "Show quotes on filenames.",
+      "type": ["boolean", "null"],
+      "default": false
+    },
+    "truncate-owner": {
+      "description": "Username and group-name truncation settings.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "after": {
+              "description": "Number of characters to keep before truncating owner or group names.",
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
+            "marker": {
+              "description": "String appended to truncated owner or group names.",
+              "type": ["string", "null"],
+              "default": ""
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/src/schemas/json/lsd-icons.json
+++ b/src/schemas/json/lsd-icons.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/lsd-icons.json",
+  "$comment": "Sources: https://github.com/lsd-rs/lsd#customizing-lsd-configuration-and-theming and https://github.com/lsd-rs/lsd/blob/main/src/theme/icon.rs",
+  "title": "lsd icons.yaml",
+  "description": "Icon theme configuration for lsd.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/iconMap",
+      "description": "Icon overrides keyed by file or directory name."
+    },
+    "extension": {
+      "$ref": "#/definitions/iconMap",
+      "description": "Icon overrides keyed by file extension."
+    },
+    "filetype": {
+      "description": "Icon overrides keyed by filesystem entry type.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dir": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        },
+        "pipe": {
+          "type": "string"
+        },
+        "socket": {
+          "type": "string"
+        },
+        "executable": {
+          "type": "string"
+        },
+        "device-char": {
+          "type": "string"
+        },
+        "device-block": {
+          "type": "string"
+        },
+        "special": {
+          "type": "string"
+        },
+        "symlink-dir": {
+          "type": "string"
+        },
+        "symlink-file": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "iconMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/lsd-colors/colors.yaml
+++ b/src/test/lsd-colors/colors.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-colors.json
+
+user: 159
+group: 231
+permission:
+  read: dark_green
+  write: dark_yellow
+  exec: dark_red
+  exec-sticky: 5
+  no-access: 245
+  octal: 6
+  acl: dark_cyan
+  context: cyan
+attributes:
+  archive: dark_green
+  read: dark_yellow
+  hidden: 13
+  system: [255, 0, 127]
+date:
+  hour-old: 146
+  day-old: 103
+  older: '#44475a'
+  relative:
+    - threshold: 1h
+      color: 40
+  absolute:
+    - threshold: '%Y-%m-%d'
+      color: blue
+size:
+  none: 60
+  small: 120
+  medium: 215
+  large: 210
+inode:
+  valid: 231
+  invalid: 210
+links:
+  valid: 159
+  invalid: 210
+tree-edge: 183
+git-status:
+  default: 103
+  unmodified: 103
+  ignored: 60
+  new-in-index: 120
+  new-in-workdir: 159
+  typechange: 215
+  deleted: 210
+  renamed: 183
+  modified: 215
+  conflicted: 212

--- a/src/test/lsd-config/config.yaml
+++ b/src/test/lsd-config/config.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-config.json
+
+classic: false
+blocks:
+  - permission
+  - name
+  - size
+  - date
+  - git
+color:
+  when: auto
+  theme: custom
+date: date
+dereference: false
+display: visible-only
+icons:
+  when: auto
+  theme: fancy
+  separator: ' '
+ignore-globs:
+  - .git
+  - node_modules
+indicators: true
+layout: grid
+recursion:
+  enabled: false
+  depth: 2
+size: short
+permission: attributes
+sorting:
+  column: name
+  reverse: false
+  dir-grouping: last
+no-symlink: false
+total-size: false
+hyperlink: auto
+symlink-arrow: '->'
+header: true
+literal: true
+truncate-owner:
+  after: 24
+  marker: '...'

--- a/src/test/lsd-icons/icons.yaml
+++ b/src/test/lsd-icons/icons.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../schemas/json/lsd-icons.json
+
+filetype:
+  dir: D
+  file: F
+  pipe: P
+  socket: S
+  executable: E
+  symlink-dir: L
+  symlink-file: l
+  device-char: C
+  device-block: B
+  special: X
+name:
+  cargo.toml: R
+  .gitignore: G
+extension:
+  rs: R
+  json: J


### PR DESCRIPTION
## Summary
- add separate schemas for lsd config.yaml, colors.yaml, and icons.yaml
- register each schema with fileMatch scoped to **/.config/lsd/<file>.yaml
- add positive and negative YAML fixtures for all three schemas

## Validation
- node ./cli.js check --schema-name=lsd-config.json
- node ./cli.js check --schema-name=lsd-colors.json
- node ./cli.js check --schema-name=lsd-icons.json
- validated local C:/Users/Nick/.config/lsd/config.yaml, colors.yaml, and icons.yaml with Ajv/js-yaml against the new schemas