### PR TITLE
Expand Maestro Flow schema for full command autocomplete

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4790,7 +4790,7 @@
     },
     {
       "name": "Maestro Flow",
-      "description": "Maestro mobile and web UI test flow (YAML)",
+      "description": "Maestro mobile and web UI test flow (YAML) with full command definitions for IDE autocomplete (tapOn, extendedWaitUntil, runFlow, launchApp, and more)",
       "fileMatch": [
         "**/.maestro/**/*.yaml",
         "**/.maestro/**/*.yml",

--- a/src/negative_test/maestro-flow/invalid-launch-app-type.yaml
+++ b/src/negative_test/maestro-flow/invalid-launch-app-type.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- launchApp: 12345

--- a/src/negative_test/maestro-flow/invalid-multi-key-command.yaml
+++ b/src/negative_test/maestro-flow/invalid-multi-key-command.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- tapOn: Login
+  inputText: hi

--- a/src/negative_test/maestro-flow/invalid-step-type.yaml
+++ b/src/negative_test/maestro-flow/invalid-step-type.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- 42

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -332,7 +332,6 @@
     "jsone.json",
     "pgrls.json",
     "license-report-config.json",
-    "maestro-flow.json",
     "openweather.current.json",
     "openweather.roadrisk.json",
     "openhab-5.1.json",

--- a/src/schemas/json/maestro-flow.json
+++ b/src/schemas/json/maestro-flow.json
@@ -1269,12 +1269,26 @@
           "description": "Type text into the focused field.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
         },
         "inputRandomText": {
-          "$ref": "#/$defs/randomInputValue",
-          "description": "Type random text.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
+          "description": "Type random text.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
         },
         "inputRandomNumber": {
-          "$ref": "#/$defs/randomInputValue",
-          "description": "Type a random number.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
+          "description": "Type a random number.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
         },
         "inputRandomEmail": {
           "description": "Type a random email.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",

--- a/src/schemas/json/maestro-flow.json
+++ b/src/schemas/json/maestro-flow.json
@@ -1,121 +1,1567 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/maestro-flow.json",
   "$defs": {
+    "selectorObject": {
+      "title": "selector object",
+      "description": "Element selector map. Combine properties with AND semantics.\nhttps://docs.maestro.dev/reference/selectors.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "text": {
+          "title": "text",
+          "type": "string",
+          "description": "Visible text or accessibility label (regex).\nhttps://docs.maestro.dev/reference/selectors/core-selectors.md"
+        },
+        "id": {
+          "title": "id",
+          "type": "string",
+          "description": "Accessibility identifier / resource id (regex).\nhttps://docs.maestro.dev/reference/selectors/core-selectors.md"
+        },
+        "index": {
+          "title": "index",
+          "description": "0-based index among matches. May be a number or a JavaScript expression string.\nhttps://docs.maestro.dev/reference/selectors/core-selectors.md",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "point": {
+          "title": "point",
+          "type": "string",
+          "description": "Screen coordinate: relative (\"50%,50%\") or absolute (\"100,200\").\nhttps://docs.maestro.dev/reference/selectors/core-selectors.md"
+        },
+        "css": {
+          "title": "css",
+          "type": "string",
+          "description": "Web-only CSS selector.\nhttps://docs.maestro.dev/reference/selectors/core-selectors.md"
+        },
+        "enabled": {
+          "title": "enabled",
+          "type": "boolean",
+          "description": "Match enabled state.\nhttps://docs.maestro.dev/reference/selectors/state-selectors.md"
+        },
+        "checked": {
+          "title": "checked",
+          "type": "boolean",
+          "description": "Match checked state.\nhttps://docs.maestro.dev/reference/selectors/state-selectors.md"
+        },
+        "focused": {
+          "title": "focused",
+          "type": "boolean",
+          "description": "Match focused state.\nhttps://docs.maestro.dev/reference/selectors/state-selectors.md"
+        },
+        "selected": {
+          "title": "selected",
+          "type": "boolean",
+          "description": "Match selected state.\nhttps://docs.maestro.dev/reference/selectors/state-selectors.md"
+        },
+        "above": {
+          "$ref": "#/$defs/selector",
+          "title": "above",
+          "description": "Element is above this selector.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "below": {
+          "$ref": "#/$defs/selector",
+          "title": "below",
+          "description": "Element is below this selector.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "leftOf": {
+          "$ref": "#/$defs/selector",
+          "title": "leftOf",
+          "description": "Element is left of this selector.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "rightOf": {
+          "$ref": "#/$defs/selector",
+          "title": "rightOf",
+          "description": "Element is right of this selector.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "containsChild": {
+          "$ref": "#/$defs/selector",
+          "title": "containsChild",
+          "description": "Contains this direct child.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "childOf": {
+          "$ref": "#/$defs/selector",
+          "title": "childOf",
+          "description": "Direct child of this parent.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md"
+        },
+        "containsDescendants": {
+          "title": "containsDescendants",
+          "description": "Contains all listed descendants.\nhttps://docs.maestro.dev/reference/selectors/relational-selectors.md",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/selector"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/selector"
+              }
+            }
+          ]
+        },
+        "traits": {
+          "title": "traits",
+          "type": "string",
+          "description": "Element trait filter.\nhttps://docs.maestro.dev/reference/selectors/element-traits.md",
+          "examples": ["text", "long-text", "square"]
+        },
+        "width": {
+          "title": "width",
+          "type": "number",
+          "description": "Match element width.\nhttps://docs.maestro.dev/reference/selectors/dimension-matchers.md"
+        },
+        "height": {
+          "title": "height",
+          "type": "number",
+          "description": "Match element height.\nhttps://docs.maestro.dev/reference/selectors/dimension-matchers.md"
+        },
+        "tolerance": {
+          "title": "tolerance",
+          "type": "number",
+          "description": "Tolerance for width/height matching.\nhttps://docs.maestro.dev/reference/selectors/dimension-matchers.md"
+        },
+        "optional": {
+          "title": "optional",
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "label": {
+          "title": "label",
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "repeat": {
+          "title": "repeat",
+          "type": "integer",
+          "minimum": 1,
+          "description": "Repeat the tap N times.\nhttps://docs.maestro.dev/reference/commands-available/tapon.md"
+        },
+        "delay": {
+          "title": "delay",
+          "type": "integer",
+          "minimum": 0,
+          "description": "Delay in ms between repeated taps.\nhttps://docs.maestro.dev/reference/commands-available/tapon.md"
+        },
+        "retryTapIfNoChange": {
+          "title": "retryTapIfNoChange",
+          "type": "boolean",
+          "description": "Retry the tap if the UI does not change.\nhttps://docs.maestro.dev/reference/commands-available/tapon.md"
+        }
+      }
+    },
+    "selector": {
+      "title": "selector",
+      "description": "Element selector: shorthand string (text match) or selector object.\nhttps://docs.maestro.dev/reference/selectors.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Shorthand text selector"
+        },
+        {
+          "$ref": "#/$defs/selectorObject"
+        }
+      ]
+    },
+    "condition": {
+      "title": "condition",
+      "description": "when condition for conditional commands (AND if multiple keys).\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/conditions.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/selector",
+          "title": "visible",
+          "description": "Run when this element is visible"
+        },
+        "notVisible": {
+          "$ref": "#/$defs/selector",
+          "title": "notVisible",
+          "description": "Run when this element is not visible"
+        },
+        "platform": {
+          "title": "platform",
+          "type": "string",
+          "description": "Run on a specific platform (Android, iOS, or Web).\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/conditions.md",
+          "examples": ["Android", "iOS", "Web"]
+        },
+        "true": {
+          "title": "true",
+          "type": "string",
+          "description": "JavaScript expression that must evaluate to true"
+        }
+      }
+    },
+    "commandMeta": {
+      "title": "command meta",
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "stringMap": {
+      "title": "string map",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "permissionValue": {
+      "title": "permission value",
+      "type": "string",
+      "description": "Permission grant state.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/permissions.md",
+      "examples": ["allow", "deny", "unset"]
+    },
+    "permissionsMap": {
+      "title": "permissions map",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/permissionValue"
+      },
+      "properties": {
+        "all": {
+          "$ref": "#/$defs/permissionValue"
+        }
+      }
+    },
+    "swipeDirection": {
+      "title": "swipe direction",
+      "type": "string",
+      "description": "Swipe/scroll direction.",
+      "examples": ["LEFT", "RIGHT", "UP", "DOWN"]
+    },
+    "commandList": {
+      "title": "command list",
+      "description": "Ordered list of Maestro commands.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/commandStep"
+      }
+    },
     "flowConfiguration": {
+      "title": "flow configuration",
+      "description": "Flow header (YAML document above ---). Also accepts workspace config.yaml keys via additionalProperties.\nhttps://docs.maestro.dev/maestro-flows/readme.md",
       "type": "object",
       "additionalProperties": true,
       "properties": {
         "appId": {
+          "title": "appId",
           "type": "string",
-          "title": "Application ID",
-          "description": "Android package name or iOS bundle ID under test. May use ${ENV_VAR} interpolation.",
+          "description": "Android package name or iOS bundle ID under test. Supports ${ENV} interpolation.\nhttps://docs.maestro.dev/maestro-flows/readme.md",
           "examples": ["com.example.app", "${APP_ID}"]
         },
         "url": {
+          "title": "url",
           "type": "string",
-          "title": "Web URL under test",
-          "description": "For web flows, the starting URL (see Maestro web testing docs).",
-          "format": "uri"
+          "description": "Starting URL for web flows.\nhttps://docs.maestro.dev/get-started/supported-platform/web-browser.md"
         },
         "name": {
+          "title": "name",
           "type": "string",
           "description": "Human-readable flow name for reports."
         },
         "tags": {
+          "title": "tags",
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Tags for filtering and organization."
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags for filtering which flows run.\nhttps://docs.maestro.dev/maestro-flows/workspace-management/test-discovery-and-tags.md"
         },
         "env": {
+          "title": "env",
+          "description": "Default environment variables for this flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/parameters-and-constants.md",
           "type": "object",
-          "additionalProperties": { "type": "string" },
-          "description": "Default environment variables for this flow (${VAR_NAME} in commands)."
+          "additionalProperties": true
+        },
+        "jsEngine": {
+          "title": "jsEngine",
+          "type": "string",
+          "description": "JavaScript engine for scripts in this flow.",
+          "examples": ["rhino", "graaljs"]
         },
         "onFlowStart": {
           "$ref": "#/$defs/commandList",
-          "description": "Commands run before the main flow body; failure fails the flow."
+          "title": "onFlowStart",
+          "description": "Commands run before the flow body.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/hooks.md"
         },
         "onFlowComplete": {
           "$ref": "#/$defs/commandList",
-          "description": "Commands run after the main flow (e.g. teardown)."
+          "title": "onFlowComplete",
+          "description": "Commands run after the flow body (success or failure).\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/hooks.md"
         }
       }
     },
