### PR TITLE
fix(cargo-make): allow install_crate object with only crate_name

### DIFF
--- a/src/schemas/json/cargo-make.json
+++ b/src/schemas/json/cargo-make.json
@@ -808,7 +808,7 @@
               "title": "Crate Install Options",
               "description": "Instructions on how to install a crate",
               "type": "object",
-              "required": ["crate_name", "binary", "test_arg"],
+              "required": ["crate_name"],
               "additionalProperties": false,
               "properties": {
                 "crate_name": {

--- a/src/test/cargo-make/cargo-make.json
+++ b/src/test/cargo-make/cargo-make.json
@@ -1,19 +1,36 @@
 {
   "config": {
-    "unstable_features": ["CTRL_C_HANDLING"]
+    "unstable_features": [
+      "CTRL_C_HANDLING"
+    ]
   },
   "tasks": {
     "format": {
-      "args": ["fmt", "--", "--emit=files"],
+      "args": [
+        "fmt",
+        "--",
+        "--emit=files"
+      ],
       "command": "cargo",
       "install_crate": "rustfmt"
     },
     "format2": {
       "condition": {
         "condition_type": "Or",
-        "files_exist": ["src/main.rs", "src/lib.rs"]
+        "files_exist": [
+          "src/main.rs",
+          "src/lib.rs"
+        ]
       },
-      "dependencies": ["format"]
+      "dependencies": [
+        "format"
+      ]
+    },
+    "test_task": {
+      "install_crate": {
+        "crate_name": "cargo-expand",
+        "version": "1.0.80"
+      }
     }
   }
 }

--- a/src/test/cargo-make/cargo-make.json
+++ b/src/test/cargo-make/cargo-make.json
@@ -1,30 +1,19 @@
 {
   "config": {
-    "unstable_features": [
-      "CTRL_C_HANDLING"
-    ]
+    "unstable_features": ["CTRL_C_HANDLING"]
   },
   "tasks": {
     "format": {
-      "args": [
-        "fmt",
-        "--",
-        "--emit=files"
-      ],
+      "args": ["fmt", "--", "--emit=files"],
       "command": "cargo",
       "install_crate": "rustfmt"
     },
     "format2": {
       "condition": {
         "condition_type": "Or",
-        "files_exist": [
-          "src/main.rs",
-          "src/lib.rs"
-        ]
+        "files_exist": ["src/main.rs", "src/lib.rs"]
       },
-      "dependencies": [
-        "format"
-      ]
+      "dependencies": ["format"]
     },
     "test_task": {
       "install_crate": {


### PR DESCRIPTION
## Summary

`cargo-make` accepts `install_crate` objects that only require `crate_name` (with optional `version` / `min_version` / `binary` / `test_arg`). The JSON Schema incorrectly required `crate_name`, `binary`, and `test_arg` together, so valid entries like:

```toml
[tasks.test_task]
install_crate = { crate_name = "cargo-expand", version = "1.0.80" }
```

failed validation (#3684).

## Fix

Relax the **Crate Install Options** branch `required` list to `["crate_name"]`.

## Tests

- Extended `src/test/cargo-make/cargo-make.json` with the issue’s object form
- Validated fixture against the schema (`jsonschema.validate` OK)

Fixes #3684
