### PR TITLE
Add Skillcheck configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6789,6 +6789,12 @@
       "url": "https://www.schemastore.org/size-limit.json"
     },
     {
+      "name": "Skillcheck",
+      "description": "Configuration for Skillcheck, a cross-agent quality gate for SKILL.md files",
+      "fileMatch": ["skillcheck.toml"],
+      "url": "https://www.schemastore.org/skillcheck.json"
+    },
+    {
       "name": "Slack app manifest",
       "description": "A manifest file containing the settings for a Slack app",
       "url": "https://www.schemastore.org/slack-app-manifest.json"

--- a/src/negative_test/skillcheck/invalid-extension-field.toml
+++ b/src/negative_test/skillcheck/invalid-extension-field.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/skillcheck.json
+[frontmatter]
+extension_fields = ["license", false]

--- a/src/negative_test/skillcheck/invalid-format.toml
+++ b/src/negative_test/skillcheck/invalid-format.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/skillcheck.json
+format = "yaml"

--- a/src/negative_test/skillcheck/invalid-ignore-item.toml
+++ b/src/negative_test/skillcheck/invalid-ignore-item.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/skillcheck.json
+ignore = ["frontmatter", 1]

--- a/src/negative_test/skillcheck/invalid-reserved-word.toml
+++ b/src/negative_test/skillcheck/invalid-reserved-word.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/skillcheck.json
+[frontmatter]
+reserved_words = ["acme", 42]

--- a/src/negative_test/skillcheck/invalid-target-agent.toml
+++ b/src/negative_test/skillcheck/invalid-target-agent.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/skillcheck.json
+target-agent = "windsurf"

--- a/src/negative_test/skillcheck/invalid-type.toml
+++ b/src/negative_test/skillcheck/invalid-type.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/skillcheck.json
+strict-vscode = "yes"

--- a/src/negative_test/skillcheck/unknown-frontmatter-key.toml
+++ b/src/negative_test/skillcheck/unknown-frontmatter-key.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/skillcheck.json
+[frontmatter]
+allow_unknown_fields = true

--- a/src/negative_test/skillcheck/unknown-root-key.toml
+++ b/src/negative_test/skillcheck/unknown-root-key.toml
@@ -1,0 +1,2 @@
+#:schema ../../schemas/json/skillcheck.json
+quiet = true

--- a/src/schemas/json/skillcheck.json
+++ b/src/schemas/json/skillcheck.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/skillcheck.json",
+  "$comment": "Sources: https://github.com/moonrunnerkc/skillcheck/blob/main/src/skillcheck/config_loader.py and https://github.com/moonrunnerkc/skillcheck/blob/main/src/skillcheck/cli.py",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "skillcheck configuration",
+  "description": "Configuration for Skillcheck, a cross-agent quality gate for SKILL.md files. Python 3.11 and newer use a TOML 1.0.0 parser; the Python 3.10 fallback accepts a smaller portable subset.\nhttps://github.com/moonrunnerkc/skillcheck",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "format": {
+      "description": "Validation report output format.",
+      "type": "string",
+      "enum": ["text", "json", "md", "agent", "github"],
+      "default": "text"
+    },
+    "max-lines": {
+      "description": "Line-count threshold above which Skillcheck reports a sizing warning.",
+      "type": "integer",
+      "default": 500
+    },
+    "max_lines": {
+      "description": "UNDOCUMENTED. Underscore alias for `max-lines`.",
+      "type": "integer"
+    },
+    "max-tokens": {
+      "description": "Estimated token-count threshold above which Skillcheck reports a sizing warning.",
+      "type": "integer",
+      "default": 8000
+    },
+    "max_tokens": {
+      "description": "UNDOCUMENTED. Underscore alias for `max-tokens`.",
+      "type": "integer"
+    },
+    "min-desc-score": {
+      "description": "Minimum description quality score. Values greater than zero enable the threshold rule; zero or a negative value disables it. The CLI describes a 0-100 range, but the parser accepts any integer.",
+      "type": "integer",
+      "default": 0
+    },
+    "min_desc_score": {
+      "description": "UNDOCUMENTED. Underscore alias for `min-desc-score`.",
+      "type": "integer"
+    },
+    "target-agent": {
+      "description": "Agent ecosystem to use for compatibility checks.",
+      "type": "string",
+      "enum": ["claude", "vscode", "cursor", "all"],
+      "default": "all"
+    },
+    "target_agent": {
+      "description": "UNDOCUMENTED. Underscore alias for `target-agent`.",
+      "type": "string",
+      "enum": ["claude", "vscode", "cursor", "all"]
+    },
+    "strict-vscode": {
+      "description": "Promote VS Code compatibility findings to errors.",
+      "type": "boolean",
+      "default": false
+    },
+    "strict_vscode": {
+      "description": "UNDOCUMENTED. Underscore alias for `strict-vscode`.",
+      "type": "boolean"
+    },
+    "strict-cursor": {
+      "description": "Promote Cursor compatibility findings to errors.",
+      "type": "boolean",
+      "default": false
+    },
+    "strict_cursor": {
+      "description": "UNDOCUMENTED. Underscore alias for `strict-cursor`.",
+      "type": "boolean"
+    },
+    "strict-all": {
+      "description": "Enable umbrella strict mode: promote VS Code and Cursor compatibility findings to errors and fail warning-only runs.",
+      "type": "boolean",
+      "default": false
+    },
+    "strict_all": {
+      "description": "UNDOCUMENTED. Underscore alias for `strict-all`.",
+      "type": "boolean"
+    },
+    "skip-dirname-check": {
+      "description": "Skip validation that a skill name matches its parent directory.",
+      "type": "boolean",
+      "default": false
+    },
+    "skip_dirname_check": {
+      "description": "UNDOCUMENTED. Underscore alias for `skip-dirname-check`.",
+      "type": "boolean"
+    },
+    "skip-ref-check": {
+      "description": "Skip validation of file references and reference depth.",
+      "type": "boolean",
+      "default": false
+    },
+    "skip_ref_check": {
+      "description": "UNDOCUMENTED. Underscore alias for `skip-ref-check`.",
+      "type": "boolean"
+    },
+    "ignore": {
+      "description": "Diagnostic rule ID prefixes to suppress. Prefix matching is case-sensitive; an empty string suppresses every diagnostic.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "analyze-graph": {
+      "description": "Run heuristic capability-graph analyzers and merge their diagnostics into the validation report.",
+      "type": "boolean",
+      "default": false
+    },
+    "analyze_graph": {
+      "description": "UNDOCUMENTED. Underscore alias for `analyze-graph`.",
+      "type": "boolean"
+    },
+    "semantic": {
+      "description": "Enable semantic-adjacent validation. This implies heuristic graph analysis unless a graph is ingested through the CLI.",
+      "type": "boolean",
+      "default": false
+    },
+    "history": {
+      "description": "Append validation records to `.skillcheck-history.json` files beside validated skills. This does not enable the CLI-only fail-on-regression behavior.",
+      "type": "boolean",
+      "default": false
+    },
+    "critique-agent": {
+      "description": "Agent variant for critique workflows. Configuring this value requires a matching critique or agent-reason CLI mode during invocation.",
+      "type": "string",
+      "enum": ["claude", "codex", "cursor"],
+      "default": "claude"
+    },
+    "critique_agent": {
+      "description": "UNDOCUMENTED. Underscore alias for `critique-agent`.",
+      "type": "string",
+      "enum": ["claude", "codex", "cursor"]
+    },
+    "graph-agent": {
+      "description": "Agent variant for graph-extraction workflows. Configuring this value requires a matching graph or agent-reason CLI mode during invocation.",
+      "type": "string",
+      "enum": ["claude", "codex", "cursor"],
+      "default": "claude"
+    },
+    "graph_agent": {
+      "description": "UNDOCUMENTED. Underscore alias for `graph-agent`.",
+      "type": "string",
+      "enum": ["claude", "codex", "cursor"]
+    },
+    "frontmatter": {
+      "description": "Configuration for accepted SKILL.md frontmatter fields and reserved words.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extension_fields": {
+          "description": "Additional frontmatter field names to accept without unknown-field or ecosystem diagnostics.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "reserved_words": {
+          "description": "Case-insensitive substrings prohibited in skill names. An empty array restores the built-in defaults rather than disabling the check.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["anthropic", "claude"]
+        }
+      }
+    }
+  }
+}

