### PR TITLE
feat: add Draugr Saga

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2560,6 +2560,12 @@
       "url": "https://www.schemastore.org/debugsettings.json"
     },
     {
+      "name": "Draugr Saga",
+      "description": "Draugr Saga - a declarative account of an application's security surface and the controls that must pass",
+      "fileMatch": ["*.saga.yaml", "*.saga.yml", ".saga.yaml", ".saga.yml"],
+      "url": "https://draugr.dev/schema/draugr.saga.schema.json"
+    },
+    {
       "name": "Deno Config (deno.json)",
       "description": "A JSON representation of a Deno configuration file",
       "fileMatch": ["deno.json", "deno.jsonc"],


### PR DESCRIPTION
Registers the schema for [Draugr](https://github.com/draugr-dev/draugr)'s descriptor, `*.saga.yaml`.

Draugr is an open-source security scanning orchestrator; a Saga declares an application's security surface (repositories, container images, endpoints) and which security controls must pass. The schema is **self-hosted** at https://draugr.dev/schema/draugr.saga.schema.json, following the self-hosted/remote section of CONTRIBUTING.

**On the `fileMatch` patterns.** `*.saga.yaml` is the file *type*, not a single filename — the CLI loads whatever path it's given, so a repository commonly holds several (`draugr.saga.yaml`, `payments.saga.yaml`, one per service directory). The `.yml` and dotfile forms are listed separately rather than as a `{...}` alternation, per the "use simple patterns" guidance, and every pattern carries a `.ya?ml` extension so the RedHat YAML language server applies it correctly.

The schema is JSON Schema 2020-12, uses only internal `$ref`s, and carries `description` on every property so editors show useful hover text and completion.