### PR TITLE
Add Open Data Governance Standard (ODGS) schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5368,6 +5368,24 @@
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/fields.json"
     },
     {
+      "name": "ODGS Standard Metrics",
+      "description": "Open Data Governance Standard (ODGS) metric definitions — KPI logic, lineage, and compliance mappings",
+      "fileMatch": ["*.odgs-metrics.json"],
+      "url": "https://www.schemastore.org/odgs-standard-metrics.json"
+    },
+    {
+      "name": "ODGS Data Rules",
+      "description": "ODGS validation and permissibility rules — mechanically executable data governance constraints",
+      "fileMatch": ["*.odgs-rules.json"],
+      "url": "https://www.schemastore.org/odgs-data-rules.json"
+    },
+    {
+      "name": "ODGS Ontology Graph",
+      "description": "ODGS business-entity ontology graph for AI graph traversal",
+      "fileMatch": ["*.odgs-ontology.json"],
+      "url": "https://www.schemastore.org/odgs-ontology-graph.json"
+    },
+    {
       "name": "ogen",
       "description": "ogen code generator configuration, see https://ogen.dev/docs/config",
       "fileMatch": ["ogen.yml", "ogen.yaml", ".ogen.yml", ".ogen.yaml"],

--- a/src/negative_test/odgs-data-rules/invalid-severity-and-missing-name.json
+++ b/src/negative_test/odgs-data-rules/invalid-severity-and-missing-name.json
@@ -1,0 +1,6 @@
+[
+  {
+    "rule_id": "BAD_RULE_1",
+    "severity": "CRITICAL"
+  }
+]

--- a/src/negative_test/odgs-ontology-graph/missing-graph-edges.json
+++ b/src/negative_test/odgs-ontology-graph/missing-graph-edges.json
@@ -1,0 +1,6 @@
+{
+  "domains": {},
+  "meta": {
+    "project_name": "Incomplete_Ontology"
+  }
+}

--- a/src/negative_test/odgs-standard-metrics/missing-required-fields.json
+++ b/src/negative_test/odgs-standard-metrics/missing-required-fields.json
@@ -1,0 +1,6 @@
+[
+  {
+    "description": "Missing the required 'name' and 'domain' fields entirely.",
+    "metric_id": "M-2003"
+  }
+]

--- a/src/schemas/json/odgs-data-rules.json
+++ b/src/schemas/json/odgs-data-rules.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/odgs-data-rules.json",
+  "$comment": "Vendored from the Open Data Governance Standard (ODGS) reference implementation, https://github.com/MetricProvenance/odgs-protocol/blob/main/1_NORMATIVE_SPECIFICATION/schemas/meta/rule.schema.json (canonical $id: urn:odgs:schema:rule). ODGS is on a path toward formal standardization; learn more at https://www.metricprovenance.com/start.",
+  "title": "ODGS Data Rules",
+  "description": "ODGS validation and permissibility rules \u2014 mechanically executable data governance constraints.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "ODGS Standard Data Rule",
+    "description": "A single rule definition in the ODGS Judiciary plane.",
+    "required": ["rule_id", "name"],
+    "properties": {
+      "rule_id": {
+        "type": "string"
+      },
+      "urn": {
+        "type": "string",
+        "pattern": "^urn:odgs:rule:"
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "definition": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "domain": {
+        "type": "string"
+      },
+      "businessRule": {
+        "type": "string"
+      },
+      "severity": {
+        "type": "string",
+        "enum": ["HARD_STOP", "SOFT_STOP", "WARNING", "INFO"],
+        "description": "HARD_STOP: unconditional halt. SOFT_STOP: halt unless override token provided. WARNING: logged, non-blocking. INFO: informational only."
+      },
+      "logic_expression": {
+        "type": "string"
+      },
+      "calculation_logic": {
+        "type": "string"
+      },
+      "requires_human_review": {
+        "type": "boolean"
+      },
+      "depends_on": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^urn:odgs:rule:"
+        },
+        "description": "Rule URNs that must pass before this rule is evaluated (a DAG for evaluation ordering)."
+      },
+      "version": {
+        "type": "string",
+        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+        "description": "Semantic version of the rule definition, tracked in S-Cert audit logs."
+      },
+      "effective_from": {
+        "type": "string",
+        "format": "date"
+      },
+      "effective_to": {
+        "type": "string",
+        "format": "date"
+      },
+      "icon": {
+        "type": "string"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "exampleGood": {
+        "type": "string"
+      },
+      "examplePoor": {
+        "type": "string"
+      },
+      "targetIndustries": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "improvesDqDimensionIds": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      "semantic_hash": {
+        "type": "string",
+        "description": "SHA-256 hash of the rule's legislative provenance, for drift detection."
+      },
+      "metadata": {
+        "type": "object"
+      },
+      "framework_tags": {
+        "type": "object",
+        "description": "Bindings to enterprise frameworks (APQC, DAMA DMBOK, BIAN, CDMC)."
+      },
+      "sovereign_refs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "urn": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "References to sovereign/internal definitions this rule is bound to."
+      }
+    },
+    "additionalProperties": true
+  }
+}

