### PR TITLE
feat: add Amazon S3 bucket CORS configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -123,6 +123,16 @@
       "url": "https://www.schemastore.org/accelerator.json"
     },
     {
+      "name": "Amazon S3 bucket CORS",
+      "description": "JSON CORS configuration for Amazon S3 buckets",
+      "fileMatch": [
+        "**/s3-cors.json",
+        "**/s3-bucket-cors.json",
+        "**/s3-cors-configuration.json"
+      ],
+      "url": "https://www.schemastore.org/s3-bucket-cors.json"
+    },
+    {
       "name": "amplify.yml",
       "description": "AWS Amplify Console build settings file",
       "fileMatch": ["amplify.yml", "amplify.yaml"],

--- a/src/negative_test/s3-bucket-cors/invalid-method.json
+++ b/src/negative_test/s3-bucket-cors/invalid-method.json
@@ -1,0 +1,6 @@
+[
+  {
+    "AllowedMethods": ["PATCH"],
+    "AllowedOrigins": ["http://www.example.com"]
+  }
+]

--- a/src/negative_test/s3-bucket-cors/missing-methods.json
+++ b/src/negative_test/s3-bucket-cors/missing-methods.json
@@ -1,0 +1,5 @@
+[
+  {
+    "AllowedOrigins": ["http://www.example.com"]
+  }
+]

--- a/src/schemas/json/s3-bucket-cors.json
+++ b/src/schemas/json/s3-bucket-cors.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/s3-bucket-cors.json",
+  "$comment": "Amazon S3 bucket CORS configuration (JSON form used by the S3 console). Docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html",
+  "title": "Amazon S3 bucket CORS configuration",
+  "description": "JSON CORS configuration document for an Amazon S3 bucket. Matches the array-of-rules shape accepted by the S3 console and PutBucketCors.",
+  "type": "array",
+  "minItems": 1,
+  "maxItems": 100,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["AllowedMethods", "AllowedOrigins"],
+    "properties": {
+      "ID": {
+        "type": "string",
+        "description": "Optional unique identifier for the rule."
+      },
+      "AllowedMethods": {
+        "type": "array",
+        "description": "HTTP methods the origin is allowed to execute.",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "enum": ["GET", "PUT", "POST", "DELETE", "HEAD"]
+        }
+      },
+      "AllowedOrigins": {
+        "type": "array",
+        "description": "Origins allowed to make cross-origin requests. Use * to allow all.",
+        "minItems": 1,
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "AllowedHeaders": {
+        "type": "array",
+        "description": "Headers allowed in a preflight Access-Control-Request-Headers value. Supports a single * wildcard per entry.",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "ExposeHeaders": {
+        "type": "array",
+        "description": "Response headers that browsers may expose to client applications.",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "MaxAgeSeconds": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Seconds browsers may cache a preflight response."
+      }
+    }
+  }
+}

--- a/src/test/s3-bucket-cors/basic.json
+++ b/src/test/s3-bucket-cors/basic.json
@@ -1,0 +1,13 @@
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["PUT", "POST", "DELETE"],
+    "AllowedOrigins": ["http://www.example.com"],
+    "ExposeHeaders": [
+      "x-amz-server-side-encryption",
+      "x-amz-request-id",
+      "x-amz-id-2"
+    ],
+    "MaxAgeSeconds": 3000
+  }
+]

--- a/src/test/s3-bucket-cors/multi-rule.json
+++ b/src/test/s3-bucket-cors/multi-rule.json
@@ -1,0 +1,14 @@
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["PUT", "POST", "DELETE"],
+    "AllowedOrigins": ["http://www.example1.com"],
+    "ExposeHeaders": []
+  },
+  {
+    "AllowedHeaders": [],
+    "AllowedMethods": ["GET"],
+    "AllowedOrigins": ["*"],
+    "ExposeHeaders": []
+  }
+]


### PR DESCRIPTION
## Summary
- Add `s3-bucket-cors.json` for Amazon S3 bucket CORS configuration (JSON array-of-rules form).
- Register catalog entry with common CORS config filenames.
- Include positive AWS-doc examples and negative fixtures (missing methods / invalid method).

## Context
Closes #4118.

Based on AWS documentation:
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html

Rules model `AllowedMethods`, `AllowedOrigins`, optional `AllowedHeaders`, `ExposeHeaders`, `MaxAgeSeconds`, and `ID`, with the documented 100-rule limit.

## Test plan
- [ ] SchemaStore CI validates positive/negative tests
- [ ] Catalog lint passes
- [ ] Optional check against S3 console sample CORS JSON