### PR TITLE
feat(dependabot-2.0): add npm registry `scope` property

### DIFF
--- a/src/negative_test/dependabot-2.0/registries-scope-wrong-type.json
+++ b/src/negative_test/dependabot-2.0/registries-scope-wrong-type.json
@@ -1,0 +1,21 @@
+{
+  "registries": {
+    "github-packages": {
+      "scope": 42,
+      "token": "${{ secrets.GH_PACKAGES_PAT }}",
+      "type": "npm-registry",
+      "url": "https://npm.pkg.github.com"
+    }
+  },
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "npm",
+      "registries": ["github-packages"],
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1219,6 +1219,25 @@
             "description": "For registries with type: python-index, if the boolean value is true, pip resolves dependencies by using the specified URL rather than the base URL of the Python Package Index (by default https://pypi.org/simple).",
             "type": "boolean"
           },
+          "scope": {
+            "$comment": "'scope' must be either a single npm scope, or an array of them.",
+            "description": "For registries with type: npm-registry, the npm scope or scopes served by this registry, for example '@my-org'. Dependabot binds only the listed scopes to this registry when generating the .npmrc, so packages outside those scopes continue to resolve from the base registry. This value takes precedence over scope inference from an existing .npmrc or from the lockfile.",
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "minItems": 1
+              },
+              {
+                "type": "string",
+                "minLength": 1
+              }
+            ]
+          },
           "organization": {
             "description": "",
             "type": "string"

--- a/src/test/dependabot-2.0/registries-npm-scope.json
+++ b/src/test/dependabot-2.0/registries-npm-scope.json
@@ -1,0 +1,27 @@
+{
+  "registries": {
+    "github-packages-multi-scope": {
+      "scope": ["@my-org", "@my-other-org"],
+      "token": "${{ secrets.GH_PACKAGES_PAT }}",
+      "type": "npm-registry",
+      "url": "https://npm.pkg.github.com"
+    },
+    "github-packages-single-scope": {
+      "scope": "@my-org",
+      "token": "${{ secrets.GH_PACKAGES_PAT }}",
+      "type": "npm-registry",
+      "url": "https://npm.pkg.github.com"
+    }
+  },
+  "updates": [
+    {
+      "directory": "/",
+      "package-ecosystem": "npm",
+      "registries": ["github-packages-single-scope"],
+      "schedule": {
+        "interval": "daily"
+      }
+    }
+  ],
+  "version": 2
+}


### PR DESCRIPTION
Adds the `scope` property to `definitions.registry` in `dependabot-2.0.json`.

## Why

Dependabot supports `scope` on `npm-registry` entries, but the schema does not model it. Because `definitions.registry` sets `additionalProperties: false`, a `dependabot.yml` that uses `scope` — and works correctly in production — is reported as invalid by editors and language servers:

> Property scope is not allowed

Upstream support landed in two merged PRs:

- [dependabot/dependabot-core#15219](https://github.com/dependabot/dependabot-core/pull/15219) (merged 2026-06-09) — adds `scope` as a property of `npm_registry` credentials.
- [dependabot/dependabot-core#15264](https://github.com/dependabot/dependabot-core/pull/15264) (merged 2026-06-16) — makes it authoritative: the scoped credential registry is consulted ahead of `.npmrc` and lockfile inference.

## Type

Per [`common/lib/dependabot/credential.rb`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/credential.rb), `scope` is accepted as either a single string or an array of strings, normalized internally to an array:

```ruby
raw_scope = credential.delete("scope")
@scope = T.let(
  case raw_scope
  when String then [raw_scope]
  when Array then raw_scope
  end,
  T.nilable(T::Array[String])
)
```

The schema models both forms with a `oneOf`, matching the existing convention used by `updates[].registries` in this same file.

## Context

`scope` matters most for organizations that publish to GitHub Packages. Dependabot may use the org's GitHub Packages registry as the base npm registry, which breaks resolution of public packages; binding the private registry to an explicit scope keeps everything else on the base registry. Related discussion in [dependabot/dependabot-core#15415](https://github.com/dependabot/dependabot-core/issues/15415), which is still open — this PR does not claim to resolve it, and is only about bringing the schema in line with the `scope` property that dependabot-core already parses.

## Tests

- `src/test/dependabot-2.0/registries-npm-scope.json` — covers both the single-string and array forms.
- `src/negative_test/dependabot-2.0/registries-scope-wrong-type.json` — rejects a non-string, non-array value.

Verified that the positive test fails against the unmodified schema with `must NOT have additional properties`, and that both tests pass with the change. `node ./cli.js check --schema-name=dependabot-2.0.json` is green, and the files are prettier-clean.

## Note on overlap

[#5962](https://github.com/SchemaStore/schemastore/pull/5962) also touches `dependabot*.json`. This change is a small additive block inside `definitions.registry` and should rebase cleanly either way; happy to rebase if that one lands first.
