### PR TITLE
Migrated detekt-*.json to draft-07

### DIFF
--- a/src/schemas/json/detekt-1.14.1.json
+++ b/src/schemas/json/detekt-1.14.1.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/detekt-1.14.1.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/detekt-1.14.1.json",
   "properties": {
     "build": {
       "type": "object",

--- a/src/schemas/json/detekt-1.14.1.json
+++ b/src/schemas/json/detekt-1.14.1.json
@@ -12,10 +12,17 @@
           "type": "boolean"
         },
         "weights": {
-          "type": ["object", "null"],
-          "additionalProperties": {
-            "type": "number"
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -68,10 +75,17 @@
           "type": "boolean"
         },
         "exclude": {
-          "type": ["array", "null"],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/src/schemas/json/detekt-1.22.0.json
+++ b/src/schemas/json/detekt-1.22.0.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/detekt-1.22.0.json",
   "$defs": {
     "ruleProperties": {
       "type": "object",
@@ -28,7 +29,6 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/detekt-1.22.0.json",
   "properties": {
     "build": {
       "type": "object",

--- a/src/schemas/json/detekt-1.22.0.json
+++ b/src/schemas/json/detekt-1.22.0.json
@@ -113,12 +113,8 @@
           "type": "boolean"
         },
         "AbsentOrWrongFileLicense": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "licenseTemplateFile": {
               "type": "string"
@@ -129,36 +125,20 @@
           }
         },
         "CommentOverPrivateFunction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "CommentOverPrivateProperty": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "DeprecatedBlockTag": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EndOfSentenceFormat": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "endOfSentenceFormat": {
               "type": "string"
@@ -166,20 +146,12 @@
           }
         },
         "KDocReferencesNonPublicProperty": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "OutdatedDocumentation": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "matchTypeParameters": {
               "type": "boolean"
@@ -193,12 +165,8 @@
           }
         },
         "UndocumentedPublicClass": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "searchInNestedClass": {
               "type": "boolean"
@@ -218,12 +186,8 @@
           }
         },
         "UndocumentedPublicFunction": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "searchProtectedFunction": {
               "type": "boolean"
@@ -231,12 +195,8 @@
           }
         },
         "UndocumentedPublicProperty": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "searchProtectedProperty": {
               "type": "boolean"
@@ -252,12 +212,8 @@
           "type": "boolean"
         },
         "CognitiveComplexMethod": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -265,12 +221,8 @@
           }
         },
         "ComplexCondition": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -278,12 +230,8 @@
           }
         },
         "ComplexInterface": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -300,12 +248,8 @@
           }
         },
         "CyclomaticComplexMethod": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -328,12 +272,8 @@
           }
         },
         "LabeledExpression": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoredLabels": {
               "type": "array",
@@ -344,12 +284,8 @@
           }
         },
         "LargeClass": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -357,12 +293,8 @@
           }
         },
         "LongMethod": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -370,12 +302,8 @@
           }
         },
         "LongParameterList": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "functionThreshold": {
               "type": "integer"
@@ -398,12 +326,8 @@
           }
         },
         "MethodOverloading": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -411,12 +335,8 @@
           }
         },
         "NamedArguments": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -427,12 +347,8 @@
           }
         },
         "NestedBlockDepth": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -440,12 +356,8 @@
           }
         },
         "NestedScopeFunctions": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -459,20 +371,12 @@
           }
         },
         "ReplaceSafeCallChainWithRun": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "StringLiteralDuplication": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -489,12 +393,8 @@
           }
         },
         "TooManyFunctions": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "thresholdInFiles": {
               "type": "integer"
@@ -531,20 +431,12 @@
           "type": "boolean"
         },
         "GlobalCoroutineUsage": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "InjectDispatcher": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "dispatcherNames": {
               "type": "array",
@@ -555,36 +447,20 @@
           }
         },
         "RedundantSuspendModifier": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SleepInsteadOfDelay": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SuspendFunWithCoroutineScopeReceiver": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SuspendFunWithFlowReturnType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     },
@@ -595,12 +471,8 @@
           "type": "boolean"
         },
         "EmptyCatchBlock": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowedExceptionNameRegex": {
               "type": "string"
@@ -608,60 +480,32 @@
           }
         },
         "EmptyClassBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyDefaultConstructor": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyDoWhileBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyElseBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyFinallyBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyForBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyFunctionBlock": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreOverridden": {
               "type": "boolean"
@@ -669,60 +513,32 @@
           }
         },
         "EmptyIfBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyInitBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyKtFile": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptySecondaryConstructor": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyTryBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyWhenBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EmptyWhileBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     },
