### PR TITLE
Add chezmoi configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1577,6 +1577,18 @@
       "url": "https://raw.githubusercontent.com/canonical/charmcraft/main/schema/charmcraft.json"
     },
     {
+      "name": "chezmoi configuration",
+      "description": "JSON, JSONC, TOML, and YAML configuration for chezmoi",
+      "fileMatch": [
+        "chezmoi.json",
+        "chezmoi.jsonc",
+        "chezmoi.toml",
+        "chezmoi.yaml",
+        "chezmoi.yml"
+      ],
+      "url": "https://www.schemastore.org/chezmoi.json"
+    },
+    {
       "name": "ChordPro Configuration",
       "description": "Configuration files for ChordPro",
       "fileMatch": [

--- a/src/negative_test/chezmoi/entry-types-string.toml
+++ b/src/negative_test/chezmoi/entry-types-string.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[status]
+exclude = "scripts,externals"

--- a/src/negative_test/chezmoi/env-and-script-env.toml
+++ b/src/negative_test/chezmoi/env-and-script-env.toml
@@ -1,0 +1,7 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[env]
+EDITOR = "code"
+
+[scriptEnv]
+CI = "true"

--- a/src/negative_test/chezmoi/git-template-conflict.toml
+++ b/src/negative_test/chezmoi/git-template-conflict.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[git]
+commitMessageTemplate = "message"
+commitMessageTemplateFile = "message.tmpl"

--- a/src/negative_test/chezmoi/hook-command-and-script.toml
+++ b/src/negative_test/chezmoi/hook-command-and-script.toml
@@ -1,0 +1,5 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[hooks.apply.pre]
+command = "echo"
+script = "echo invalid"

--- a/src/negative_test/chezmoi/invalid-add-secrets.toml
+++ b/src/negative_test/chezmoi/invalid-add-secrets.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[add]
+secrets = 1

--- a/src/negative_test/chezmoi/invalid-auto-bool.toml
+++ b/src/negative_test/chezmoi/invalid-auto-bool.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+color = 1

--- a/src/negative_test/chezmoi/invalid-encryption.toml
+++ b/src/negative_test/chezmoi/invalid-encryption.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+encryption = "sops"

--- a/src/negative_test/chezmoi/invalid-entry-type.toml
+++ b/src/negative_test/chezmoi/invalid-entry-type.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[status]
+exclude = ["unknown"]

--- a/src/negative_test/chezmoi/invalid-environment.toml
+++ b/src/negative_test/chezmoi/invalid-environment.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[env]
+RETRIES = 3

--- a/src/negative_test/chezmoi/invalid-format.toml
+++ b/src/negative_test/chezmoi/invalid-format.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+format = 1

--- a/src/negative_test/chezmoi/invalid-mode.toml
+++ b/src/negative_test/chezmoi/invalid-mode.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+mode = true

--- a/src/negative_test/chezmoi/invalid-onepassword-mode.toml
+++ b/src/negative_test/chezmoi/invalid-onepassword-mode.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[onepassword]
+mode = 1

--- a/src/negative_test/chezmoi/invalid-output-format-jsonc.toml
+++ b/src/negative_test/chezmoi/invalid-output-format-jsonc.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+format = "jsonc"

--- a/src/negative_test/chezmoi/invalid-output-format-toml.toml
+++ b/src/negative_test/chezmoi/invalid-output-format-toml.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+format = "toml"

--- a/src/negative_test/chezmoi/invalid-status-path-style.toml
+++ b/src/negative_test/chezmoi/invalid-status-path-style.toml
@@ -1,0 +1,4 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[status]
+pathStyle = true

--- a/src/negative_test/chezmoi/invalid-textconv.toml
+++ b/src/negative_test/chezmoi/invalid-textconv.toml
@@ -1,0 +1,3 @@
+#:schema ../../schemas/json/chezmoi.json
+
+textConv = ["cat"]

--- a/src/schemas/json/chezmoi.json
+++ b/src/schemas/json/chezmoi.json
@@ -1,0 +1,1001 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/chezmoi.json",
+  "x-tombi-toml-version": "v1.0.0",
+  "title": "chezmoi configuration",
+  "description": "Configuration for chezmoi, a dotfile manager across multiple machines.\nhttps://www.chezmoi.io/reference/configuration-file/",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "description": "URI of the JSON Schema used to validate this configuration.\nhttps://json-schema.org/understanding-json-schema/reference/schema.html",
+      "type": "string",
+      "format": "uri"
+    },
+    "cacheDir": {
+      "$ref": "#/definitions/path"
+    },
+    "color": {
+      "$ref": "#/definitions/autoBool"
+    },
+    "data": {
+      "description": "Arbitrary data made available to templates.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "env": {
+      "$ref": "#/definitions/environment"
+    },
+    "format": {
+      "description": "Default structured-data output format. TOML is supported as an input format but not as an output format.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "anyOf": [
+        {
+          "enum": ["json", "yaml"]
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "not": {
+        "enum": ["jsonc", "toml"]
+      },
+      "default": "json"
+    },
+    "destDir": {
+      "$ref": "#/definitions/path"
+    },
+    "gitHub": {
+      "$ref": "#/definitions/gitHub"
+    },
+    "hooks": {
+      "description": "Commands to run before or after chezmoi events, keyed by event name.\nhttps://www.chezmoi.io/reference/configuration-file/hooks/",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/hook"
+      }
+    },
+    "interactive": {
+      "description": "Whether chezmoi may prompt for input.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "boolean"
+    },
+    "interpreters": {
+      "description": "Custom interpreters keyed by file extension without the leading period.\nhttps://www.chezmoi.io/reference/configuration-file/interpreters/",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/interpreter"
+      }
+    },
+    "lessInteractive": {
+      "description": "UNDOCUMENTED. Whether chezmoi should reduce interactive behavior.\nhttps://github.com/twpayne/chezmoi/blob/v2.71.1/internal/cmd/config.go",
+      "type": "boolean"
+    },
+    "mode": {
+      "description": "How the source state is represented.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "anyOf": [
+        {
+          "enum": ["file", "symlink"]
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": "file"
+    },
+    "pager": {
+      "description": "Pager command used for long output.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "string"
+    },
+    "pagerArgs": {
+      "$ref": "#/definitions/stringList"
+    },
+    "persistentState": {
+      "$ref": "#/definitions/path"
+    },
+    "pinentry": {
+      "$ref": "#/definitions/pinentry"
+    },
+    "progress": {
+      "$ref": "#/definitions/autoBool"
+    },
+    "safe": {
+      "description": "UNDOCUMENTED. Whether potentially unsafe operations are disabled.\nhttps://github.com/twpayne/chezmoi/blob/v2.71.1/internal/cmd/config.go",
+      "type": "boolean",
+      "default": true
+    },
+    "scriptEnv": {
+      "$ref": "#/definitions/environment"
+    },
+    "scriptTempDir": {
+      "$ref": "#/definitions/path"
+    },
+    "sourceDir": {
+      "$ref": "#/definitions/path"
+    },
+    "tempDir": {
+      "$ref": "#/definitions/path"
+    },
+    "template": {
+      "$ref": "#/definitions/template"
+    },
+    "textConv": {
+      "description": "Text conversion commands used when computing diffs.\nhttps://www.chezmoi.io/reference/configuration-file/textconv/",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/textConv"
+      }
+    },
+    "umask": {
+      "description": "File creation mask. TOML supports octal literals such as 0o22; JSON and YAML use the equivalent decimal value.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "integer",
+      "minimum": 0
+    },
+    "useBuiltinAge": {
+      "$ref": "#/definitions/autoBool"
+    },
+    "useBuiltinGit": {
+      "$ref": "#/definitions/autoBool"
+    },
+    "verbose": {
+      "description": "Whether verbose output is enabled.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "boolean"
+    },
+    "warnings": {
+      "$ref": "#/definitions/warnings"
+    },
+    "workingTree": {
+      "$ref": "#/definitions/path"
+    },
+    "awsSecretsManager": {
+      "$ref": "#/definitions/awsSecretsManager"
+    },
+    "azureKeyVault": {
+      "$ref": "#/definitions/azureKeyVault"
+    },
+    "bitwarden": {
+      "$ref": "#/definitions/bitwarden"
+    },
+    "bitwardenSecrets": {
+      "$ref": "#/definitions/bitwardenSecrets"
+    },
+    "dashlane": {
+      "$ref": "#/definitions/dashlane"
+    },
+    "doppler": {
+      "$ref": "#/definitions/doppler"
+    },
+    "ejson": {
+      "$ref": "#/definitions/ejson"
+    },
+    "gopass": {
+      "$ref": "#/definitions/gopass"
+    },
+    "keepassxc": {
+      "$ref": "#/definitions/keepassxc"
+    },
+    "keeper": {
+      "$ref": "#/definitions/keeper"
+    },
+    "lastpass": {
+      "$ref": "#/definitions/lastpass"
+    },
+    "onepassword": {
+      "$ref": "#/definitions/onepassword"
+    },
+    "pass": {
+      "$ref": "#/definitions/pass"
+    },
+    "passhole": {
+      "$ref": "#/definitions/passhole"
+    },
+    "protonPass": {
+      "$ref": "#/definitions/protonPass"
+    },
+    "rbw": {
+      "$ref": "#/definitions/rbw"
+    },
+    "secret": {
+      "$ref": "#/definitions/command"
+    },
+    "vault": {
+      "$ref": "#/definitions/vault"
+    },
+    "encryption": {
+      "description": "Encryption method. An empty value enables automatic detection from the age or GPG sections.\nhttps://www.chezmoi.io/reference/configuration-file/encryption/",
+      "type": "string",
+      "enum": ["", "age", "gpg", "transparent"]
+    },
+    "age": {
+      "$ref": "#/definitions/age"
+    },
+    "gpg": {
+      "$ref": "#/definitions/gpg"
+    },
+    "add": {
+      "$ref": "#/definitions/add"
+    },
+    "cd": {
+      "$ref": "#/definitions/command"
+    },
+    "completion": {
+      "$ref": "#/definitions/completion"
+    },
+    "docker": {
+      "$ref": "#/definitions/docker"
+    },
+    "diff": {
+      "$ref": "#/definitions/diff"
+    },
+    "edit": {
+      "$ref": "#/definitions/edit"
+    },
+    "git": {
+      "$ref": "#/definitions/git"
+    },
+    "merge": {
+      "$ref": "#/definitions/command"
+    },
+    "status": {
+      "$ref": "#/definitions/status"
+    },
+    "update": {
+      "$ref": "#/definitions/update"
+    },
+    "verify": {
+      "$ref": "#/definitions/verify"
+    }
+  },
+  "not": {
+    "properties": {
+      "env": {
+        "type": "object",
+        "minProperties": 1
+      },
+      "scriptEnv": {
+        "type": "object",
+        "minProperties": 1
+      }
+    },
+    "required": ["env", "scriptEnv"]
+  },
+  "definitions": {
+    "path": {
+      "description": "Filesystem path. Relative paths are resolved according to chezmoi's configuration rules.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "string"
+    },
+    "autoBool": {
+      "description": "Automatic boolean setting. Accepts a boolean, 'auto', or a string representation recognized by chezmoi.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "stringList": {
+      "description": "List of strings. Chezmoi also accepts a comma-separated string through its configuration decoder.\nhttps://www.chezmoi.io/reference/configuration-file/",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "duration": {
+      "description": "Go duration string such as '1s' or '1m'. Integer nanosecond values are also accepted.\nhttps://pkg.go.dev/time#ParseDuration",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "environment": {
+      "description": "Environment variables keyed by name.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "command": {
+      "description": "External command configuration.\nhttps://www.chezmoi.io/reference/configuration-file/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "hookCommand": {
+      "description": "Command or inline script executed by a hook.\nhttps://www.chezmoi.io/reference/configuration-file/hooks/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "script": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      },
+      "not": {
+        "properties": {
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "script": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["command", "script"]
+      }
+    },
+    "hook": {
+      "description": "Commands run before and after a chezmoi event.\nhttps://www.chezmoi.io/reference/configuration-file/hooks/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "pre": {
+          "$ref": "#/definitions/hookCommand"
+        },
+        "post": {
+          "$ref": "#/definitions/hookCommand"
+        }
+      }
+    },
+    "interpreter": {
+      "description": "Interpreter command for files with a specific extension.\nhttps://www.chezmoi.io/reference/configuration-file/interpreters/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "entryTypes": {
+      "description": "Entry types to include or exclude.\nhttps://www.chezmoi.io/reference/command-line-flags/global/",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "all",
+          "always",
+          "dirs",
+          "encrypted",
+          "externals",
+          "files",
+          "noalways",
+          "nodirs",
+          "noencrypted",
+          "noexternals",
+          "nofiles",
+          "none",
+          "noremove",
+          "noscripts",
+          "nosymlinks",
+          "notemplates",
+          "remove",
+          "scripts",
+          "symlinks",
+          "templates"
+        ]
+      }
+    },
+    "gitHub": {
+      "description": "GitHub API cache settings.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "refreshPeriod": {
+          "$ref": "#/definitions/duration",
+          "default": "1m"
+        }
+      }
+    },
+    "pinentry": {
+      "description": "Pinentry command used for passphrase prompts.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "options": {
+          "$ref": "#/definitions/stringList",
+          "default": ["allow-external-password-cache"]
+        }
+      }
+    },
+    "template": {
+      "description": "Go template engine options.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/stringList",
+          "default": ["missingkey=error"]
+        }
+      }
+    },
+    "textConv": {
+      "description": "Text conversion command selected by a path pattern.\nhttps://www.chezmoi.io/reference/configuration-file/textconv/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "pattern": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "warnings": {
+      "description": "Warning controls.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "configFileTemplateHasChanged": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "awsSecretsManager": {
+      "description": "AWS Secrets Manager settings.\nhttps://www.chezmoi.io/reference/templates/aws-secrets-manager-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "region": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        }
+      }
+    },
+    "azureKeyVault": {
+      "description": "Azure Key Vault settings.\nhttps://www.chezmoi.io/reference/templates/azure-key-vault-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "defaultVault": {
+          "type": "string"
+        }
+      }
+    },
+    "bitwarden": {
+      "description": "Bitwarden CLI settings.\nhttps://www.chezmoi.io/reference/templates/bitwarden-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "bw"
+        },
+        "unlock": {
+          "$ref": "#/definitions/autoBool"
+        }
+      }
+    },
+    "bitwardenSecrets": {
+      "description": "Bitwarden Secrets Manager CLI settings.\nhttps://www.chezmoi.io/reference/templates/bitwarden-secrets-manager-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "bws"
+        }
+      }
+    },
+    "dashlane": {
+      "description": "Dashlane CLI settings.\nhttps://www.chezmoi.io/reference/templates/dashlane-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "dcli"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "doppler": {
+      "description": "Doppler CLI settings.\nhttps://www.chezmoi.io/reference/templates/doppler-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "doppler"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "project": {
+          "type": "string"
+        },
+        "config": {
+          "type": "string"
+        }
+      }
+    },
+    "ejson": {
+      "description": "EJSON settings.\nhttps://www.chezmoi.io/reference/templates/ejson-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "keyDir": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      }
+    },
+    "gopass": {
+      "description": "gopass settings.\nhttps://www.chezmoi.io/reference/templates/gopass-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "gopass"
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "enum": ["", "builtin"]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "keepassxc": {
+      "description": "KeePassXC CLI settings.\nhttps://www.chezmoi.io/reference/templates/keepassxc-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "keepassxc-cli"
+        },
+        "database": {
+          "type": "string"
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "enum": ["builtin", "cache-password", "open"]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "cache-password"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "prompt": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "keeper": {
+      "description": "Keeper Commander settings.\nhttps://www.chezmoi.io/reference/templates/keeper-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "keeper"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        }
+      }
+    },
+    "lastpass": {
+      "description": "LastPass CLI settings.\nhttps://www.chezmoi.io/reference/templates/lastpass-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "lpass"
+        }
+      }
+    },
+    "onepassword": {
+      "description": "1Password CLI settings.\nhttps://www.chezmoi.io/reference/templates/1password-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "op"
+        },
+        "prompt": {
+          "type": "boolean",
+          "default": true
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "enum": ["account", "connect", "service"]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "account"
+        }
+      }
+    },
+    "pass": {
+      "description": "pass password-store settings.\nhttps://www.chezmoi.io/reference/templates/pass-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "pass"
+        }
+      }
+    },
+    "passhole": {
+      "description": "passhole settings.\nhttps://www.chezmoi.io/reference/templates/passhole-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "ph"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "prompt": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "protonPass": {
+      "description": "Proton Pass CLI settings.\nhttps://www.chezmoi.io/reference/templates/proton-pass-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "pass-cli"
+        }
+      }
+    },
+    "rbw": {
+      "description": "rbw Bitwarden CLI settings.\nhttps://www.chezmoi.io/reference/templates/rbw-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "rbw"
+        }
+      }
+    },
+    "vault": {
+      "description": "HashiCorp Vault CLI settings.\nhttps://www.chezmoi.io/reference/templates/vault-functions/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "vault"
+        }
+      }
+    },
+    "age": {
+      "description": "age encryption settings.\nhttps://www.chezmoi.io/reference/configuration-file/encryption/age/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "useBuiltin": {
+          "description": "UNDOCUMENTED. Internal age implementation selection; prefer the top-level useBuiltinAge setting.\nhttps://github.com/twpayne/chezmoi/blob/v2.71.1/internal/chezmoi/ageencryption.go",
+          "type": "boolean"
+        },
+        "command": {
+          "type": "string",
+          "default": "age"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "identity": {
+          "type": "string"
+        },
+        "identities": {
+          "$ref": "#/definitions/stringList"
+        },
+        "passphrase": {
+          "type": "boolean"
+        },
+        "recipient": {
+          "type": "string"
+        },
+        "recipients": {
+          "$ref": "#/definitions/stringList"
+        },
+        "recipientsFile": {
+          "type": "string"
+        },
+        "recipientsFiles": {
+          "$ref": "#/definitions/stringList"
+        },
+        "suffix": {
+          "type": "string",
+          "default": ".age"
+        },
+        "symmetric": {
+          "type": "boolean"
+        }
+      }
+    },
+    "gpg": {
+      "description": "GnuPG encryption settings.\nhttps://www.chezmoi.io/reference/configuration-file/encryption/gpg/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "gpg"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "recipient": {
+          "type": "string"
+        },
+        "recipients": {
+          "$ref": "#/definitions/stringList"
+        },
+        "symmetric": {
+          "type": "boolean"
+        },
+        "suffix": {
+          "type": "string",
+          "default": ".asc"
+        }
+      }
+    },
+    "add": {
+      "description": "Defaults for the add command.\nhttps://www.chezmoi.io/reference/commands/add/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "encrypt": {
+          "type": "boolean"
+        },
+        "secrets": {
+          "anyOf": [
+            {
+              "enum": ["ignore", "warning", "error"]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "warning"
+        },
+        "templateSymlinks": {
+          "type": "boolean"
+        }
+      }
+    },
+    "completion": {
+      "description": "Shell completion settings.\nhttps://www.chezmoi.io/reference/commands/completion/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "custom": {
+          "type": "boolean"
+        }
+      }
+    },
+    "docker": {
+      "description": "Docker command settings.\nhttps://www.chezmoi.io/reference/commands/docker/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "docker"
+        }
+      }
+    },
+    "diff": {
+      "description": "Defaults for the diff command.\nhttps://www.chezmoi.io/reference/commands/diff/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "exclude": {
+          "$ref": "#/definitions/entryTypes"
+        },
+        "pager": {
+          "type": "string"
+        },
+        "pagerArgs": {
+          "$ref": "#/definitions/stringList"
+        },
+        "reverse": {
+          "type": "boolean"
+        },
+        "scriptContents": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "edit": {
+      "description": "Defaults for the edit command.\nhttps://www.chezmoi.io/reference/commands/edit/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "hardlink": {
+          "type": "boolean",
+          "default": true
+        },
+        "minDuration": {
+          "$ref": "#/definitions/duration",
+          "default": "1s"
+        },
+        "watch": {
+          "type": "boolean"
+        },
+        "apply": {
+          "type": "boolean"
+        }
+      }
+    },
+    "git": {
+      "description": "Git integration settings.\nhttps://www.chezmoi.io/reference/configuration-file/variables/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "default": "git"
+        },
+        "autoAdd": {
+          "type": "boolean"
+        },
+        "autoCommit": {
+          "type": "boolean"
+        },
+        "autoPush": {
+          "type": "boolean"
+        },
+        "commitMessageTemplate": {
+          "type": "string"
+        },
+        "commitMessageTemplateFile": {
+          "type": "string"
+        },
+        "lfs": {
+          "type": "boolean"
+        }
+      },
+      "not": {
+        "properties": {
+          "commitMessageTemplate": {
+            "type": "string",
+            "minLength": 1
+          },
+          "commitMessageTemplateFile": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["commitMessageTemplate", "commitMessageTemplateFile"]
+      }
+    },
+    "status": {
+      "description": "Defaults for the status command.\nhttps://www.chezmoi.io/reference/commands/status/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "exclude": {
+          "$ref": "#/definitions/entryTypes"
+        },
+        "pathStyle": {
+          "anyOf": [
+            {
+              "enum": ["absolute", "relative"]
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": "relative"
+        }
+      }
+    },
+    "update": {
+      "description": "Defaults for the update command.\nhttps://www.chezmoi.io/reference/commands/update/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "$ref": "#/definitions/stringList"
+        },
+        "apply": {
+          "type": "boolean",
+          "default": true
+        },
+        "recurseSubmodules": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "verify": {
+      "description": "Defaults for the verify command.\nhttps://www.chezmoi.io/reference/commands/verify/",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "exclude": {
+          "$ref": "#/definitions/entryTypes"
+        }
+      }
+    }
+  }
+}