--- a/src/test/skillcheck/all-options.toml
+++ b/src/test/skillcheck/all-options.toml
@@ -1,0 +1,21 @@
+#:schema ../../schemas/json/skillcheck.json
+format = "github"
+max-lines = 500
+max-tokens = 8000
+min-desc-score = 50
+target-agent = "vscode"
+strict-vscode = true
+strict-cursor = true
+strict-all = false
+skip-dirname-check = true
+skip-ref-check = true
+ignore = ["frontmatter", "references.depth"]
+analyze-graph = true
+semantic = true
+history = false
+critique-agent = "codex"
+graph-agent = "cursor"
+
+[frontmatter]
+extension_fields = ["license", "metadata"]
+reserved_words = ["acme", "internal"]

--- a/src/test/skillcheck/skillcheck.toml
+++ b/src/test/skillcheck/skillcheck.toml
@@ -1,0 +1,11 @@
+#:schema ../../schemas/json/skillcheck.json
+max-tokens = 8000
+max-lines = 750
+min-desc-score = 25
+strict-vscode = true
+strict-cursor = true
+target-agent = "all"
+semantic = true
+
+[frontmatter]
+extension_fields = ["license", "metadata"]

--- a/src/test/skillcheck/underscore-aliases.toml
+++ b/src/test/skillcheck/underscore-aliases.toml
@@ -1,0 +1,13 @@
+#:schema ../../schemas/json/skillcheck.json
+max_lines = 600
+max_tokens = 9000
+min_desc_score = 20
+target_agent = "cursor"
+strict_vscode = false
+strict_cursor = true
+strict_all = false
+skip_dirname_check = false
+skip_ref_check = true
+analyze_graph = false
+critique_agent = "claude"
+graph_agent = "codex"


