### PR TITLE
Add repo-settings-as-code catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6435,6 +6435,12 @@
       "url": "https://www.schemastore.org/replit.json"
     },
     {
+      "name": "repo-settings-as-code",
+      "description": "Declarative GitHub repository settings applied by the repo-settings-as-code action; accepts Probot Settings app files as-is. Documentation: https://github.com/Vivswan/repo-settings-as-code",
+      "fileMatch": ["**/.github/settings.yml"],
+      "url": "https://raw.githubusercontent.com/Vivswan/repo-settings-as-code/main/lib/settings.schema.json"
+    },
+    {
       "name": "reposets Configuration",
       "description": "Configuration for the reposets CLI tool for syncing GitHub repository settings",
       "fileMatch": ["reposets.config.toml", "reposets.config.json"],


### PR DESCRIPTION
Registers a self-hosted schema for `.github/settings.yml` files used by [repo-settings-as-code](https://github.com/Vivswan/repo-settings-as-code), a GitHub Action that applies declarative repository settings (rulesets, labels, branch protection, environments, and more).

The schema lives in the action's repo and is regenerated from its TypeScript types on every build, so it stays current with the action. `node ./cli.js check` passes.

On the `fileMatch`: `.github/settings.yml` is the same path the Probot Settings app and safe-settings use, and no catalog entry claims it today. The schema is written for that shared audience: it accepts Probot-format files as-is and keeps every object open (`additionalProperties` is never false), so it adds autocomplete and hover docs without marking anyone's existing file invalid.