### PR TITLE
Add MockServer Expectation catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5003,6 +5003,11 @@
       "url": "https://raw.githubusercontent.com/getmockd/mockd/main/schema/mockd.schema.json"
     },
     {
+      "name": "MockServer Expectation",
+      "description": "MockServer expectation configuration defining a single request matcher and response action. For files holding an array of expectations, use the \"MockServer Expectations\" entry. See https://www.mock-server.com",
+      "url": "https://www.mock-server.com/schema/expectation.json"
+    },
+    {
       "name": "MockServer Expectations",
       "description": "MockServer expectations configuration for defining request matchers and response actions. See https://www.mock-server.com",
       "fileMatch": [


### PR DESCRIPTION
## Summary

Adds a catalog entry for MockServer's **single-expectation** schema, complementing the `MockServer Expectations` entry added in #5672 which covers the array form.

Both are self-hosted, self-contained draft-07 documents with `$id` matching their URL:

| Entry | URL | Shape |
|---|---|---|
| MockServer Expectations (already in catalog) | https://www.mock-server.com/schema/expectations.json | array |
| **MockServer Expectation** (this PR) | https://www.mock-server.com/schema/expectation.json | object |

## Why `fileMatch` is omitted

Deliberate, not an oversight:

- MockServer has no conventional filename for a lone expectation — its initializer (`initializationJsonPath`) always reads the array form.
- The existing `MockServer Expectations` entry already claims the `mockserver*.json` namespace, so any glob here would either be a false positive or trip the duplicate-`fileMatch` check.

This follows the *Avoid Generic `fileMatch` Patterns* guidance in CONTRIBUTING — "Omit `fileMatch` or set it to an empty array (which still allows the user to manually select it)".

## Validation

`node ./cli.js check` passes locally:

```
✔️ catalog.json validates against its schema
✔️ catalog.json has no fields that break guidelines
✔️ catalog.json has no duplicate "fileMatch" values
✔️ catalog.json has no invalid schema URLs
✔️ catalog.json has all local entries that exist in file total
```

`prettier --check` also passes. Both schema URLs return `200 application/schema+json`.

## Note

This supersedes #5674, which was a duplicate of #5672 and conflicted with it. This PR is rebased on current `master` and adds only the one entry that #5672 did not cover.