### PR TITLE
Migrated cosmos-config.json to draft-07

### DIFF
--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/cosmos-config.json",
   "additionalProperties": false,
-  "id": "https://json.schemastore.org/cosmos-config.json",
   "properties": {
     "$schema": {
       "type": "string"
@@ -210,7 +210,7 @@
               "minLength": 1
             },
             {
-              "enum": [false]
+              "const": false
             }
           ]
         },

--- a/src/schemas/json/cosmos-config.json
+++ b/src/schemas/json/cosmos-config.json
@@ -192,8 +192,15 @@
       "properties": {
         "containerQuerySelector": {
           "description": "Document selector for existing element to use as component parent (eg. #root). A blank container element is created from scratch if no selector is provided. [default: null]",
-          "type": ["string", "null"],
-          "minLength": 1
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
- Migrated from draft-04 to draft-07
- Made validation stricter

As an aside, if this schema had any tests prior to these changes, it would've failed strict validation.