--- a/src/test/chezmoi/complete.toml
+++ b/src/test/chezmoi/complete.toml
@@ -1,0 +1,213 @@
+#:schema ../../schemas/json/chezmoi.json
+
+cacheDir = ".cache"
+color = "auto"
+format = "json"
+destDir = "."
+interactive = true
+lessInteractive = false
+mode = "file"
+pager = "less"
+pagerArgs = ["-FRX"]
+persistentState = ".state"
+progress = true
+safe = true
+scriptTempDir = ".tmp"
+sourceDir = "."
+tempDir = ".tmp"
+umask = 0o22
+useBuiltinAge = "auto"
+useBuiltinGit = false
+verbose = true
+workingTree = "."
+encryption = "transparent"
+
+[data]
+owner = "example"
+
+[env]
+EDITOR = "code"
+
+[gitHub]
+refreshPeriod = "1m"
+
+[hooks.apply.pre]
+command = "echo"
+args = ["before apply"]
+
+[hooks.apply.post]
+script = "echo after apply"
+
+[interpreters.ps1]
+command = "pwsh"
+args = ["-NoProfile", "-File"]
+
+[pinentry]
+command = "pinentry"
+args = ["--ttyname", "console"]
+options = ["allow-external-password-cache"]
+
+[template]
+options = ["missingkey=error"]
+
+[[textConv]]
+pattern = "*.txt"
+command = "cat"
+args = ["--"]
+
+[warnings]
+configFileTemplateHasChanged = true
+
+[awsSecretsManager]
+region = "us-east-1"
+profile = "default"
+
+[azureKeyVault]
+defaultVault = "example-vault"
+
+[bitwarden]
+command = "bw"
+unlock = "auto"
+
+[bitwardenSecrets]
+command = "bws"
+
+[dashlane]
+command = "dcli"
+args = ["--no-color"]
+
+[doppler]
+command = "doppler"
+args = ["--silent"]
+project = "example"
+config = "dev"
+
+[ejson]
+keyDir = ".keys"
+key = "example"
+
+[gopass]
+command = "gopass"
+mode = "builtin"
+
+[keepassxc]
+command = "keepassxc-cli"
+database = "passwords.kdbx"
+mode = "cache-password"
+args = ["--quiet"]
+prompt = true
+
+[keeper]
+command = "keeper"
+args = ["--batch-mode"]
+
+[lastpass]
+command = "lpass"
+
+[onepassword]
+command = "op"
+prompt = true
+mode = "account"
+
+[pass]
+command = "pass"
+
+[passhole]
+command = "ph"
+args = ["--quiet"]
+prompt = true
+
+[protonPass]
+command = "pass-cli"
+
+[rbw]
+command = "rbw"
+
+[secret]
+command = "secret-helper"
+args = ["get"]
+
+[vault]
+command = "vault"
+
+[age]
+useBuiltin = true
+command = "age"
+args = ["--armor"]
+identity = "identity.txt"
+identities = ["identity-2.txt"]
+passphrase = false
+recipient = "age1example"
+recipients = ["age1example2"]
+recipientsFile = "recipients.txt"
+recipientsFiles = ["recipients-2.txt"]
+suffix = ".age"
+symmetric = false
+
+[gpg]
+command = "gpg"
+args = ["--batch"]
+recipient = "example@example.com"
+recipients = ["another@example.com"]
+symmetric = false
+suffix = ".asc"
+
+[add]
+encrypt = false
+secrets = "warning"
+templateSymlinks = true
+
+[cd]
+command = "pwsh"
+args = ["-NoExit"]
+
+[completion]
+custom = true
+
+[docker]
+command = "docker"
+
+[diff]
+command = "diff"
+args = ["--unified"]
+exclude = ["scripts", "externals"]
+pager = "less"
+pagerArgs = ["-FRX"]
+reverse = false
+scriptContents = true
+
+[edit]
+command = "code"
+args = ["--wait"]
+hardlink = true
+minDuration = "1s"
+watch = true
+apply = false
+
+[git]
+command = "git"
+autoAdd = true
+autoCommit = true
+autoPush = false
+commitMessageTemplate = "Apply changes"
+lfs = true
+
+[merge]
+command = "vimdiff"
+args = ["-f"]
+
+[status]
+exclude = ["scripts", "externals"]
+pathStyle = "relative"
+
+[update]
+command = "git"
+args = ["pull", "--ff-only"]
+apply = true
+recurseSubmodules = true
+
+[verify]
+exclude = ["externals"]
+
+[futureSection]
+futureOption = true

