### PR TITLE
feat: register Trivy config schema in catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7319,7 +7319,7 @@
     },
     {
       "name": "Trivy",
-      "description": "Configuration file for Trivy security scanner (trivy.yaml) using the official Aqua Security schema",
+      "description": "Configuration file for Trivy security scanner (trivy.yaml)",
       "fileMatch": ["trivy.yaml", "trivy.yml", ".trivy.yaml", ".trivy.yml"],
       "url": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7318,6 +7318,12 @@
       "url": "https://raw.githubusercontent.com/osfans/trime/develop/doc/trime-schema.json"
     },
     {
+      "name": "Trivy",
+      "description": "Configuration file for Trivy security scanner (trivy.yaml). Official schema maintained by Aqua Security.",
+      "fileMatch": ["trivy.yaml", "trivy.yml", ".trivy.yaml", ".trivy.yml"],
+      "url": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json"
+    },
+    {
       "name": "TrueScript for *.tscript files",
       "description": "The Ultimate Script Language for monday.com - \u00a9 2024 MakeITSimple",
       "fileMatch": ["*.tscript", "*.tscript.yaml", "*.tscript.yml"],

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7319,7 +7319,7 @@
     },
     {
       "name": "Trivy",
-      "description": "Configuration file for Trivy security scanner (trivy.yaml). Official schema maintained by Aqua Security.",
+      "description": "Configuration file for Trivy security scanner (trivy.yaml) using the official Aqua Security schema",
       "fileMatch": ["trivy.yaml", "trivy.yml", ".trivy.yaml", ".trivy.yml"],
       "url": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json"
     },


### PR DESCRIPTION
## Summary
- Register Trivy (`trivy.yaml`) in the SchemaStore catalog.
- Point `url` at the official Aqua Security schema so editors can validate Trivy config files.

## Source of truth
- Schema: https://github.com/aquasecurity/trivy/blob/main/schema/trivy-config.json
- Docs: https://trivy.dev/docs/latest/references/configuration/config-file/
- Example: https://github.com/aquasecurity/trivy/blob/main/examples/trivy-conf/trivy.yaml

## Test plan
- [x] Catalog JSON still parses
- [x] Official schema URL returns a valid JSON Schema document
- [x] `fileMatch` limited to common Trivy config filenames (`trivy.yaml`, `trivy.yml`, `.trivy.yaml`, `.trivy.yml`)

Signed-off-by: Alex Chen <l46983284@gmail.com>