-    "commandList": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/commandStep" },
-      "description": "Sequence of Maestro commands executed in order."
-    },
-    "commandStep": {
+    "elementCommandValue": {
+      "title": "element command value",
+      "description": "Shorthand string or selector/options object.",
       "oneOf": [
         {
-          "$ref": "#/$defs/bareCommandName",
-          "description": "Shorthand step with no parameters (YAML scalar list item)."
+          "type": "string",
+          "minLength": 1
         },
         {
-          "$ref": "#/$defs/commandObject",
-          "description": "Single-key object: command name -> arguments map, string, or null."
+          "$ref": "#/$defs/selectorObject"
         }
       ]
     },
-    "bareCommandName": {
-      "type": "string",
-      "title": "Bare command",
-      "description": "Commands that need no argument object. Maestro accepts many more; list is indicative.",
-      "examples": [
-        "launchApp",
-        "hideKeyboard",
-        "back",
-        "stopApp",
-        "clearState",
-        "clearKeychain",
-        "waitForAnimationToEnd",
-        "takeScreenshot",
-        "startRecording",
-        "stopRecording"
+    "launchAppValue": {
+      "title": "launchApp value",
+      "description": "Launch app arguments or bare app id.\nhttps://docs.maestro.dev/reference/commands-available/launchapp.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "App id to launch"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "appId": {
+              "type": "string",
+              "description": "Package name / bundle ID"
+            },
+            "clearState": {
+              "type": "boolean",
+              "description": "Clear app data before launch"
+            },
+            "clearKeychain": {
+              "type": "boolean",
+              "description": "Clear entire iOS keychain"
+            },
+            "stopApp": {
+              "type": "boolean",
+              "description": "Stop the app before launching (default true)"
+            },
+            "permissions": {
+              "$ref": "#/$defs/permissionsMap"
+            },
+            "arguments": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Launch arguments (string, boolean, number)"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
       ]
     },
+    "runFlowValue": {
+      "title": "runFlow value",
+      "description": "Run a subflow file or inline commands.\nhttps://docs.maestro.dev/reference/commands-available/runflow.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to subflow file"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "file": {
+              "type": "string",
+              "description": "Relative path to the flow file"
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "Environment variables for the subflow"
+            },
+            "commands": {
+              "$ref": "#/$defs/commandList",
+              "description": "Inline commands"
+            },
+            "when": {
+              "$ref": "#/$defs/condition"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "runScriptValue": {
+      "title": "runScript value",
+      "description": "Run a JavaScript file.\nhttps://docs.maestro.dev/reference/commands-available/runscript.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to JS file"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "file": {
+              "type": "string"
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "inputTextValue": {
+      "title": "inputText value",
+      "description": "Text to type into the focused field.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Text to input"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "openLinkValue": {
+      "title": "openLink value",
+      "description": "Open a URL or deep link.\nhttps://docs.maestro.dev/reference/commands-available/openlink.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "link": {
+              "type": "string",
+              "description": "URL or custom scheme"
+            },
+            "autoVerify": {
+              "type": "boolean",
+              "description": "Android: auto-verify app link handling"
+            },
+            "browser": {
+              "type": "boolean",
+              "description": "Android: force open in Chrome"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "extendedWaitUntilValue": {
+      "title": "extendedWaitUntil value",
+      "description": "Wait until visible/notVisible with custom timeout.\nhttps://docs.maestro.dev/reference/commands-available/extendedwaituntil.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "visible": {
+          "$ref": "#/$defs/selector"
+        },
+        "notVisible": {
+          "$ref": "#/$defs/selector"
+        },
+        "timeout": {
+          "description": "Timeout in milliseconds",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "repeatValue": {
+      "title": "repeat value",
+      "description": "Repeat commands times or while condition.\nhttps://docs.maestro.dev/reference/commands-available/repeat.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "times": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "while": {
+          "$ref": "#/$defs/condition"
+        },
+        "commands": {
+          "$ref": "#/$defs/commandList"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "retryValue": {
+      "title": "retry value",
+      "description": "Retry commands or a flow file on failure.\nhttps://docs.maestro.dev/reference/commands-available/retry.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "maxRetries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "commands": {
+          "$ref": "#/$defs/commandList"
+        },
+        "file": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "swipeValue": {
+      "title": "swipe value",
+      "description": "Swipe by direction, coordinates, or from an element.\nhttps://docs.maestro.dev/reference/commands-available/swipe.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/swipeDirection"
+        },
+        "start": {
+          "type": "string",
+          "description": "Start point \"x, y\" or \"x%, y%\""
+        },
+        "end": {
+          "type": "string",
+          "description": "End point \"x, y\" or \"x%, y%\""
+        },
+        "from": {
+          "$ref": "#/$defs/selector"
+        },
+        "duration": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Duration in ms"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "scrollUntilVisibleValue": {
+      "title": "scrollUntilVisible value",
+      "description": "Scroll until an element is visible.\nhttps://docs.maestro.dev/reference/commands-available/scrolluntilvisible.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "element": {
+          "$ref": "#/$defs/selector"
+        },
+        "direction": {
+          "$ref": "#/$defs/swipeDirection"
+        },
+        "timeout": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "speed": {
+          "type": "number"
+        },
+        "visibilityPercentage": {
+          "type": "number"
+        },
+        "centerElement": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "setLocationValue": {
+      "title": "setLocation value",
+      "description": "Mock device GPS coordinates.\nhttps://docs.maestro.dev/reference/commands-available/setlocation.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "travelValue": {
+      "title": "travel value",
+      "description": "Simulate movement along GPS points.\nhttps://docs.maestro.dev/reference/commands-available/travel.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "points": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Coordinate strings \"lat, lon\""
+        },
+        "speed": {
+          "type": "number",
+          "description": "Speed in km/h"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "assertTrueValue": {
+      "title": "assertTrue value",
+      "description": "Assert a JavaScript expression is truthy.\nhttps://docs.maestro.dev/reference/commands-available/asserttrue.md",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "condition": {
+              "type": "string",
+              "description": "Expression to evaluate"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "assertWithAIValue": {
+      "title": "assertWithAI value",
+      "description": "Natural-language UI assertion via AI.\nhttps://docs.maestro.dev/reference/commands-available/assertwithai.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "assertion": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "extractTextWithAIValue": {
+      "title": "extractTextWithAI value",
+      "description": "Extract text from the screen with AI.\nhttps://docs.maestro.dev/reference/commands-available/extracttextwithai.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Query string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "query": {
+              "type": "string"
+            },
+            "outputVariable": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "assertScreenshotValue": {
+      "title": "assertScreenshot value",
+      "description": "Visual regression against a baseline screenshot.\nhttps://docs.maestro.dev/reference/commands-available/assertscreenshot.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Path to baseline image"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "cropOn": {
+              "$ref": "#/$defs/selector"
+            },
+            "thresholdPercentage": {
+              "type": "number"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "takeScreenshotValue": {
+      "title": "takeScreenshot value",
+      "description": "Capture a screenshot.\nhttps://docs.maestro.dev/reference/commands-available/takescreenshot.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Output path / name"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "cropOn": {
+              "$ref": "#/$defs/selector"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "startRecordingValue": {
+      "title": "startRecording value",
+      "description": "Start screen recording.\nhttps://docs.maestro.dev/reference/commands-available/startrecording.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Recording path / name"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "eraseTextValue": {
+      "title": "eraseText value",
+      "description": "Erase characters from the focused field.\nhttps://docs.maestro.dev/reference/commands-available/erasetext.md",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "charactersToErase": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "setPermissionsValue": {
+      "title": "setPermissions value",
+      "description": "Grant or deny permissions mid-flow.\nhttps://docs.maestro.dev/reference/commands-available/setpermissions.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "permissions": {
+          "$ref": "#/$defs/permissionsMap"
+        },
+        "appId": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "waitForAnimationToEndValue": {
+      "title": "waitForAnimationToEnd value",
+      "description": "Wait for UI animations to finish.\nhttps://docs.maestro.dev/reference/commands-available/waitforanimationtoend.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "timeout": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
+    "addMediaValue": {
+      "title": "addMedia value",
+      "description": "Add media files to the device gallery.\nhttps://docs.maestro.dev/reference/commands-available/addmedia.md",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "stopAppValue": {
+      "title": "stopApp value",
+      "description": "Stop an app without clearing data.\nhttps://docs.maestro.dev/reference/commands-available/stopapp.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "App id"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "appId": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "killAppValue": {
+      "title": "killApp value",
+      "description": "Force-stop an app.\nhttps://docs.maestro.dev/reference/commands-available/killapp.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "App id"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "appId": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "clearStateValue": {
+      "title": "clearState value",
+      "description": "Clear app data / cache.\nhttps://docs.maestro.dev/reference/commands-available/clearstate.md",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "App id"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "appId": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            },
+            "optional": {
+              "type": "boolean",
+              "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+            }
+          }
+        }
+      ]
+    },
+    "pressKeyValue": {
+      "title": "pressKey value",
+      "description": "Hardware / soft key name.\nhttps://docs.maestro.dev/reference/commands-available/presskey.md",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "home",
+        "lock",
+        "enter",
+        "backspace",
+        "volume up",
+        "volume down",
+        "back",
+        "power",
+        "tab"
+      ]
+    },
+    "setAirplaneModeValue": {
+      "title": "setAirplaneMode value",
+      "type": "string",
+      "description": "Enable or disable airplane mode (Android).\nhttps://docs.maestro.dev/reference/commands-available/setairplanemode.md",
+      "examples": ["enabled", "disabled"]
+    },
+    "setOrientationValue": {
+      "title": "setOrientation value",
+      "description": "Device orientation.\nhttps://docs.maestro.dev/reference/commands-available/setorientation.md",
+      "type": "string",
+      "examples": [
+        "PORTRAIT",
+        "LANDSCAPE_LEFT",
+        "LANDSCAPE_RIGHT",
+        "UPSIDE_DOWN"
+      ]
+    },
+    "setClipboardValue": {
+      "title": "setClipboard value",
+      "description": "Set clipboard text.\nhttps://docs.maestro.dev/reference/commands-available/setclipboard.md",
+      "type": "string"
+    },
+    "evalScriptValue": {
+      "title": "evalScript value",
+      "description": "Inline JavaScript expression.\nhttps://docs.maestro.dev/reference/commands-available/evalscript.md",
+      "type": "string"
+    },
+    "randomInputValue": {
+      "title": "random input value",
+      "description": "Random input options (length for text/number).\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "length": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+        }
+      }
+    },
     "commandObject": {
+      "title": "command object",
+      "description": "Single Maestro command as a one-key mapping (e.g. tapOn: Login, launchApp: { clearState: true }). Unknown future commands are allowed via additionalProperties.",
       "type": "object",
       "minProperties": 1,
       "maxProperties": 1,
-      "additionalProperties": {
-        "$ref": "#/$defs/commandValue"
-      },
-      "propertyNames": {
-        "type": "string",
-        "description": "Maestro command name (typically camelCase, e.g. tapOn, runFlow)."
+      "additionalProperties": true,
+      "properties": {
+        "addMedia": {
+          "$ref": "#/$defs/addMediaValue",
+          "description": "Add media to the gallery.\nhttps://docs.maestro.dev/reference/commands-available/addmedia.md"
+        },
+        "assertNoDefectsWithAI": {
+          "description": "AI visual defect check.\nhttps://docs.maestro.dev/reference/commands-available/assertnodefectswithai.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "assertNotVisible": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Assert element is not visible.\nhttps://docs.maestro.dev/reference/commands-available/assertnotvisible.md"
+        },
+        "assertScreenshot": {
+          "$ref": "#/$defs/assertScreenshotValue",
+          "description": "Visual regression assertion.\nhttps://docs.maestro.dev/reference/commands-available/assertscreenshot.md"
+        },
+        "assertTrue": {
+          "$ref": "#/$defs/assertTrueValue",
+          "description": "Assert JS expression is true.\nhttps://docs.maestro.dev/reference/commands-available/asserttrue.md"
+        },
+        "assertVisible": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Assert element is visible.\nhttps://docs.maestro.dev/reference/commands-available/assertvisible.md"
+        },
+        "assertWithAI": {
+          "$ref": "#/$defs/assertWithAIValue",
+          "description": "Natural-language AI assertion.\nhttps://docs.maestro.dev/reference/commands-available/assertwithai.md"
+        },
+        "back": {
+          "description": "Press system back.\nhttps://docs.maestro.dev/reference/commands-available/back.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "clearKeychain": {
+          "description": "Clear iOS keychain.\nhttps://docs.maestro.dev/reference/commands-available/clearkeychain.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "clearState": {
+          "$ref": "#/$defs/clearStateValue",
+          "description": "Clear app state.\nhttps://docs.maestro.dev/reference/commands-available/clearstate.md"
+        },
+        "copyTextFrom": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Copy text from an element.\nhttps://docs.maestro.dev/reference/commands-available/copytextfrom.md"
+        },
+        "doubleTapOn": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Double-tap an element.\nhttps://docs.maestro.dev/reference/commands-available/doubletapon.md"
+        },
+        "eraseText": {
+          "$ref": "#/$defs/eraseTextValue",
+          "description": "Erase focused text.\nhttps://docs.maestro.dev/reference/commands-available/erasetext.md"
+        },
+        "evalScript": {
+          "$ref": "#/$defs/evalScriptValue",
+          "description": "Evaluate inline JavaScript.\nhttps://docs.maestro.dev/reference/commands-available/evalscript.md"
+        },
+        "extendedWaitUntil": {
+          "$ref": "#/$defs/extendedWaitUntilValue",
+          "description": "Wait with custom timeout.\nhttps://docs.maestro.dev/reference/commands-available/extendedwaituntil.md"
+        },
+        "extractTextWithAI": {
+          "$ref": "#/$defs/extractTextWithAIValue",
+          "description": "Extract text with AI.\nhttps://docs.maestro.dev/reference/commands-available/extracttextwithai.md"
+        },
+        "hideKeyboard": {
+          "description": "Dismiss the soft keyboard.\nhttps://docs.maestro.dev/reference/commands-available/hidekeyboard.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "inputText": {
+          "$ref": "#/$defs/inputTextValue",
+          "description": "Type text into the focused field.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
+        },
+        "inputRandomText": {
+          "$ref": "#/$defs/randomInputValue",
+          "description": "Type random text.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
+        },
+        "inputRandomNumber": {
+          "$ref": "#/$defs/randomInputValue",
+          "description": "Type a random number.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md"
+        },
+        "inputRandomEmail": {
+          "description": "Type a random email.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
+        },
+        "inputRandomPersonName": {
+          "description": "Type a random person name.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
+        },
+        "inputRandomCityName": {
+          "description": "Type a random city name.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
+        },
+        "inputRandomCountryName": {
+          "description": "Type a random country name.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
+        },
+        "inputRandomColorName": {
+          "description": "Type a random color name.\nhttps://docs.maestro.dev/reference/commands-available/inputtext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/randomInputValue"
+            }
+          ]
+        },
+        "killApp": {
+          "$ref": "#/$defs/killAppValue",
+          "description": "Force-stop an app.\nhttps://docs.maestro.dev/reference/commands-available/killapp.md"
+        },
+        "launchApp": {
+          "$ref": "#/$defs/launchAppValue",
+          "description": "Launch an app.\nhttps://docs.maestro.dev/reference/commands-available/launchapp.md"
+        },
+        "longPressOn": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Long-press an element.\nhttps://docs.maestro.dev/reference/commands-available/longpresson.md"
+        },
+        "openLink": {
+          "$ref": "#/$defs/openLinkValue",
+          "description": "Open a URL or deep link.\nhttps://docs.maestro.dev/reference/commands-available/openlink.md"
+        },
+        "pasteText": {
+          "description": "Paste clipboard into the focused field.\nhttps://docs.maestro.dev/reference/commands-available/pastetext.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "pressKey": {
+          "$ref": "#/$defs/pressKeyValue",
+          "description": "Press a hardware/soft key.\nhttps://docs.maestro.dev/reference/commands-available/presskey.md"
+        },
+        "repeat": {
+          "$ref": "#/$defs/repeatValue",
+          "description": "Repeat commands.\nhttps://docs.maestro.dev/reference/commands-available/repeat.md"
+        },
+        "retry": {
+          "$ref": "#/$defs/retryValue",
+          "description": "Retry commands on failure.\nhttps://docs.maestro.dev/reference/commands-available/retry.md"
+        },
+        "runFlow": {
+          "$ref": "#/$defs/runFlowValue",
+          "description": "Run a nested flow.\nhttps://docs.maestro.dev/reference/commands-available/runflow.md"
+        },
+        "runScript": {
+          "$ref": "#/$defs/runScriptValue",
+          "description": "Run a JavaScript file.\nhttps://docs.maestro.dev/reference/commands-available/runscript.md"
+        },
+        "scroll": {
+          "description": "Simple vertical scroll.\nhttps://docs.maestro.dev/reference/commands-available/scroll.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "scrollUntilVisible": {
+          "$ref": "#/$defs/scrollUntilVisibleValue",
+          "description": "Scroll until element is visible.\nhttps://docs.maestro.dev/reference/commands-available/scrolluntilvisible.md"
+        },
+        "setAirplaneMode": {
+          "$ref": "#/$defs/setAirplaneModeValue",
+          "description": "Set airplane mode.\nhttps://docs.maestro.dev/reference/commands-available/setairplanemode.md"
+        },
+        "setClipboard": {
+          "$ref": "#/$defs/setClipboardValue",
+          "description": "Set clipboard contents.\nhttps://docs.maestro.dev/reference/commands-available/setclipboard.md"
+        },
+        "setLocation": {
+          "$ref": "#/$defs/setLocationValue",
+          "description": "Set GPS location.\nhttps://docs.maestro.dev/reference/commands-available/setlocation.md"
+        },
+        "setOrientation": {
+          "$ref": "#/$defs/setOrientationValue",
+          "description": "Set device orientation.\nhttps://docs.maestro.dev/reference/commands-available/setorientation.md"
+        },
+        "setPermissions": {
+          "$ref": "#/$defs/setPermissionsValue",
+          "description": "Set app permissions.\nhttps://docs.maestro.dev/reference/commands-available/setpermissions.md"
+        },
+        "startRecording": {
+          "$ref": "#/$defs/startRecordingValue",
+          "description": "Start screen recording.\nhttps://docs.maestro.dev/reference/commands-available/startrecording.md"
+        },
+        "stopApp": {
+          "$ref": "#/$defs/stopAppValue",
+          "description": "Stop an app.\nhttps://docs.maestro.dev/reference/commands-available/stopapp.md"
+        },
+        "stopRecording": {
+          "description": "Stop screen recording.\nhttps://docs.maestro.dev/reference/commands-available/stoprecording.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "swipe": {
+          "$ref": "#/$defs/swipeValue",
+          "description": "Swipe gesture.\nhttps://docs.maestro.dev/reference/commands-available/swipe.md"
+        },
+        "takeScreenshot": {
+          "$ref": "#/$defs/takeScreenshotValue",
+          "description": "Capture a screenshot.\nhttps://docs.maestro.dev/reference/commands-available/takescreenshot.md"
+        },
+        "tapOn": {
+          "$ref": "#/$defs/elementCommandValue",
+          "description": "Tap an element or coordinate.\nhttps://docs.maestro.dev/reference/commands-available/tapon.md"
+        },
+        "toggleAirplaneMode": {
+          "description": "Toggle airplane mode.\nhttps://docs.maestro.dev/reference/commands-available/toggleairplanemode.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "description": "Human-readable step label for reports.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                },
+                "optional": {
+                  "type": "boolean",
+                  "description": "If true, failure does not fail the flow.\nhttps://docs.maestro.dev/maestro-flows/flow-control-and-logic/labeling-and-error-handling.md"
+                }
+              }
+            }
+          ]
+        },
+        "travel": {
+          "$ref": "#/$defs/travelValue",
+          "description": "Travel along GPS points.\nhttps://docs.maestro.dev/reference/commands-available/travel.md"
+        },
+        "waitForAnimationToEnd": {
+          "description": "Wait for animations to end.\nhttps://docs.maestro.dev/reference/commands-available/waitforanimationtoend.md",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/waitForAnimationToEndValue"
+            }
+          ]
+        }
       }
     },
-    "commandValue": {
-      "title": "Command arguments",
-      "description": "Depends on the command: omitted/null, boolean, string selector, number, array of nested steps, or parameter object.",
-      "oneOf": [
-        { "type": "null" },
-        { "type": "boolean" },
-        { "type": "number" },
-        { "type": "string" },
-        { "type": "array", "items": { "$ref": "#/$defs/commandStep" } },
-        { "$ref": "#/$defs/argumentMap" }
+    "bareCommand": {
+      "title": "bare command",
+      "description": "Commands that may be written as a bare YAML scalar with no arguments (e.g. launchApp, hideKeyboard, scroll).",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "launchApp",
+        "hideKeyboard",
+        "scroll",
+        "back",
+        "pasteText",
+        "stopRecording",
+        "waitForAnimationToEnd",
+        "toggleAirplaneMode",
+        "clearKeychain",
+        "clearState",
+        "stopApp",
+        "killApp",
+        "inputRandomText",
+        "inputRandomNumber",
+        "inputRandomEmail",
+        "inputRandomPersonName",
+        "assertNoDefectsWithAI"
       ]
     },
-    "argumentMap": {
-      "type": "object",
-      "additionalProperties": true,
-      "description": "Command-specific parameters. Commands: https://docs.maestro.dev/reference/commands-available/ — Selectors: https://docs.maestro.dev/reference/selectors — Conditions (when): https://docs.maestro.dev/maestro-flows/flow-control-and-logic/conditions — runFlow: https://docs.maestro.dev/reference/commands-available/runflow — launchApp: https://docs.maestro.dev/reference/commands-available/launchapp — extendedWaitUntil: https://docs.maestro.dev/reference/commands-available/extendedwaituntil"
+    "commandStep": {
+      "title": "command step",
+      "description": "One flow step: bare command name or single-key command object.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/bareCommand"
+        },
+        {
+          "$ref": "#/$defs/commandObject"
+        }
+      ]
     }
   },
   "title": "Maestro Flow",
-  "description": "YAML flow file for Maestro (mobile & web UI automation). A single file is usually two YAML documents separated by ---: (1) flow configuration, (2) command list. Assign this schema to *.flow.yaml or **/.maestro/**/*.yaml. Official docs: https://docs.maestro.dev/",
+  "description": "YAML flow file for Maestro (mobile and web UI automation). A file is usually two YAML documents separated by ---: (1) flow configuration, (2) ordered command list.\nhttps://docs.maestro.dev/maestro-flows/readme.md",
   "oneOf": [
     {
-      "$ref": "#/$defs/flowConfiguration",
-      "description": "First document: app/url, env, tags, hooks."
+      "$ref": "#/$defs/flowConfiguration"
     },
     {
-      "$ref": "#/$defs/commandList",
-      "description": "Second document: ordered list of Maestro commands."
+      "$ref": "#/$defs/commandList"
     }
   ]
 }

--- a/src/test/maestro-flow/flow-control.yaml
+++ b/src/test/maestro-flow/flow-control.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- runFlow: Login.yaml
+- runFlow:
+    file: anotherFlow.yaml
+    env:
+      MY_PARAMETER: "123"
+- runFlow:
+    when:
+      platform: iOS
+    file: subflows/ios-permissions.yaml
+- runFlow:
+    when:
+      notVisible: "Biometric Login"
+    commands:
+      - tapOn: "Standard Login"
+- repeat:
+    times: 3
+    commands:
+      - tapOn: Button
+      - scroll
+- repeat:
+    while:
+      notVisible: "ValueX"
+    commands:
+      - tapOn: Button
+- retry:
+    maxRetries: 3
+    commands:
+      - tapOn:
+          id: button-that-might-not-be-here-yet
+- evalScript: ${output.counter = 0}
+- assertTrue:
+    condition: ${output.counter == 0}
+    label: Counter starts at zero
+- runScript: myScript.js
+- runScript:
+    file: script.js
+    env:
+      myParameter: Parameter
+- assertWithAI:
+    assertion: Login and password text fields are visible.
+- extractTextWithAI: CAPTCHA value
+- inputRandomText:
+    length: 12
+- inputRandomEmail
+- travel:
+    points:
+      - "48.8578065, 2.295188"
+      - "46.2276, 5.9900"
+    speed: 150000
+- doubleTapOn:
+    id: icon
+- longPressOn:
+    text: Options
+- copyTextFrom:
+    id: title

--- a/src/test/maestro-flow/flow-control.yaml
+++ b/src/test/maestro-flow/flow-control.yaml
@@ -3,16 +3,16 @@
 - runFlow:
     file: anotherFlow.yaml
     env:
-      MY_PARAMETER: "123"
+      MY_PARAMETER: '123'
 - runFlow:
     when:
       platform: iOS
     file: subflows/ios-permissions.yaml
 - runFlow:
     when:
-      notVisible: "Biometric Login"
+      notVisible: 'Biometric Login'
     commands:
-      - tapOn: "Standard Login"
+      - tapOn: 'Standard Login'
 - repeat:
     times: 3
     commands:
@@ -20,7 +20,7 @@
       - scroll
 - repeat:
     while:
-      notVisible: "ValueX"
+      notVisible: 'ValueX'
     commands:
       - tapOn: Button
 - retry:
@@ -45,8 +45,8 @@
 - inputRandomEmail
 - travel:
     points:
-      - "48.8578065, 2.295188"
-      - "46.2276, 5.9900"
+      - '48.8578065, 2.295188'
+      - '46.2276, 5.9900'
     speed: 150000
 - doubleTapOn:
     id: icon

--- a/src/test/maestro-flow/flow-device-and-media.yaml
+++ b/src/test/maestro-flow/flow-device-and-media.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- launchApp:
+    appId: com.example.app
+    clearState: true
+    clearKeychain: true
+    permissions:
+      all: deny
+      camera: allow
+- setPermissions:
+    permissions:
+      all: allow
+- setLocation:
+    latitude: 52.3599976
+    longitude: 4.8830301
+- setOrientation: PORTRAIT
+- setAirplaneMode: enabled
+- toggleAirplaneMode
+- setClipboard: custom@example.com
+- pasteText
+- addMedia:
+  - "./assets/foo.png"
+  - "./assets/foo.mp4"
+- takeScreenshot: MainScreen
+- takeScreenshot:
+    path: LoginScreen
+    cropOn:
+      id: LoginFormContainer
+- assertScreenshot: splash.png
+- startRecording: recording
+- stopRecording
+- pressKey: enter
+- eraseText: 10
+- openLink:
+    link: https://example.com
+    browser: true
+- killApp: com.example.app
+- stopApp
+- clearState
+- waitForAnimationToEnd:
+    timeout: 5000

--- a/src/test/maestro-flow/flow-device-and-media.yaml
+++ b/src/test/maestro-flow/flow-device-and-media.yaml
@@ -18,8 +18,8 @@
 - setClipboard: custom@example.com
 - pasteText
 - addMedia:
-  - "./assets/foo.png"
-  - "./assets/foo.mp4"
+    - './assets/foo.png'
+    - './assets/foo.mp4'
 - takeScreenshot: MainScreen
 - takeScreenshot:
     path: LoginScreen

--- a/src/test/maestro-flow/flow-header.yaml
+++ b/src/test/maestro-flow/flow-header.yaml
@@ -3,5 +3,8 @@ appId: com.example.maestro
 name: sample flow
 tags:
   - e2e
+  - smoke-test
 env:
   API_URL: https://api.example.test
+  USERNAME: user@example.com
+jsEngine: graaljs

--- a/src/test/maestro-flow/flow-hooks.yaml
+++ b/src/test/maestro-flow/flow-hooks.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+appId: com.example.app
+onFlowStart:
+  - launchApp
+  - clearState
+onFlowComplete:
+  - stopApp

--- a/src/test/maestro-flow/flow-login-helper.yaml
+++ b/src/test/maestro-flow/flow-login-helper.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- launchApp:
+    clearState: true
+    arguments:
+      e2eSkipHealth: "true"
+- extendedWaitUntil:
+    visible:
+      id: "welcome-login-btn"
+    timeout: 20000
+- tapOn:
+    id: "welcome-login-btn"
+- tapOn:
+    id: "login-email-input"
+- inputText: ${E2E_EMAIL}
+- tapOn:
+    id: "login-password-input"
+- inputText: ${E2E_PASSWORD}
+- tapOn:
+    id: "login-submit-btn"
+- extendedWaitUntil:
+    visible: "Save Password?"
+    timeout: 12000
+    optional: true
+- runFlow:
+    when:
+      visible: "Save Password?"
+    commands:
+      - tapOn: "Not Now"
+- runFlow:
+    when:
+      visible:
+        id: "timezone-mismatch-keep-btn"
+    commands:
+      - tapOn:
+          id: "timezone-mismatch-keep-btn"
+- extendedWaitUntil:
+    visible:
+      id: "header-home-logo"
+    timeout: 20000
+- assertVisible: "Today"

--- a/src/test/maestro-flow/flow-login-helper.yaml
+++ b/src/test/maestro-flow/flow-login-helper.yaml
@@ -2,39 +2,39 @@
 - launchApp:
     clearState: true
     arguments:
-      e2eSkipHealth: "true"
+      e2eSkipHealth: 'true'
 - extendedWaitUntil:
     visible:
-      id: "welcome-login-btn"
+      id: 'welcome-login-btn'
     timeout: 20000
 - tapOn:
-    id: "welcome-login-btn"
+    id: 'welcome-login-btn'
 - tapOn:
-    id: "login-email-input"
+    id: 'login-email-input'
 - inputText: ${E2E_EMAIL}
 - tapOn:
-    id: "login-password-input"
+    id: 'login-password-input'
 - inputText: ${E2E_PASSWORD}
 - tapOn:
-    id: "login-submit-btn"
+    id: 'login-submit-btn'
 - extendedWaitUntil:
-    visible: "Save Password?"
+    visible: 'Save Password?'
     timeout: 12000
     optional: true
 - runFlow:
     when:
-      visible: "Save Password?"
+      visible: 'Save Password?'
     commands:
-      - tapOn: "Not Now"
+      - tapOn: 'Not Now'
 - runFlow:
     when:
       visible:
-        id: "timezone-mismatch-keep-btn"
+        id: 'timezone-mismatch-keep-btn'
     commands:
       - tapOn:
-          id: "timezone-mismatch-keep-btn"
+          id: 'timezone-mismatch-keep-btn'
 - extendedWaitUntil:
     visible:
-      id: "header-home-logo"
+      id: 'header-home-logo'
     timeout: 20000
-- assertVisible: "Today"
+- assertVisible: 'Today'

--- a/src/test/maestro-flow/flow-selectors.yaml
+++ b/src/test/maestro-flow/flow-selectors.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+- tapOn: Login
+- tapOn:
+    text: ".*Continue.*"
+- tapOn:
+    id: login_button
+    enabled: true
+- tapOn:
+    id: buy_button
+    index: 2
+- tapOn:
+    css: .secondaryButton
+- tapOn:
+    point: "50%, 50%"
+- tapOn:
+    text: Submit
+    below:
+      text: Terms
+- assertVisible:
+    id: header_icon
+    focused: false
+- swipe:
+    direction: LEFT
+    duration: 2000
+- swipe:
+    from:
+      id: feeditem_identifier
+    direction: UP
+- scrollUntilVisible:
+    element:
+      text: Footer
+    direction: DOWN
+    timeout: 15000

--- a/src/test/maestro-flow/flow-selectors.yaml
+++ b/src/test/maestro-flow/flow-selectors.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../schemas/json/maestro-flow.json
 - tapOn: Login
 - tapOn:
-    text: ".*Continue.*"
+    text: '.*Continue.*'
 - tapOn:
     id: login_button
     enabled: true
@@ -11,7 +11,7 @@
 - tapOn:
     css: .secondaryButton
 - tapOn:
-    point: "50%, 50%"
+    point: '50%, 50%'
 - tapOn:
     text: Submit
     below:

--- a/src/test/maestro-flow/flow-web-header.yaml
+++ b/src/test/maestro-flow/flow-web-header.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/maestro-flow.json
+url: https://docs.maestro.dev/
+name: web smoke
+tags:
+  - web


### PR DESCRIPTION
## Summary

- Replaces the minimal `maestro-flow.json` (loose command objects) with a **draft-07** schema aligned to the official Maestro docs: flow configuration, selectors, and documented commands for IDE autocomplete/validation.
- Structures command steps as a **single-key command object** (plus bare command strings) instead of a large per-command `oneOf`, which caused yaml-language-server (VS Code / Zed) to offer each command twice (property + skeleton).
- Keeps `additionalProperties` open on config and command objects so new Maestro features do not break existing flows.
- Moves the schema off draft 2020-12 (`highSchemaVersion`) to draft-07; it passes Ajv **strict** mode without an `ajvNotStrictMode` exemption.
- Adds positive tests (header, web, selectors, device/media, control, hooks, login-style helper) and negative tests (bad step type, multi-key step, invalid `launchApp` value).

Sources: [Maestro Flows](https://docs.maestro.dev/maestro-flows/readme.md), [Commands](https://docs.maestro.dev/reference/commands-available.md), [Selectors](https://docs.maestro.dev/reference/selectors.md).

## Test plan

- [x] `node ./cli.js check --schema-name=maestro-flow.json`
- [x] Positive tests under `src/test/maestro-flow/` validate
- [x] Negative tests under `src/negative_test/maestro-flow/` fail as expected
- [x] Confirm IDE autocomplete (VS Code Red Hat YAML / Zed) suggests `tapOn`, `launchApp`, `runFlow`, etc. once each for a `.maestro/**/*.yaml` flow