### PR TITLE
Add harness.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3972,6 +3972,12 @@
       "url": "https://www.schemastore.org/grunt-task.json"
     },
     {
+      "name": "harness.json",
+      "description": "Manifest for AI coding-harness configuration: workflow packs, versions, and install receipts for a repo or machine",
+      "fileMatch": ["harness.json"],
+      "url": "https://baselane.sh/harness.schema.json"
+    },
+    {
       "name": "HashiCorp Vault",
       "description": "HashiCorp's Vault configuration file",
       "fileMatch": ["vault.json", "vault.config.json"],


### PR DESCRIPTION
Adds a catalog entry for `harness.json` — a manifest for AI coding-harness configuration (workflow packs, exact version pins, and install receipts for a repo or machine).

- Schema is self-hosted at https://baselane.sh/harness.schema.json (`$id` matches)
- Spec: https://github.com/baselane-sh/harness.json (examples there all validate against the schema and carry the `$schema` key)
- Reference implementation: https://github.com/baselane-sh/baselane (the `baselane` CLI writes and validates this file)
- `fileMatch`: `harness.json` at the repo root