@@ -733,12 +549,8 @@
           "type": "boolean"
         },
         "ExceptionRaisedInUnexpectedLocation": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "methodNames": {
               "type": "array",
@@ -749,52 +561,28 @@
           }
         },
         "InstanceOfCheckForException": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NotImplementedDeclaration": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ObjectExtendsThrowable": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "PrintStackTrace": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "RethrowCaughtException": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ReturnFromFinally": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreLabeled": {
               "type": "boolean"
@@ -802,12 +590,8 @@
           }
         },
         "SwallowedException": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoredExceptionTypes": {
               "type": "array",
@@ -821,28 +605,16 @@
           }
         },
         "ThrowingExceptionFromFinally": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ThrowingExceptionInMain": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ThrowingExceptionsWithoutMessageOrCause": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "exceptions": {
               "type": "array",
@@ -853,20 +625,12 @@
           }
         },
         "ThrowingNewInstanceOfSameException": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "TooGenericExceptionCaught": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "exceptionNames": {
               "type": "array",
@@ -880,12 +644,8 @@
           }
         },
         "TooGenericExceptionThrown": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "exceptionNames": {
               "type": "array",
@@ -904,12 +664,8 @@
           "type": "boolean"
         },
         "BooleanPropertyNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowedPattern": {
               "type": "string"
@@ -920,12 +676,8 @@
           }
         },
         "ClassNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "classPattern": {
               "type": "string"
@@ -933,12 +685,8 @@
           }
         },
         "ConstructorParameterNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "parameterPattern": {
               "type": "string"
@@ -955,12 +703,8 @@
           }
         },
         "EnumNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "enumEntryPattern": {
               "type": "string"
@@ -968,12 +712,8 @@
           }
         },
         "ForbiddenClassName": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "forbiddenName": {
               "type": "array",
@@ -984,12 +724,8 @@
           }
         },
         "FunctionMaxLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maximumFunctionNameLength": {
               "type": "integer"
@@ -997,12 +733,8 @@
           }
         },
         "FunctionMinLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "minimumFunctionNameLength": {
               "type": "integer"
@@ -1010,12 +742,8 @@
           }
         },
         "FunctionNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "functionPattern": {
               "type": "string"
@@ -1029,12 +757,8 @@
           }
         },
         "FunctionParameterNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "parameterPattern": {
               "type": "string"
@@ -1048,12 +772,8 @@
           }
         },
         "InvalidPackageDeclaration": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "rootPackage": {
               "type": "string"
@@ -1064,12 +784,8 @@
           }
         },
         "LambdaParameterNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "parameterPattern": {
               "type": "string"
@@ -1077,12 +793,8 @@
           }
         },
         "MatchingDeclarationName": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "mustBeFirst": {
               "type": "boolean"
@@ -1090,12 +802,8 @@
           }
         },
         "MemberNameEqualsClassName": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreOverridden": {
               "type": "boolean"
@@ -1103,28 +811,16 @@
           }
         },
         "NoNameShadowing": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NonBooleanPropertyPrefixedWithIs": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ObjectPropertyNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "constantPattern": {
               "type": "string"
@@ -1138,12 +834,8 @@
           }
         },
         "PackageNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "packagePattern": {
               "type": "string"
@@ -1151,12 +843,8 @@
           }
         },
         "TopLevelPropertyNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "constantPattern": {
               "type": "string"
@@ -1170,12 +858,8 @@
           }
         },
         "VariableMaxLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maximumVariableNameLength": {
               "type": "integer"
@@ -1183,12 +867,8 @@
           }
         },
         "VariableMinLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "minimumVariableNameLength": {
               "type": "integer"
@@ -1196,12 +876,8 @@
           }
         },
         "VariableNaming": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "variablePattern": {
               "type": "string"
@@ -1226,20 +902,12 @@
           "type": "boolean"
         },
         "ArrayPrimitive": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "CouldBeSequence": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "threshold": {
               "type": "integer"
@@ -1247,36 +915,20 @@
           }
         },
         "ForEachOnRange": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SpreadOperator": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryPartOfBinaryExpression": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryTemporaryInstantiation": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     },
