### PR TITLE
fix(typo3): allow static route source and content properties

### DIFF
--- a/src/schemas/json/typo3.json
+++ b/src/schemas/json/typo3.json
@@ -185,6 +185,14 @@
           "description": "Route Type",
           "type": "string",
           "enum": ["uri", "staticText"]
+        },
+        "source": {
+          "description": "Page, File or URL",
+          "type": "string"
+        },
+        "content": {
+          "description": "Static Text",
+          "type": "string"
         }
       },
       "if": {
@@ -195,21 +203,9 @@
         }
       },
       "then": {
-        "properties": {
-          "source": {
-            "description": "Page, File or URL",
-            "type": "string"
-          }
-        },
         "required": ["source"]
       },
       "else": {
-        "properties": {
-          "content": {
-            "description": "Static Text",
-            "type": "string"
-          }
-        },
         "required": ["content"]
       },
       "required": ["route", "type"],

--- a/src/test/typo3/typo3.yml
+++ b/src/test/typo3/typo3.yml
@@ -36,6 +36,13 @@ languages:
     fallbacks: '11,2,16,1,12,17'
     flag: global
 rootPageId: 275
+routes:
+  - route: sitemap.xml
+    type: uri
+    source: 't3://page?uid=1&type=1533906435'
+  - route: robots.txt
+    type: staticText
+    content: "User-agent: *\r\nDisallow: /typo3/"
 routeEnhancers:
   PageTypeSuffix:
     type: 'Simple'


### PR DESCRIPTION
## Summary

- declare `source` and `content` in the static route object's parent `properties` so draft-07 `additionalProperties` recognizes them
- keep the conditional requirements for `uri` and `staticText` routes
- cover both route types in the TYPO3 positive test fixture

Fixes #6020

## Testing

- `node ./cli.js check --schema-name=typo3.json`
- `node ./cli.js check`
- `node ./cli.js coverage`
- `npm run typecheck`
- `npm run eslint`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/typo3.json src/test/typo3/typo3.yml`