### PR TITLE
feat: add kind cluster configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4553,6 +4553,17 @@
       "url": "https://kubri.dev/schema.json"
     },
     {
+      "name": "kind cluster",
+      "description": "Configuration file for kind (Kubernetes IN Docker) clusters",
+      "fileMatch": [
+        "kind.yaml",
+        "kind.yml",
+        "**/kind-config.yaml",
+        "**/kind-config.yml"
+      ],
+      "url": "https://www.schemastore.org/kind-cluster.json"
+    },
+    {
       "name": "kustomization.yaml",
       "description": "Kubernetes native configuration management",
       "fileMatch": ["kustomization.yaml", "kustomization.yml"],

--- a/src/negative_test/kind-cluster/invalid-kind.yaml
+++ b/src/negative_test/kind-cluster/invalid-kind.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/kind-cluster.json
+kind: Node
+apiVersion: kind.x-k8s.io/v1alpha4

--- a/src/negative_test/kind-cluster/invalid-role.yaml
+++ b/src/negative_test/kind-cluster/invalid-role.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/kind-cluster.json
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: master

--- a/src/schemas/json/kind-cluster.json
+++ b/src/schemas/json/kind-cluster.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/kind-cluster.json",
+  "$comment": "Schema for Kubernetes kind cluster config (kind.x-k8s.io/v1alpha4). Docs: https://kind.sigs.k8s.io/docs/user/configuration/",
+  "title": "kind cluster configuration",
+  "description": "Configuration file for kind (Kubernetes IN Docker) clusters using apiVersion kind.x-k8s.io/v1alpha4.",
+  "type": "object",
+  "required": ["kind", "apiVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "Cluster",
+      "description": "Resource kind. Must be Cluster."
+    },
+    "apiVersion": {
+      "type": "string",
+      "const": "kind.x-k8s.io/v1alpha4",
+      "description": "kind config API version."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Cluster name. Overridden by --name / KIND_CLUSTER_NAME."
+    },
+    "nodes": {
+      "type": "array",
+      "description": "Node definitions. Defaults to a single control-plane node when omitted.",
+      "items": {
+        "$ref": "#/definitions/node"
+      }
+    },
+    "networking": {
+      "$ref": "#/definitions/networking"
+    },
+    "featureGates": {
+      "type": "object",
+      "description": "Kubernetes feature gates applied cluster-wide.",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "runtimeConfig": {
+      "type": "object",
+      "description": "kube-apiserver --runtime-config key/value pairs.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "kubeadmConfigPatches": {
+      "type": "array",
+      "description": "RFC 7386 merge patches (inline YAML) applied to kubeadm config.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "kubeadmConfigPatchesJSON6902": {
+      "type": "array",
+      "description": "RFC 6902 JSON patches for kubeadm config.",
+      "items": {
+        "$ref": "#/definitions/patchJSON6902"
+      }
+    },
+    "containerdConfigPatches": {
+      "type": "array",
+      "description": "TOML merge patches applied to every node containerd config.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "containerdConfigPatchesJSON6902": {
+      "type": "array",
+      "description": "RFC 6902 patches applied to every node containerd config.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string",
+          "enum": ["control-plane", "worker"],
+          "default": "control-plane",
+          "description": "Node role in the kind cluster."
+        },
+        "image": {
+          "type": "string",
+          "description": "Node container image (kindest/node tag)."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels applied to the node."
+        },
+        "extraMounts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/mount"
+          }
+        },
+        "extraPortMappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/portMapping"
+          }
+        },
+        "kubeadmConfigPatches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kubeadmConfigPatchesJSON6902": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/patchJSON6902"
+          }
+        }
+      }
+    },
+    "mount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostPath", "containerPath"],
+      "properties": {
+        "hostPath": {
+          "type": "string"
+        },
+        "containerPath": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "selinuxRelabel": {
+          "type": "boolean"
+        },
+        "propagation": {
+          "type": "string",
+          "enum": ["None", "HostToContainer", "Bidirectional"]
+        }
+      }
+    },
+    "portMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["containerPort"],
+      "properties": {
+        "containerPort": {
+          "type": "integer"
+        },
+        "hostPort": {
+          "type": "integer"
+        },
+        "listenAddress": {
+          "type": "string"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": ["TCP", "UDP", "SCTP"]
+        }
+      }
+    },
+    "networking": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ipFamily": {
+          "type": "string",
+          "enum": ["ipv4", "ipv6", "dual"]
+        },
+        "apiServerPort": {
+          "type": "integer"
+        },
+        "apiServerAddress": {
+          "type": "string"
+        },
+        "podSubnet": {
+          "type": "string"
+        },
+        "serviceSubnet": {
+          "type": "string"
+        },
+        "disableDefaultCNI": {
+          "type": "boolean"
+        },
+        "kubeProxyMode": {
+          "type": "string",
+          "enum": ["iptables", "ipvs", "nftables", "none"]
+        },
+        "dnsSearch": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "patchJSON6902": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["patch"],
+      "properties": {
+        "group": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "patch": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/kind-cluster/minimal.yaml
+++ b/src/test/kind-cluster/minimal.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/kind-cluster.json
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4

--- a/src/test/kind-cluster/multi-node.yaml
+++ b/src/test/kind-cluster/multi-node.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../schemas/json/kind-cluster.json
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: app-1-cluster
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+  - role: worker
+    image: kindest/node:v1.31.0
+networking:
+  ipFamily: ipv4
+  disableDefaultCNI: false
+  kubeProxyMode: iptables
+featureGates:
+  CSIMigration: true


### PR DESCRIPTION
## Summary
- Add `kind-cluster.json` for `kind.x-k8s.io/v1alpha4` cluster configs.
- Register catalog entry with common `kind.yaml` / `kind-config.yaml` file matches.
- Include positive multi-node examples and negative invalid kind/role fixtures.

## Context
Closes #4892.

Based on the kind config docs and `pkg/apis/config/v1alpha4` types:
- https://kind.sigs.k8s.io/docs/user/configuration/
- https://pkg.go.dev/sigs.k8s.io/kind/pkg/apis/config/v1alpha4

## Test plan
- [ ] SchemaStore CI validates positive/negative tests
- [ ] Catalog lint passes
- [ ] Optional editor check with YAML language server + `$schema`