--- a/src/schemas/json/odgs-ontology-graph.json
+++ b/src/schemas/json/odgs-ontology-graph.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/odgs-ontology-graph.json",
+  "$comment": "Vendored from the Open Data Governance Standard (ODGS) reference implementation, https://github.com/MetricProvenance/odgs-protocol/blob/main/2_INFORMATIVE_REFERENCE/src/odgs/schemas/validation/ontology.schema.json (canonical $id: https://odgs.org/schemas/ontology.schema.json). ODGS is on a path toward formal standardization; learn more at https://www.metricprovenance.com/start.",
+  "title": "ODGS Ontology Graph",
+  "description": "ODGS business-entity ontology graph for AI graph traversal.",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "schema_version": {
+          "type": "string"
+        },
+        "project_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "urn_format": {
+          "type": "string"
+        }
+      },
+      "required": ["project_name"]
+    },
+    "domains": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "object",
+          "properties": {
+            "source_file": {
+              "type": "string"
+            },
+            "urn_prefix": {
+              "type": "string"
+            }
+          },
+          "required": ["urn_prefix"]
+        }
+      }
+    },
+    "relationship_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": ["type"]
+      }
+    },
+    "graph_edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "string"
+          },
+          "link_id": {
+            "type": "string"
+          },
+          "source_urn": {
+            "type": "string"
+          },
+          "target_urn": {
+            "type": "string"
+          },
+          "relationship": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "anyOf": [
+          {
+            "properties": {
+              "comment": {
+                "type": "string"
+              }
+            },
+            "required": ["comment"]
+          },
+          {
+            "properties": {
+              "link_id": {
+                "type": "string"
+              },
+              "source_urn": {
+                "type": "string"
+              },
+              "target_urn": {
+                "type": "string"
+              },
+              "relationship": {
+                "type": "string"
+              }
+            },
+            "required": ["link_id", "source_urn", "target_urn", "relationship"]
+          }
+        ]
+      }
+    }
+  },
+  "required": ["graph_edges"]
+}

--- a/src/schemas/json/odgs-standard-metrics.json
+++ b/src/schemas/json/odgs-standard-metrics.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/odgs-standard-metrics.json",
+  "$comment": "Vendored from the Open Data Governance Standard (ODGS) reference implementation, https://github.com/MetricProvenance/odgs-protocol/blob/main/1_NORMATIVE_SPECIFICATION/schemas/meta/metric.schema.json (canonical $id: urn:odgs:schema:metric). ODGS is on a path toward formal standardization; learn more at https://www.metricprovenance.com/start.",
+  "title": "ODGS Standard Metrics",
+  "description": "Open Data Governance Standard (ODGS) metric definitions \u2014 KPI logic, lineage, and compliance mappings.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "ODGS Standard Metric",
+    "description": "A single metric definition in the ODGS Legislative plane.",
+    "required": ["metric_id", "name", "domain"],
+    "properties": {
+      "metric_id": {
+        "type": "string"
+      },
+      "urn": {
+        "type": "string",
+        "pattern": "^urn:odgs:metric:"
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "domain": {
+        "type": "string",
+        "minLength": 1
+      },
+      "definition": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "icon": {
+        "type": "string"
+      },
+      "owner": {
+        "type": "string"
+      },
+      "calculation_logic": {
+        "type": "object"
+      },
+      "abstract_calculation": {
+        "type": "string"
+      },
+      "sql_pattern": {
+        "type": "string"
+      },
+      "dax_pattern": {
+        "type": "string"
+      },
+      "example": {
+        "type": "string"
+      },
+      "interpretation": {
+        "type": "string"
+      },
+      "targetIndustries": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "criticalDqDimensionIds": {
+        "type": "array",
+        "items": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        }
+      },
+      "framework_tags": {
+        "type": "object",
+        "description": "Bindings to enterprise frameworks (APQC, DAMA DMBOK, BIAN, CDMC), e.g. dama_id."
+      }
+    },
+    "additionalProperties": true
+  }
+}