@@ -1287,12 +939,8 @@
           "type": "boolean"
         },
         "AvoidReferentialEquality": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "forbiddenTypePatterns": {
               "type": "array",
@@ -1303,36 +951,20 @@
           }
         },
         "CastToNullableType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "Deprecation": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "DontDowncastCollectionTypes": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "DoubleMutabilityForCollection": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "mutableTypes": {
               "type": "array",
@@ -1343,60 +975,32 @@
           }
         },
         "ElseCaseInsteadOfExhaustiveWhen": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EqualsAlwaysReturnsTrueOrFalse": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EqualsWithHashCodeExist": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ExitOutsideMain": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ExplicitGarbageCollectionCall": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "HasPlatformType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "IgnoredReturnValue": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "restrictToConfig": {
               "type": "boolean"
@@ -1428,20 +1032,12 @@
           }
         },
         "ImplicitDefaultLocale": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ImplicitUnitReturnType": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowExplicitReturnType": {
               "type": "boolean"
@@ -1449,36 +1045,20 @@
           }
         },
         "InvalidRange": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "IteratorHasNextCallsNextMethod": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "IteratorNotThrowingNoSuchElementException": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "LateinitUsage": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreOnClassesPattern": {
               "type": "string"
@@ -1486,124 +1066,64 @@
           }
         },
         "MapGetWithNotNullAssertionOperator": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "MissingPackageDeclaration": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NullCheckOnMutableProperty": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NullableToStringCall": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnconditionalJumpStatementInLoop": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryNotNullCheck": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryNotNullOperator": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessarySafeCall": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnreachableCatchBlock": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnreachableCode": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnsafeCallOnNullableType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnsafeCast": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnusedUnaryOperator": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UselessPostfixExpression": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "WrongEqualsTypeParameter": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     },
@@ -1614,28 +1134,16 @@
           "type": "boolean"
         },
         "AlsoCouldBeApply": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "CanBeNonNullable": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "CascadingCallWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "includeElvis": {
               "type": "boolean"
@@ -1643,28 +1151,16 @@
           }
         },
         "ClassOrdering": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "CollapsibleIfStatements": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "DataClassContainsFunctions": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "conversionFunctionPrefix": {
               "type": "array",
@@ -1675,20 +1171,12 @@
           }
         },
         "DataClassShouldBeImmutable": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "DestructuringDeclarationWithTooManyEntries": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maxDestructuringEntries": {
               "type": "integer"
@@ -1696,44 +1184,24 @@
           }
         },
         "EqualsNullCall": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "EqualsOnSignatureLine": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ExplicitCollectionElementAccessMethod": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ExplicitItLambdaParameter": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ExpressionBodySyntax": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "includeLineWrapping": {
               "type": "boolean"
@@ -1741,12 +1209,8 @@
           }
         },
         "ForbiddenComment": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "values": {
               "type": "array",
@@ -1763,12 +1227,8 @@
           }
         },
         "ForbiddenImport": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "imports": {
               "type": "array",
@@ -1791,12 +1251,8 @@
           }
         },
         "ForbiddenMethodCall": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "methods": {
               "type": "array",
@@ -1816,12 +1272,8 @@
           }
         },
         "ForbiddenSuppress": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "rules": {
               "type": "array",
@@ -1832,12 +1284,8 @@
           }
         },
         "ForbiddenVoid": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreOverridden": {
               "type": "boolean"
@@ -1848,12 +1296,8 @@
           }
         },
         "FunctionOnlyReturningConstant": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreOverridableFunction": {
               "type": "boolean"
@@ -1870,12 +1314,8 @@
           }
         },
         "LoopWithTooManyJumpStatements": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maxJumpCount": {
               "type": "integer"
@@ -1883,12 +1323,8 @@
           }
         },
         "MagicNumber": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreNumbers": {
               "type": "array",
@@ -1929,28 +1365,16 @@
           }
         },
         "MandatoryBracesIfStatements": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "MandatoryBracesLoops": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "MaxChainedCallsOnSameLine": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maxChainedCalls": {
               "type": "integer"
@@ -1958,12 +1382,8 @@
           }
         },
         "MaxLineLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maxLineLength": {
               "type": "integer"
@@ -1983,36 +1403,20 @@
           }
         },
         "MayBeConst": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ModifierOrder": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "MultilineLambdaItParameter": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "MultilineRawStringIndentation": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "indentSize": {
               "type": "integer"
