### PR TITLE
Add allowScripts field to package.json schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -1326,6 +1326,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "allowScripts": {
+      "description": "Records which dependencies are permitted to run install scripts (preinstall, install, postinstall, and prepare for non-registry sources). Maintained via the \"npm approve-scripts\" command, which enforces a default-deny policy: install scripts for any dependency without a matching entry are silently skipped. Keys are package identifiers — either name-only (e.g. \"pkg\") or pinned with a version (e.g. \"pkg@1.2.3\"); by default entries are pinned so approval is version-specific. A value of true allows the dependency's install scripts to run, while false explicitly denies them (existing false entries are never silently overridden).",
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
     }
   },
   "$id": "https://json.schemastore.org/package.json"


### PR DESCRIPTION
Add the `allowScripts` field to the package.json schema based on the npm approve-scripts command (CLI v12). The field is an object mapping package identifiers (name-only or pinned with version) to booleans that control whether each dependency's install scripts (preinstall, install, postinstall, and prepare for non-registry sources) are permitted to run, enforcing a default-deny policy.

https://docs.npmjs.com/cli/v12/commands/npm-approve-scripts

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
