### PR TITLE
fix(kustomization): relax valuesInline constraint

### DIFF
--- a/src/schemas/json/kustomization.json
+++ b/src/schemas/json/kustomization.json
@@ -140,12 +140,8 @@
         },
         "valuesInline": {
           "type": "object",
-          "patternProperties": {
-            ".*": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
+          "additionalProperties": true,
+          "properties": {}
         },
         "valuesMerge": {
           "type": "string",

--- a/src/test/kustomization/helmCharts3.yaml
+++ b/src/test/kustomization/helmCharts3.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../schemas/json/kustomization.json
+helmCharts:
+  - repo: https://kubernetes-sigs.github.io/descheduler
+    name: descheduler
+    version: 0.33.0
+    releaseName: descheduler
+    namespace: kube-system
+    valuesInline:
+      kind: CronJob
+      suspend: true
+      failedJobsHistoryLimit: 1
+      imagePullSecrets: null
+      tolerations: []
+      resources: {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Recently I have noticed that `valuesInline` would complain if the value are not type of object

I have found out that the change introduced in https://github.com/SchemaStore/schemastore/pull/6018 would enforce that the value needs to be type of object

This PR aims to fix that issue by relaxing the constraint to allow additional property on `valuesInline` which would enable it to accept any type of value