### PR TITLE
feat(schema): add swaggerUrl to specmatic config schema

### DIFF
--- a/src/negative_test/specmatic/v3-run-options-openapi-spec-swagger-url-wrong-type.json
+++ b/src/negative_test/specmatic/v3-run-options-openapi-spec-swagger-url-wrong-type.json
@@ -1,0 +1,19 @@
+{
+  "components": {
+    "runOptions": {
+      "orderApiService": {
+        "openapi": {
+          "specs": [
+            {
+              "spec": {
+                "swaggerUrl": 8080
+              }
+            }
+          ],
+          "type": "test"
+        }
+      }
+    }
+  },
+  "version": 3
+}

--- a/src/schemas/json/specmatic.json
+++ b/src/schemas/json/specmatic.json
@@ -1997,6 +1997,9 @@
         "baseUrl": {
           "$ref": "#/definitions/SubstitutableString"
         },
+        "swaggerUrl": {
+          "$ref": "#/definitions/SubstitutableString"
+        },
         "overlayFilePath": {
           "$ref": "#/definitions/SubstitutableString"
         },

--- a/src/test/specmatic/v3-run-options-openapi-spec-swagger-url.json
+++ b/src/test/specmatic/v3-run-options-openapi-spec-swagger-url.json
@@ -1,0 +1,19 @@
+{
+  "components": {
+    "runOptions": {
+      "orderApiService": {
+        "openapi": {
+          "specs": [
+            {
+              "spec": {
+                "swaggerUrl": "http://localhost:8080/v3/api-docs"
+              }
+            }
+          ],
+          "type": "test"
+        }
+      }
+    }
+  },
+  "version": 3
+}


### PR DESCRIPTION
This PR updates Spematic's config json schema with support for the new spec-level `swaggerUrl` override.