### PR TITLE
Migrated typings*.json to draft-07

### DIFF
--- a/src/schemas/json/typings.json
+++ b/src/schemas/json/typings.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/typings.json",
   "additionalProperties": true,
-  "id": "https://json.schemastore.org/typings.json",
   "properties": {
     "main": {
       "description": "The entry point to the definition (canonical to `\"main\"` in NPM's `package.json`).",

--- a/src/schemas/json/typings.json
+++ b/src/schemas/json/typings.json
@@ -8,8 +8,15 @@
       "type": "string"
     },
     "browser": {
-      "description": "A string, or map of paths, to override during resolution. See spec: https://github.com/defunctzombie/package-browser-field-spec",
-      "type": ["object", "string"]
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "A string, or map of paths, to override during resolution. See spec: https://github.com/defunctzombie/package-browser-field-spec"
     },
     "version": {
       "description": "The semver range this definition is typed for",
@@ -20,8 +27,15 @@
       "type": "string"
     },
     "resolution": {
-      "description": "Map of resolutions to install",
-      "type": ["object", "string"]
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Map of resolutions to install"
     },
     "files": {
       "description": "Used as an alternative or to complement `main`, specify an array of files that are exported but aren't already part of the resolution from `main`.",

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/typingsrc.json",
   "additionalProperties": true,
-  "id": "https://json.schemastore.org/typingsrc.json",
   "properties": {
     "ca": {
       "type": ["array", "string"],

--- a/src/schemas/json/typingsrc.json
+++ b/src/schemas/json/typingsrc.json
@@ -4,11 +4,18 @@
   "additionalProperties": true,
   "properties": {
     "ca": {
-      "type": ["array", "string"],
-      "description": "A string or array of strings of trusted certificates in PEM format",
-      "items": {
-        "type": "string"
-      }
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "A string or array of strings of trusted certificates in PEM format"
     },
     "cert": {
       "type": "string",


### PR DESCRIPTION
- Migrated from draft-04 to draft-07 (with the assistance of [ajv-validator/json-schema-migrate](https://github.com/ajv-validator/json-schema-migrate), though manually reviewed)
- Enabled strict validation
