### PR TITLE
Add CVX cv-content schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1739,6 +1739,66 @@
       "url": "https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/docs/CVE_Record_Format_bundled.json"
     },
     {
+      "name": "CVX personal.yaml",
+      "description": "Identity and contact details for a CVX CV (name, title, contact rows)",
+      "fileMatch": ["**/cv-content/personal.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/personal.schema.json"
+    },
+    {
+      "name": "CVX summary.yaml",
+      "description": "Professional-summary bullets for a CVX CV",
+      "fileMatch": ["**/cv-content/summary.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/summary.schema.json"
+    },
+    {
+      "name": "CVX experience.yaml",
+      "description": "Work history entries for a CVX CV (roles, progression, impact bullets)",
+      "fileMatch": ["**/cv-content/experience.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/experience.schema.json"
+    },
+    {
+      "name": "CVX education.yaml",
+      "description": "Education entries for a CVX CV",
+      "fileMatch": ["**/cv-content/education.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/education.schema.json"
+    },
+    {
+      "name": "CVX competencies.yaml",
+      "description": "Skill tags for a CVX CV",
+      "fileMatch": ["**/cv-content/competencies.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/competencies.schema.json"
+    },
+    {
+      "name": "CVX achievements.yaml",
+      "description": "Awards and recognitions for a CVX CV",
+      "fileMatch": ["**/cv-content/achievements.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/achievements.schema.json"
+    },
+    {
+      "name": "CVX referees.yaml",
+      "description": "References for a CVX CV",
+      "fileMatch": ["**/cv-content/referees.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/referees.schema.json"
+    },
+    {
+      "name": "CVX keywords.yaml",
+      "description": "ATS keywords embedded in CVX PDF metadata",
+      "fileMatch": ["**/cv-content/keywords.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/keywords.schema.json"
+    },
+    {
+      "name": "CVX config.yaml",
+      "description": "CVX build configuration (theme, layout, pagination, ATS keywords)",
+      "fileMatch": ["**/cv-content/config.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/config.schema.json"
+    },
+    {
+      "name": "CVX layout",
+      "description": "Custom page layout for a CVX CV (section placement per page)",
+      "fileMatch": ["**/cv-content/layouts/*.yaml"],
+      "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/layout.schema.json"
+    },
+    {
       "name": "Cycle Stack File",
       "description": "A Cycle.io stack file for environments as code",
       "fileMatch": ["cycle.json", "cycle.yml", "cycle.yaml"],


### PR DESCRIPTION
## What

Adds catalog entries for [CVX](https://github.com/hrtips/cvx) (`@hrtips/cvx` on npm) — an open-source, local-only CLI that renders CVs from plain YAML files to PDF. One entry per content file (`**/cv-content/<file>.yaml`) plus one for custom layouts (`**/cv-content/layouts/*.yaml`), so editors resolve a precise schema per file rather than a weak union.

## Schema hosting & stability

- Schemas are draft 2020-12, hosted in the CVX repo under a versioned path (`/schema/v1/`), each catalog URL a small single-purpose schema that `$ref`s one canonical definitions file.
- They compile clean under ajv strict mode and are exercised in CVX's CI on every commit (positive: the shipped example content; negative: seeded mistakes).
- Documented compatibility promise: content files never break within a schema major version, so these URLs stay stable.

Files scaffolded by `npx @hrtips/cvx init` already carry inline `# yaml-language-server: $schema=…` headers; these catalog entries cover hand-created files and catalog-consuming tools.