### PR TITLE
Add ATTW configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -523,6 +523,12 @@
       "url": "https://www.schemastore.org/artifacthub-repo.json"
     },
     {
+      "name": "Are The Types Wrong?",
+      "description": "Configuration for the Are The Types Wrong? CLI",
+      "fileMatch": [".attw.json"],
+      "url": "https://www.schemastore.org/attw.json"
+    },
+    {
       "name": "asm-lsp",
       "description": "Configuration file for asm-lsp",
       "fileMatch": [".asm-lsp.toml", "asm-lsp.toml"],

--- a/src/negative_test/attw/incompatible-source.json
+++ b/src/negative_test/attw/incompatible-source.json
@@ -1,0 +1,4 @@
+{
+  "fromNpm": true,
+  "pack": true
+}

--- a/src/negative_test/attw/invalid-ignore-resolution.json
+++ b/src/negative_test/attw/invalid-ignore-resolution.json
@@ -1,0 +1,3 @@
+{
+  "ignoreResolutions": ["deno"]
+}

--- a/src/negative_test/attw/invalid-profile.json
+++ b/src/negative_test/attw/invalid-profile.json
@@ -1,0 +1,3 @@
+{
+  "profile": "browser"
+}

--- a/src/schemas/json/attw.json
+++ b/src/schemas/json/attw.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/attw.json",
-  "$comment": "Sources: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/README.md and https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/index.ts",
+  "$comment": "Sources: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/README.md, https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/index.ts, and https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/render/index.ts",
   "title": "attw configuration",
   "description": "Configuration for the Are The Types Wrong? CLI.",
   "type": "object",
@@ -56,7 +56,6 @@
     "ignoreRules": {
       "description": "Rules or problems to ignore.",
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "type": "string",
         "enum": [
@@ -76,6 +75,15 @@
       },
       "default": []
     },
+    "ignoreResolutions": {
+      "description": "UNDOCUMENTED. Legacy config-only list of module resolution modes to ignore. These values are combined with the modes ignored by the selected profile.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["node10", "node16-cjs", "node16-esm", "bundler"]
+      },
+      "default": []
+    },
     "profile": {
       "description": "Analysis profile.",
       "enum": ["strict", "node16", "esm-only"],
@@ -92,6 +100,17 @@
     "color": {
       "description": "Print output with colors.",
       "type": "boolean"
+    }
+  },
+  "not": {
+    "required": ["pack", "fromNpm"],
+    "properties": {
+      "pack": {
+        "const": true
+      },
+      "fromNpm": {
+        "const": true
+      }
     }
   },
   "definitions": {

--- a/src/schemas/json/attw.json
+++ b/src/schemas/json/attw.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/attw.json",
+  "$comment": "Sources: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/README.md and https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/index.ts",
+  "title": "attw configuration",
+  "description": "Configuration for the Are The Types Wrong? CLI.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "pack": {
+      "description": "Run npm pack in the specified directory and delete the resulting tarball afterwards.",
+      "type": "boolean"
+    },
+    "fromNpm": {
+      "description": "Read from the npm registry instead of a local file.",
+      "type": "boolean"
+    },
+    "definitelyTyped": {
+      "description": "Whether to include DefinitelyTyped types, or the version/range/path of the @types package to use.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        }
+      ],
+      "default": true
+    },
+    "format": {
+      "description": "Output format.",
+      "enum": ["auto", "table", "table-flipped", "ascii", "json"],
+      "default": "auto"
+    },
+    "quiet": {
+      "description": "Do not print anything to STDOUT.",
+      "type": "boolean"
+    },
+    "entrypoints": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Exhaustive list of entrypoints to check. Specifying this disables automatic entrypoint discovery and overrides includeEntrypoints and excludeEntrypoints."
+    },
+    "includeEntrypoints": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Entrypoints to check in addition to automatically discovered ones."
+    },
+    "excludeEntrypoints": {
+      "$ref": "#/definitions/stringArray",
+      "description": "Entrypoints to exclude from checking."
+    },
+    "entrypointsLegacy": {
+      "description": "In packages without exports, consider every published code file as an entrypoint when no entrypoints are otherwise detected or configured.",
+      "type": "boolean"
+    },
+    "ignoreRules": {
+      "description": "Rules or problems to ignore.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "no-resolution",
+          "untyped-resolution",
+          "false-cjs",
+          "false-esm",
+          "cjs-resolves-to-esm",
+          "fallback-condition",
+          "cjs-only-exports-default",
+          "named-exports",
+          "false-export-default",
+          "missing-export-equals",
+          "unexpected-module-syntax",
+          "internal-resolution-error"
+        ]
+      },
+      "default": []
+    },
+    "profile": {
+      "description": "Analysis profile.",
+      "enum": ["strict", "node16", "esm-only"],
+      "default": "strict"
+    },
+    "summary": {
+      "description": "Print summary information about the different errors.",
+      "type": "boolean"
+    },
+    "emoji": {
+      "description": "Print information with emojis.",
+      "type": "boolean"
+    },
+    "color": {
+      "description": "Print output with colors.",
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/src/test/attw/config.json
+++ b/src/test/attw/config.json
@@ -4,6 +4,7 @@
   "emoji": true,
   "entrypoints": ["."],
   "format": "json",
+  "ignoreResolutions": ["node10"],
   "ignoreRules": ["cjs-only-exports-default"],
   "pack": true,
   "profile": "esm-only",

--- a/src/test/attw/config.json
+++ b/src/test/attw/config.json
@@ -1,0 +1,11 @@
+{
+  "color": true,
+  "definitelyTyped": false,
+  "emoji": true,
+  "entrypoints": ["."],
+  "format": "json",
+  "ignoreRules": ["cjs-only-exports-default"],
+  "pack": true,
+  "profile": "esm-only",
+  "summary": false
+}

--- a/src/test/attw/npm-config.json
+++ b/src/test/attw/npm-config.json
@@ -1,0 +1,10 @@
+{
+  "entrypointsLegacy": true,
+  "excludeEntrypoints": ["./legacy"],
+  "format": "auto",
+  "fromNpm": true,
+  "includeEntrypoints": ["./browser"],
+  "pack": false,
+  "profile": "esm-only",
+  "quiet": true
+}


### PR DESCRIPTION
## Summary
- add a schema for ATTW `.attw.json` configuration
- model every supported camelCase CLI-backed option
- include the undocumented but operational `ignoreResolutions` config-only property
- reject the runtime-invalid `pack: true` plus `fromNpm: true` combination
- add positive and negative fixtures for the complete option surface

## Evidence
- https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/README.md
- https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/index.ts
- https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/readConfig.ts
- https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/packages/cli/src/render/index.ts

## Validation
- `node ./cli.js check --schema-name=attw.json`
- `npm run typecheck`
- `npm run eslint`
- `npm run prettier`
- SchemaStore PR audit: no warnings

The repository-wide `node ./cli.js check` currently reaches an unrelated Ajv stack overflow while compiling `cargo-lints-clippy.json`; the same failure reproduces with `node ./cli.js check --schema-name=cargo-lints-clippy.json`.