### PR TITLE
feat: support `nub` as a pacakge manager in `package.json` schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -825,7 +825,7 @@
       "type": "string",
       "oneOf": [
         {
-          "pattern": "(npm|pnpm|yarn|bun|aube)@\\d+\\.\\d+\\.\\d+(-.+)?"
+          "pattern": "(npm|pnpm|yarn|bun|aube|nub)@\\d+\\.\\d+\\.\\d+(-.+)?"
         },
         {
           "const": "bun"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR updates the `package.json` schema to support [nub](https://nubjs.com/) as a valid package manager.

Reference: https://nubjs.com/docs/pm#pinning-nub-itself