### PR TITLE
fix: remove overeager GCP Blueprint Metadata fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3492,7 +3492,6 @@
     {
       "name": "GCP Blueprint Metadata",
       "description": "Blueprint Solutions for Google Cloud",
-      "fileMatch": ["metadata.yaml", "metadata.display.yaml"],
       "url": "https://www.schemastore.org/gcp-blueprint-metadata.json"
     },
     {


### PR DESCRIPTION
## Summary

Removes the automatic `fileMatch` for **GCP Blueprint Metadata** so IDE schema association no longer treats every `metadata.yaml` / `metadata.display.yaml` as a GCP Blueprint.

## Why

`metadata.yaml` is an extremely common filename. Matching it globally causes false-positive schema validation for unrelated projects (issue #5985).

Maintainer note on the issue: a PR that **removes both `fileMatch`es** is welcome / mergeable. Users can still select the schema manually when they are actually editing GCP Blueprint metadata.

## Change

- `src/api/json/catalog.json`: drop `fileMatch` from the `GCP Blueprint Metadata` catalog entry (schema URL unchanged).

Closes #5985
