### PR TITLE
change APP schema to match *.app-profile.json instead

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -147,7 +147,7 @@
     {
       "name": "Applicant Profile Protocol",
       "description": "Structured JSON format for professional profiles, resumes, and CVs with skills, experience, education, and certifications",
-      "fileMatch": ["*.app.json"],
+      "fileMatch": ["*.app-profile.json"],
       "url": "https://app-protocol.org/schema/app-1.0.json"
     },
     {


### PR DESCRIPTION
Closes SchemaStore/schemastore#5530

I'm currently out right now so I'm drafting this until I can be 100% sure tests pass (I don't think it should affect anything anyways, but I'll check)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
