### PR TITLE
Added ZAPP schema updates 1.9.0, 1.10.0, 1.10.2

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4123,7 +4123,7 @@
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
       "fileMatch": ["zapp.yaml", "zapp.yml", "zapp.json"],
-      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.8.0.json",
+      "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.10.2.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json",
         "1.1.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.1.0.json",
@@ -4134,7 +4134,10 @@
         "1.5.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.5.0.json",
         "1.6.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.6.0.json",
         "1.7.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.7.0.json",
-        "1.8.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.8.0.json"
+        "1.8.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.8.0.json",
+        "1.9.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.9.0.json",
+        "1.10.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.10.0.json",
+        "1.10.2": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.10.2.json"
       }
     },
     {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

New version of the JSON schema first introduced with this PR: https://github.com/SchemaStore/schemastore/pull/2860 and most recently updated with https://github.com/SchemaStore/schemastore/pull/5203

This schema is used by free development tools provided by IBM: https://ibm.github.io/zopeneditor-about/Docs/zapp.html