### PR TITLE
Fix Hatch code version source schema

### DIFF
--- a/src/schemas/json/hatch.json
+++ b/src/schemas/json/hatch.json
@@ -881,6 +881,29 @@
           },
           "type": "string"
         },
+        "expression": {
+          "title": "Expression",
+          "description": "A Python expression that will be evaluated in the context of the loaded file to return the version",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/latest/plugins/version-source/code/#options"
+            }
+          },
+          "type": "string"
+        },
+        "search-paths": {
+          "title": "Search paths",
+          "description": "A list of relative paths to directories that will be prepended to Python's search path",
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/latest/plugins/version-source/code/#options"
+            }
+          },
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "source": {
           "title": "Source",
           "description": "A source to use for retrieving and updating the version.",
@@ -1030,6 +1053,7 @@
           "type": "object",
           "required": ["path"],
           "properties": {
+            "source": false,
             "path": { "type": "string" },
             "pattern": { "type": "string" }
           }
@@ -1048,7 +1072,52 @@
           "type": "object",
           "required": ["source"],
           "properties": {
-            "source": { "type": "string" }
+            "path": false,
+            "source": { "type": "string", "not": { "enum": ["code", "regex"] } }
+          }
+        }
+      }
+    },
+    {
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/latest/version/"
+            }
+          },
+          "type": "object",
+          "required": ["path", "source"],
+          "properties": {
+            "source": { "const": "regex" },
+            "path": { "type": "string" },
+            "pattern": { "type": "string" }
+          }
+        }
+      }
+    },
+    {
+      "required": ["version"],
+      "properties": {
+        "version": {
+          "x-taplo": {
+            "links": {
+              "key": "https://hatch.pypa.io/latest/plugins/version-source/code/"
+            }
+          },
+          "type": "object",
+          "required": ["path", "source"],
+          "properties": {
+            "source": { "const": "code" },
+            "path": { "type": "string" },
+            "expression": { "type": "string" },
+            "search-paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         }
       }

--- a/src/test/hatch/version-code-source.toml
+++ b/src/test/hatch/version-code-source.toml
@@ -1,0 +1,6 @@
+#:schema ../../schemas/json/hatch.json
+[version]
+source = "code"
+path = "src/pkg/__init__.py"
+expression = "__version__"
+search-paths = ["src"]


### PR DESCRIPTION
## Summary
- allow Hatch version sources that use both source and path, such as source = code
- model code version source options including expression and search-paths
- keep source-only version plugins separate from path-based configuration
- add a Hatch fixture for the documented code version source configuration

## Validation
- node ./cli.js check --schema-name=hatch.json
- pnpm exec prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/hatch.json src/test/hatch/version-code-source.toml
- uv run --with jsonschema python ... checked all src/test/hatch/*.toml as valid
- uv run --with jsonschema python ... checked all src/negative_test/hatch/*.toml remain invalid
- validated inline-snapshot's [tool.hatch] table against the patched schema