### PR TITLE
Add GitHub secret scanning schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3616,6 +3616,12 @@
       "url": "https://www.schemastore.org/github-pages-jekyll.json"
     },
     {
+      "name": "GitHub Secret Scanning",
+      "description": "YAML configuration for GitHub secret scanning exclusions",
+      "fileMatch": ["**/.github/secret_scanning.yml"],
+      "url": "https://www.schemastore.org/github-secret-scanning.json"
+    },
+    {
       "name": "GitHub Workflow",
       "description": "YAML GitHub Workflow",
       "fileMatch": [

--- a/src/negative_test/github-secret-scanning/unknown-key.yml
+++ b/src/negative_test/github-secret-scanning/unknown-key.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/github-secret-scanning.json
+
+paths-ignore:
+  - 'docs/**'
+paths:
+  - 'tmp/**'

--- a/src/schemas/json/github-secret-scanning.json
+++ b/src/schemas/json/github-secret-scanning.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-secret-scanning.json",
+  "$comment": "Source: https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files",
+  "title": "GitHub secret_scanning.yml",
+  "description": "Configuration for excluding paths from GitHub secret scanning alerts and push protection.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["paths-ignore"],
+  "properties": {
+    "paths-ignore": {
+      "description": "Paths and glob patterns to exclude from GitHub secret scanning. GitHub only uses the first 1,000 entries.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1000,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/src/test/github-secret-scanning/secret_scanning.yml
+++ b/src/test/github-secret-scanning/secret_scanning.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/github-secret-scanning.json
+
+paths-ignore:
+  - 'docs/**'
+  - 'foo/bar/*.js'


### PR DESCRIPTION
## Summary
- add a schema for GitHub `.github/secret_scanning.yml`
- model the documented `paths-ignore` configuration with the GitHub 1,000-entry limit
- register a narrow fileMatch for `**/.github/secret_scanning.yml`

## Validation
- node ./cli.js check --schema-name=github-secret-scanning.json

## Source
- https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files