### PR TITLE
Migrated vsext.json to draft-07

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -253,7 +253,6 @@
     "vector.json",
     "vega-lite.json",
     "vs-nesting.json",
-    "vsext.json",
     "vsix-manifestinjection.json",
     "vsix-publish.json",
     "vss-extension.json",

--- a/src/schemas/json/vsext.json
+++ b/src/schemas/json/vsext.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/vsext.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/vsext.json",
   "properties": {
     "id": {
       "description": "A unique identifier for the extension pack. This is to uniquely identify the extension pack and will not be shown to the user.",

--- a/src/schemas/json/vsext.json
+++ b/src/schemas/json/vsext.json
@@ -26,6 +26,7 @@
       "description": "A list of extension objects.",
       "type": "array",
       "items": {
+        "type": "object",
         "required": ["vsixId"],
         "properties": {
           "name": {


### PR DESCRIPTION
- Migrated from draft-04 to draft-07 (with the assistance of [ajv-validator/json-schema-migrate](https://github.com/ajv-validator/json-schema-migrate), though manually reviewed)
- Enabled strict validation