@@ -2020,116 +1424,60 @@
           }
         },
         "NestedClassesVisibility": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NewLineAtEndOfFile": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NoTabs": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "NullableBooleanCheck": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ObjectLiteralToLambda": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "OptionalAbstractKeyword": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "OptionalUnit": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "OptionalWhenBraces": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "PreferToOverPairSyntax": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ProtectedMemberInFinalClass": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "RedundantExplicitType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "RedundantHigherOrderMapUsage": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "RedundantVisibilityModifierRule": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ReturnCount": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "max": {
               "type": "integer"
@@ -2152,36 +1500,20 @@
           }
         },
         "SafeCast": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SerialVersionUIDInSerializableClass": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "SpacingBetweenPackageAndImports": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ThrowsCount": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "max": {
               "type": "integer"
@@ -2192,28 +1524,16 @@
           }
         },
         "TrailingWhitespace": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "TrimMultilineRawString": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnderscoresInNumericLiterals": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "acceptableLength": {
               "type": "integer"
@@ -2224,76 +1544,40 @@
           }
         },
         "UnnecessaryAbstractClass": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryAnnotationUseSiteTarget": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryApply": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryBackticks": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryFilter": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryInheritance": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryInnerClass": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryLet": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnnecessaryParentheses": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowForUnclearPrecedence": {
               "type": "boolean"
@@ -2301,36 +1585,20 @@
           }
         },
         "UntilInsteadOfRangeTo": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnusedImports": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnusedPrivateClass": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UnusedPrivateMember": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowedNames": {
               "type": "string"
@@ -2338,44 +1606,24 @@
           }
         },
         "UseAnyOrNoneInsteadOfFind": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseArrayLiteralsInAnnotations": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseCheckNotNull": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseCheckOrError": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseDataClass": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "allowVars": {
               "type": "boolean"
@@ -2383,92 +1631,48 @@
           }
         },
         "UseEmptyCounterpart": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseIfEmptyOrIfBlank": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseIfInsteadOfWhen": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseIsNullOrEmpty": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseOrEmpty": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseRequire": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseRequireNotNull": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UseSumOfInsteadOfFlatMapSize": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UselessCallOnNotNull": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "UtilityClassWithPublicConstructor": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "VarCouldBeVal": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignoreLateinitVar": {
               "type": "boolean"