--- a/src/test/chezmoi/dynamic.yaml
+++ b/src/test/chezmoi/dynamic.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../schemas/json/chezmoi.json
+hooks:
+  read-source-state:
+    pre:
+      command: echo
+      args: [reading]
+interpreters:
+  py:
+    command: python
+    args: [-B]
+textConv:
+  - pattern: '*.md'
+    command: pandoc
+    args: ['--to', 'plain']
+data:
+  nested:
+    enabled: true
+scriptEnv:
+  CI: 'true'

--- a/src/test/chezmoi/empty-mutual-exclusion-values.toml
+++ b/src/test/chezmoi/empty-mutual-exclusion-values.toml
@@ -1,0 +1,14 @@
+#:schema ../../schemas/json/chezmoi.json
+
+[env]
+
+[scriptEnv]
+CI = "true"
+
+[hooks.apply.pre]
+command = ""
+script = "apply.ps1"
+
+[git]
+commitMessageTemplate = ""
+commitMessageTemplateFile = "commit-message.tmpl"

--- a/src/test/chezmoi/forward-compatible-choices.toml
+++ b/src/test/chezmoi/forward-compatible-choices.toml
@@ -1,0 +1,19 @@
+#:schema ../../schemas/json/chezmoi.json
+
+format = "future-format"
+mode = "future-mode"
+
+[add]
+secrets = "notice"
+
+[gopass]
+mode = "future-mode"
+
+[keepassxc]
+mode = "future-mode"
+
+[onepassword]
+mode = "future-mode"
+
+[status]
+pathStyle = "future-style"

