### PR TITLE
fix: partial-pytest schema by removing redundant 'x-tombi-array-values-order' property from command line arguments description.

### DIFF
--- a/src/schemas/json/partial-pytest.json
+++ b/src/schemas/json/partial-pytest.json
@@ -47,8 +47,7 @@
               "type": "string"
             }
           ],
-          "description": "Add the specified OPTS to the set of command line arguments as if they had been specified by the user.",
-          "x-tombi-array-values-order": "ascending"
+          "description": "Add the specified OPTS to the set of command line arguments as if they had been specified by the user."
         },
         "cache_dir": {
           "type": "string",
@@ -716,8 +715,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Add the specified OPTS to the set of command line arguments as if they had been specified by the user.",
-          "x-tombi-array-values-order": "ascending"
+          "description": "Add the specified OPTS to the set of command line arguments as if they had been specified by the user."
         },
         "cache_dir": {
           "type": "string",


### PR DESCRIPTION
Related: https://github.com/tombi-toml/tombi/issues/2038