### PR TITLE
Add gh-dash schema catalog entry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3615,6 +3615,12 @@
       "url": "https://www.schemastore.org/gitea-issue-forms.json"
     },
     {
+      "name": "gh-dash",
+      "description": "Configuration for the gh-dash GitHub CLI dashboard",
+      "fileMatch": [".gh-dash.yml", ".gh-dash.yaml", "**/gh-dash/config.yml"],
+      "url": "https://gh-dash.dev/schema.json"
+    },
+    {
       "name": "GitHub Action",
       "description": "YAML GitHub Actions",
       "fileMatch": ["action.yml", "action.yaml"],


### PR DESCRIPTION
## Summary
- register gh-dash's upstream-owned configuration schema
- match repository-local `.gh-dash.yml` and `.gh-dash.yaml` files
- match only the documented `gh-dash/config.yml` directory suffix for global/XDG configuration
- avoid the generic `config.yml` matcher and the currently unused global `config.yaml` filename

## External ownership
- schema: https://gh-dash.dev/schema.json
- documentation: https://www.gh-dash.dev/configuration/schema/
- configuration discovery: https://www.gh-dash.dev/configuration/

The upstream schema and all referenced `/schema/*.json` resources return JSON successfully. gh-dash has 12.1k GitHub stars as of July 23, 2026.

## Dependency

The current published schema incorrectly declares `defaults.dateFormat` as an integer even though the released Go type and docs require a string. This draft must remain blocked until gh-dash publishes a human-authored upstream correction. Its strict no-AI policy prohibits submitting that fix from this AI-assisted workflow.

## Validation
- `npm clean-install`
- `npm run typecheck`
- `npm run eslint`
- targeted Prettier formatting
- SchemaStore PR audit (expected catalog-only warning only)
- live HTTP/JSON checks for the root schema and representative relative references
- catalog preconditions passed during `node ./cli.js check`; the full Windows run then reaches the existing unrelated Ajv stack overflow in `cargo-lints-clippy.json`