### PR TITLE
Add editorconfig-checker config schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2802,6 +2802,15 @@
       "url": "https://eca.dev/config.json"
     },
     {
+      "name": "editorconfig-checker",
+      "description": "editorconfig-checker configuration file",
+      "fileMatch": [".editorconfig-checker.json"],
+      "url": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/main/.editorconfig-checker.schema.json",
+      "versions": {
+        "3.8.0": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/v3.8.0/.editorconfig-checker.schema.json"
+      }
+    },
+    {
       "name": "eksctl",
       "description": "eksctl cluster configuration file",
       "url": "https://raw.githubusercontent.com/weaveworks/eksctl/main/pkg/apis/eksctl.io/v1alpha5/assets/schema.json"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR adds a JSON Schema entry for the [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) configuration file.

The schema was first released in [v3.8.0](https://github.com/editorconfig-checker/editorconfig-checker/tree/v3.8.0), so the `versions` map starts from v3.8.0.