--- a/src/test/odgs-data-rules/odgs-data-rules.json
+++ b/src/test/odgs-data-rules/odgs-data-rules.json
@@ -1,0 +1,23 @@
+[
+  {
+    "calculation_logic": "has_explicit_consent == True or processing_basis == 'vital_interests'",
+    "definition": "GDPR Art 9: biometric processing requires explicit consent.",
+    "domain": "Legislative Compliance",
+    "framework_tags": {
+      "dama_id": "SEC-04"
+    },
+    "name": "Biometric Data Explicit Consent",
+    "requires_human_review": false,
+    "rule_id": "GDPR_ART_9_BIOMETRIC_CONSENT",
+    "severity": "HARD_STOP",
+    "sovereign_refs": [{ "urn": "urn:odgs:sovereign:eu_gdpr:art_9" }],
+    "urn": "urn:odgs:rule:gdpr_art_9_biometric_consent",
+    "version": "1.0.0"
+  },
+  {
+    "logic_expression": "data_deletion_sla_days <= 30",
+    "name": "Data Deletion SLA",
+    "rule_id": "7001",
+    "severity": "WARNING"
+  }
+]

--- a/src/test/odgs-ontology-graph/odgs-ontology-graph.json
+++ b/src/test/odgs-ontology-graph/odgs-ontology-graph.json
@@ -1,0 +1,35 @@
+{
+  "domains": {
+    "metric": {
+      "source_file": "standard_metrics.json",
+      "urn_prefix": "urn:odgs:metric:"
+    },
+    "rule": {
+      "source_file": "standard_data_rules.json",
+      "urn_prefix": "urn:odgs:rule:"
+    }
+  },
+  "graph_edges": [
+    {
+      "link_id": "L-001",
+      "relationship": "enforces",
+      "source_urn": "urn:odgs:rule:gdpr_art_9_biometric_consent",
+      "target_urn": "urn:odgs:metric:data_completeness_rate"
+    },
+    {
+      "comment": "Legacy edge retained for backward compatibility with v5 graphs."
+    }
+  ],
+  "meta": {
+    "description": "The connective tissue linking Metrics, Rules, Processes, Factors, and Dimensions into a single traversable graph for AI grounding and automated governance.",
+    "project_name": "ODGS_Master_Ontology",
+    "schema_version": "1.0",
+    "urn_format": "urn:odgs:<domain>:<id>"
+  },
+  "relationship_types": [
+    {
+      "description": "A rule enforces a metric's definition.",
+      "type": "enforces"
+    }
+  ]
+}

--- a/src/test/odgs-standard-metrics/odgs-standard-metrics.json
+++ b/src/test/odgs-standard-metrics/odgs-standard-metrics.json
@@ -1,0 +1,25 @@
+[
+  {
+    "calculation_logic": {
+      "denominator": "count(required_fields)",
+      "numerator": "count(non_null_required_fields)",
+      "type": "ratio"
+    },
+    "definition": "Percentage of required fields populated across a dataset.",
+    "domain": "Data Quality",
+    "framework_tags": {
+      "dama_id": "DQ-01"
+    },
+    "metric_id": "M-2001",
+    "name": "Data Completeness Rate",
+    "owner": "Data Governance Office",
+    "targetIndustries": ["Financial Services", "Healthcare"],
+    "urn": "urn:odgs:metric:data_completeness_rate"
+  },
+  {
+    "criticalDqDimensionIds": ["DQ-09", 12],
+    "domain": "Privacy",
+    "metric_id": "M-2002",
+    "name": "Consent Capture Rate"
+  }
+]


### PR DESCRIPTION
## What
Adds three schemas for the Open Data Governance Standard (ODGS) — an open-source, Apache 2.0 JSON protocol (`pip install odgs` / `npm install odgs`, [repo](https://github.com/MetricProvenance/odgs-protocol)) that turns data-governance policy into mechanically executable constraints:

- **odgs-standard-metrics.json** — metric/KPI definitions
- **odgs-data-rules.json** — validation/permissibility rules
- **odgs-ontology-graph.json** — business-entity ontology graph

## fileMatch
Led with a project-specific extension (`*.odgs-metrics.json`, `*.odgs-rules.json`, `*.odgs-ontology.json`) rather than the generic filenames these files are conventionally saved as (`standard_metrics.json` etc.), since CONTRIBUTING.md flags generic patterns as a false-positive risk. Happy to add the generic names as additional `fileMatch` entries if maintainers are comfortable with that given the specificity of the schema content itself — deferring to your judgment.

## Testing
Each schema has positive and negative test fixtures under `src/test/`/`src/negative_test/` and passes individually:
```
node cli.js check --schema-name=odgs-standard-metrics.json
node cli.js check --schema-name=odgs-data-rules.json
node cli.js check --schema-name=odgs-ontology-graph.json
```
All three report "Completed pre-checks" + "Completed Ajv validation" with no errors. Ran `npm run prettier:fix` on all new/changed files.

Two of the three schemas (metrics, rules) validate a top-level array of objects — each item schema was adapted from the project's single-object dev-time schema and wrapped in `{"type":"array","items":...}` to match the real file shape. `additionalProperties` is left permissive on those two since the underlying format has evolving optional fields (framework/enterprise-binding tags); happy to tighten if preferred.