### PR TITLE
Add the native_parser option for mypy

### DIFF
--- a/src/schemas/json/partial-mypy.json
+++ b/src/schemas/json/partial-mypy.json
@@ -651,6 +651,11 @@
         }
       ]
     },
+    "native_parser": {
+      "description": "This enables fast Rust-based parser that parses directly to mypy AST. It will become the default parser in one of the next mypy releases.",
+      "x-intellij-html-description": "This enables fast Rust-based parser that parses directly to mypy AST. It will become the default parser in one of the next mypy releases.",
+      "type": "boolean"
+    },
     "overrides": {
       "type": "array",
       "items": {

--- a/src/test/pyproject/mypy-02.toml
+++ b/src/test/pyproject/mypy-02.toml
@@ -5,6 +5,7 @@ python_version = "3.8"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
+native_parser = true
 
 # You can disable imports or control per-module/file settings here
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Mypy recently introduced a new native-extension-based parser.

[1] https://mypy.readthedocs.io/en/stable/config_file.html#confval-native_parser
