### PR TITLE
Add misata.yaml (synthetic data schema)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7902,6 +7902,17 @@
       "url": "https://www.schemastore.org/mdxlintrc.json"
     },
     {
+      "name": "misata.yaml",
+      "description": "Misata synthetic-data declaration: tables, relationships, exact aggregate curves, and identities for the misata generator",
+      "fileMatch": [
+        "misata.yaml",
+        "misata.yml",
+        "*.misata.yaml",
+        "*.misata.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/rasinmuhammed/misata/main/schema/misata.schema.json"
+    },
+    {
       "name": "mirrord config",
       "description": "mirrord",
       "fileMatch": [


### PR DESCRIPTION
Adds a catalog entry for misata.yaml, the schema file of the misata synthetic-data generator (https://github.com/rasinmuhammed/misata, MIT, on PyPI). The JSON Schema is self-hosted at the linked raw URL, is draft 2020-12, and is kept in sync with the library by a test in the project's suite. fileMatch covers the canonical misata.yaml plus the *.misata.yaml variant used for multiple schemas in one repo.