### PR TITLE
feat: register Hoverfly simulation schema in catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4060,6 +4060,12 @@
       "url": "https://html-validate.org/schemas/config.json"
     },
     {
+      "name": "Hoverfly Simulation",
+      "description": "Hoverfly API simulation file for captured or authored HTTP request-response pairs",
+      "fileMatch": [],
+      "url": "https://raw.githubusercontent.com/SpectoLabs/hoverfly/master/core/handlers/v2/schema.json"
+    },
+    {
       "name": "Ory Hydra configuration",
       "description": "Ory Hydra configuration file",
       "fileMatch": ["hydra.json", "hydra.yml", "hydra.yaml", "hydra.toml"],


### PR DESCRIPTION
## Summary
Register the official Hoverfly simulation JSON Schema in the SchemaStore catalog as a remote entry.

- Name: `Hoverfly Simulation`
- URL: https://raw.githubusercontent.com/SpectoLabs/hoverfly/master/core/handlers/v2/schema.json
- `fileMatch` left empty (simulation files use various names; associate via `$schema` or editor UI)

Closes #3434

## Source of truth
- Upstream schema: https://github.com/SpectoLabs/hoverfly/blob/master/core/handlers/v2/schema.json
- Docs: https://docs.hoverfly.io/en/latest/pages/keyconcepts/simulations/simulations.html

## Test plan
- [x] Catalog JSON parses after surgical insert
- [x] Upstream schema URL returns valid JSON (`Hoverfly simulation schema`)
- [x] Catalog lint: name/description have no trailing punctuation and do not contain the word "schema"
