### PR TITLE
feat: point dbt catalog entries at fusion schema paths

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1781,25 +1781,25 @@
       "name": "dbt Dependencies",
       "description": "dbt's dependencies.yml file for external packages and cross-project refs",
       "fileMatch": ["**/*dbt*/dependencies.yaml", "**/*dbt*/dependencies.yml"],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dependencies-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dependencies-latest-fusion.json"
     },
     {
       "name": "dbt Project",
       "description": "dbt's project configuration file",
       "fileMatch": ["dbt_project.yaml", "dbt_project.yml"],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_project-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dbt_project-latest-fusion.json"
     },
     {
       "name": "dbt Packages",
       "description": "dbt's packages.yml file for external packages",
       "fileMatch": ["**/*dbt*/packages.yaml", "**/*dbt*/packages.yml"],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/packages-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/packages-latest-fusion.json"
     },
     {
       "name": "dbt Selectors",
       "description": "dbt's selectors.yml file for configuring YAML selectors",
       "fileMatch": ["**/*dbt*/selectors.yaml", "**/*dbt*/selectors.yml"],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/selectors-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/selectors-latest-fusion.json"
     },
     {
       "name": "dbt YAML files",
@@ -1814,7 +1814,7 @@
         "**/*dbt*/snapshots/**/*.yaml",
         "**/*dbt*/snapshots/**/*.yml"
       ],
-      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest/dbt_yml_files-latest.json"
+      "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dbt_yml_files-latest-fusion.json"
     },
     {
       "name": "Debian Upstream Metadata file",


### PR DESCRIPTION
## Summary
- Point existing dbt catalog entries at the official `dbt-jsonschema` fusion schema paths under `schemas/latest_fusion/`.
- Covers dbt Project, Packages, Selectors, YAML files (as listed in #5487) and the sibling dbt Dependencies entry for path consistency.
- No local schema host, no `fileMatch` changes — URL-only catalog update.

## Source of truth
- Issue: https://github.com/SchemaStore/schemastore/issues/5487
- Upstream schemas: https://github.com/dbt-labs/dbt-jsonschema

## Test plan
- [x] `json.loads` on `src/api/json/catalog.json`
- [x] HTTP 200 for all five updated raw fusion URLs
- [x] name/description catalog lint hygiene (no trailing punctuation, no word `schema`)

Closes #5487