@@ -2476,12 +1680,8 @@
           }
         },
         "WildcardImport": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "excludeImports": {
               "type": "array",
@@ -2506,12 +1706,8 @@
           "type": "boolean"
         },
         "AnnotationOnSeparateLine": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2519,12 +1715,8 @@
           }
         },
         "AnnotationSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2532,12 +1724,8 @@
           }
         },
         "ArgumentListWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2551,12 +1739,8 @@
           }
         },
         "BlockCommentInitialStarAlignment": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2564,12 +1748,8 @@
           }
         },
         "ChainWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2577,12 +1757,8 @@
           }
         },
         "CommentSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2590,12 +1766,8 @@
           }
         },
         "CommentWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2606,12 +1778,8 @@
           }
         },
         "DiscouragedCommentLocation": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2619,12 +1787,8 @@
           }
         },
         "EnumEntryNameCase": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2632,20 +1796,12 @@
           }
         },
         "Filename": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "FinalNewline": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2656,12 +1812,8 @@
           }
         },
         "FunKeywordSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2669,12 +1821,8 @@
           }
         },
         "FunctionReturnTypeSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2682,12 +1830,8 @@
           }
         },
         "FunctionSignature": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2707,12 +1851,8 @@
           }
         },
         "FunctionStartOfBodySpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2720,12 +1860,8 @@
           }
         },
         "FunctionTypeReferenceSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2733,12 +1869,8 @@
           }
         },
         "ImportOrdering": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2749,12 +1881,8 @@
           }
         },
         "Indentation": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2765,12 +1893,8 @@
           }
         },
         "KdocWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2781,12 +1905,8 @@
           }
         },
         "MaximumLineLength": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "maxLineLength": {
               "type": "integer"
@@ -2797,12 +1917,8 @@
           }
         },
         "ModifierListSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2810,12 +1926,8 @@
           }
         },
         "ModifierOrdering": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2823,12 +1935,8 @@
           }
         },
         "MultiLineIfElse": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2836,12 +1944,8 @@
           }
         },
         "NoBlankLineBeforeRbrace": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2849,12 +1953,8 @@
           }
         },
         "NoBlankLinesInChainedMethodCalls": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2862,12 +1962,8 @@
           }
         },
         "NoConsecutiveBlankLines": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2875,12 +1971,8 @@
           }
         },
         "NoEmptyClassBody": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2888,12 +1980,8 @@
           }
         },
         "NoEmptyFirstLineInMethodBlock": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2901,12 +1989,8 @@
           }
         },
         "NoLineBreakAfterElse": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2914,12 +1998,8 @@
           }
         },
         "NoLineBreakBeforeAssignment": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2927,12 +2007,8 @@
           }
         },
         "NoMultipleSpaces": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2940,12 +2016,8 @@
           }
         },
         "NoSemicolons": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2953,12 +2025,8 @@
           }
         },
         "NoTrailingSpaces": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2966,12 +2034,8 @@
           }
         },
         "NoUnitReturn": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2979,12 +2043,8 @@
           }
         },
         "NoUnusedImports": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -2992,12 +2052,8 @@
           }
         },
         "NoWildcardImports": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "packagesToUseImportOnDemandProperty": {
               "type": "string"
@@ -3005,12 +2061,8 @@
           }
         },
         "NullableTypeSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3018,12 +2070,8 @@
           }
         },
         "PackageName": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3031,12 +2079,8 @@
           }
         },
         "ParameterListSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3044,12 +2088,8 @@
           }
         },
         "ParameterListWrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3060,12 +2100,8 @@
           }
         },
         "SpacingAroundAngleBrackets": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3073,12 +2109,8 @@
           }
         },
         "SpacingAroundColon": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3086,12 +2118,8 @@
           }
         },
         "SpacingAroundComma": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3099,12 +2127,8 @@
           }
         },
         "SpacingAroundCurly": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3112,12 +2136,8 @@
           }
         },
         "SpacingAroundDot": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3125,12 +2145,8 @@
           }
         },
         "SpacingAroundDoubleColon": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3138,12 +2154,8 @@
           }
         },
         "SpacingAroundKeyword": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3151,12 +2163,8 @@
           }
         },
         "SpacingAroundOperators": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3164,12 +2172,8 @@
           }
         },
         "SpacingAroundParens": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3177,12 +2181,8 @@
           }
         },
         "SpacingAroundRangeOperator": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3190,12 +2190,8 @@
           }
         },
         "SpacingAroundUnaryOperator": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3203,12 +2199,8 @@
           }
         },
         "SpacingBetweenDeclarationsWithAnnotations": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3216,12 +2208,8 @@
           }
         },
         "SpacingBetweenDeclarationsWithComments": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3229,12 +2217,8 @@
           }
         },
         "SpacingBetweenFunctionNameAndOpeningParenthesis": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3242,12 +2226,8 @@
           }
         },
         "StringTemplate": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3255,12 +2235,8 @@
           }
         },
         "TrailingCommaOnCallSite": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3271,12 +2247,8 @@
           }
         },
         "TrailingCommaOnDeclarationSite": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3287,12 +2259,8 @@
           }
         },
         "TypeArgumentListSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3300,12 +2268,8 @@
           }
         },
         "TypeParameterListSpacing": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3313,12 +2277,8 @@
           }
         },
         "UnnecessaryParenthesesBeforeTrailingLambda": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3326,12 +2286,8 @@
           }
         },
         "Wrapping": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "autoCorrect": {
               "type": "boolean"
@@ -3350,12 +2306,8 @@
           "type": "boolean"
         },
         "ForbiddenPublicDataClass": {
+          "$ref": "#/$defs/ruleProperties",
           "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ],
           "properties": {
             "ignorePackages": {
               "type": "array",
@@ -3366,20 +2318,12 @@
           }
         },
         "LibraryCodeMustSpecifyReturnType": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "LibraryEntitiesShouldNotBePublic": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     },
@@ -3390,20 +2334,12 @@
           "type": "boolean"
         },
         "UseEntityAtName": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         },
         "ViolatesTypeResolutionRequirements": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/$defs/ruleProperties"
-            }
-          ]
+          "$ref": "#/$defs/ruleProperties",
+          "type": "object"
         }
       }
     }


### PR DESCRIPTION
- Migrated from draft-04 to draft-07
- Made validation stricter

In spite of not being included in `ajvNotStrictMode`, this schema was somehow allowed to have `"type": ["string", "null"]`. If there is a setting that enabels this behavior, it should be disabled to enforce full strict validation.