### PR TITLE
Update Knip schema URLs to v6

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3431,9 +3431,15 @@
     },
     {
       "name": "Knip",
-      "description": "Knip configuration files",
-      "fileMatch": ["knip.json", ".knip.json", "knip.jsonc", ".knip.jsonc"],
-      "url": "https://unpkg.com/knip@5/schema.json"
+      "description": "Knip JSON configuration files",
+      "fileMatch": ["knip.json", ".knip.json"],
+      "url": "https://unpkg.com/knip@6/schema.json"
+    },
+    {
+      "name": "Knip JSONC",
+      "description": "Knip JSONC configuration files",
+      "fileMatch": ["knip.jsonc", ".knip.jsonc"],
+      "url": "https://unpkg.com/knip@6/schema-jsonc.json"
     },
     {
       "name": "KSail",


### PR DESCRIPTION
## Summary
- update Knip JSON configurations from the v5 schema to the current major-scoped v6 schema
- associate JSONC filenames with Knip's dedicated JSONC schema
- keep all four existing supported configuration filenames without matching JavaScript or TypeScript configs

## Evidence
- https://knip.dev/reference/configuration
- https://knip.dev/overview/configuration
- https://unpkg.com/knip@6/schema.json
- https://unpkg.com/knip@6/schema-jsonc.json

Knip's official documentation recommends the `@6` URLs. A major-scoped URL receives compatible v6 schema updates without silently crossing into a future breaking v7 release. The project currently has 11.8k GitHub stars and 44.3M npm downloads over the most recent complete 30-day measurement window (measured July 23, 2026).

## Validation
- `npm clean-install`
- `npm run typecheck`
- `npm run eslint`
- targeted Prettier formatting
- SchemaStore PR audit (expected catalog-only warning only)
- live HTTP and JSON checks for both upstream schema URLs
- repository-wide `node ./cli.js check` passes catalog preconditions, then reaches the existing Windows-only Ajv stack overflow while compiling unrelated `cargo-lints-clippy.json`