### PR DESCRIPTION
## Summary
- add a draft-07 schema for `skillcheck.toml`
- model every config key accepted by Skillcheck 1.4.1, including parser-supported underscore aliases
- enforce Skillcheck's strict root and `[frontmatter]` key handling
- declare TOML 1.0.0 for Tombi with `x-tombi-toml-version`
- associate only the exact discovered filename `skillcheck.toml`
- add three positive fixtures and eight isolated negative fixtures

## Evidence
- https://github.com/moonrunnerkc/skillcheck/blob/main/src/skillcheck/config_loader.py
- https://github.com/moonrunnerkc/skillcheck/blob/main/src/skillcheck/cli.py
- https://github.com/moonrunnerkc/skillcheck/blob/main/src/skillcheck/config.py
- https://github.com/moonrunnerkc/skillcheck/blob/main/tests/test_config_loader.py

The schema intentionally leaves numeric thresholds unbounded because the parser accepts every integer, even where CLI help describes a narrower range. It also avoids `uniqueItems` because Skillcheck accepts duplicate array entries.

## Validation
- `npm clean-install`
- `node ./cli.js check --schema-name=skillcheck.json`
- `npm run typecheck`
- `npm run eslint`
- `npm run prettier`
- SchemaStore PR audit: 13 changed files, no warnings
- direct Ajv/TOML validation of `C:/Repos/codex-skills/skillcheck.toml`
- upstream `SkillcheckConfig` parsing of all positive fixtures
- upstream CLI rejection of all eight negative fixtures
- independent source-level review found no schema, catalog, compatibility, or overconstraint defects

The repository-wide `node ./cli.js check` currently reaches an unrelated Ajv stack overflow while compiling `cargo-lints-clippy.json`; the same failure reproduces with `node ./cli.js check --schema-name=cargo-lints-clippy.json`.