### PR TITLE
test(ruff): cover human-readable rule selectors

### DIFF
--- a/src/test/ruff/human-readable-rule-selectors.toml
+++ b/src/test/ruff/human-readable-rule-selectors.toml
@@ -1,0 +1,9 @@
+#:schema ../../schemas/json/ruff.json
+preview = true
+
+[lint]
+extend-select = ["print"]
+ignore = ["unused-import"]
+
+[lint.per-file-ignores]
+"tests/**" = ["assert"]


### PR DESCRIPTION
## Summary

- add a Ruff TOML regression fixture for human-readable rule selectors
- cover `extend-select`, `ignore`, and per-file ignores
- document through the test that the current synced Ruff schema already accepts the reported selectors

The current `ruff.json` already contains these selector names from the Ruff schema sync in #5844, so this deliberately adds regression coverage rather than changing or loosening the schema.

## Verification

- `node ./cli.js check --schema-name=ruff.json`
- `npm run typecheck`
- `npm run prettier`
- `git diff --check`

Closes #6082