--- a/src/test/chezmoi/minimal.json
+++ b/src/test/chezmoi/minimal.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/chezmoi.json",
+  "mode": "file"
+}


### PR DESCRIPTION
## Summary
- add a draft-07 schema for chezmoi v2.71.1 configuration files
- model all 62 released root configuration keys and their nested command, encryption, password-manager, hook, interpreter, and text-conversion structures
- associate the schema with the five filenames discovered by chezmoi: `chezmoi.json`, `chezmoi.jsonc`, `chezmoi.toml`, `chezmoi.yaml`, and `chezmoi.yml`
- declare TOML 1.0 support for TOML language servers
- add broad positive and isolated negative fixtures, including runtime mutual exclusions and known input-only output formats

## Evidence
- https://www.chezmoi.io/reference/configuration-file/
- https://www.chezmoi.io/user-guide/setup/#create-a-config-file-on-a-new-machine-automatically
- https://github.com/twpayne/chezmoi/blob/v2.71.1/internal/cmd/config.go
- https://github.com/twpayne/chezmoi/blob/v2.71.1/internal/chezmoi/format.go
- https://github.com/twpayne/chezmoi/releases/tag/v2.71.1

The released `ConfigFile` Go type and schema contain the same 62 root keys. Unknown object properties and non-runtime-strict string choices remain forward compatible. Values that chezmoi validates at load or use time, including encryption methods, entry types, incompatible environment sections, conflicting hook commands, conflicting Git templates, and input-only output formats, remain constrained.

chezmoi has 20,790 GitHub stars as measured on July 23, 2026: https://github.com/twpayne/chezmoi

## Validation
- `npm clean-install`
- `node ./cli.js check --schema-name=chezmoi.json`
- `npm run typecheck`
- `npm run eslint`
- `npm run prettier`
- SchemaStore PR audit: no warnings or missing schema/test/catalog surfaces
- installed chezmoi v2.71.1 accepts the complete, empty-value, and forward-compatible fixtures
- the user's live `chezmoi.toml` validates against the schema and loads in chezmoi v2.71.1
- independent source-level review, followed by a clean re-review after fixes

The repository-wide Windows check passes all preconditions and reaches the existing unrelated Ajv `Maximum call stack size exceeded` failure while compiling `cargo-lints-clippy.json`. The targeted strict check passes.