### PR TITLE
Add Dust configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2760,6 +2760,12 @@
       "url": "https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/latest/schemas/configuration.json"
     },
     {
+      "name": "Dust configuration",
+      "description": "TOML configuration for Dust",
+      "fileMatch": [".dust.toml", "**/.config/dust/config.toml"],
+      "url": "https://www.schemastore.org/dust.json"
+    },
+    {
       "name": "dvc.yaml",
       "description": "dvc.yaml file",
       "fileMatch": ["dvc.yaml"],

--- a/src/negative_test/dust/invalid-boolean.toml
+++ b/src/negative_test/dust/invalid-boolean.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+reverse = "yes"

--- a/src/negative_test/dust/invalid-collapse-item.toml
+++ b/src/negative_test/dust/invalid-collapse-item.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+collapse = ["target", 42]

--- a/src/negative_test/dust/invalid-collapse.toml
+++ b/src/negative_test/dust/invalid-collapse.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+collapse = "target"

--- a/src/negative_test/dust/invalid-files-from.toml
+++ b/src/negative_test/dust/invalid-files-from.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+files-from = ["paths.txt"]

--- a/src/negative_test/dust/invalid-output-format.toml
+++ b/src/negative_test/dust/invalid-output-format.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+output-format = 1024

--- a/src/negative_test/dust/negative-integer.toml
+++ b/src/negative_test/dust/negative-integer.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+depth = -1

--- a/src/schemas/json/dust.json
+++ b/src/schemas/json/dust.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/dust.json",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "Dust configuration",
+  "description": "Configuration for Dust, a more intuitive version of du.\nhttps://github.com/bootandy/dust/tree/v1.2.4#config-file",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "display-full-paths": {
+      "description": "Display full paths instead of file and directory names.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "display-apparent-size": {
+      "description": "Use apparent file sizes instead of disk usage.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "reverse": {
+      "description": "Reverse the output order so the largest entries appear first.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "no-colors": {
+      "description": "Disable colored output.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "force-colors": {
+      "description": "Force colored output even when stdout is not a terminal.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "no-bars": {
+      "description": "Hide the percent bars and percentages.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "skip-total": {
+      "description": "Do not display the total row.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "screen-reader": {
+      "description": "Present output in a format suitable for screen readers.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "ignore-hidden": {
+      "description": "Ignore hidden files and directories.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "only-dir": {
+      "description": "Display directories but not files.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "only-file": {
+      "description": "Display files but not directories.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "disable-progress": {
+      "description": "Disable the progress indicator.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "bars-on-right": {
+      "description": "Place percent bars on the right side of the output.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "output-json": {
+      "description": "Emit JSON output.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "print-errors": {
+      "description": "Print filesystem access errors.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "boolean",
+      "default": false
+    },
+    "output-format": {
+      "description": "Size output format. Common values include si, b, k, kib, m, mib, g, gib, t, tib, kb, mb, gb, and tb; Dust accepts other strings.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "string",
+      "examples": ["si", "kib", "gb"]
+    },
+    "min-size": {
+      "description": "Minimum size threshold for displayed entries, such as 10M or 1G.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "string"
+    },
+    "files0-from": {
+      "description": "Read NUL-terminated input paths from this file, or from standard input when set to '-'.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "string"
+    },
+    "files-from": {
+      "description": "Read newline-delimited input paths from this file, or from standard input when set to '-'.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "string"
+    },
+    "depth": {
+      "description": "Maximum directory depth to display. Omit for unlimited depth.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "integer",
+      "minimum": 0
+    },
+    "stack-size": {
+      "description": "Worker thread stack size in bytes.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "integer",
+      "minimum": 0
+    },
+    "threads": {
+      "description": "Number of worker threads.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "integer",
+      "minimum": 0
+    },
+    "number-of-lines": {
+      "description": "Maximum number of output lines.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "integer",
+      "minimum": 0
+    },
+    "collapse": {
+      "description": "Paths whose contents should be collapsed into a single entry.\nhttps://github.com/bootandy/dust/blob/v1.2.4/src/config.rs",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/test/dust/complete.toml
+++ b/src/test/dust/complete.toml
@@ -1,0 +1,27 @@
+#:schema ../../schemas/json/dust.json
+
+display-full-paths = true
+display-apparent-size = true
+reverse = true
+no-colors = false
+force-colors = true
+no-bars = true
+skip-total = true
+screen-reader = false
+ignore-hidden = true
+only-dir = true
+only-file = true
+disable-progress = true
+bars-on-right = true
+output-json = true
+print-errors = true
+output-format = "gib"
+min-size = "10M"
+files0-from = "paths.bin"
+files-from = "paths.txt"
+depth = 4
+stack-size = 8388608
+threads = 8
+number-of-lines = 40
+collapse = ["target", "node_modules"]
+future-option = "accepted by Dust"

--- a/src/test/dust/minimal.toml
+++ b/src/test/dust/minimal.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/dust.json
+
+reverse = true


### PR DESCRIPTION
## Summary
- add a draft-07 schema for Dust v1.2.4 configuration files
- model all 24 kebab-case fields in the released Rust `Config` type
- declare TOML 1.0.0 for Tombi-compatible editors
- keep unknown keys allowed because Dust's Serde model ignores them
- match only the two automatic discovery paths, not generic `config.toml` files
- add comprehensive positive and focused negative TOML fixtures

## Evidence
- https://github.com/bootandy/dust/blob/v1.2.4/src/config.rs
- https://github.com/bootandy/dust/blob/v1.2.4/config/config.toml
- https://github.com/bootandy/dust/tree/v1.2.4#config-file

The README sample's YAML claim is stale: the released build enables only the config-file crate's TOML support. `output-format` remains a string rather than an enum because the configuration deserializer accepts arbitrary strings. Dust has 12.0k GitHub stars as of July 23, 2026.

## Validation
- `npm clean-install`
- `node ./cli.js check --schema-name=dust.json`
- `npm run typecheck`
- `npm run eslint`
- targeted Prettier formatting
- SchemaStore PR audit: no warnings or missing surfaces
- installed Dust 1.2.4 accepts the user's live config and the minimal fixture
- the live config validates against the schema without exposing its contents
- independent source-level review, followed by the reviewed wording fix

The repository-wide check is known to hit a Windows-only Ajv stack overflow while compiling unrelated `cargo-lints-clippy.json`; CI will run full validation on Linux.