### PR TITLE
fix(claude-code-settings): drop global leftArrowOpensAgents key

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4156,10 +4156,6 @@
       "description": "Whether including the keyword \"ultracode\" in a prompt triggers a dynamic workflow. Requires Claude Code v2.1.157 or later. See https://code.claude.com/docs/en/settings#available-settings",
       "default": true
     },
-    "leftArrowOpensAgents": {
-      "type": "boolean",
-      "description": "Whether the Left arrow key at the start of an empty prompt opens the agents view. Turn it off in /config (the leftArrowOpensAgents setting). See https://code.claude.com/docs/en/agent-view"
-    },
     "askUserQuestionTimeout": {
       "type": "string",
       "description": "Idle time before an unanswered AskUserQuestion dialog auto-continues with whatever options you had already selected. Accepts \"60s\", \"5m\", \"10m\", or \"never\" (default: \"never\", which waits until you answer). Appears in /config as Question auto-continue timeout, which writes this key to user settings. Not read from project or local settings. Requires Claude Code v2.1.200 or later. See https://code.claude.com/docs/en/settings#available-settings",

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -341,7 +341,6 @@
   "includeGitInstructions": false,
   "inputNeededNotifEnabled": true,
   "language": "english",
-  "leftArrowOpensAgents": true,
   "managedMcpServers": [
     {
       "name": "corp-tools",


### PR DESCRIPTION
## Summary
`leftArrowOpensAgents` is a Claude Code global-config preference stored in `~/.claude.json` (via `/config`), not a `.claude/settings.json` property. The SchemaStore schema currently advertises it for the catalog `fileMatch` of settings files, so editors autocomplete a key Claude Code ignores there.

This removes the property from `claude-code-settings.json` and drops it from the modern complete positive fixture.

## Evidence
- Claude Code docs: [Global config settings](https://code.claude.com/docs/en/settings#global-config-settings) live in `~/.claude.json`; that category is ignored in `settings.json`.
- [Agent View](https://code.claude.com/docs/en/agent-view) points at `/config` for this shortcut.
- Anthropic VS Code extension settings schema for `.claude/settings.json` does not declare `leftArrowOpensAgents` (it does declare `disableAgentView`).
- Reported on #6126 with Claude Code v2.1.218.

## Test plan
- [x] `json.loads` on updated schema + fixtures
- [x] assert `leftArrowOpensAgents` absent from schema `properties` and `modern-complete-config.json`
- [x] leave remaining settings fixtures intact

Closes #6126
