### PR TITLE
Add GitHub CLI configuration schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3621,6 +3621,18 @@
       "url": "https://www.schemastore.org/github-action.json"
     },
     {
+      "name": "GitHub CLI configuration",
+      "description": "Global configuration for the GitHub CLI",
+      "fileMatch": ["**/gh/config.yml", "**/GitHub CLI/config.yml"],
+      "url": "https://www.schemastore.org/github-cli-config.json"
+    },
+    {
+      "name": "GitHub CLI hosts",
+      "description": "Authentication and per-host configuration for the GitHub CLI",
+      "fileMatch": ["**/gh/hosts.yml", "**/GitHub CLI/hosts.yml"],
+      "url": "https://www.schemastore.org/github-cli-hosts.json"
+    },
+    {
       "name": "GitHub Discussion",
       "description": "YAML GitHub Discussions",
       "fileMatch": [

--- a/src/negative_test/github-cli-config/invalid-alias.yml
+++ b/src/negative_test/github-cli-config/invalid-alias.yml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+aliases:
+  issue: 123

--- a/src/negative_test/github-cli-config/invalid-git-protocol.yml
+++ b/src/negative_test/github-cli-config/invalid-git-protocol.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+git_protocol: git

--- a/src/negative_test/github-cli-config/invalid-telemetry.yml
+++ b/src/negative_test/github-cli-config/invalid-telemetry.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+telemetry: verbose

--- a/src/negative_test/github-cli-config/root-array.yml
+++ b/src/negative_test/github-cli-config/root-array.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+- version: 1

--- a/src/negative_test/github-cli-config/unsupported-version.yml
+++ b/src/negative_test/github-cli-config/unsupported-version.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+version: 2

--- a/src/negative_test/github-cli-hosts/invalid-git-protocol.yml
+++ b/src/negative_test/github-cli-hosts/invalid-git-protocol.yml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  git_protocol: git

--- a/src/negative_test/github-cli-hosts/invalid-host-spinner.yml
+++ b/src/negative_test/github-cli-hosts/invalid-host-spinner.yml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  spinner: maybe

--- a/src/negative_test/github-cli-hosts/invalid-host.yml
+++ b/src/negative_test/github-cli-hosts/invalid-host.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com: github-user

--- a/src/negative_test/github-cli-hosts/invalid-token.yml
+++ b/src/negative_test/github-cli-hosts/invalid-token.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  oauth_token:
+    value: not-a-real-token

--- a/src/negative_test/github-cli-hosts/invalid-user-prompt.yml
+++ b/src/negative_test/github-cli-hosts/invalid-user-prompt.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  users:
+    example-user:
+      prompt: maybe

--- a/src/negative_test/github-cli-hosts/invalid-user.yml
+++ b/src/negative_test/github-cli-hosts/invalid-user.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  users:
+    example-user: enabled

--- a/src/negative_test/github-cli-hosts/invalid-users.yml
+++ b/src/negative_test/github-cli-hosts/invalid-users.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  users:
+    - example-user

--- a/src/negative_test/github-cli-hosts/root-array.yml
+++ b/src/negative_test/github-cli-hosts/root-array.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+- github.com: {}

--- a/src/schemas/json/github-cli-config.json
+++ b/src/schemas/json/github-cli-config.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-cli-config.json",
+  "title": "GitHub CLI configuration",
+  "description": "Global configuration for the GitHub CLI.\nhttps://cli.github.com/manual/gh_config",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "description": "URI of the JSON Schema used to validate this configuration.\nhttps://json-schema.org/understanding-json-schema/reference/schema.html",
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "description": "Internal GitHub CLI configuration format version.\nhttps://github.com/cli/cli/blob/v2.96.0/internal/config/config.go",
+      "type": "integer",
+      "const": 1,
+      "default": 1
+    },
+    "git_protocol": {
+      "description": "Protocol to use for Git operations.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["https", "ssh"],
+      "default": "https"
+    },
+    "editor": {
+      "description": "Text editor command used by GitHub CLI.\nhttps://cli.github.com/manual/gh_config",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "prompt": {
+      "description": "Whether interactive prompting is enabled.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "enabled"
+    },
+    "prefer_editor_prompt": {
+      "description": "Whether GitHub CLI should prefer opening an editor instead of prompting in the terminal.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "disabled"
+    },
+    "pager": {
+      "description": "Terminal pager command used by GitHub CLI.\nhttps://cli.github.com/manual/gh_config",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "aliases": {
+      "description": "GitHub CLI aliases, keyed by alias name with command expansions as values.\nhttps://cli.github.com/manual/gh_alias",
+      "type": ["object", "null"],
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "http_unix_socket": {
+      "description": "Path to a Unix domain socket to use for HTTP connections.\nhttps://cli.github.com/manual/gh_config",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "browser": {
+      "description": "Web browser command used to open URLs.\nhttps://cli.github.com/manual/gh_config",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "color_labels": {
+      "description": "Whether label colors are displayed using their RGB values.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "disabled"
+    },
+    "accessible_colors": {
+      "description": "Whether the accessible four-bit color palette is enabled.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "disabled"
+    },
+    "accessible_prompter": {
+      "description": "Whether the accessible interactive prompter is enabled.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "disabled"
+    },
+    "spinner": {
+      "description": "Whether terminal spinner animations are enabled.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled"],
+      "default": "enabled"
+    },
+    "telemetry": {
+      "description": "Telemetry mode. The log mode writes telemetry events to stderr instead of sending them.\nhttps://cli.github.com/manual/gh_config",
+      "type": "string",
+      "enum": ["enabled", "disabled", "log"],
+      "default": "enabled"
+    }
+  }
+}

--- a/src/schemas/json/github-cli-hosts.json
+++ b/src/schemas/json/github-cli-hosts.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/github-cli-hosts.json",
+  "title": "GitHub CLI hosts configuration",
+  "description": "Authentication and per-host configuration for the GitHub CLI.\nhttps://cli.github.com/manual/gh_auth_status",
+  "type": "object",
+  "additionalProperties": {
+    "$ref": "#/definitions/host"
+  },
+  "definitions": {
+    "configOptions": {
+      "description": "GitHub CLI options that may be overridden for a host or preserved for an account.\nhttps://github.com/cli/cli/blob/v2.96.0/internal/config/config.go",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "git_protocol": {
+          "description": "Protocol to use for Git operations with this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["https", "ssh"]
+        },
+        "editor": {
+          "description": "Text editor command used for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": ["string", "null"]
+        },
+        "prompt": {
+          "description": "Whether interactive prompting is enabled for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        },
+        "prefer_editor_prompt": {
+          "description": "Whether GitHub CLI should prefer opening an editor instead of prompting in the terminal for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        },
+        "pager": {
+          "description": "Terminal pager command used for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": ["string", "null"]
+        },
+        "http_unix_socket": {
+          "description": "Path to a Unix domain socket used for HTTP connections to this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": ["string", "null"]
+        },
+        "browser": {
+          "description": "Web browser command used for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": ["string", "null"]
+        },
+        "color_labels": {
+          "description": "Whether label colors are displayed using their RGB values for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        },
+        "accessible_colors": {
+          "description": "Whether the accessible four-bit color palette is enabled for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        },
+        "accessible_prompter": {
+          "description": "Whether the accessible interactive prompter is enabled for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        },
+        "spinner": {
+          "description": "Whether terminal spinner animations are enabled for this host.\nhttps://cli.github.com/manual/gh_config",
+          "type": "string",
+          "enum": ["enabled", "disabled"]
+        }
+      }
+    },
+    "host": {
+      "description": "Configuration for a GitHub.com or GitHub Enterprise host.\nhttps://github.com/cli/cli/blob/v2.96.0/docs/multiple-accounts.md",
+      "allOf": [
+        {
+          "$ref": "#/definitions/configOptions"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "user": {
+              "description": "Username of the active account for this host.\nhttps://cli.github.com/manual/gh_auth_switch",
+              "type": "string"
+            },
+            "oauth_token": {
+              "description": "Sensitive plaintext authentication token used when secure credential storage is unavailable. Prefer storing credentials with gh auth login.\nhttps://cli.github.com/manual/gh_auth_login",
+              "type": "string"
+            },
+            "users": {
+              "description": "Accounts known for this host. A null value indicates that the account token is stored in the operating system credential store.\nhttps://github.com/cli/cli/blob/v2.96.0/docs/multiple-accounts.md",
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/definitions/user"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "user": {
+      "description": "Per-account configuration stored for a host.\nhttps://github.com/cli/cli/blob/v2.96.0/docs/multiple-accounts.md",
+      "allOf": [
+        {
+          "$ref": "#/definitions/configOptions"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "oauth_token": {
+              "description": "Sensitive plaintext authentication token used when secure credential storage is unavailable. Prefer storing credentials with gh auth login.\nhttps://cli.github.com/manual/gh_auth_login",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/github-cli-config/complete.yml
+++ b/src/test/github-cli-config/complete.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+version: 1
+git_protocol: ssh
+editor: code --wait
+prompt: enabled
+prefer_editor_prompt: disabled
+pager: less -FRX
+aliases:
+  co: pr checkout
+  bugs: issue list --label bug
+  shell: "!printf 'hello\\n'"
+http_unix_socket:
+browser: firefox
+color_labels: enabled
+accessible_colors: enabled
+accessible_prompter: disabled
+spinner: enabled
+telemetry: log

--- a/src/test/github-cli-config/forward-compatible.yml
+++ b/src/test/github-cli-config/forward-compatible.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-config.json
+version: 1
+editor:
+pager:
+aliases:
+future_option: future-value

--- a/src/test/github-cli-hosts/empty.yml
+++ b/src/test/github-cli-hosts/empty.yml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+{}

--- a/src/test/github-cli-hosts/multiple-hosts.yml
+++ b/src/test/github-cli-hosts/multiple-hosts.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  user: primary-user
+  git_protocol: ssh
+  editor: code --wait
+  prompt: enabled
+  prefer_editor_prompt: disabled
+  pager: less -FRX
+  http_unix_socket:
+  browser: firefox
+  color_labels: enabled
+  accessible_colors: enabled
+  accessible_prompter: disabled
+  spinner: enabled
+  oauth_token: not-a-real-token
+  users:
+    primary-user:
+      oauth_token: not-a-real-token
+      spinner: disabled
+    secure-user:
+    future-user:
+      future_option: future-value
+github.example.com:
+  user: enterprise-user
+  git_protocol: https
+  users:
+    enterprise-user:
+github.localhost:
+  custom_option: true

--- a/src/test/github-cli-hosts/secure-storage.yml
+++ b/src/test/github-cli-hosts/secure-storage.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../schemas/json/github-cli-hosts.json
+github.com:
+  user: example-user
+  git_protocol: https
+  users:
+    example-user:


### PR DESCRIPTION
## Summary
- add draft-07 schemas for GitHub CLI `config.yml` and the internal multi-account `hosts.yml` format
- model all v2.96.0 global and host/account-scoped settings, nullable serialized values, secure-keyring account entries, and plaintext token fallbacks
- keep unknown fields allowed because GitHub CLI preserves unknown keys and `hosts.yml` is an evolving internal format
- use directory-specific file matches for XDG/home and Windows AppData locations
- add representative positive fixtures and isolated negative fixtures for both schemas

## Evidence
- https://cli.github.com/manual/gh_config
- https://cli.github.com/manual/gh_help_environment
- https://github.com/cli/cli/blob/v2.96.0/internal/config/config.go
- https://github.com/cli/cli/blob/v2.96.0/docs/multiple-accounts.md
- https://github.com/cli/go-gh/blob/v2.13.0/pkg/config/config.go

GitHub CLI has 45.4k GitHub stars as of July 23, 2026. The `hosts.yml` schema deliberately permits arbitrary hostnames for GitHub Enterprise and does not constrain token formats. Test tokens are unmistakable placeholders.

## Validation
- `npm clean-install`
- `node ./cli.js check --schema-name=github-cli-config.json`
- `node ./cli.js check --schema-name=github-cli-hosts.json`
- `npm run typecheck`
- `npm run eslint`
- targeted Prettier formatting
- SchemaStore PR audit: no warnings or missing surfaces
- both live local GitHub CLI files validate without exposing their contents
- independent source-level review, followed by a clean re-review after fixes

The repository-wide check is known to hit a Windows-only Ajv stack overflow while compiling unrelated `cargo-lints-clippy.json`; the targeted commands include all catalog precondition checks, and CI will run the full validation on Linux.