### PR TITLE
feat: add Renovate 43's JSON Schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,dout,foto,vor,wel,NAM,BRIN,everyTime,afterAll,beforeAll,ontainer,mis-match',
+            'crate,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,dout,foto,vor,wel,NAM,BRIN,everyTime,afterAll,beforeAll,ontainer,mis-match,explicilty,hashin,paket',
           ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6619,6 +6619,7 @@
       ],
       "url": "https://docs.renovatebot.com/renovate-schema.json",
       "versions": {
+        "43": "https://www.schemastore.org/renovate-43.json",
         "42": "https://www.schemastore.org/renovate-42.json",
         "41": "https://www.schemastore.org/renovate-41.json",
         "40": "https://www.schemastore.org/renovate-40.json",
@@ -6631,6 +6632,7 @@
       "fileMatch": [],
       "url": "https://docs.renovatebot.com/renovate-global-schema.json",
       "versions": {
+        "43": "https://www.schemastore.org/renovate-global-schema-43.json",
         "42": "https://www.schemastore.org/renovate-global-schema-42.json",
         "41": "https://www.schemastore.org/renovate-global-schema-41.json"
       }
@@ -6641,6 +6643,7 @@
       "fileMatch": [],
       "url": "https://docs.renovatebot.com/renovate-inherited-schema.json",
       "versions": {
+        "43": "https://www.schemastore.org/renovate-inherited-schema-43.json",
         "42": "https://www.schemastore.org/renovate-inherited-schema-42.json"
       }
     },

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -220,9 +220,12 @@
     "renovate-40.json",
     "renovate-41.json",
     "renovate-42.json",
+    "renovate-43.json",
     "renovate-global-schema-41.json",
     "renovate-global-schema-42.json",
+    "renovate-global-schema-43.json",
     "renovate-inherited-schema-42.json",
+    "renovate-inherited-schema-43.json",
     "resjson.json",
     "sarif-1.0.0.json",
     "sigmacv.json",
@@ -1483,13 +1486,22 @@
     "renovate-42.json": {
       "unknownKeywords": ["allowComments", "x-renovate-version"]
     },
+    "renovate-43.json": {
+      "unknownKeywords": ["allowComments", "x-renovate-version"]
+    },
     "renovate-global-schema-41.json": {
       "unknownKeywords": ["allowComments", "x-renovate-version"]
     },
     "renovate-global-schema-42.json": {
       "unknownKeywords": ["allowComments", "x-renovate-version"]
     },
+    "renovate-global-schema-43.json": {
+      "unknownKeywords": ["allowComments", "x-renovate-version"]
+    },
     "renovate-inherited-schema-42.json": {
+      "unknownKeywords": ["allowComments", "x-renovate-version"]
+    },
+    "renovate-inherited-schema-43.json": {
       "unknownKeywords": ["allowComments", "x-renovate-version"]
     },
     "rc3-collection-0.0.3.json": {

--- a/src/schemas/json/renovate-43.json
+++ b/src/schemas/json/renovate-43.json
@@ -1,0 +1,9321 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/renovate-43.json",
+  "title": "JSON schema for Renovate 43.288.0 config files (https://renovatebot.com/)",
+  "x-renovate-version": "43.288.0",
+  "allowComments": true,
+  "type": "object",
+  "definitions": {
+    "abandonmentThreshold": {
+      "description": "Flags packages that have not been updated within this period as abandoned.\nSee also: https://docs.renovatebot.com/configuration-options/#abandonmentthreshold",
+      "markdownDescription": "Flags packages that have not been updated within this period as abandoned.\n\nSee also: [abandonmentThreshold](https://docs.renovatebot.com/configuration-options/#abandonmentthreshold)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "abortIgnoreStatusCodes": {
+      "description": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes",
+      "markdownDescription": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\n\nSee also: [abortIgnoreStatusCodes](https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes)",
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "abortOnError": {
+      "description": "If enabled, Renovate aborts its run when HTTP request errors occur.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror",
+      "markdownDescription": "If enabled, Renovate aborts its run when HTTP request errors occur.\n\nSee also: [abortOnError](https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror)",
+      "type": "boolean",
+      "default": false
+    },
+    "addLabels": {
+      "description": "Labels to add to Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#addlabels",
+      "markdownDescription": "Labels to add to Pull Request.\n\nSee also: [addLabels](https://docs.renovatebot.com/configuration-options/#addlabels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additionalBranchPrefix": {
+      "description": "Additional string value to be appended to `branchPrefix`.\nSee also: https://docs.renovatebot.com/configuration-options/#additionalbranchprefix",
+      "markdownDescription": "Additional string value to be appended to `branchPrefix`.\n\nSee also: [additionalBranchPrefix](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix)",
+      "type": "string",
+      "default": ""
+    },
+    "additionalReviewers": {
+      "description": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\nSee also: https://docs.renovatebot.com/configuration-options/#additionalreviewers",
+      "markdownDescription": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\n\nSee also: [additionalReviewers](https://docs.renovatebot.com/configuration-options/#additionalreviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "allowedVersions": {
+      "description": "A version range or regex pattern capturing allowed versions for dependencies.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions",
+      "markdownDescription": "A version range or regex pattern capturing allowed versions for dependencies.\n\nSee also: [allowedVersions](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)",
+      "type": "string"
+    },
+    "ansible": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible",
+      "markdownDescription": "Configuration object for the ansible manager\n\nSee also: [ansible](https://docs.renovatebot.com/configuration-options/#ansible)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)tasks/[^/]+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ansible-galaxy": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible-galaxy manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible-galaxy",
+      "markdownDescription": "Configuration object for the ansible-galaxy manager\n\nSee also: [ansible-galaxy](https://docs.renovatebot.com/configuration-options/#ansible-galaxy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(galaxy|requirements)(\\.ansible)?\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ant": {
+      "$ref": "#",
+      "description": "Configuration object for the ant manager\nSee also: https://docs.renovatebot.com/configuration-options/#ant",
+      "markdownDescription": "Configuration object for the ant manager\n\nSee also: [ant](https://docs.renovatebot.com/configuration-options/#ant)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/build.xml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "argocd": {
+      "$ref": "#",
+      "description": "Configuration object for the argocd manager\nSee also: https://docs.renovatebot.com/configuration-options/#argocd",
+      "markdownDescription": "Configuration object for the argocd manager\n\nSee also: [argocd](https://docs.renovatebot.com/configuration-options/#argocd)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "artifactAuth": {
+      "description": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth",
+      "markdownDescription": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\n\nSee also: [artifactAuth](https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "enum": ["composer"]
+      },
+      "default": null
+    },
+    "asdf": {
+      "$ref": "#",
+      "description": "Configuration object for the asdf manager\nSee also: https://docs.renovatebot.com/configuration-options/#asdf",
+      "markdownDescription": "Configuration object for the asdf manager\n\nSee also: [asdf](https://docs.renovatebot.com/configuration-options/#asdf)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.tool-versions$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "assignAutomerge": {
+      "description": "Assign reviewers and assignees even if the PR is to be automerged.\nSee also: https://docs.renovatebot.com/configuration-options/#assignautomerge",
+      "markdownDescription": "Assign reviewers and assignees even if the PR is to be automerged.\n\nSee also: [assignAutomerge](https://docs.renovatebot.com/configuration-options/#assignautomerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "assignees": {
+      "description": "Assignees for Pull Request (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#assignees",
+      "markdownDescription": "Assignees for Pull Request (either username or email address depending on the platform).\n\nSee also: [assignees](https://docs.renovatebot.com/configuration-options/#assignees)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "assigneesFromCodeOwners": {
+      "description": "Determine assignees based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners",
+      "markdownDescription": "Determine assignees based on configured code owners and changes in PR.\n\nSee also: [assigneesFromCodeOwners](https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "assigneesSampleSize": {
+      "description": "Take a random sample of given size from `assignees`.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneessamplesize",
+      "markdownDescription": "Take a random sample of given size from `assignees`.\n\nSee also: [assigneesSampleSize](https://docs.renovatebot.com/configuration-options/#assigneessamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "authType": {
+      "description": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesauthtype",
+      "markdownDescription": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\n\nSee also: [authType](https://docs.renovatebot.com/configuration-options/#hostrulesauthtype)",
+      "type": "string",
+      "default": "Bearer"
+    },
+    "autoApprove": {
+      "description": "Set to `true` to automatically approve PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#autoapprove",
+      "markdownDescription": "Set to `true` to automatically approve PRs.\n\nSee also: [autoApprove](https://docs.renovatebot.com/configuration-options/#autoapprove)",
+      "type": "boolean",
+      "default": false
+    },
+    "autoReplaceGlobalMatch": {
+      "description": "Control whether replacement regular expressions are global matches or only the first match.\nSee also: https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch",
+      "markdownDescription": "Control whether replacement regular expressions are global matches or only the first match.\n\nSee also: [autoReplaceGlobalMatch](https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch)",
+      "type": "boolean",
+      "default": true
+    },
+    "autoReplaceStringTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [autoReplaceStringTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate)",
+      "type": "string"
+    },
+    "automerge": {
+      "description": "Whether to automerge branches/PRs automatically, without human intervention.\nSee also: https://docs.renovatebot.com/configuration-options/#automerge",
+      "markdownDescription": "Whether to automerge branches/PRs automatically, without human intervention.\n\nSee also: [automerge](https://docs.renovatebot.com/configuration-options/#automerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "automergeComment": {
+      "description": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergecomment",
+      "markdownDescription": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\n\nSee also: [automergeComment](https://docs.renovatebot.com/configuration-options/#automergecomment)",
+      "type": "string",
+      "default": "automergeComment"
+    },
+    "automergeSchedule": {
+      "description": "Limit automerge to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#automergeschedule",
+      "markdownDescription": "Limit automerge to these times of day or week.\n\nSee also: [automergeSchedule](https://docs.renovatebot.com/configuration-options/#automergeschedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "automergeStrategy": {
+      "description": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergestrategy",
+      "markdownDescription": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\n\nSee also: [automergeStrategy](https://docs.renovatebot.com/configuration-options/#automergestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "fast-forward",
+        "merge-commit",
+        "rebase",
+        "rebase-merge",
+        "squash"
+      ],
+      "default": "auto"
+    },
+    "automergeType": {
+      "description": "How to automerge, if enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#automergetype",
+      "markdownDescription": "How to automerge, if enabled.\n\nSee also: [automergeType](https://docs.renovatebot.com/configuration-options/#automergetype)",
+      "type": "string",
+      "enum": ["branch", "pr", "pr-comment"],
+      "default": "pr"
+    },
+    "azure-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the azure-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#azure-pipelines",
+      "markdownDescription": "Configuration object for the azure-pipelines manager\n\nSee also: [azure-pipelines](https://docs.renovatebot.com/configuration-options/#azure-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/).azuredevops/.+\\.ya?ml$/",
+          "/azure.*pipelines?.*\\.ya?ml$/"
+        ],
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "azureWorkItemId": {
+      "description": "The id of an existing work item on Azure Boards to link to each PR.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemid",
+      "markdownDescription": "The id of an existing work item on Azure Boards to link to each PR.\n\nSee also: [azureWorkItemId](https://docs.renovatebot.com/configuration-options/#azureworkitemid)",
+      "type": "integer",
+      "default": 0
+    },
+    "azureWorkItemType": {
+      "description": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemtype",
+      "markdownDescription": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\n\nSee also: [azureWorkItemType](https://docs.renovatebot.com/configuration-options/#azureworkitemtype)",
+      "type": "string",
+      "default": "Issue"
+    },
+    "baseBranchPatterns": {
+      "description": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\nSee also: https://docs.renovatebot.com/configuration-options/#basebranchpatterns",
+      "markdownDescription": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\n\nSee also: [baseBranchPatterns](https://docs.renovatebot.com/configuration-options/#basebranchpatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "batect": {
+      "$ref": "#",
+      "description": "Configuration object for the batect manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect",
+      "markdownDescription": "Configuration object for the batect manager\n\nSee also: [batect](https://docs.renovatebot.com/configuration-options/#batect)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect(-bundle)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "batect-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the batect-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect-wrapper",
+      "markdownDescription": "Configuration object for the batect-wrapper manager\n\nSee also: [batect-wrapper](https://docs.renovatebot.com/configuration-options/#batect-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect$/"],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel",
+      "markdownDescription": "Configuration object for the bazel manager\n\nSee also: [bazel](https://docs.renovatebot.com/configuration-options/#bazel)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)WORKSPACE(|\\.bazel|\\.bzlmod)$/",
+          "/\\.WORKSPACE\\.bazel$/",
+          "/\\.bzl$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel-module": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel-module manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel-module",
+      "markdownDescription": "Configuration object for the bazel-module manager\n\nSee also: [bazel-module](https://docs.renovatebot.com/configuration-options/#bazel-module)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/|\\.)MODULE\\.bazel$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazelisk": {
+      "$ref": "#",
+      "description": "Configuration object for the bazelisk manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazelisk",
+      "markdownDescription": "Configuration object for the bazelisk manager\n\nSee also: [bazelisk](https://docs.renovatebot.com/configuration-options/#bazelisk)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bazelversion$/"],
+        "pinDigests": false,
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bbAutoResolvePrTasks": {
+      "description": "The PR tasks will be automatically completed after the PR is raised.\nSee also: https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks",
+      "markdownDescription": "The PR tasks will be automatically completed after the PR is raised.\n\nSee also: [bbAutoResolvePrTasks](https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks)",
+      "type": "boolean",
+      "default": false
+    },
+    "bbUseDefaultReviewers": {
+      "description": "Use the default reviewers (Bitbucket only).\nSee also: https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers",
+      "markdownDescription": "Use the default reviewers (Bitbucket only).\n\nSee also: [bbUseDefaultReviewers](https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers)",
+      "type": "boolean",
+      "default": true
+    },
+    "bicep": {
+      "$ref": "#",
+      "description": "Configuration object for the bicep manager\nSee also: https://docs.renovatebot.com/configuration-options/#bicep",
+      "markdownDescription": "Configuration object for the bicep manager\n\nSee also: [bicep](https://docs.renovatebot.com/configuration-options/#bicep)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.bicep$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the bitbucket-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines",
+      "markdownDescription": "Configuration object for the bitbucket-pipelines manager\n\nSee also: [bitbucket-pipelines](https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/*-pipelines.yml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bitrise": {
+      "$ref": "#",
+      "description": "Configuration object for the bitrise manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitrise",
+      "markdownDescription": "Configuration object for the bitrise manager\n\nSee also: [bitrise](https://docs.renovatebot.com/configuration-options/#bitrise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bitrise\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "branchConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\nSee also: https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\n\nSee also: [branchConcurrentLimit](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "branchName": {
+      "description": "Branch name template.\nSee also: https://docs.renovatebot.com/configuration-options/#branchname",
+      "markdownDescription": "Branch name template.\n\nSee also: [branchName](https://docs.renovatebot.com/configuration-options/#branchname)",
+      "type": "string",
+      "default": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}"
+    },
+    "branchNameStrict": {
+      "description": "Whether to be strict about the use of special characters within the branch name.\nSee also: https://docs.renovatebot.com/configuration-options/#branchnamestrict",
+      "markdownDescription": "Whether to be strict about the use of special characters within the branch name.\n\nSee also: [branchNameStrict](https://docs.renovatebot.com/configuration-options/#branchnamestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "branchPrefix": {
+      "description": "Prefix to use for all branch names.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefix",
+      "markdownDescription": "Prefix to use for all branch names.\n\nSee also: [branchPrefix](https://docs.renovatebot.com/configuration-options/#branchprefix)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchPrefixOld": {
+      "description": "Old branchPrefix value to check for existing PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefixold",
+      "markdownDescription": "Old branchPrefix value to check for existing PRs.\n\nSee also: [branchPrefixOld](https://docs.renovatebot.com/configuration-options/#branchprefixold)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchTopic": {
+      "description": "Branch topic.\nSee also: https://docs.renovatebot.com/configuration-options/#branchtopic",
+      "markdownDescription": "Branch topic.\n\nSee also: [branchTopic](https://docs.renovatebot.com/configuration-options/#branchtopic)",
+      "type": "string",
+      "default": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}.{{{newMinor}}}{{/if}}{{/if}}{{#if separateMultipleMinor}}{{#if isMinor}}.{{{newMinor}}}{{/if}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}"
+    },
+    "buildkite": {
+      "$ref": "#",
+      "description": "Configuration object for the buildkite manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildkite",
+      "markdownDescription": "Configuration object for the buildkite manager\n\nSee also: [buildkite](https://docs.renovatebot.com/configuration-options/#buildkite)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/buildkite\\.ya?ml/",
+          "/\\.buildkite/.+\\.ya?ml$/"
+        ],
+        "commitMessageTopic": "buildkite plugin {{depName}}",
+        "commitMessageExtra": "to {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{{newValue}}}{{/if}}"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "buildpacks": {
+      "$ref": "#",
+      "description": "Configuration object for the buildpacks manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildpacks",
+      "markdownDescription": "Configuration object for the buildpacks manager\n\nSee also: [buildpacks](https://docs.renovatebot.com/configuration-options/#buildpacks)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "buildpack {{depName}}",
+        "managerFilePatterns": ["/(^|/)project\\.toml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bumpType": {
+      "description": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype",
+      "markdownDescription": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\n\nSee also: [bumpType](https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype)",
+      "type": "string",
+      "anyOf": [
+        {
+          "enum": ["major", "minor", "patch", "sync"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "bumpVersion": {
+      "description": "Bump the version in the package file being updated.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversion",
+      "markdownDescription": "Bump the version in the package file being updated.\n\nSee also: [bumpVersion](https://docs.renovatebot.com/configuration-options/#bumpversion)",
+      "type": "string",
+      "enum": ["major", "minor", "patch", "prerelease"]
+    },
+    "bumpVersions": {
+      "description": "A list of bumpVersion config options to bump generic version numbers.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversions",
+      "markdownDescription": "A list of bumpVersion config options to bump generic version numbers.\n\nSee also: [bumpVersions](https://docs.renovatebot.com/configuration-options/#bumpversions)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "bumpType": {
+                "$ref": "#/definitions/bumpType"
+              },
+              "filePatterns": {
+                "$ref": "#/definitions/filePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "name": {
+                "$ref": "#/definitions/name"
+              }
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "bun": {
+      "$ref": "#",
+      "description": "Configuration object for the bun manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun",
+      "markdownDescription": "Configuration object for the bun manager\n\nSee also: [bun](https://docs.renovatebot.com/configuration-options/#bun)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)bun\\.lockb?$/",
+          "/(^|/)package\\.json$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bun-version": {
+      "$ref": "#",
+      "description": "Configuration object for the bun-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun-version",
+      "markdownDescription": "Configuration object for the bun-version manager\n\nSee also: [bun-version](https://docs.renovatebot.com/configuration-options/#bun-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bun-version$/"],
+        "versioning": "npm"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#bundler",
+      "markdownDescription": "Configuration object for the bundler manager\n\nSee also: [bundler](https://docs.renovatebot.com/configuration-options/#bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Gemfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cake": {
+      "$ref": "#",
+      "description": "Configuration object for the cake manager\nSee also: https://docs.renovatebot.com/configuration-options/#cake",
+      "markdownDescription": "Configuration object for the cake manager\n\nSee also: [cake](https://docs.renovatebot.com/configuration-options/#cake)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cake$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cargo": {
+      "$ref": "#",
+      "description": "Configuration object for the cargo manager\nSee also: https://docs.renovatebot.com/configuration-options/#cargo",
+      "markdownDescription": "Configuration object for the cargo manager\n\nSee also: [cargo](https://docs.renovatebot.com/configuration-options/#cargo)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust crate {{depName}}",
+        "managerFilePatterns": ["/(^|/)Cargo\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cdnurl": {
+      "$ref": "#",
+      "description": "Configuration object for the cdnurl manager\nSee also: https://docs.renovatebot.com/configuration-options/#cdnurl",
+      "markdownDescription": "Configuration object for the cdnurl manager\n\nSee also: [cdnurl](https://docs.renovatebot.com/configuration-options/#cdnurl)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "changelogUrl": {
+      "description": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\nSee also: https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl",
+      "markdownDescription": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\n\nSee also: [changelogUrl](https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl)",
+      "type": "string"
+    },
+    "circleci": {
+      "$ref": "#",
+      "description": "Configuration object for the circleci manager\nSee also: https://docs.renovatebot.com/configuration-options/#circleci",
+      "markdownDescription": "Configuration object for the circleci manager\n\nSee also: [circleci](https://docs.renovatebot.com/configuration-options/#circleci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.circleci/.+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cloneSubmodules": {
+      "description": "Set to `true` to initialize submodules during repository clone.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodules",
+      "markdownDescription": "Set to `true` to initialize submodules during repository clone.\n\nSee also: [cloneSubmodules](https://docs.renovatebot.com/configuration-options/#clonesubmodules)",
+      "type": "boolean",
+      "default": false
+    },
+    "cloneSubmodulesFilter": {
+      "description": "List of submodules names or patterns to clone when cloneSubmodules=true.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter",
+      "markdownDescription": "List of submodules names or patterns to clone when cloneSubmodules=true.\n\nSee also: [cloneSubmodulesFilter](https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["*"]
+    },
+    "cloudbuild": {
+      "$ref": "#",
+      "description": "Configuration object for the cloudbuild manager\nSee also: https://docs.renovatebot.com/configuration-options/#cloudbuild",
+      "markdownDescription": "Configuration object for the cloudbuild manager\n\nSee also: [cloudbuild](https://docs.renovatebot.com/configuration-options/#cloudbuild)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cloudbuild\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cocoapods": {
+      "$ref": "#",
+      "description": "Configuration object for the cocoapods manager\nSee also: https://docs.renovatebot.com/configuration-options/#cocoapods",
+      "markdownDescription": "Configuration object for the cocoapods manager\n\nSee also: [cocoapods](https://docs.renovatebot.com/configuration-options/#cocoapods)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Podfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "commands": {
+      "description": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands",
+      "markdownDescription": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\n\nSee also: [commands](https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "commitBody": {
+      "description": "Commit message body template. Will be appended to commit message, separated by two line returns.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbody",
+      "markdownDescription": "Commit message body template. Will be appended to commit message, separated by two line returns.\n\nSee also: [commitBody](https://docs.renovatebot.com/configuration-options/#commitbody)",
+      "type": "string"
+    },
+    "commitBodyTable": {
+      "description": "If enabled, append a table in the commit message body describing all updates in the commit.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbodytable",
+      "markdownDescription": "If enabled, append a table in the commit message body describing all updates in the commit.\n\nSee also: [commitBodyTable](https://docs.renovatebot.com/configuration-options/#commitbodytable)",
+      "type": "boolean",
+      "default": false
+    },
+    "commitHourlyLimit": {
+      "description": "Rate limit commits to maximum x per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#commithourlylimit",
+      "markdownDescription": "Rate limit commits to maximum x per hour. 0 means no limit.\n\nSee also: [commitHourlyLimit](https://docs.renovatebot.com/configuration-options/#commithourlylimit)",
+      "type": "integer",
+      "default": 0
+    },
+    "commitMessage": {
+      "description": "Message to use for commit messages and pull request titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessage",
+      "markdownDescription": "Message to use for commit messages and pull request titles.\n\nSee also: [commitMessage](https://docs.renovatebot.com/configuration-options/#commitmessage)",
+      "type": "string",
+      "default": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}"
+    },
+    "commitMessageAction": {
+      "description": "Action verb to use in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageaction",
+      "markdownDescription": "Action verb to use in commit messages and PR titles.\n\nSee also: [commitMessageAction](https://docs.renovatebot.com/configuration-options/#commitmessageaction)",
+      "type": "string",
+      "default": "Update"
+    },
+    "commitMessageExtra": {
+      "description": "Extra description used after the commit message topic - typically the version.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageextra",
+      "markdownDescription": "Extra description used after the commit message topic - typically the version.\n\nSee also: [commitMessageExtra](https://docs.renovatebot.com/configuration-options/#commitmessageextra)",
+      "type": "string",
+      "default": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}"
+    },
+    "commitMessageLowerCase": {
+      "description": "Lowercase PR- and commit titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagelowercase",
+      "markdownDescription": "Lowercase PR- and commit titles.\n\nSee also: [commitMessageLowerCase](https://docs.renovatebot.com/configuration-options/#commitmessagelowercase)",
+      "type": "string",
+      "enum": ["auto", "never"],
+      "default": "auto"
+    },
+    "commitMessagePrefix": {
+      "description": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageprefix",
+      "markdownDescription": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\n\nSee also: [commitMessagePrefix](https://docs.renovatebot.com/configuration-options/#commitmessageprefix)",
+      "type": "string"
+    },
+    "commitMessageSuffix": {
+      "description": "Suffix to add to end of commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagesuffix",
+      "markdownDescription": "Suffix to add to end of commit messages and PR titles.\n\nSee also: [commitMessageSuffix](https://docs.renovatebot.com/configuration-options/#commitmessagesuffix)",
+      "type": "string"
+    },
+    "commitMessageTopic": {
+      "description": "The upgrade topic/noun used in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagetopic",
+      "markdownDescription": "The upgrade topic/noun used in commit messages and PR titles.\n\nSee also: [commitMessageTopic](https://docs.renovatebot.com/configuration-options/#commitmessagetopic)",
+      "type": "string",
+      "default": "dependency {{depName}}"
+    },
+    "commitTrailers": {
+      "description": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\nSee also: https://docs.renovatebot.com/configuration-options/#committrailers",
+      "markdownDescription": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\n\nSee also: [commitTrailers](https://docs.renovatebot.com/configuration-options/#committrailers)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "composer": {
+      "$ref": "#",
+      "description": "Configuration object for the composer manager\nSee also: https://docs.renovatebot.com/configuration-options/#composer",
+      "markdownDescription": "Configuration object for the composer manager\n\nSee also: [composer](https://docs.renovatebot.com/configuration-options/#composer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)([\\w-]*)composer\\.json$/"],
+        "versioning": "composer"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "composerIgnorePlatformReqs": {
+      "description": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\nSee also: https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs",
+      "markdownDescription": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\n\nSee also: [composerIgnorePlatformReqs](https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "conan": {
+      "$ref": "#",
+      "description": "Configuration object for the conan manager\nSee also: https://docs.renovatebot.com/configuration-options/#conan",
+      "markdownDescription": "Configuration object for the conan manager\n\nSee also: [conan](https://docs.renovatebot.com/configuration-options/#conan)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)conanfile\\.(txt|py)$/"],
+        "datasource": "conan",
+        "versioning": "conan"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "concurrentRequestLimit": {
+      "description": "Limit concurrent requests per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit",
+      "markdownDescription": "Limit concurrent requests per host.\n\nSee also: [concurrentRequestLimit](https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "confidential": {
+      "description": "If enabled, issues created by Renovate are set as confidential.\nSee also: https://docs.renovatebot.com/configuration-options/#confidential",
+      "markdownDescription": "If enabled, issues created by Renovate are set as confidential.\n\nSee also: [confidential](https://docs.renovatebot.com/configuration-options/#confidential)",
+      "type": "boolean",
+      "default": false
+    },
+    "configMigration": {
+      "description": "Enable this to get config migration PRs when needed.\nSee also: https://docs.renovatebot.com/configuration-options/#configmigration",
+      "markdownDescription": "Enable this to get config migration PRs when needed.\n\nSee also: [configMigration](https://docs.renovatebot.com/configuration-options/#configmigration)",
+      "type": "boolean",
+      "default": false
+    },
+    "configWarningReuseIssue": {
+      "description": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\nSee also: https://docs.renovatebot.com/configuration-options/#configwarningreuseissue",
+      "markdownDescription": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\n\nSee also: [configWarningReuseIssue](https://docs.renovatebot.com/configuration-options/#configwarningreuseissue)",
+      "type": "boolean",
+      "default": false
+    },
+    "constraints": {
+      "description": "Configuration object to define language or manager version constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraints",
+      "markdownDescription": "Configuration object to define language or manager version constraints.\n\nSee also: [constraints](https://docs.renovatebot.com/configuration-options/#constraints)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "string",
+          "description": "A constraint for the `bazelisk` Containerbase tool"
+        },
+        "bun": {
+          "type": "string",
+          "description": "A constraint for the `bun` Containerbase tool"
+        },
+        "bundler": {
+          "type": "string",
+          "description": "A constraint for the `bundler` Containerbase tool"
+        },
+        "cocoapods": {
+          "type": "string",
+          "description": "A constraint for the `cocoapods` Containerbase tool"
+        },
+        "composer": {
+          "type": "string",
+          "description": "A constraint for the `composer` Containerbase tool"
+        },
+        "conan": {
+          "type": "string",
+          "description": "A constraint for the `conan` Containerbase tool"
+        },
+        "copier": {
+          "type": "string",
+          "description": "A constraint for the `copier` Containerbase tool"
+        },
+        "corepack": {
+          "type": "string",
+          "description": "A constraint for the `corepack` Containerbase tool"
+        },
+        "deno": {
+          "type": "string",
+          "description": "A constraint for the `deno` Containerbase tool"
+        },
+        "devbox": {
+          "type": "string",
+          "description": "A constraint for the `devbox` Containerbase tool"
+        },
+        "dotnet": {
+          "type": "string",
+          "description": "A constraint for the `dotnet` Containerbase tool"
+        },
+        "erlang": {
+          "type": "string",
+          "description": "A constraint for the `erlang` Containerbase tool"
+        },
+        "elixir": {
+          "type": "string",
+          "description": "A constraint for the `elixir` Containerbase tool"
+        },
+        "flux": {
+          "type": "string",
+          "description": "A constraint for the `flux` Containerbase tool"
+        },
+        "gleam": {
+          "type": "string",
+          "description": "A constraint for the `gleam` Containerbase tool"
+        },
+        "golang": {
+          "type": "string",
+          "description": "A constraint for the `golang` Containerbase tool"
+        },
+        "gradle": {
+          "type": "string",
+          "description": "A constraint for the `gradle` Containerbase tool"
+        },
+        "hashin": {
+          "type": "string",
+          "description": "A constraint for the `hashin` Containerbase tool"
+        },
+        "helm": {
+          "type": "string",
+          "description": "A constraint for the `helm` Containerbase tool"
+        },
+        "helmfile": {
+          "type": "string",
+          "description": "A constraint for the `helmfile` Containerbase tool"
+        },
+        "java": {
+          "type": "string",
+          "description": "A constraint for the `java` Containerbase tool"
+        },
+        "java-maven": {
+          "type": "string",
+          "description": "A constraint for the `java-maven` Containerbase tool"
+        },
+        "jb": {
+          "type": "string",
+          "description": "A constraint for the `jb` Containerbase tool"
+        },
+        "kustomize": {
+          "type": "string",
+          "description": "A constraint for the `kustomize` Containerbase tool"
+        },
+        "maven": {
+          "type": "string",
+          "description": "A constraint for the `maven` Containerbase tool"
+        },
+        "mise": {
+          "type": "string",
+          "description": "A constraint for the `mise` Containerbase tool"
+        },
+        "nix": {
+          "type": "string",
+          "description": "A constraint for the `nix` Containerbase tool"
+        },
+        "node": {
+          "type": "string",
+          "description": "A constraint for the `node` Containerbase tool"
+        },
+        "npm": {
+          "type": "string",
+          "description": "A constraint for the `npm` Containerbase tool"
+        },
+        "pdm": {
+          "type": "string",
+          "description": "A constraint for the `pdm` Containerbase tool"
+        },
+        "php": {
+          "type": "string",
+          "description": "A constraint for the `php` Containerbase tool"
+        },
+        "pip-tools": {
+          "type": "string",
+          "description": "A constraint for the `pip-tools` Containerbase tool"
+        },
+        "pipenv": {
+          "type": "string",
+          "description": "A constraint for the `pipenv` Containerbase tool"
+        },
+        "pnpm": {
+          "type": "string",
+          "description": "A constraint for the `pnpm` Containerbase tool"
+        },
+        "pixi": {
+          "type": "string",
+          "description": "A constraint for the `pixi` Containerbase tool"
+        },
+        "poetry": {
+          "type": "string",
+          "description": "A constraint for the `poetry` Containerbase tool"
+        },
+        "python": {
+          "type": "string",
+          "description": "A constraint for the `python` Containerbase tool"
+        },
+        "ruby": {
+          "type": "string",
+          "description": "A constraint for the `ruby` Containerbase tool. Also used in the `rubygems` Datasource"
+        },
+        "rust": {
+          "type": "string",
+          "description": "A constraint for the `rust` Containerbase tool"
+        },
+        "uv": {
+          "type": "string",
+          "description": "A constraint for the `uv` Containerbase tool"
+        },
+        "yarn": {
+          "type": "string",
+          "description": "A constraint for the `yarn` Containerbase tool"
+        },
+        "yarn-slim": {
+          "type": "string",
+          "description": "A constraint for the `yarn-slim` Containerbase tool"
+        },
+        "dart": {
+          "type": "string",
+          "description": "A constraint for the `dart` Containerbase tool"
+        },
+        "flutter": {
+          "type": "string",
+          "description": "A constraint for the `flutter` Containerbase tool"
+        },
+        "vendir": {
+          "type": "string",
+          "description": "A constraint for the `vendir` Containerbase tool"
+        },
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "constraintsFiltering": {
+      "description": "Perform release filtering based on language constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsfiltering",
+      "markdownDescription": "Perform release filtering based on language constraints.\n\nSee also: [constraintsFiltering](https://docs.renovatebot.com/configuration-options/#constraintsfiltering)",
+      "type": "string",
+      "enum": ["none", "strict"],
+      "default": "none"
+    },
+    "constraintsVersioning": {
+      "description": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsversioning",
+      "markdownDescription": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\n\nSee also: [constraintsVersioning](https://docs.renovatebot.com/configuration-options/#constraintsversioning)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "copier": {
+      "$ref": "#",
+      "description": "Configuration object for the copier manager\nSee also: https://docs.renovatebot.com/configuration-options/#copier",
+      "markdownDescription": "Configuration object for the copier manager\n\nSee also: [copier](https://docs.renovatebot.com/configuration-options/#copier)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.copier-answers(\\..+)?\\.ya?ml/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cpanfile": {
+      "$ref": "#",
+      "description": "Configuration object for the cpanfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#cpanfile",
+      "markdownDescription": "Configuration object for the cpanfile manager\n\nSee also: [cpanfile](https://docs.renovatebot.com/configuration-options/#cpanfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cpanfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crossplane": {
+      "$ref": "#",
+      "description": "Configuration object for the crossplane manager\nSee also: https://docs.renovatebot.com/configuration-options/#crossplane",
+      "markdownDescription": "Configuration object for the crossplane manager\n\nSee also: [crossplane](https://docs.renovatebot.com/configuration-options/#crossplane)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crow": {
+      "$ref": "#",
+      "description": "Configuration object for the crow manager\nSee also: https://docs.renovatebot.com/configuration-options/#crow",
+      "markdownDescription": "Configuration object for the crow manager\n\nSee also: [crow](https://docs.renovatebot.com/configuration-options/#crow)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.crow(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "currentValueTemplate": {
+      "description": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate",
+      "markdownDescription": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [currentValueTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate)",
+      "type": "string"
+    },
+    "customDatasources": {
+      "$ref": "#",
+      "description": "Defines custom datasources for usage by managers.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasources",
+      "markdownDescription": "Defines custom datasources for usage by managers.\n\nSee also: [customDatasources](https://docs.renovatebot.com/configuration-options/#customdatasources)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "defaultRegistryUrlTemplate": {
+                "$ref": "#/definitions/defaultRegistryUrlTemplate"
+              },
+              "format": {
+                "$ref": "#/definitions/format"
+              },
+              "transformTemplates": {
+                "$ref": "#/definitions/transformTemplates"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "customManagers": {
+      "description": "Custom managers using regex matching.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagers",
+      "markdownDescription": "Custom managers using regex matching.\n\nSee also: [customManagers](https://docs.renovatebot.com/configuration-options/#custommanagers)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "autoReplaceStringTemplate": {
+                "$ref": "#/definitions/autoReplaceStringTemplate"
+              },
+              "currentValueTemplate": {
+                "$ref": "#/definitions/currentValueTemplate"
+              },
+              "customType": {
+                "$ref": "#/definitions/customType"
+              },
+              "datasourceTemplate": {
+                "$ref": "#/definitions/datasourceTemplate"
+              },
+              "depNameTemplate": {
+                "$ref": "#/definitions/depNameTemplate"
+              },
+              "depTypeTemplate": {
+                "$ref": "#/definitions/depTypeTemplate"
+              },
+              "extractVersionTemplate": {
+                "$ref": "#/definitions/extractVersionTemplate"
+              },
+              "fileFormat": {
+                "$ref": "#/definitions/fileFormat"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "matchStringsStrategy": {
+                "$ref": "#/definitions/matchStringsStrategy"
+              },
+              "packageNameTemplate": {
+                "$ref": "#/definitions/packageNameTemplate"
+              },
+              "registryUrlTemplate": {
+                "$ref": "#/definitions/registryUrlTemplate"
+              },
+              "versioningTemplate": {
+                "$ref": "#/definitions/versioningTemplate"
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "customType": {
+                  "const": "jsonata"
+                }
+              },
+              "required": ["customType"]
+            },
+            "then": {
+              "required": ["fileFormat"]
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "customType": {
+      "description": "Custom manager to use. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype",
+      "markdownDescription": "Custom manager to use. Valid only within a `customManagers` object.\n\nSee also: [customType](https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype)",
+      "type": "string",
+      "enum": ["jsonata", "regex"]
+    },
+    "customizeDashboard": {
+      "description": "Customize sections in the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#customizedashboard",
+      "markdownDescription": "Customize sections in the Dependency Dashboard issue.\n\nSee also: [customizeDashboard](https://docs.renovatebot.com/configuration-options/#customizedashboard)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dataFileTemplate": {
+      "description": "A template to create post-upgrade command data file from.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate",
+      "markdownDescription": "A template to create post-upgrade command data file from.\n\nSee also: [dataFileTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate)",
+      "type": "string"
+    },
+    "datasourceTemplate": {
+      "description": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate",
+      "markdownDescription": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [datasourceTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate)",
+      "type": "string"
+    },
+    "defaultRegistryUrlTemplate": {
+      "description": "Template for generating a `defaultRegistryUrl` for custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate",
+      "markdownDescription": "Template for generating a `defaultRegistryUrl` for custom datasource.\n\nSee also: [defaultRegistryUrlTemplate](https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate)",
+      "type": "string",
+      "default": ""
+    },
+    "defaultRegistryUrls": {
+      "description": "List of registry URLs to use as the default for a datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#defaultregistryurls",
+      "markdownDescription": "List of registry URLs to use as the default for a datasource.\n\nSee also: [defaultRegistryUrls](https://docs.renovatebot.com/configuration-options/#defaultregistryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "deno": {
+      "$ref": "#",
+      "description": "Configuration object for the deno manager\nSee also: https://docs.renovatebot.com/configuration-options/#deno",
+      "markdownDescription": "Configuration object for the deno manager\n\nSee also: [deno](https://docs.renovatebot.com/configuration-options/#deno)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)deno\\.lock$/",
+          "/(^|/)deno\\.(json|jsonc)$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "{{#if (equals datasource \"npm\")}}[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}}){{else}}{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}{{/if}}"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "depNameTemplate": {
+      "description": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate",
+      "markdownDescription": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate)",
+      "type": "string"
+    },
+    "depTypeTemplate": {
+      "description": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate",
+      "markdownDescription": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depTypeTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate)",
+      "type": "string"
+    },
+    "dependencyDashboard": {
+      "description": "Whether to create a \"Dependency Dashboard\" issue in the repository.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboard",
+      "markdownDescription": "Whether to create a \"Dependency Dashboard\" issue in the repository.\n\nSee also: [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardApproval": {
+      "description": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval",
+      "markdownDescription": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\n\nSee also: [dependencyDashboardApproval](https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardAutoclose": {
+      "description": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose",
+      "markdownDescription": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\n\nSee also: [dependencyDashboardAutoclose](https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardCategory": {
+      "description": "The category to group branches on the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory",
+      "markdownDescription": "The category to group branches on the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardCategory](https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "dependencyDashboardFooter": {
+      "description": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter",
+      "markdownDescription": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\n\nSee also: [dependencyDashboardFooter](https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter)",
+      "type": "string"
+    },
+    "dependencyDashboardHeader": {
+      "description": "Any text added here will be placed first in the Dependency Dashboard issue body.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardheader",
+      "markdownDescription": "Any text added here will be placed first in the Dependency Dashboard issue body.\n\nSee also: [dependencyDashboardHeader](https://docs.renovatebot.com/configuration-options/#dependencydashboardheader)",
+      "type": "string",
+      "default": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more."
+    },
+    "dependencyDashboardLabels": {
+      "description": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels",
+      "markdownDescription": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\n\nSee also: [dependencyDashboardLabels](https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "description": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary",
+      "markdownDescription": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\n\nSee also: [dependencyDashboardOSVVulnerabilitySummary](https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary)",
+      "type": "string",
+      "enum": ["none", "all", "unresolved"],
+      "default": "none"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "description": "Controls whether abandoned packages are reported in the dependency dashboard.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment",
+      "markdownDescription": "Controls whether abandoned packages are reported in the dependency dashboard.\n\nSee also: [dependencyDashboardReportAbandonment](https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment)",
+      "type": "boolean",
+      "default": true
+    },
+    "dependencyDashboardTitle": {
+      "description": "Title for the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle",
+      "markdownDescription": "Title for the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardTitle](https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle)",
+      "type": "string",
+      "default": "Dependency Dashboard"
+    },
+    "deps-edn": {
+      "$ref": "#",
+      "description": "Configuration object for the deps-edn manager\nSee also: https://docs.renovatebot.com/configuration-options/#deps-edn",
+      "markdownDescription": "Configuration object for the deps-edn manager\n\nSee also: [deps-edn](https://docs.renovatebot.com/configuration-options/#deps-edn)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:deps|bb)\\.edn$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "description": {
+      "description": "Plain text description for a config or preset.\nSee also: https://docs.renovatebot.com/configuration-options/#description",
+      "markdownDescription": "Plain text description for a config or preset.\n\nSee also: [description](https://docs.renovatebot.com/configuration-options/#description)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "devbox": {
+      "$ref": "#",
+      "description": "Configuration object for the devbox manager\nSee also: https://docs.renovatebot.com/configuration-options/#devbox",
+      "markdownDescription": "Configuration object for the devbox manager\n\nSee also: [devbox](https://docs.renovatebot.com/configuration-options/#devbox)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)devbox\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "devcontainer": {
+      "$ref": "#",
+      "description": "Configuration object for the devcontainer manager\nSee also: https://docs.renovatebot.com/configuration-options/#devcontainer",
+      "markdownDescription": "Configuration object for the devcontainer manager\n\nSee also: [devcontainer](https://docs.renovatebot.com/configuration-options/#devcontainer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/^.devcontainer/devcontainer.json$/",
+          "/^.devcontainer.json$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "digest": {
+      "$ref": "#",
+      "description": "Configuration to apply when updating a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#digest",
+      "markdownDescription": "Configuration to apply when updating a digest (no change in tag/version).\n\nSee also: [digest](https://docs.renovatebot.com/configuration-options/#digest)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-digest",
+        "commitMessageExtra": "to {{newDigestShort}}",
+        "commitMessageTopic": "{{{depName}}} digest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dnsCache": {
+      "description": "Enable got DNS cache.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesdnscache",
+      "markdownDescription": "Enable got DNS cache.\n\nSee also: [dnsCache](https://docs.renovatebot.com/configuration-options/#hostrulesdnscache)",
+      "type": "boolean",
+      "default": false
+    },
+    "docker-compose": {
+      "$ref": "#",
+      "description": "Configuration object for the docker-compose manager\nSee also: https://docs.renovatebot.com/configuration-options/#docker-compose",
+      "markdownDescription": "Configuration object for the docker-compose manager\n\nSee also: [docker-compose](https://docs.renovatebot.com/configuration-options/#docker-compose)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dockerfile": {
+      "$ref": "#",
+      "description": "Configuration object for the dockerfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#dockerfile",
+      "markdownDescription": "Configuration object for the dockerfile manager\n\nSee also: [dockerfile](https://docs.renovatebot.com/configuration-options/#dockerfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/",
+          "/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "draftPR": {
+      "description": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#draftpr",
+      "markdownDescription": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\n\nSee also: [draftPR](https://docs.renovatebot.com/configuration-options/#draftpr)",
+      "type": "boolean",
+      "default": false
+    },
+    "droneci": {
+      "$ref": "#",
+      "description": "Configuration object for the droneci manager\nSee also: https://docs.renovatebot.com/configuration-options/#droneci",
+      "markdownDescription": "Configuration object for the droneci manager\n\nSee also: [droneci](https://docs.renovatebot.com/configuration-options/#droneci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.drone\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "enableHttp2": {
+      "description": "Enable got HTTP/2 support.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2",
+      "markdownDescription": "Enable got HTTP/2 support.\n\nSee also: [enableHttp2](https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2)",
+      "type": "boolean",
+      "default": false
+    },
+    "enabled": {
+      "description": "Enable or disable corresponding functionality.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesenabled",
+      "markdownDescription": "Enable or disable corresponding functionality.\n\nSee also: [enabled](https://docs.renovatebot.com/configuration-options/#packagerulesenabled)",
+      "type": "boolean",
+      "default": true
+    },
+    "enabledManagers": {
+      "description": "A list of package managers to enable. Only managers on the list are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#enabledmanagers",
+      "markdownDescription": "A list of package managers to enable. Only managers on the list are enabled.\n\nSee also: [enabledManagers](https://docs.renovatebot.com/configuration-options/#enabledmanagers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "encrypted": {
+      "$ref": "#",
+      "description": "An object containing configuration encrypted with project key.\nSee also: https://docs.renovatebot.com/configuration-options/#encrypted",
+      "markdownDescription": "An object containing configuration encrypted with project key.\n\nSee also: [encrypted](https://docs.renovatebot.com/configuration-options/#encrypted)",
+      "type": ["object", "null"],
+      "default": null
+    },
+    "env": {
+      "$ref": "#",
+      "description": "Environment variables that Renovate uses when executing package manager commands.\nSee also: https://docs.renovatebot.com/configuration-options/#env",
+      "markdownDescription": "Environment variables that Renovate uses when executing package manager commands.\n\nSee also: [env](https://docs.renovatebot.com/configuration-options/#env)",
+      "type": "object",
+      "default": {}
+    },
+    "excludeCommitPaths": {
+      "description": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\nSee also: https://docs.renovatebot.com/configuration-options/#excludecommitpaths",
+      "markdownDescription": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\n\nSee also: [excludeCommitPaths](https://docs.renovatebot.com/configuration-options/#excludecommitpaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "executionMode": {
+      "description": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode",
+      "markdownDescription": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\n\nSee also: [executionMode](https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode)",
+      "type": "string",
+      "enum": ["update", "branch"],
+      "default": "update"
+    },
+    "expandCodeOwnersGroups": {
+      "description": "Expand the configured code owner groups into a full list of group members.\nSee also: https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups",
+      "markdownDescription": "Expand the configured code owner groups into a full list of group members.\n\nSee also: [expandCodeOwnersGroups](https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups)",
+      "type": "boolean",
+      "default": false
+    },
+    "extends": {
+      "description": "Configuration presets to use or extend.\nSee also: https://docs.renovatebot.com/configuration-options/#extends",
+      "markdownDescription": "Configuration presets to use or extend.\n\nSee also: [extends](https://docs.renovatebot.com/configuration-options/#extends)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "enum": [
+                  "config:best-practices",
+                  "config:recommended",
+                  "mergeConfidence:all-badges",
+                  "abandonments:recommended",
+                  "group:all",
+                  "replacements:all",
+                  "security:minimumReleaseAgeNpm",
+                  "security:only-security-updates"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "extractVersion": {
+      "description": "A regex (`re2`) to extract a version from a datasource's raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#extractversion",
+      "markdownDescription": "A regex (`re2`) to extract a version from a datasource's raw version string.\n\nSee also: [extractVersion](https://docs.renovatebot.com/configuration-options/#extractversion)",
+      "type": "string",
+      "format": "regex"
+    },
+    "extractVersionTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [extractVersionTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate)",
+      "type": "string"
+    },
+    "fetchChangeLogs": {
+      "description": "Controls if and when changelogs/release notes are fetched.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs",
+      "markdownDescription": "Controls if and when changelogs/release notes are fetched.\n\nSee also: [fetchChangeLogs](https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs)",
+      "type": "string",
+      "enum": ["off", "branch", "pr"],
+      "default": "pr"
+    },
+    "fileFilters": {
+      "description": "Files that match the glob pattern will be committed after running a post-upgrade task.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters",
+      "markdownDescription": "Files that match the glob pattern will be committed after running a post-upgrade task.\n\nSee also: [fileFilters](https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/*"]
+    },
+    "fileFormat": {
+      "description": "It specifies the syntax of the package file being managed by the custom JSONata manager.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersfileformat",
+      "markdownDescription": "It specifies the syntax of the package file being managed by the custom JSONata manager.\n\nSee also: [fileFormat](https://docs.renovatebot.com/configuration-options/#custommanagersfileformat)",
+      "type": "string",
+      "enum": ["json", "toml", "yaml"]
+    },
+    "filePatterns": {
+      "description": "A list of patterns to match files that contain the version string.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns",
+      "markdownDescription": "A list of patterns to match files that contain the version string.\n\nSee also: [filePatterns](https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "filterUnavailableUsers": {
+      "description": "Filter reviewers and assignees based on their availability.\nSee also: https://docs.renovatebot.com/configuration-options/#filterunavailableusers",
+      "markdownDescription": "Filter reviewers and assignees based on their availability.\n\nSee also: [filterUnavailableUsers](https://docs.renovatebot.com/configuration-options/#filterunavailableusers)",
+      "type": "boolean",
+      "default": false
+    },
+    "fleet": {
+      "$ref": "#",
+      "description": "Configuration object for the fleet manager\nSee also: https://docs.renovatebot.com/configuration-options/#fleet",
+      "markdownDescription": "Configuration object for the fleet manager\n\nSee also: [fleet](https://docs.renovatebot.com/configuration-options/#fleet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)fleet\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "flux": {
+      "$ref": "#",
+      "description": "Configuration object for the flux manager\nSee also: https://docs.renovatebot.com/configuration-options/#flux",
+      "markdownDescription": "Configuration object for the flux manager\n\nSee also: [flux](https://docs.renovatebot.com/configuration-options/#flux)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(?:^|/)gotk-components\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "followTag": {
+      "description": "If defined, packages will follow this release tag exactly.\nSee also: https://docs.renovatebot.com/configuration-options/#followtag",
+      "markdownDescription": "If defined, packages will follow this release tag exactly.\n\nSee also: [followTag](https://docs.renovatebot.com/configuration-options/#followtag)",
+      "type": "string"
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "description": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits",
+      "markdownDescription": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\n\nSee also: [forkModeDisallowMaintainerEdits](https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits)",
+      "type": "boolean",
+      "default": false
+    },
+    "forkProcessing": {
+      "description": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkprocessing",
+      "markdownDescription": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\n\nSee also: [forkProcessing](https://docs.renovatebot.com/configuration-options/#forkprocessing)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "format": {
+      "description": "Format of the custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesformat",
+      "markdownDescription": "Format of the custom datasource.\n\nSee also: [format](https://docs.renovatebot.com/configuration-options/#customdatasourcesformat)",
+      "type": "string",
+      "enum": ["json", "plain"],
+      "default": "json"
+    },
+    "fvm": {
+      "$ref": "#",
+      "description": "Configuration object for the fvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#fvm",
+      "markdownDescription": "Configuration object for the fvm manager\n\nSee also: [fvm](https://docs.renovatebot.com/configuration-options/#fvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)\\.fvm/fvm_config\\.json$/",
+          "/(^|/)\\.fvmrc$/"
+        ],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "git-submodules": {
+      "$ref": "#",
+      "description": "Configuration object for the git-submodules manager\nSee also: https://docs.renovatebot.com/configuration-options/#git-submodules",
+      "markdownDescription": "Configuration object for the git-submodules manager\n\nSee also: [git-submodules](https://docs.renovatebot.com/configuration-options/#git-submodules)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "versioning": "git",
+        "managerFilePatterns": ["/(^|/)\\.gitmodules$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitAuthor": {
+      "description": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitauthor",
+      "markdownDescription": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitAuthor](https://docs.renovatebot.com/configuration-options/#gitauthor)",
+      "type": "string"
+    },
+    "gitIgnoredAuthors": {
+      "description": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitignoredauthors",
+      "markdownDescription": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitIgnoredAuthors](https://docs.renovatebot.com/configuration-options/#gitignoredauthors)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gitLabIgnoreApprovals": {
+      "description": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals",
+      "markdownDescription": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\n\nSee also: [gitLabIgnoreApprovals](https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals)",
+      "type": "boolean",
+      "default": false
+    },
+    "github-actions": {
+      "$ref": "#",
+      "description": "Configuration object for the github-actions manager\nSee also: https://docs.renovatebot.com/configuration-options/#github-actions",
+      "markdownDescription": "Configuration object for the github-actions manager\n\nSee also: [github-actions](https://docs.renovatebot.com/configuration-options/#github-actions)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+          "/(^|/)action\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitlabci": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci",
+      "markdownDescription": "Configuration object for the gitlabci manager\n\nSee also: [gitlabci](https://docs.renovatebot.com/configuration-options/#gitlabci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitlabci-include": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci-include manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci-include",
+      "markdownDescription": "Configuration object for the gitlabci-include manager\n\nSee also: [gitlabci-include](https://docs.renovatebot.com/configuration-options/#gitlabci-include)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "glasskube": {
+      "$ref": "#",
+      "description": "Configuration object for the glasskube manager\nSee also: https://docs.renovatebot.com/configuration-options/#glasskube",
+      "markdownDescription": "Configuration object for the glasskube manager\n\nSee also: [glasskube](https://docs.renovatebot.com/configuration-options/#glasskube)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gleam": {
+      "$ref": "#",
+      "description": "Configuration object for the gleam manager\nSee also: https://docs.renovatebot.com/configuration-options/#gleam",
+      "markdownDescription": "Configuration object for the gleam manager\n\nSee also: [gleam](https://docs.renovatebot.com/configuration-options/#gleam)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)gleam.toml$/"],
+        "versioning": "hex"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "goGetDirs": {
+      "description": "Directory pattern to run `go get` on.\nSee also: https://docs.renovatebot.com/configuration-options/#gogetdirs",
+      "markdownDescription": "Directory pattern to run `go get` on.\n\nSee also: [goGetDirs](https://docs.renovatebot.com/configuration-options/#gogetdirs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["./..."]
+    },
+    "gomod": {
+      "$ref": "#",
+      "description": "Configuration object for the gomod manager\nSee also: https://docs.renovatebot.com/configuration-options/#gomod",
+      "markdownDescription": "Configuration object for the gomod manager\n\nSee also: [gomod](https://docs.renovatebot.com/configuration-options/#gomod)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)go\\.mod$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle",
+      "markdownDescription": "Configuration object for the gradle manager\n\nSee also: [gradle](https://docs.renovatebot.com/configuration-options/#gradle)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.gradle(\\.kts)?$/",
+          "/(^|/)gradle\\.properties$/",
+          "/(^|/)gradle/.+\\.toml$/",
+          "/(^|/)buildSrc/.+\\.kt$/",
+          "/\\.versions\\.toml$/",
+          "/(^|/)versions.props$/",
+          "/(^|/)versions.lock$/"
+        ],
+        "timeout": 600,
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle-wrapper",
+      "markdownDescription": "Configuration object for the gradle-wrapper manager\n\nSee also: [gradle-wrapper](https://docs.renovatebot.com/configuration-options/#gradle-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)gradle/wrapper/gradle-wrapper\\.properties$/"
+        ],
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "group": {
+      "$ref": "#",
+      "description": "Config if `groupName` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#group",
+      "markdownDescription": "Config if `groupName` is enabled.\n\nSee also: [group](https://docs.renovatebot.com/configuration-options/#group)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{groupSlug}}}",
+        "commitMessageTopic": "{{{groupName}}}"
+      }
+    },
+    "groupName": {
+      "description": "Human understandable name for the dependency group.\nSee also: https://docs.renovatebot.com/configuration-options/#groupname",
+      "markdownDescription": "Human understandable name for the dependency group.\n\nSee also: [groupName](https://docs.renovatebot.com/configuration-options/#groupname)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "groupSingleUpdates": {
+      "description": "Apply group settings even when the group contains only one update.\nSee also: https://docs.renovatebot.com/configuration-options/#groupsingleupdates",
+      "markdownDescription": "Apply group settings even when the group contains only one update.\n\nSee also: [groupSingleUpdates](https://docs.renovatebot.com/configuration-options/#groupsingleupdates)",
+      "type": "boolean",
+      "default": false
+    },
+    "groupSlug": {
+      "description": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#groupslug",
+      "markdownDescription": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\n\nSee also: [groupSlug](https://docs.renovatebot.com/configuration-options/#groupslug)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "hashedBranchLength": {
+      "description": "If enabled, branch names will use a hashing function to ensure each branch has that length.\nSee also: https://docs.renovatebot.com/configuration-options/#hashedbranchlength",
+      "markdownDescription": "If enabled, branch names will use a hashing function to ensure each branch has that length.\n\nSee also: [hashedBranchLength](https://docs.renovatebot.com/configuration-options/#hashedbranchlength)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "haskell-cabal": {
+      "$ref": "#",
+      "description": "Configuration object for the haskell-cabal manager\nSee also: https://docs.renovatebot.com/configuration-options/#haskell-cabal",
+      "markdownDescription": "Configuration object for the haskell-cabal manager\n\nSee also: [haskell-cabal](https://docs.renovatebot.com/configuration-options/#haskell-cabal)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cabal$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "headers": {
+      "$ref": "#",
+      "description": "Put fields to be forwarded to the HTTP request headers in the headers config option.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesheaders",
+      "markdownDescription": "Put fields to be forwarded to the HTTP request headers in the headers config option.\n\nSee also: [headers](https://docs.renovatebot.com/configuration-options/#hostrulesheaders)",
+      "type": "object"
+    },
+    "helm-requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-requirements",
+      "markdownDescription": "Configuration object for the helm-requirements manager\n\nSee also: [helm-requirements](https://docs.renovatebot.com/configuration-options/#helm-requirements)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)requirements\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helm-values": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-values manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-values",
+      "markdownDescription": "Configuration object for the helm-values manager\n\nSee also: [helm-values](https://docs.renovatebot.com/configuration-options/#helm-values)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "helm values {{depName}}",
+        "managerFilePatterns": ["/(^|/)values\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmfile": {
+      "$ref": "#",
+      "description": "Configuration object for the helmfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmfile",
+      "markdownDescription": "Configuration object for the helmfile manager\n\nSee also: [helmfile](https://docs.renovatebot.com/configuration-options/#helmfile)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": [
+          "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?$/",
+          "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmsman": {
+      "$ref": "#",
+      "description": "Configuration object for the helmsman manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmsman",
+      "markdownDescription": "Configuration object for the helmsman manager\n\nSee also: [helmsman](https://docs.renovatebot.com/configuration-options/#helmsman)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmv3": {
+      "$ref": "#",
+      "description": "Configuration object for the helmv3 manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmv3",
+      "markdownDescription": "Configuration object for the helmv3 manager\n\nSee also: [helmv3](https://docs.renovatebot.com/configuration-options/#helmv3)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)Chart\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hermit": {
+      "$ref": "#",
+      "description": "Configuration object for the hermit manager\nSee also: https://docs.renovatebot.com/configuration-options/#hermit",
+      "markdownDescription": "Configuration object for the hermit manager\n\nSee also: [hermit](https://docs.renovatebot.com/configuration-options/#hermit)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bin/hermit$/"],
+        "excludeCommitPaths": ["**/bin/hermit"],
+        "versioning": "hermit"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homeassistant-manifest": {
+      "$ref": "#",
+      "description": "Configuration object for the homeassistant-manifest manager\nSee also: https://docs.renovatebot.com/configuration-options/#homeassistant-manifest",
+      "markdownDescription": "Configuration object for the homeassistant-manifest manager\n\nSee also: [homeassistant-manifest](https://docs.renovatebot.com/configuration-options/#homeassistant-manifest)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)manifest\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homebrew": {
+      "$ref": "#",
+      "description": "Configuration object for the homebrew manager\nSee also: https://docs.renovatebot.com/configuration-options/#homebrew",
+      "markdownDescription": "Configuration object for the homebrew manager\n\nSee also: [homebrew](https://docs.renovatebot.com/configuration-options/#homebrew)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Homebrew Formula {{depName}}",
+        "managerFilePatterns": ["/^Formula/\\w*/?[^/]+[.]rb$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostRules": {
+      "description": "Host rules/configuration including credentials.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrules",
+      "markdownDescription": "Host rules/configuration including credentials.\n\nSee also: [hostRules](https://docs.renovatebot.com/configuration-options/#hostrules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "abortIgnoreStatusCodes": {
+                "$ref": "#/definitions/abortIgnoreStatusCodes"
+              },
+              "abortOnError": {
+                "$ref": "#/definitions/abortOnError"
+              },
+              "artifactAuth": {
+                "$ref": "#/definitions/artifactAuth"
+              },
+              "authType": {
+                "$ref": "#/definitions/authType"
+              },
+              "concurrentRequestLimit": {
+                "$ref": "#/definitions/concurrentRequestLimit"
+              },
+              "dnsCache": {
+                "$ref": "#/definitions/dnsCache"
+              },
+              "enableHttp2": {
+                "$ref": "#/definitions/enableHttp2"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "headers": {
+                "$ref": "#/definitions/headers"
+              },
+              "hostType": {
+                "$ref": "#/definitions/hostType"
+              },
+              "httpsCertificate": {
+                "$ref": "#/definitions/httpsCertificate"
+              },
+              "httpsCertificateAuthority": {
+                "$ref": "#/definitions/httpsCertificateAuthority"
+              },
+              "httpsPrivateKey": {
+                "$ref": "#/definitions/httpsPrivateKey"
+              },
+              "insecureRegistry": {
+                "$ref": "#/definitions/insecureRegistry"
+              },
+              "keepAlive": {
+                "$ref": "#/definitions/keepAlive"
+              },
+              "matchHost": {
+                "$ref": "#/definitions/matchHost"
+              },
+              "maxRequestsPerSecond": {
+                "$ref": "#/definitions/maxRequestsPerSecond"
+              },
+              "maxRetryAfter": {
+                "$ref": "#/definitions/maxRetryAfter"
+              },
+              "readOnly": {
+                "$ref": "#/definitions/readOnly"
+              },
+              "timeout": {
+                "$ref": "#/definitions/timeout"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostType": {
+      "description": "hostType for a package rule. Can be a platform name or a datasource name.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshosttype",
+      "markdownDescription": "hostType for a package rule. Can be a platform name or a datasource name.\n\nSee also: [hostType](https://docs.renovatebot.com/configuration-options/#hostruleshosttype)",
+      "type": "string"
+    },
+    "html": {
+      "$ref": "#",
+      "description": "Configuration object for the html manager\nSee also: https://docs.renovatebot.com/configuration-options/#html",
+      "markdownDescription": "Configuration object for the html manager\n\nSee also: [html](https://docs.renovatebot.com/configuration-options/#html)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.html?$/"],
+        "versioning": "semver",
+        "digest": {
+          "enabled": false
+        },
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "httpsCertificate": {
+      "description": "The certificate chains in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate",
+      "markdownDescription": "The certificate chains in PEM format.\n\nSee also: [httpsCertificate](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsCertificateAuthority": {
+      "description": "The overriding trusted CA certificate.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority",
+      "markdownDescription": "The overriding trusted CA certificate.\n\nSee also: [httpsCertificateAuthority](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsPrivateKey": {
+      "description": "The private key in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey",
+      "markdownDescription": "The private key in PEM format.\n\nSee also: [httpsPrivateKey](https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "ignoreDeprecated": {
+      "description": "Avoid upgrading from a non-deprecated version to a deprecated one.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeprecated",
+      "markdownDescription": "Avoid upgrading from a non-deprecated version to a deprecated one.\n\nSee also: [ignoreDeprecated](https://docs.renovatebot.com/configuration-options/#ignoredeprecated)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreDeps": {
+      "description": "Dependencies to ignore.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeps",
+      "markdownDescription": "Dependencies to ignore.\n\nSee also: [ignoreDeps](https://docs.renovatebot.com/configuration-options/#ignoredeps)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignorePaths": {
+      "description": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepaths",
+      "markdownDescription": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\n\nSee also: [ignorePaths](https://docs.renovatebot.com/configuration-options/#ignorepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/node_modules/**", "**/bower_components/**"]
+    },
+    "ignorePlugins": {
+      "description": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreplugins",
+      "markdownDescription": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\n\nSee also: [ignorePlugins](https://docs.renovatebot.com/configuration-options/#ignoreplugins)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignorePresets": {
+      "description": "A list of presets to ignore, including any that are nested inside an `extends` array.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepresets",
+      "markdownDescription": "A list of presets to ignore, including any that are nested inside an `extends` array.\n\nSee also: [ignorePresets](https://docs.renovatebot.com/configuration-options/#ignorepresets)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ignoreReviewers": {
+      "description": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#ignorereviewers",
+      "markdownDescription": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\n\nSee also: [ignoreReviewers](https://docs.renovatebot.com/configuration-options/#ignorereviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignoreScripts": {
+      "description": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorescripts",
+      "markdownDescription": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\n\nSee also: [ignoreScripts](https://docs.renovatebot.com/configuration-options/#ignorescripts)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreTests": {
+      "description": "Set to `true` to enable automerging without tests.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoretests",
+      "markdownDescription": "Set to `true` to enable automerging without tests.\n\nSee also: [ignoreTests](https://docs.renovatebot.com/configuration-options/#ignoretests)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignoreUnstable": {
+      "description": "Ignore versions with unstable SemVer.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreunstable",
+      "markdownDescription": "Ignore versions with unstable SemVer.\n\nSee also: [ignoreUnstable](https://docs.renovatebot.com/configuration-options/#ignoreunstable)",
+      "type": "boolean",
+      "default": true
+    },
+    "includePaths": {
+      "description": "Include package files only within these defined paths.\nSee also: https://docs.renovatebot.com/configuration-options/#includepaths",
+      "markdownDescription": "Include package files only within these defined paths.\n\nSee also: [includePaths](https://docs.renovatebot.com/configuration-options/#includepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "insecureRegistry": {
+      "description": "Explicitly turn on insecure Docker registry access (HTTP).\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry",
+      "markdownDescription": "Explicitly turn on insecure Docker registry access (HTTP).\n\nSee also: [insecureRegistry](https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry)",
+      "type": "boolean",
+      "default": false
+    },
+    "installTools": {
+      "description": "Install tools before executing commands\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools",
+      "markdownDescription": "Install tools before executing commands\n\nSee also: [installTools](https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "object",
+          "description": "Install the `bazelisk` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bun": {
+          "type": "object",
+          "description": "Install the `bun` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bundler": {
+          "type": "object",
+          "description": "Install the `bundler` Containerbase tool",
+          "additionalProperties": false
+        },
+        "cocoapods": {
+          "type": "object",
+          "description": "Install the `cocoapods` Containerbase tool",
+          "additionalProperties": false
+        },
+        "composer": {
+          "type": "object",
+          "description": "Install the `composer` Containerbase tool",
+          "additionalProperties": false
+        },
+        "conan": {
+          "type": "object",
+          "description": "Install the `conan` Containerbase tool",
+          "additionalProperties": false
+        },
+        "copier": {
+          "type": "object",
+          "description": "Install the `copier` Containerbase tool",
+          "additionalProperties": false
+        },
+        "corepack": {
+          "type": "object",
+          "description": "Install the `corepack` Containerbase tool",
+          "additionalProperties": false
+        },
+        "deno": {
+          "type": "object",
+          "description": "Install the `deno` Containerbase tool",
+          "additionalProperties": false
+        },
+        "devbox": {
+          "type": "object",
+          "description": "Install the `devbox` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dotnet": {
+          "type": "object",
+          "description": "Install the `dotnet` Containerbase tool",
+          "additionalProperties": false
+        },
+        "erlang": {
+          "type": "object",
+          "description": "Install the `erlang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "elixir": {
+          "type": "object",
+          "description": "Install the `elixir` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flux": {
+          "type": "object",
+          "description": "Install the `flux` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gleam": {
+          "type": "object",
+          "description": "Install the `gleam` Containerbase tool",
+          "additionalProperties": false
+        },
+        "golang": {
+          "type": "object",
+          "description": "Install the `golang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gradle": {
+          "type": "object",
+          "description": "Install the `gradle` Containerbase tool",
+          "additionalProperties": false
+        },
+        "hashin": {
+          "type": "object",
+          "description": "Install the `hashin` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helm": {
+          "type": "object",
+          "description": "Install the `helm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helmfile": {
+          "type": "object",
+          "description": "Install the `helmfile` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java": {
+          "type": "object",
+          "description": "Install the `java` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java-maven": {
+          "type": "object",
+          "description": "Install the `java-maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "jb": {
+          "type": "object",
+          "description": "Install the `jb` Containerbase tool",
+          "additionalProperties": false
+        },
+        "kustomize": {
+          "type": "object",
+          "description": "Install the `kustomize` Containerbase tool",
+          "additionalProperties": false
+        },
+        "maven": {
+          "type": "object",
+          "description": "Install the `maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "mise": {
+          "type": "object",
+          "description": "Install the `mise` Containerbase tool",
+          "additionalProperties": false
+        },
+        "nix": {
+          "type": "object",
+          "description": "Install the `nix` Containerbase tool",
+          "additionalProperties": false
+        },
+        "node": {
+          "type": "object",
+          "description": "Install the `node` Containerbase tool",
+          "additionalProperties": false
+        },
+        "npm": {
+          "type": "object",
+          "description": "Install the `npm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pdm": {
+          "type": "object",
+          "description": "Install the `pdm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "php": {
+          "type": "object",
+          "description": "Install the `php` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pip-tools": {
+          "type": "object",
+          "description": "Install the `pip-tools` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pipenv": {
+          "type": "object",
+          "description": "Install the `pipenv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pnpm": {
+          "type": "object",
+          "description": "Install the `pnpm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pixi": {
+          "type": "object",
+          "description": "Install the `pixi` Containerbase tool",
+          "additionalProperties": false
+        },
+        "poetry": {
+          "type": "object",
+          "description": "Install the `poetry` Containerbase tool",
+          "additionalProperties": false
+        },
+        "python": {
+          "type": "object",
+          "description": "Install the `python` Containerbase tool",
+          "additionalProperties": false
+        },
+        "ruby": {
+          "type": "object",
+          "description": "Install the `ruby` Containerbase tool. Also used in the `rubygems` Datasource",
+          "additionalProperties": false
+        },
+        "rust": {
+          "type": "object",
+          "description": "Install the `rust` Containerbase tool",
+          "additionalProperties": false
+        },
+        "uv": {
+          "type": "object",
+          "description": "Install the `uv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn": {
+          "type": "object",
+          "description": "Install the `yarn` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn-slim": {
+          "type": "object",
+          "description": "Install the `yarn-slim` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dart": {
+          "type": "object",
+          "description": "Install the `dart` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flutter": {
+          "type": "object",
+          "description": "Install the `flutter` Containerbase tool",
+          "additionalProperties": false
+        },
+        "vendir": {
+          "type": "object",
+          "description": "Install the `vendir` Containerbase tool",
+          "additionalProperties": false
+        }
+      }
+    },
+    "internalChecksAsSuccess": {
+      "description": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksassuccess",
+      "markdownDescription": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\n\nSee also: [internalChecksAsSuccess](https://docs.renovatebot.com/configuration-options/#internalchecksassuccess)",
+      "type": "boolean",
+      "default": false
+    },
+    "internalChecksFilter": {
+      "description": "When and how to filter based on internal checks.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksfilter",
+      "markdownDescription": "When and how to filter based on internal checks.\n\nSee also: [internalChecksFilter](https://docs.renovatebot.com/configuration-options/#internalchecksfilter)",
+      "type": "string",
+      "enum": ["strict", "flexible", "none"],
+      "default": "strict"
+    },
+    "jenkins": {
+      "$ref": "#",
+      "description": "Configuration object for the jenkins manager\nSee also: https://docs.renovatebot.com/configuration-options/#jenkins",
+      "markdownDescription": "Configuration object for the jenkins manager\n\nSee also: [jenkins](https://docs.renovatebot.com/configuration-options/#jenkins)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)plugins\\.(txt|ya?ml)$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jsonata": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonata manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonata",
+      "markdownDescription": "Configuration object for the jsonata manager\n\nSee also: [jsonata](https://docs.renovatebot.com/configuration-options/#jsonata)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "jsonnet-bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonnet-bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonnet-bundler",
+      "markdownDescription": "Configuration object for the jsonnet-bundler manager\n\nSee also: [jsonnet-bundler](https://docs.renovatebot.com/configuration-options/#jsonnet-bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)jsonnetfile\\.json$/"],
+        "datasource": "git-tags"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jvmMaxMemory": {
+      "description": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory",
+      "markdownDescription": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory)",
+      "type": "integer"
+    },
+    "jvmMemory": {
+      "description": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory",
+      "markdownDescription": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory)",
+      "type": "integer"
+    },
+    "keepAlive": {
+      "description": "Enable HTTP keep-alive for hosts.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleskeepalive",
+      "markdownDescription": "Enable HTTP keep-alive for hosts.\n\nSee also: [keepAlive](https://docs.renovatebot.com/configuration-options/#hostruleskeepalive)",
+      "type": "boolean",
+      "default": false
+    },
+    "keepUpdatedLabel": {
+      "description": "If set, users can add this label to PRs to request they be kept updated with the base branch.\nSee also: https://docs.renovatebot.com/configuration-options/#keepupdatedlabel",
+      "markdownDescription": "If set, users can add this label to PRs to request they be kept updated with the base branch.\n\nSee also: [keepUpdatedLabel](https://docs.renovatebot.com/configuration-options/#keepupdatedlabel)",
+      "type": "string"
+    },
+    "kotlin-script": {
+      "$ref": "#",
+      "description": "Configuration object for the kotlin-script manager\nSee also: https://docs.renovatebot.com/configuration-options/#kotlin-script",
+      "markdownDescription": "Configuration object for the kotlin-script manager\n\nSee also: [kotlin-script](https://docs.renovatebot.com/configuration-options/#kotlin-script)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^.+\\.main\\.kts$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kubernetes": {
+      "$ref": "#",
+      "description": "Configuration object for the kubernetes manager\nSee also: https://docs.renovatebot.com/configuration-options/#kubernetes",
+      "markdownDescription": "Configuration object for the kubernetes manager\n\nSee also: [kubernetes](https://docs.renovatebot.com/configuration-options/#kubernetes)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kustomize": {
+      "$ref": "#",
+      "description": "Configuration object for the kustomize manager\nSee also: https://docs.renovatebot.com/configuration-options/#kustomize",
+      "markdownDescription": "Configuration object for the kustomize manager\n\nSee also: [kustomize](https://docs.renovatebot.com/configuration-options/#kustomize)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)kustomization\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "labels": {
+      "description": "Labels to set in Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#labels",
+      "markdownDescription": "Labels to set in Pull Request.\n\nSee also: [labels](https://docs.renovatebot.com/configuration-options/#labels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "leiningen": {
+      "$ref": "#",
+      "description": "Configuration object for the leiningen manager\nSee also: https://docs.renovatebot.com/configuration-options/#leiningen",
+      "markdownDescription": "Configuration object for the leiningen manager\n\nSee also: [leiningen](https://docs.renovatebot.com/configuration-options/#leiningen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)project\\.clj$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "lockFileMaintenance": {
+      "$ref": "#",
+      "description": "Configuration for lock file maintenance.\nSee also: https://docs.renovatebot.com/configuration-options/#lockfilemaintenance",
+      "markdownDescription": "Configuration for lock file maintenance.\n\nSee also: [lockFileMaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "recreateWhen": "always",
+        "branchTopic": "lock-file-maintenance",
+        "commitMessageAction": "Lock file maintenance",
+        "commitMessageTopic": null,
+        "commitMessageExtra": null,
+        "schedule": ["before 4am on monday"],
+        "groupName": null,
+        "prBodyDefinitions": {
+          "Change": "All locks refreshed"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "logLevelRemap": {
+      "description": "Remap log levels to different levels.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremap",
+      "markdownDescription": "Remap log levels to different levels.\n\nSee also: [logLevelRemap](https://docs.renovatebot.com/configuration-options/#loglevelremap)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "matchMessage": {
+                "$ref": "#/definitions/matchMessage"
+              },
+              "newLogLevel": {
+                "$ref": "#/definitions/newLogLevel"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "major": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `major`.\nSee also: https://docs.renovatebot.com/configuration-options/#major",
+      "markdownDescription": "Configuration to apply when an update type is `major`.\n\nSee also: [major](https://docs.renovatebot.com/configuration-options/#major)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "managerFilePatterns": {
+      "description": "RegEx (`re2`) and glob patterns for matching manager files.\nSee also: https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns",
+      "markdownDescription": "RegEx (`re2`) and glob patterns for matching manager files.\n\nSee also: [managerFilePatterns](https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchBaseBranches": {
+      "description": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches",
+      "markdownDescription": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchBaseBranches](https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchCategories": {
+      "description": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories",
+      "markdownDescription": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchCategories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchConfidence": {
+      "description": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence",
+      "markdownDescription": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\n\nSee also: [matchConfidence](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": ["low", "neutral", "high", "very high"]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": ["low", "neutral", "high", "very high"]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "matchCurrentAge": {
+      "description": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage",
+      "markdownDescription": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentAge](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage)",
+      "type": "string"
+    },
+    "matchCurrentValue": {
+      "description": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue)",
+      "type": "string"
+    },
+    "matchCurrentVersion": {
+      "description": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion",
+      "markdownDescription": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentVersion](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion)",
+      "type": "string"
+    },
+    "matchDatasources": {
+      "description": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources",
+      "markdownDescription": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchDatasources](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepNames": {
+      "description": "Dep names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames",
+      "markdownDescription": "Dep names to match. Valid only within a `packageRules` object.\n\nSee also: [matchDepNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepTypes": {
+      "description": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes",
+      "markdownDescription": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\n\nSee also: [matchDepTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchFileNames": {
+      "description": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames",
+      "markdownDescription": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\n\nSee also: [matchFileNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchHost": {
+      "description": "A domain name, host name or base URL to match against.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost",
+      "markdownDescription": "A domain name, host name or base URL to match against.\n\nSee also: [matchHost](https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost)",
+      "type": "string"
+    },
+    "matchJsonata": {
+      "description": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata",
+      "markdownDescription": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\n\nSee also: [matchJsonata](https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchManagers": {
+      "description": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers",
+      "markdownDescription": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchManagers](https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchMessage": {
+      "description": "Regex/minimatch expression to match against log message.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage",
+      "markdownDescription": "Regex/minimatch expression to match against log message.\n\nSee also: [matchMessage](https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage)",
+      "type": "string"
+    },
+    "matchNewValue": {
+      "description": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchNewValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue)",
+      "type": "string"
+    },
+    "matchPackageNames": {
+      "description": "Package names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames",
+      "markdownDescription": "Package names to match. Valid only within a `packageRules` object.\n\nSee also: [matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRegistryUrls": {
+      "description": "A list of URLs (or URL patterns) to match against registryUrls.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls",
+      "markdownDescription": "A list of URLs (or URL patterns) to match against registryUrls.\n\nSee also: [matchRegistryUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRepositories": {
+      "description": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories",
+      "markdownDescription": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchRepositories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchSourceUrls": {
+      "description": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls",
+      "markdownDescription": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\n\nSee also: [matchSourceUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchStrings": {
+      "description": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings",
+      "markdownDescription": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\n\nSee also: [matchStrings](https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchStringsStrategy": {
+      "description": "Strategy how to interpret matchStrings.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy",
+      "markdownDescription": "Strategy how to interpret matchStrings.\n\nSee also: [matchStringsStrategy](https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy)",
+      "type": "string",
+      "enum": ["any", "recursive", "combination"],
+      "default": "any"
+    },
+    "matchUpdateTypes": {
+      "description": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes",
+      "markdownDescription": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\n\nSee also: [matchUpdateTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "major",
+                  "minor",
+                  "patch",
+                  "pin",
+                  "pinDigest",
+                  "digest",
+                  "lockFileMaintenance",
+                  "rollback",
+                  "bump",
+                  "replacement"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "major",
+                "minor",
+                "patch",
+                "pin",
+                "pinDigest",
+                "digest",
+                "lockFileMaintenance",
+                "rollback",
+                "bump",
+                "replacement"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "maven": {
+      "$ref": "#",
+      "description": "Configuration object for the maven manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven",
+      "markdownDescription": "Configuration object for the maven manager\n\nSee also: [maven](https://docs.renovatebot.com/configuration-options/#maven)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)pom\\.xml$/",
+          "/(^|/)pom\\.template\\.xml$/",
+          "/^(((\\.mvn)|(\\.m2))/)?settings\\.xml$/",
+          "/(^|/)\\.mvn/extensions\\.xml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maven-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the maven-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven-wrapper",
+      "markdownDescription": "Configuration object for the maven-wrapper manager\n\nSee also: [maven-wrapper](https://docs.renovatebot.com/configuration-options/#maven-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|\\/).mvn/wrapper/maven-wrapper.properties$/",
+          "/(^|\\/)mvnw(.cmd)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maxMajorIncrement": {
+      "description": "Limit the maximum major version increment allowed. Set to 0 to disable.\nSee also: https://docs.renovatebot.com/configuration-options/#maxmajorincrement",
+      "markdownDescription": "Limit the maximum major version increment allowed. Set to 0 to disable.\n\nSee also: [maxMajorIncrement](https://docs.renovatebot.com/configuration-options/#maxmajorincrement)",
+      "type": "integer",
+      "default": 500
+    },
+    "maxRequestsPerSecond": {
+      "description": "Limit requests rate per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond",
+      "markdownDescription": "Limit requests rate per host.\n\nSee also: [maxRequestsPerSecond](https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond)",
+      "type": "integer",
+      "default": 0
+    },
+    "maxRetryAfter": {
+      "description": "Maximum retry-after header value to wait for before retrying a failed request.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter",
+      "markdownDescription": "Maximum retry-after header value to wait for before retrying a failed request.\n\nSee also: [maxRetryAfter](https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter)",
+      "type": "integer",
+      "default": 60
+    },
+    "meteor": {
+      "$ref": "#",
+      "description": "Configuration object for the meteor manager\nSee also: https://docs.renovatebot.com/configuration-options/#meteor",
+      "markdownDescription": "Configuration object for the meteor manager\n\nSee also: [meteor](https://docs.renovatebot.com/configuration-options/#meteor)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)package\\.js$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "milestone": {
+      "description": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\nSee also: https://docs.renovatebot.com/configuration-options/#milestone",
+      "markdownDescription": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\n\nSee also: [milestone](https://docs.renovatebot.com/configuration-options/#milestone)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "minimumGroupSize": {
+      "description": "The minimum number of updates which must be in a group for branches to be created.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumgroupsize",
+      "markdownDescription": "The minimum number of updates which must be in a group for branches to be created.\n\nSee also: [minimumGroupSize](https://docs.renovatebot.com/configuration-options/#minimumgroupsize)",
+      "type": "integer",
+      "default": 1
+    },
+    "minimumReleaseAge": {
+      "description": "Time required before a new release is considered stable.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseage",
+      "markdownDescription": "Time required before a new release is considered stable.\n\nSee also: [minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "minimumReleaseAgeBehaviour": {
+      "description": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour",
+      "markdownDescription": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\n\nSee also: [minimumReleaseAgeBehaviour](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour)",
+      "type": "string",
+      "enum": ["timestamp-required", "timestamp-optional"],
+      "default": "timestamp-required"
+    },
+    "minor": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `minor`.\nSee also: https://docs.renovatebot.com/configuration-options/#minor",
+      "markdownDescription": "Configuration to apply when an update type is `minor`.\n\nSee also: [minor](https://docs.renovatebot.com/configuration-options/#minor)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mint": {
+      "$ref": "#",
+      "description": "Configuration object for the mint manager\nSee also: https://docs.renovatebot.com/configuration-options/#mint",
+      "markdownDescription": "Configuration object for the mint manager\n\nSee also: [mint](https://docs.renovatebot.com/configuration-options/#mint)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Mintfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mise": {
+      "$ref": "#",
+      "description": "Configuration object for the mise manager\nSee also: https://docs.renovatebot.com/configuration-options/#mise",
+      "markdownDescription": "Configuration object for the mise manager\n\nSee also: [mise](https://docs.renovatebot.com/configuration-options/#mise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "**/{,.}mise{,.*}.toml",
+          "**/{,.}mise/config{,.*}.toml",
+          "**/.config/mise{,.*}.toml",
+          "**/.config/mise/{mise,config}{,.*}.toml",
+          "**/.config/mise/conf.d/*.toml",
+          "**/.rtx{,.*}.toml"
+        ],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mix": {
+      "$ref": "#",
+      "description": "Configuration object for the mix manager\nSee also: https://docs.renovatebot.com/configuration-options/#mix",
+      "markdownDescription": "Configuration object for the mix manager\n\nSee also: [mix](https://docs.renovatebot.com/configuration-options/#mix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)mix\\.exs$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mode": {
+      "description": "Mode of operation.\nSee also: https://docs.renovatebot.com/configuration-options/#mode",
+      "markdownDescription": "Mode of operation.\n\nSee also: [mode](https://docs.renovatebot.com/configuration-options/#mode)",
+      "type": "string",
+      "enum": ["full", "silent"],
+      "default": "full"
+    },
+    "name": {
+      "description": "A name for the bumpVersion config. This is used for logging and debugging.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsname",
+      "markdownDescription": "A name for the bumpVersion config. This is used for logging and debugging.\n\nSee also: [name](https://docs.renovatebot.com/configuration-options/#bumpversionsname)",
+      "type": "string"
+    },
+    "newLogLevel": {
+      "description": "New log level to use if matchMessage matches.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel",
+      "markdownDescription": "New log level to use if matchMessage matches.\n\nSee also: [newLogLevel](https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel)",
+      "type": "string",
+      "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+    },
+    "nix": {
+      "$ref": "#",
+      "description": "Configuration object for the nix manager\nSee also: https://docs.renovatebot.com/configuration-options/#nix",
+      "markdownDescription": "Configuration object for the nix manager\n\nSee also: [nix](https://docs.renovatebot.com/configuration-options/#nix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)flake\\.nix$/"],
+        "commitMessageTopic": "nix",
+        "commitMessageExtra": "to {{newValue}}",
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nodeMaxMemory": {
+      "description": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory",
+      "markdownDescription": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\n\nSee also: [nodeMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory)",
+      "type": "integer"
+    },
+    "nodenv": {
+      "$ref": "#",
+      "description": "Configuration object for the nodenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#nodenv",
+      "markdownDescription": "Configuration object for the nodenv manager\n\nSee also: [nodenv](https://docs.renovatebot.com/configuration-options/#nodenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.node-version$/"],
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npm": {
+      "$ref": "#",
+      "description": "Configuration object for the npm manager\nSee also: https://docs.renovatebot.com/configuration-options/#npm",
+      "markdownDescription": "Configuration object for the npm manager\n\nSee also: [npm](https://docs.renovatebot.com/configuration-options/#npm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)package\\.json$/",
+          "/(^|/)pnpm-workspace\\.yaml$/",
+          "/(^|/)\\.yarnrc\\.yml$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npmToken": {
+      "description": "npm token used to authenticate with the default registry.\nSee also: https://docs.renovatebot.com/configuration-options/#npmtoken",
+      "markdownDescription": "npm token used to authenticate with the default registry.\n\nSee also: [npmToken](https://docs.renovatebot.com/configuration-options/#npmtoken)",
+      "type": "string"
+    },
+    "npmrc": {
+      "description": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrc",
+      "markdownDescription": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\n\nSee also: [npmrc](https://docs.renovatebot.com/configuration-options/#npmrc)",
+      "type": "string"
+    },
+    "npmrcMerge": {
+      "description": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrcmerge",
+      "markdownDescription": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\n\nSee also: [npmrcMerge](https://docs.renovatebot.com/configuration-options/#npmrcmerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "nuget": {
+      "$ref": "#",
+      "description": "Configuration object for the nuget manager\nSee also: https://docs.renovatebot.com/configuration-options/#nuget",
+      "markdownDescription": "Configuration object for the nuget manager\n\nSee also: [nuget](https://docs.renovatebot.com/configuration-options/#nuget)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.(?:cs|fs|vb|sql)proj$/",
+          "/\\.(?:props|targets)$/",
+          "/(^|/)dotnet-tools\\.json$/",
+          "/(^|/)global\\.json$/"
+        ],
+        "rangeStrategy": "bump",
+        "packageRules": [
+          {
+            "matchDepTypes": ["msbuild-sdk"],
+            "rangeStrategy": "bump"
+          }
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nvm": {
+      "$ref": "#",
+      "description": "Configuration object for the nvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#nvm",
+      "markdownDescription": "Configuration object for the nvm manager\n\nSee also: [nvm](https://docs.renovatebot.com/configuration-options/#nvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.nvmrc$/"],
+        "versioning": "node",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ocb": {
+      "$ref": "#",
+      "description": "Configuration object for the ocb manager\nSee also: https://docs.renovatebot.com/configuration-options/#ocb",
+      "markdownDescription": "Configuration object for the ocb manager\n\nSee also: [ocb](https://docs.renovatebot.com/configuration-options/#ocb)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "osgi": {
+      "$ref": "#",
+      "description": "Configuration object for the osgi manager\nSee also: https://docs.renovatebot.com/configuration-options/#osgi",
+      "markdownDescription": "Configuration object for the osgi manager\n\nSee also: [osgi](https://docs.renovatebot.com/configuration-options/#osgi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)src/main/features/.+\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "osvVulnerabilityAlerts": {
+      "description": "Use vulnerability alerts from `osv.dev`.\nSee also: https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts",
+      "markdownDescription": "Use vulnerability alerts from `osv.dev`.\n\nSee also: [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)",
+      "type": "boolean",
+      "default": false
+    },
+    "overrideDatasource": {
+      "description": "Override the datasource value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource",
+      "markdownDescription": "Override the datasource value.\n\nSee also: [overrideDatasource](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource)",
+      "type": "string"
+    },
+    "overrideDepName": {
+      "description": "Override the depName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname",
+      "markdownDescription": "Override the depName value.\n\nSee also: [overrideDepName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname)",
+      "type": "string"
+    },
+    "overridePackageName": {
+      "description": "Override the packageName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename",
+      "markdownDescription": "Override the packageName value.\n\nSee also: [overridePackageName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename)",
+      "type": "string"
+    },
+    "packageNameTemplate": {
+      "description": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate",
+      "markdownDescription": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\n\nSee also: [packageNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate)",
+      "type": "string"
+    },
+    "packageRules": {
+      "description": "Rules for matching packages.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerules",
+      "markdownDescription": "Rules for matching packages.\n\nSee also: [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "allowedVersions": {
+                "$ref": "#/definitions/allowedVersions"
+              },
+              "changelogUrl": {
+                "$ref": "#/definitions/changelogUrl"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "fetchChangeLogs": {
+                "$ref": "#/definitions/fetchChangeLogs"
+              },
+              "matchBaseBranches": {
+                "$ref": "#/definitions/matchBaseBranches"
+              },
+              "matchCategories": {
+                "$ref": "#/definitions/matchCategories"
+              },
+              "matchConfidence": {
+                "$ref": "#/definitions/matchConfidence"
+              },
+              "matchCurrentAge": {
+                "$ref": "#/definitions/matchCurrentAge"
+              },
+              "matchCurrentValue": {
+                "$ref": "#/definitions/matchCurrentValue"
+              },
+              "matchCurrentVersion": {
+                "$ref": "#/definitions/matchCurrentVersion"
+              },
+              "matchDatasources": {
+                "$ref": "#/definitions/matchDatasources"
+              },
+              "matchDepNames": {
+                "$ref": "#/definitions/matchDepNames"
+              },
+              "matchDepTypes": {
+                "$ref": "#/definitions/matchDepTypes"
+              },
+              "matchFileNames": {
+                "$ref": "#/definitions/matchFileNames"
+              },
+              "matchJsonata": {
+                "$ref": "#/definitions/matchJsonata"
+              },
+              "matchManagers": {
+                "$ref": "#/definitions/matchManagers"
+              },
+              "matchNewValue": {
+                "$ref": "#/definitions/matchNewValue"
+              },
+              "matchPackageNames": {
+                "$ref": "#/definitions/matchPackageNames"
+              },
+              "matchRegistryUrls": {
+                "$ref": "#/definitions/matchRegistryUrls"
+              },
+              "matchRepositories": {
+                "$ref": "#/definitions/matchRepositories"
+              },
+              "matchSourceUrls": {
+                "$ref": "#/definitions/matchSourceUrls"
+              },
+              "matchUpdateTypes": {
+                "$ref": "#/definitions/matchUpdateTypes"
+              },
+              "overrideDatasource": {
+                "$ref": "#/definitions/overrideDatasource"
+              },
+              "overrideDepName": {
+                "$ref": "#/definitions/overrideDepName"
+              },
+              "overridePackageName": {
+                "$ref": "#/definitions/overridePackageName"
+              },
+              "prPriority": {
+                "$ref": "#/definitions/prPriority"
+              },
+              "replacementName": {
+                "$ref": "#/definitions/replacementName"
+              },
+              "replacementNameTemplate": {
+                "$ref": "#/definitions/replacementNameTemplate"
+              },
+              "replacementVersion": {
+                "$ref": "#/definitions/replacementVersion"
+              },
+              "replacementVersionTemplate": {
+                "$ref": "#/definitions/replacementVersionTemplate"
+              },
+              "sourceDirectory": {
+                "$ref": "#/definitions/sourceDirectory"
+              },
+              "sourceUrl": {
+                "$ref": "#/definitions/sourceUrl"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "patch": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `patch`.\nSee also: https://docs.renovatebot.com/configuration-options/#patch",
+      "markdownDescription": "Configuration to apply when an update type is `patch`.\n\nSee also: [patch](https://docs.renovatebot.com/configuration-options/#patch)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep621": {
+      "$ref": "#",
+      "description": "Configuration object for the pep621 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep621",
+      "markdownDescription": "Configuration object for the pep621 manager\n\nSee also: [pep621](https://docs.renovatebot.com/configuration-options/#pep621)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep723": {
+      "$ref": "#",
+      "description": "Configuration object for the pep723 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep723",
+      "markdownDescription": "Configuration object for the pep723 manager\n\nSee also: [pep723](https://docs.renovatebot.com/configuration-options/#pep723)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pin": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `pin`.\nSee also: https://docs.renovatebot.com/configuration-options/#pin",
+      "markdownDescription": "Configuration to apply when an update type is `pin`.\n\nSee also: [pin](https://docs.renovatebot.com/configuration-options/#pin)",
+      "type": "object",
+      "default": {
+        "rebaseWhen": "behind-base-branch",
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigest": {
+      "$ref": "#",
+      "description": "Configuration to apply when pinning a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#pindigest",
+      "markdownDescription": "Configuration to apply when pinning a digest (no change in tag/version).\n\nSee also: [pinDigest](https://docs.renovatebot.com/configuration-options/#pindigest)",
+      "type": "object",
+      "default": {
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigests": {
+      "description": "Whether to add digests to Dockerfile source images.\nSee also: https://docs.renovatebot.com/configuration-options/#pindigests",
+      "markdownDescription": "Whether to add digests to Dockerfile source images.\n\nSee also: [pinDigests](https://docs.renovatebot.com/configuration-options/#pindigests)",
+      "type": "boolean",
+      "default": false
+    },
+    "pip-compile": {
+      "$ref": "#",
+      "description": "Configuration object for the pip-compile manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip-compile",
+      "markdownDescription": "Configuration object for the pip-compile manager\n\nSee also: [pip-compile](https://docs.renovatebot.com/configuration-options/#pip-compile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "lockFileMaintenance": {
+          "enabled": true,
+          "branchTopic": "pip-compile-refresh",
+          "commitMessageAction": "Refresh pip-compile outputs"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_requirements",
+      "markdownDescription": "Configuration object for the pip_requirements manager\n\nSee also: [pip_requirements](https://docs.renovatebot.com/configuration-options/#pip_requirements)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)[\\w-]*requirements([-._]\\w+)?\\.(txt|pip)$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_setup": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_setup manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_setup",
+      "markdownDescription": "Configuration object for the pip_setup manager\n\nSee also: [pip_setup](https://docs.renovatebot.com/configuration-options/#pip_setup)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.py$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pipenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pipenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pipenv",
+      "markdownDescription": "Configuration object for the pipenv manager\n\nSee also: [pipenv](https://docs.renovatebot.com/configuration-options/#pipenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Pipfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pixi": {
+      "$ref": "#",
+      "description": "Configuration object for the pixi manager\nSee also: https://docs.renovatebot.com/configuration-options/#pixi",
+      "markdownDescription": "Configuration object for the pixi manager\n\nSee also: [pixi](https://docs.renovatebot.com/configuration-options/#pixi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)pyproject\\.toml$/",
+          "/(^|/)pixi\\.toml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "platformAutomerge": {
+      "description": "Controls if platform-native auto-merge is used.\nSee also: https://docs.renovatebot.com/configuration-options/#platformautomerge",
+      "markdownDescription": "Controls if platform-native auto-merge is used.\n\nSee also: [platformAutomerge](https://docs.renovatebot.com/configuration-options/#platformautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "platformCommit": {
+      "description": "Use platform API to perform commits instead of using Git directly.\nSee also: https://docs.renovatebot.com/configuration-options/#platformcommit",
+      "markdownDescription": "Use platform API to perform commits instead of using Git directly.\n\nSee also: [platformCommit](https://docs.renovatebot.com/configuration-options/#platformcommit)",
+      "type": "string",
+      "enum": ["auto", "disabled", "enabled"],
+      "default": "auto"
+    },
+    "poetry": {
+      "$ref": "#",
+      "description": "Configuration object for the poetry manager\nSee also: https://docs.renovatebot.com/configuration-options/#poetry",
+      "markdownDescription": "Configuration object for the poetry manager\n\nSee also: [poetry](https://docs.renovatebot.com/configuration-options/#poetry)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "postUpdateOptions": {
+      "description": "Enable post-update options to be run after package/artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#postupdateoptions",
+      "markdownDescription": "Enable post-update options to be run after package/artifact updating.\n\nSee also: [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "bundlerConservative",
+          "composerWithAll",
+          "composerNoMinimalChanges",
+          "dotnetWorkloadRestore",
+          "gomodMassage",
+          "gomodTidy",
+          "gomodTidy1.17",
+          "gomodTidyE",
+          "gomodUpdateImportPaths",
+          "gomodSkipVendor",
+          "gomodVendor",
+          "goGenerate",
+          "helmUpdateSubChartArchives",
+          "kustomizeInflateHelmCharts",
+          "npmDedupe",
+          "npmInstallTwice",
+          "pnpmDedupe",
+          "yarnDedupeFewer",
+          "yarnDedupeHighest"
+        ]
+      },
+      "default": []
+    },
+    "postUpgradeTasks": {
+      "$ref": "#",
+      "description": "Post-upgrade tasks that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasks",
+      "markdownDescription": "Post-upgrade tasks that are executed before a commit is made by Renovate.\n\nSee also: [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks)",
+      "type": "object",
+      "default": {
+        "commands": [],
+        "fileFilters": [],
+        "executionMode": "update",
+        "installTools": {}
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "commands": {
+                "$ref": "#/definitions/commands"
+              },
+              "dataFileTemplate": {
+                "$ref": "#/definitions/dataFileTemplate"
+              },
+              "executionMode": {
+                "$ref": "#/definitions/executionMode"
+              },
+              "fileFilters": {
+                "$ref": "#/definitions/fileFilters"
+              },
+              "installTools": {
+                "$ref": "#/definitions/installTools"
+              },
+              "workingDirTemplate": {
+                "$ref": "#/definitions/workingDirTemplate"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "prBodyColumns": {
+      "description": "List of columns to use in PR bodies.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodycolumns",
+      "markdownDescription": "List of columns to use in PR bodies.\n\nSee also: [prBodyColumns](https://docs.renovatebot.com/configuration-options/#prbodycolumns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["Package", "Type", "Update", "Change", "Pending"]
+    },
+    "prBodyDefinitions": {
+      "description": "Table column definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodydefinitions",
+      "markdownDescription": "Table column definitions to use in PR tables.\n\nSee also: [prBodyDefinitions](https://docs.renovatebot.com/configuration-options/#prbodydefinitions)",
+      "type": "object",
+      "default": {
+        "Package": "{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} \u2192 {{{newNameLinked}}}{{/unless}}{{/if}}",
+        "Type": "{{{depType}}}",
+        "Update": "{{{updateType}}}",
+        "Current value": "{{{currentValue}}}",
+        "New value": "{{{newValue}}}",
+        "Change": "`{{{displayFrom}}}` \u2192 `{{{displayTo}}}`",
+        "Pending": "{{{displayPending}}}",
+        "References": "{{{references}}}",
+        "Package file": "{{{packageFile}}}",
+        "Age": "{{#if newVersion}}![age](https://developer.mend.io/api/mc/badges/age/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Adoption": "{{#if newVersion}}![adoption](https://developer.mend.io/api/mc/badges/adoption/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Passing": "{{#if newVersion}}![passing](https://developer.mend.io/api/mc/badges/compatibility/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Confidence": "{{#if newVersion}}![confidence](https://developer.mend.io/api/mc/badges/confidence/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}"
+      }
+    },
+    "prBodyHeadingDefinitions": {
+      "description": "Table header definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions",
+      "markdownDescription": "Table header definitions to use in PR tables.\n\nSee also: [prBodyHeadingDefinitions](https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions)",
+      "type": "object",
+      "default": {
+        "Age": "[Age](https://docs.renovatebot.com/merge-confidence/)",
+        "Adoption": "[Adoption](https://docs.renovatebot.com/merge-confidence/)",
+        "Passing": "[Passing](https://docs.renovatebot.com/merge-confidence/)",
+        "Confidence": "[Confidence](https://docs.renovatebot.com/merge-confidence/)"
+      }
+    },
+    "prBodyNotes": {
+      "description": "List of extra notes or templates to include in the Pull Request body.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodynotes",
+      "markdownDescription": "List of extra notes or templates to include in the Pull Request body.\n\nSee also: [prBodyNotes](https://docs.renovatebot.com/configuration-options/#prbodynotes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": []
+    },
+    "prBodyTemplate": {
+      "description": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodytemplate",
+      "markdownDescription": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\n\nSee also: [prBodyTemplate](https://docs.renovatebot.com/configuration-options/#prbodytemplate)",
+      "type": "string",
+      "default": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
+    },
+    "prConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\n\nSee also: [prConcurrentLimit](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit)",
+      "type": "integer",
+      "default": 10
+    },
+    "prCreation": {
+      "description": "When to create the PR for a branch.\nSee also: https://docs.renovatebot.com/configuration-options/#prcreation",
+      "markdownDescription": "When to create the PR for a branch.\n\nSee also: [prCreation](https://docs.renovatebot.com/configuration-options/#prcreation)",
+      "type": "string",
+      "enum": ["immediate", "not-pending", "status-success", "approval"],
+      "default": "immediate"
+    },
+    "prFooter": {
+      "description": "Text added here will be placed last in the PR body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#prfooter",
+      "markdownDescription": "Text added here will be placed last in the PR body, with a divider separator before it.\n\nSee also: [prFooter](https://docs.renovatebot.com/configuration-options/#prfooter)",
+      "type": "string",
+      "default": "This PR has been generated by [Mend Renovate](https://github.com/renovatebot/renovate)."
+    },
+    "prHeader": {
+      "description": "Text added here will be placed first in the PR body.\nSee also: https://docs.renovatebot.com/configuration-options/#prheader",
+      "markdownDescription": "Text added here will be placed first in the PR body.\n\nSee also: [prHeader](https://docs.renovatebot.com/configuration-options/#prheader)",
+      "type": "string"
+    },
+    "prHourlyLimit": {
+      "description": "Rate limit PRs to maximum x created per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prhourlylimit",
+      "markdownDescription": "Rate limit PRs to maximum x created per hour. 0 means no limit.\n\nSee also: [prHourlyLimit](https://docs.renovatebot.com/configuration-options/#prhourlylimit)",
+      "type": "integer",
+      "default": 2
+    },
+    "prNotPendingHours": {
+      "description": "Timeout in hours for when `prCreation=not-pending`.\nSee also: https://docs.renovatebot.com/configuration-options/#prnotpendinghours",
+      "markdownDescription": "Timeout in hours for when `prCreation=not-pending`.\n\nSee also: [prNotPendingHours](https://docs.renovatebot.com/configuration-options/#prnotpendinghours)",
+      "type": "integer",
+      "default": 25
+    },
+    "prPriority": {
+      "description": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesprpriority",
+      "markdownDescription": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\n\nSee also: [prPriority](https://docs.renovatebot.com/configuration-options/#packagerulesprpriority)",
+      "type": "integer",
+      "default": 0
+    },
+    "prTitle": {
+      "description": "Pull Request title template. Inherits from `commitMessage` if null.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitle",
+      "markdownDescription": "Pull Request title template. Inherits from `commitMessage` if null.\n\nSee also: [prTitle](https://docs.renovatebot.com/configuration-options/#prtitle)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "prTitleStrict": {
+      "description": "Whether to bypass appending extra context to the Pull Request title.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitlestrict",
+      "markdownDescription": "Whether to bypass appending extra context to the Pull Request title.\n\nSee also: [prTitleStrict](https://docs.renovatebot.com/configuration-options/#prtitlestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "pre-commit": {
+      "$ref": "#",
+      "description": "Configuration object for the pre-commit manager\nSee also: https://docs.renovatebot.com/configuration-options/#pre-commit",
+      "markdownDescription": "Configuration object for the pre-commit manager\n\nSee also: [pre-commit](https://docs.renovatebot.com/configuration-options/#pre-commit)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "pre-commit hook {{depName}}",
+        "enabled": false,
+        "managerFilePatterns": ["/(^|/)\\.pre-commit-config\\.ya?ml$/"],
+        "prBodyNotes": [
+          "Note: The `pre-commit` manager in Renovate is not supported by the `pre-commit` maintainers or community. Please do not report any problems there, instead [create a Discussion in the Renovate repository](https://github.com/renovatebot/renovate/discussions/new) if you have any questions."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "printConfig": {
+      "description": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\nSee also: https://docs.renovatebot.com/configuration-options/#printconfig",
+      "markdownDescription": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\n\nSee also: [printConfig](https://docs.renovatebot.com/configuration-options/#printconfig)",
+      "type": "boolean",
+      "default": false
+    },
+    "proto": {
+      "$ref": "#",
+      "description": "Configuration object for the proto manager\nSee also: https://docs.renovatebot.com/configuration-options/#proto",
+      "markdownDescription": "Configuration object for the proto manager\n\nSee also: [proto](https://docs.renovatebot.com/configuration-options/#proto)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/.prototools"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pruneBranchAfterAutomerge": {
+      "description": "Set to `true` to enable branch pruning after automerging.\nSee also: https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge",
+      "markdownDescription": "Set to `true` to enable branch pruning after automerging.\n\nSee also: [pruneBranchAfterAutomerge](https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "pruneStaleBranches": {
+      "description": "Set to `false` to disable pruning stale branches.\nSee also: https://docs.renovatebot.com/configuration-options/#prunestalebranches",
+      "markdownDescription": "Set to `false` to disable pruning stale branches.\n\nSee also: [pruneStaleBranches](https://docs.renovatebot.com/configuration-options/#prunestalebranches)",
+      "type": "boolean",
+      "default": true
+    },
+    "pub": {
+      "$ref": "#",
+      "description": "Configuration object for the pub manager\nSee also: https://docs.renovatebot.com/configuration-options/#pub",
+      "markdownDescription": "Configuration object for the pub manager\n\nSee also: [pub](https://docs.renovatebot.com/configuration-options/#pub)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pubspec\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "puppet": {
+      "$ref": "#",
+      "description": "Configuration object for the puppet manager\nSee also: https://docs.renovatebot.com/configuration-options/#puppet",
+      "markdownDescription": "Configuration object for the puppet manager\n\nSee also: [puppet](https://docs.renovatebot.com/configuration-options/#puppet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Puppetfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pyenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pyenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pyenv",
+      "markdownDescription": "Configuration object for the pyenv manager\n\nSee also: [pyenv](https://docs.renovatebot.com/configuration-options/#pyenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.python-version$/"],
+        "versioning": "docker",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "quadlet": {
+      "$ref": "#",
+      "description": "Configuration object for the quadlet manager\nSee also: https://docs.renovatebot.com/configuration-options/#quadlet",
+      "markdownDescription": "Configuration object for the quadlet manager\n\nSee also: [quadlet](https://docs.renovatebot.com/configuration-options/#quadlet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/.+\\.container$/",
+          "/.+\\.image$/",
+          "/.+\\.volume$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rangeStrategy": {
+      "description": "Determines how to modify or update existing ranges.\nSee also: https://docs.renovatebot.com/configuration-options/#rangestrategy",
+      "markdownDescription": "Determines how to modify or update existing ranges.\n\nSee also: [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "pin",
+        "bump",
+        "replace",
+        "widen",
+        "update-lockfile",
+        "in-range-only"
+      ],
+      "default": "auto"
+    },
+    "readOnly": {
+      "description": "Match against requests that only read data and do not mutate anything.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesreadonly",
+      "markdownDescription": "Match against requests that only read data and do not mutate anything.\n\nSee also: [readOnly](https://docs.renovatebot.com/configuration-options/#hostrulesreadonly)",
+      "type": "boolean"
+    },
+    "rebaseLabel": {
+      "description": "Label to request a rebase from Renovate bot.\nSee also: https://docs.renovatebot.com/configuration-options/#rebaselabel",
+      "markdownDescription": "Label to request a rebase from Renovate bot.\n\nSee also: [rebaseLabel](https://docs.renovatebot.com/configuration-options/#rebaselabel)",
+      "type": "string",
+      "default": "rebase"
+    },
+    "rebaseWhen": {
+      "description": "Controls when Renovate rebases an existing branch.\nSee also: https://docs.renovatebot.com/configuration-options/#rebasewhen",
+      "markdownDescription": "Controls when Renovate rebases an existing branch.\n\nSee also: [rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "never",
+        "conflicted",
+        "behind-base-branch",
+        "automerging"
+      ],
+      "default": "auto"
+    },
+    "recreateWhen": {
+      "description": "Recreate PRs even if same ones were closed previously.\nSee also: https://docs.renovatebot.com/configuration-options/#recreatewhen",
+      "markdownDescription": "Recreate PRs even if same ones were closed previously.\n\nSee also: [recreateWhen](https://docs.renovatebot.com/configuration-options/#recreatewhen)",
+      "type": "string",
+      "enum": ["auto", "always", "never"],
+      "default": "auto"
+    },
+    "regex": {
+      "$ref": "#",
+      "description": "Configuration object for the regex manager\nSee also: https://docs.renovatebot.com/configuration-options/#regex",
+      "markdownDescription": "Configuration object for the regex manager\n\nSee also: [regex](https://docs.renovatebot.com/configuration-options/#regex)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "registryAliases": {
+      "$ref": "#",
+      "description": "Aliases for registries.\nSee also: https://docs.renovatebot.com/configuration-options/#registryaliases",
+      "markdownDescription": "Aliases for registries.\n\nSee also: [registryAliases](https://docs.renovatebot.com/configuration-options/#registryaliases)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "registryUrlTemplate": {
+      "description": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate",
+      "markdownDescription": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [registryUrlTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate)",
+      "type": "string"
+    },
+    "registryUrls": {
+      "description": "List of URLs to try for dependency lookup. Package manager specific.\nSee also: https://docs.renovatebot.com/configuration-options/#registryurls",
+      "markdownDescription": "List of URLs to try for dependency lookup. Package manager specific.\n\nSee also: [registryUrls](https://docs.renovatebot.com/configuration-options/#registryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "renovate-config": {
+      "$ref": "#",
+      "description": "Configuration object for the renovate-config manager\nSee also: https://docs.renovatebot.com/configuration-options/#renovate-config",
+      "markdownDescription": "Configuration object for the renovate-config manager\n\nSee also: [renovate-config](https://docs.renovatebot.com/configuration-options/#renovate-config)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "renovate.json",
+          "renovate.jsonc",
+          "renovate.json5",
+          ".github/renovate.json",
+          ".github/renovate.jsonc",
+          ".github/renovate.json5",
+          ".gitlab/renovate.json",
+          ".gitlab/renovate.jsonc",
+          ".gitlab/renovate.json5",
+          ".renovaterc",
+          ".renovaterc.json",
+          ".renovaterc.jsonc",
+          ".renovaterc.json5"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacement": {
+      "$ref": "#",
+      "description": "Configuration to apply when replacing a dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#replacement",
+      "markdownDescription": "Configuration to apply when replacing a dependency.\n\nSee also: [replacement](https://docs.renovatebot.com/configuration-options/#replacement)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-replacement",
+        "commitMessageAction": "Replace",
+        "commitMessageExtra": "with {{newName}} {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{#if isSingleVersion}}{{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
+        "prBodyNotes": [
+          "This is a special PR that replaces `{{{depName}}}` with the community suggested minimal stable replacement version."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacementApproach": {
+      "description": "Select whether to perform a direct replacement or alias replacement.\nSee also: https://docs.renovatebot.com/configuration-options/#replacementapproach",
+      "markdownDescription": "Select whether to perform a direct replacement or alias replacement.\n\nSee also: [replacementApproach](https://docs.renovatebot.com/configuration-options/#replacementapproach)",
+      "type": "string",
+      "enum": ["replace", "alias"],
+      "default": "replace"
+    },
+    "replacementName": {
+      "description": "The name of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname",
+      "markdownDescription": "The name of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementName](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname)",
+      "type": "string"
+    },
+    "replacementNameTemplate": {
+      "description": "Controls what the replacement package name.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate",
+      "markdownDescription": "Controls what the replacement package name.\n\nSee also: [replacementNameTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate)",
+      "type": "string",
+      "default": "{{{packageName}}}"
+    },
+    "replacementVersion": {
+      "description": "The version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion",
+      "markdownDescription": "The version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersion](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion)",
+      "type": "string"
+    },
+    "replacementVersionTemplate": {
+      "description": "Template field for the version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate",
+      "markdownDescription": "Template field for the version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersionTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate)",
+      "type": "string"
+    },
+    "respectLatest": {
+      "description": "Ignore versions newer than npm \"latest\" version.\nSee also: https://docs.renovatebot.com/configuration-options/#respectlatest",
+      "markdownDescription": "Ignore versions newer than npm \"latest\" version.\n\nSee also: [respectLatest](https://docs.renovatebot.com/configuration-options/#respectlatest)",
+      "type": "boolean",
+      "default": true
+    },
+    "reviewers": {
+      "description": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#reviewers",
+      "markdownDescription": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\n\nSee also: [reviewers](https://docs.renovatebot.com/configuration-options/#reviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reviewersFromCodeOwners": {
+      "description": "Determine reviewers based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners",
+      "markdownDescription": "Determine reviewers based on configured code owners and changes in PR.\n\nSee also: [reviewersFromCodeOwners](https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "reviewersSampleSize": {
+      "description": "Take a random sample of given size from `reviewers`.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewerssamplesize",
+      "markdownDescription": "Take a random sample of given size from `reviewers`.\n\nSee also: [reviewersSampleSize](https://docs.renovatebot.com/configuration-options/#reviewerssamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "rollback": {
+      "$ref": "#",
+      "description": "Configuration to apply when rolling back a version.\nSee also: https://docs.renovatebot.com/configuration-options/#rollback",
+      "markdownDescription": "Configuration to apply when rolling back a version.\n\nSee also: [rollback](https://docs.renovatebot.com/configuration-options/#rollback)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-rollback",
+        "commitMessageAction": "Roll back",
+        "semanticCommitType": "fix"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rollbackPrs": {
+      "description": "Create PRs to roll back versions if the current version is not found in the registry.\nSee also: https://docs.renovatebot.com/configuration-options/#rollbackprs",
+      "markdownDescription": "Create PRs to roll back versions if the current version is not found in the registry.\n\nSee also: [rollbackPrs](https://docs.renovatebot.com/configuration-options/#rollbackprs)",
+      "type": "boolean",
+      "default": false
+    },
+    "ruby-version": {
+      "$ref": "#",
+      "description": "Configuration object for the ruby-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#ruby-version",
+      "markdownDescription": "Configuration object for the ruby-version manager\n\nSee also: [ruby-version](https://docs.renovatebot.com/configuration-options/#ruby-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.ruby-version$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "runtime-version": {
+      "$ref": "#",
+      "description": "Configuration object for the runtime-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#runtime-version",
+      "markdownDescription": "Configuration object for the runtime-version manager\n\nSee also: [runtime-version](https://docs.renovatebot.com/configuration-options/#runtime-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)runtime.txt$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rust-toolchain": {
+      "$ref": "#",
+      "description": "Configuration object for the rust-toolchain manager\nSee also: https://docs.renovatebot.com/configuration-options/#rust-toolchain",
+      "markdownDescription": "Configuration object for the rust-toolchain manager\n\nSee also: [rust-toolchain](https://docs.renovatebot.com/configuration-options/#rust-toolchain)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust",
+        "managerFilePatterns": ["/(^|/)rust-toolchain(\\.toml)?$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sbt": {
+      "$ref": "#",
+      "description": "Configuration object for the sbt manager\nSee also: https://docs.renovatebot.com/configuration-options/#sbt",
+      "markdownDescription": "Configuration object for the sbt manager\n\nSee also: [sbt](https://docs.renovatebot.com/configuration-options/#sbt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.sbt$/",
+          "/project/[^/]*\\.scala$/",
+          "/project/build\\.properties$/",
+          "/(^|/)repositories$/"
+        ],
+        "versioning": "ivy"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "scalafmt": {
+      "$ref": "#",
+      "description": "Configuration object for the scalafmt manager\nSee also: https://docs.renovatebot.com/configuration-options/#scalafmt",
+      "markdownDescription": "Configuration object for the scalafmt manager\n\nSee also: [scalafmt](https://docs.renovatebot.com/configuration-options/#scalafmt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.scalafmt.conf$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "schedule": {
+      "description": "Limit branch creation to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#schedule",
+      "markdownDescription": "Limit branch creation to these times of day or week.\n\nSee also: [schedule](https://docs.renovatebot.com/configuration-options/#schedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "semanticCommitScope": {
+      "description": "Commit scope to use if Semantic Commits are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommitscope",
+      "markdownDescription": "Commit scope to use if Semantic Commits are enabled.\n\nSee also: [semanticCommitScope](https://docs.renovatebot.com/configuration-options/#semanticcommitscope)",
+      "type": "string",
+      "default": "deps"
+    },
+    "semanticCommitType": {
+      "description": "Commit type to use if Semantic Commits is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommittype",
+      "markdownDescription": "Commit type to use if Semantic Commits is enabled.\n\nSee also: [semanticCommitType](https://docs.renovatebot.com/configuration-options/#semanticcommittype)",
+      "type": "string",
+      "default": "chore"
+    },
+    "semanticCommits": {
+      "description": "Enable Semantic Commit prefixes for commits and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommits",
+      "markdownDescription": "Enable Semantic Commit prefixes for commits and PR titles.\n\nSee also: [semanticCommits](https://docs.renovatebot.com/configuration-options/#semanticcommits)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "separateMajorMinor": {
+      "description": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemajorminor",
+      "markdownDescription": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\n\nSee also: [separateMajorMinor](https://docs.renovatebot.com/configuration-options/#separatemajorminor)",
+      "type": "boolean",
+      "default": true
+    },
+    "separateMinorPatch": {
+      "description": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separateminorpatch",
+      "markdownDescription": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\n\nSee also: [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMajor": {
+      "description": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultiplemajor",
+      "markdownDescription": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\n\nSee also: [separateMultipleMajor](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMinor": {
+      "description": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultipleminor",
+      "markdownDescription": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\n\nSee also: [separateMultipleMinor](https://docs.renovatebot.com/configuration-options/#separatemultipleminor)",
+      "type": "boolean",
+      "default": false
+    },
+    "setup-cfg": {
+      "$ref": "#",
+      "description": "Configuration object for the setup-cfg manager\nSee also: https://docs.renovatebot.com/configuration-options/#setup-cfg",
+      "markdownDescription": "Configuration object for the setup-cfg manager\n\nSee also: [setup-cfg](https://docs.renovatebot.com/configuration-options/#setup-cfg)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.cfg$/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "skipArtifactsUpdate": {
+      "description": "Skip Renovate's automatic artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#skipartifactsupdate",
+      "markdownDescription": "Skip Renovate's automatic artifact updating.\n\nSee also: [skipArtifactsUpdate](https://docs.renovatebot.com/configuration-options/#skipartifactsupdate)",
+      "type": "boolean",
+      "default": false
+    },
+    "skipInstalls": {
+      "description": "Skip installing modules/dependencies if lock file updating is possible without a full install.\nSee also: https://docs.renovatebot.com/configuration-options/#skipinstalls",
+      "markdownDescription": "Skip installing modules/dependencies if lock file updating is possible without a full install.\n\nSee also: [skipInstalls](https://docs.renovatebot.com/configuration-options/#skipinstalls)",
+      "type": ["boolean", "null"],
+      "default": null
+    },
+    "smithy": {
+      "$ref": "#",
+      "description": "Configuration object for the smithy manager\nSee also: https://docs.renovatebot.com/configuration-options/#smithy",
+      "markdownDescription": "Configuration object for the smithy manager\n\nSee also: [smithy](https://docs.renovatebot.com/configuration-options/#smithy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)smithy-build\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sourceDirectory": {
+      "description": "The source directory in which the package is present at its source.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory",
+      "markdownDescription": "The source directory in which the package is present at its source.\n\nSee also: [sourceDirectory](https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory)",
+      "type": "string"
+    },
+    "sourceUrl": {
+      "description": "The source URL of the package.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourceurl",
+      "markdownDescription": "The source URL of the package.\n\nSee also: [sourceUrl](https://docs.renovatebot.com/configuration-options/#packagerulessourceurl)",
+      "type": "string"
+    },
+    "statusCheckNames": {
+      "$ref": "#",
+      "description": "Custom strings to use as status check names.\nSee also: https://docs.renovatebot.com/configuration-options/#statuschecknames",
+      "markdownDescription": "Custom strings to use as status check names.\n\nSee also: [statusCheckNames](https://docs.renovatebot.com/configuration-options/#statuschecknames)",
+      "type": "object",
+      "default": {
+        "artifactError": "renovate/artifacts",
+        "configValidation": "renovate/config-validation",
+        "mergeConfidence": "renovate/merge-confidence",
+        "minimumReleaseAge": "renovate/stability-days"
+      }
+    },
+    "statusCheckWhen": {
+      "$ref": "#",
+      "description": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\nSee also: https://docs.renovatebot.com/configuration-options/#statuscheckwhen",
+      "markdownDescription": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\n\nSee also: [statusCheckWhen](https://docs.renovatebot.com/configuration-options/#statuscheckwhen)",
+      "type": "object",
+      "default": {
+        "artifactError": "failed",
+        "configValidation": "always",
+        "mergeConfidence": "always",
+        "minimumReleaseAge": "always"
+      }
+    },
+    "stopUpdatingLabel": {
+      "description": "Label to make Renovate stop updating a PR.\nSee also: https://docs.renovatebot.com/configuration-options/#stopupdatinglabel",
+      "markdownDescription": "Label to make Renovate stop updating a PR.\n\nSee also: [stopUpdatingLabel](https://docs.renovatebot.com/configuration-options/#stopupdatinglabel)",
+      "type": "string",
+      "default": "stop-updating"
+    },
+    "suppressNotifications": {
+      "description": "Options to suppress various types of warnings and other notifications.\nSee also: https://docs.renovatebot.com/configuration-options/#suppressnotifications",
+      "markdownDescription": "Options to suppress various types of warnings and other notifications.\n\nSee also: [suppressNotifications](https://docs.renovatebot.com/configuration-options/#suppressnotifications)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "artifactErrors",
+          "branchAutomergeFailure",
+          "configErrorIssue",
+          "dependencyLookupWarnings",
+          "lockFileErrors",
+          "missingCredentialsError",
+          "onboardingClose",
+          "prEditedNotification",
+          "prIgnoreNotification"
+        ]
+      },
+      "default": []
+    },
+    "sveltos": {
+      "$ref": "#",
+      "description": "Configuration object for the sveltos manager\nSee also: https://docs.renovatebot.com/configuration-options/#sveltos",
+      "markdownDescription": "Configuration object for the sveltos manager\n\nSee also: [sveltos](https://docs.renovatebot.com/configuration-options/#sveltos)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "swift": {
+      "$ref": "#",
+      "description": "Configuration object for the swift manager\nSee also: https://docs.renovatebot.com/configuration-options/#swift",
+      "markdownDescription": "Configuration object for the swift manager\n\nSee also: [swift](https://docs.renovatebot.com/configuration-options/#swift)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Package\\.swift/"],
+        "versioning": "swift",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tekton": {
+      "$ref": "#",
+      "description": "Configuration object for the tekton manager\nSee also: https://docs.renovatebot.com/configuration-options/#tekton",
+      "markdownDescription": "Configuration object for the tekton manager\n\nSee also: [tekton](https://docs.renovatebot.com/configuration-options/#tekton)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform",
+      "markdownDescription": "Configuration object for the terraform manager\n\nSee also: [terraform](https://docs.renovatebot.com/configuration-options/#terraform)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terraform {{depName}}",
+        "managerFilePatterns": ["**/*.tf", "**/*.tofu"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform-version",
+      "markdownDescription": "Configuration object for the terraform-version manager\n\nSee also: [terraform-version](https://docs.renovatebot.com/configuration-options/#terraform-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terraform-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt",
+      "markdownDescription": "Configuration object for the terragrunt manager\n\nSee also: [terragrunt](https://docs.renovatebot.com/configuration-options/#terragrunt)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terragrunt dependency {{depName}}",
+        "managerFilePatterns": ["/(^|/)terragrunt\\.hcl$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt-version",
+      "markdownDescription": "Configuration object for the terragrunt-version manager\n\nSee also: [terragrunt-version](https://docs.renovatebot.com/configuration-options/#terragrunt-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terragrunt-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.+)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tflint-plugin": {
+      "$ref": "#",
+      "description": "Configuration object for the tflint-plugin manager\nSee also: https://docs.renovatebot.com/configuration-options/#tflint-plugin",
+      "markdownDescription": "Configuration object for the tflint-plugin manager\n\nSee also: [tflint-plugin](https://docs.renovatebot.com/configuration-options/#tflint-plugin)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "TFLint plugin {{depName}}",
+        "managerFilePatterns": ["/\\.tflint\\.hcl$/"],
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "timeout": {
+      "description": "Timeout (in milliseconds) for queries to external endpoints.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulestimeout",
+      "markdownDescription": "Timeout (in milliseconds) for queries to external endpoints.\n\nSee also: [timeout](https://docs.renovatebot.com/configuration-options/#hostrulestimeout)",
+      "type": "integer"
+    },
+    "timezone": {
+      "description": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\nSee also: https://docs.renovatebot.com/configuration-options/#timezone",
+      "markdownDescription": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\n\nSee also: [timezone](https://docs.renovatebot.com/configuration-options/#timezone)",
+      "type": "string"
+    },
+    "toolSettings": {
+      "$ref": "#",
+      "description": "Tool specific configuration. Global self-hosted configuration takes precedence.\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettings",
+      "markdownDescription": "Tool specific configuration. Global self-hosted configuration takes precedence.\n\nSee also: [toolSettings](https://docs.renovatebot.com/configuration-options/#toolsettings)",
+      "type": "object",
+      "default": {
+        "jvmMaxMemory": 512,
+        "jvmMemory": 512
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "jvmMaxMemory": {
+                "$ref": "#/definitions/jvmMaxMemory"
+              },
+              "jvmMemory": {
+                "$ref": "#/definitions/jvmMemory"
+              },
+              "nodeMaxMemory": {
+                "$ref": "#/definitions/nodeMaxMemory"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "transformTemplates": {
+      "description": "List of jsonata transformation rules.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates",
+      "markdownDescription": "List of jsonata transformation rules.\n\nSee also: [transformTemplates](https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "travis": {
+      "$ref": "#",
+      "description": "Configuration object for the travis manager\nSee also: https://docs.renovatebot.com/configuration-options/#travis",
+      "markdownDescription": "Configuration object for the travis manager\n\nSee also: [travis](https://docs.renovatebot.com/configuration-options/#travis)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.travis\\.ya?ml$/"],
+        "major": {
+          "enabled": false
+        },
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "typst": {
+      "$ref": "#",
+      "description": "Configuration object for the typst manager\nSee also: https://docs.renovatebot.com/configuration-options/#typst",
+      "markdownDescription": "Configuration object for the typst manager\n\nSee also: [typst](https://docs.renovatebot.com/configuration-options/#typst)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.typ$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "unity3d": {
+      "$ref": "#",
+      "description": "Configuration object for the unity3d manager\nSee also: https://docs.renovatebot.com/configuration-options/#unity3d",
+      "markdownDescription": "Configuration object for the unity3d manager\n\nSee also: [unity3d](https://docs.renovatebot.com/configuration-options/#unity3d)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/ProjectSettings/ProjectVersion.txt"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "updateInternalDeps": {
+      "description": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\nSee also: https://docs.renovatebot.com/configuration-options/#updateinternaldeps",
+      "markdownDescription": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\n\nSee also: [updateInternalDeps](https://docs.renovatebot.com/configuration-options/#updateinternaldeps)",
+      "type": "boolean",
+      "default": false
+    },
+    "updateNotScheduled": {
+      "description": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\nSee also: https://docs.renovatebot.com/configuration-options/#updatenotscheduled",
+      "markdownDescription": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\n\nSee also: [updateNotScheduled](https://docs.renovatebot.com/configuration-options/#updatenotscheduled)",
+      "type": "boolean",
+      "default": true
+    },
+    "updatePinnedDependencies": {
+      "description": "Whether to update pinned (single version) dependencies or not.\nSee also: https://docs.renovatebot.com/configuration-options/#updatepinneddependencies",
+      "markdownDescription": "Whether to update pinned (single version) dependencies or not.\n\nSee also: [updatePinnedDependencies](https://docs.renovatebot.com/configuration-options/#updatepinneddependencies)",
+      "type": "boolean",
+      "default": true
+    },
+    "useBaseBranchConfig": {
+      "description": "Whether to read configuration from base branches instead of only the default branch.\nSee also: https://docs.renovatebot.com/configuration-options/#usebasebranchconfig",
+      "markdownDescription": "Whether to read configuration from base branches instead of only the default branch.\n\nSee also: [useBaseBranchConfig](https://docs.renovatebot.com/configuration-options/#usebasebranchconfig)",
+      "type": "string",
+      "enum": ["merge", "none"],
+      "default": "none"
+    },
+    "userStrings": {
+      "description": "User-facing strings for the Renovate comment when a PR is closed.\nSee also: https://docs.renovatebot.com/configuration-options/#userstrings",
+      "markdownDescription": "User-facing strings for the Renovate comment when a PR is closed.\n\nSee also: [userStrings](https://docs.renovatebot.com/configuration-options/#userstrings)",
+      "type": "object",
+      "default": {
+        "ignoreTopic": "Renovate Ignore Notification",
+        "ignoreMajor": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for *any* future `{{{newMajor}}}.x` releases. But if you manually upgrade to `{{{newMajor}}}.x` then Renovate will re-enable `minor` and `patch` updates automatically.",
+        "ignoreDigest": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for the `{{{depName}}}` `{{{newDigestShort}}}` update again.",
+        "ignoreOther": "Because you closed this PR without merging, Renovate will ignore this update (`{{{newValue}}}`). You will get a PR once a newer version is released. To ignore this dependency forever, add it to the `ignoreDeps` array of your Renovate config.",
+        "artifactErrorWarning": "You probably do not want to merge this PR as-is."
+      }
+    },
+    "velaci": {
+      "$ref": "#",
+      "description": "Configuration object for the velaci manager\nSee also: https://docs.renovatebot.com/configuration-options/#velaci",
+      "markdownDescription": "Configuration object for the velaci manager\n\nSee also: [velaci](https://docs.renovatebot.com/configuration-options/#velaci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.vela\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vendir": {
+      "$ref": "#",
+      "description": "Configuration object for the vendir manager\nSee also: https://docs.renovatebot.com/configuration-options/#vendir",
+      "markdownDescription": "Configuration object for the vendir manager\n\nSee also: [vendir](https://docs.renovatebot.com/configuration-options/#vendir)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "vendir {{depName}}",
+        "managerFilePatterns": ["/(^|/)vendir\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "versionCompatibility": {
+      "description": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#versioncompatibility",
+      "markdownDescription": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\n\nSee also: [versionCompatibility](https://docs.renovatebot.com/configuration-options/#versioncompatibility)",
+      "type": "string",
+      "format": "regex"
+    },
+    "versioning": {
+      "description": "Versioning to use for filtering and comparisons.\nSee also: https://docs.renovatebot.com/configuration-options/#versioning",
+      "markdownDescription": "Versioning to use for filtering and comparisons.\n\nSee also: [versioning](https://docs.renovatebot.com/configuration-options/#versioning)",
+      "type": "string",
+      "oneOf": [
+        {
+          "enum": [
+            "apk",
+            "aws-eks-addon",
+            "aws-machine-image",
+            "azure-rest-api",
+            "bazel-module",
+            "cargo",
+            "composer",
+            "conan",
+            "conda",
+            "deb",
+            "debian",
+            "deno",
+            "devbox",
+            "docker",
+            "elm",
+            "exact",
+            "git",
+            "github-actions",
+            "glasskube",
+            "go-mod-directive",
+            "gradle",
+            "hashicorp",
+            "helm",
+            "hermit",
+            "hex",
+            "ivy",
+            "kubernetes-api",
+            "lambda-node",
+            "loose",
+            "maven",
+            "nixpkgs",
+            "node",
+            "npm",
+            "nuget",
+            "paket",
+            "pep440",
+            "perl",
+            "poetry",
+            "pvp",
+            "python",
+            "redhat",
+            "regex",
+            "rez",
+            "rpm",
+            "ruby",
+            "rust-release-channel",
+            "same-major",
+            "semver",
+            "semver-coerced",
+            "semver-partial",
+            "swift",
+            "ubuntu",
+            "unity3d",
+            "unity3d-packages"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^regex:"
+        }
+      ]
+    },
+    "versioningTemplate": {
+      "description": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate",
+      "markdownDescription": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [versioningTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate)",
+      "type": "string"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#",
+      "description": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
+      "markdownDescription": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\n\nSee also: [vulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)",
+      "type": "object",
+      "default": {
+        "groupName": null,
+        "schedule": [],
+        "dependencyDashboardApproval": false,
+        "minimumReleaseAge": null,
+        "rangeStrategy": "update-lockfile",
+        "commitMessageSuffix": "[SECURITY]",
+        "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+        "prCreation": "immediate",
+        "vulnerabilityFixStrategy": "lowest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "vulnerabilityFixStrategy": {
+                "$ref": "#/definitions/vulnerabilityFixStrategy"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vulnerabilityFixStrategy": {
+      "description": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy",
+      "markdownDescription": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\n\nSee also: [vulnerabilityFixStrategy](https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy)",
+      "type": "string",
+      "enum": ["lowest", "highest"],
+      "default": "lowest"
+    },
+    "woodpecker": {
+      "$ref": "#",
+      "description": "Configuration object for the woodpecker manager\nSee also: https://docs.renovatebot.com/configuration-options/#woodpecker",
+      "markdownDescription": "Configuration object for the woodpecker manager\n\nSee also: [woodpecker](https://docs.renovatebot.com/configuration-options/#woodpecker)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.woodpecker(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "workingDirTemplate": {
+      "description": "A template describing the working directory in which post-upgrade tasks should be executed.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate",
+      "markdownDescription": "A template describing the working directory in which post-upgrade tasks should be executed.\n\nSee also: [workingDirTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate)",
+      "type": "string"
+    },
+    "xcodegen": {
+      "$ref": "#",
+      "description": "Configuration object for the xcodegen manager\nSee also: https://docs.renovatebot.com/configuration-options/#xcodegen",
+      "markdownDescription": "Configuration object for the xcodegen manager\n\nSee also: [xcodegen](https://docs.renovatebot.com/configuration-options/#xcodegen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/project.yml"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "abandonmentThreshold": {
+      "$ref": "#/definitions/abandonmentThreshold"
+    },
+    "addLabels": {
+      "$ref": "#/definitions/addLabels"
+    },
+    "additionalBranchPrefix": {
+      "$ref": "#/definitions/additionalBranchPrefix"
+    },
+    "additionalReviewers": {
+      "$ref": "#/definitions/additionalReviewers"
+    },
+    "ansible": {
+      "$ref": "#/definitions/ansible"
+    },
+    "ansible-galaxy": {
+      "$ref": "#/definitions/ansible-galaxy"
+    },
+    "ant": {
+      "$ref": "#/definitions/ant"
+    },
+    "argocd": {
+      "$ref": "#/definitions/argocd"
+    },
+    "asdf": {
+      "$ref": "#/definitions/asdf"
+    },
+    "assignAutomerge": {
+      "$ref": "#/definitions/assignAutomerge"
+    },
+    "assignees": {
+      "$ref": "#/definitions/assignees"
+    },
+    "assigneesFromCodeOwners": {
+      "$ref": "#/definitions/assigneesFromCodeOwners"
+    },
+    "assigneesSampleSize": {
+      "$ref": "#/definitions/assigneesSampleSize"
+    },
+    "autoApprove": {
+      "$ref": "#/definitions/autoApprove"
+    },
+    "autoReplaceGlobalMatch": {
+      "$ref": "#/definitions/autoReplaceGlobalMatch"
+    },
+    "automerge": {
+      "$ref": "#/definitions/automerge"
+    },
+    "automergeComment": {
+      "$ref": "#/definitions/automergeComment"
+    },
+    "automergeSchedule": {
+      "$ref": "#/definitions/automergeSchedule"
+    },
+    "automergeStrategy": {
+      "$ref": "#/definitions/automergeStrategy"
+    },
+    "automergeType": {
+      "$ref": "#/definitions/automergeType"
+    },
+    "azure-pipelines": {
+      "$ref": "#/definitions/azure-pipelines"
+    },
+    "azureWorkItemId": {
+      "$ref": "#/definitions/azureWorkItemId"
+    },
+    "azureWorkItemType": {
+      "$ref": "#/definitions/azureWorkItemType"
+    },
+    "baseBranchPatterns": {
+      "$ref": "#/definitions/baseBranchPatterns"
+    },
+    "batect": {
+      "$ref": "#/definitions/batect"
+    },
+    "batect-wrapper": {
+      "$ref": "#/definitions/batect-wrapper"
+    },
+    "bazel": {
+      "$ref": "#/definitions/bazel"
+    },
+    "bazel-module": {
+      "$ref": "#/definitions/bazel-module"
+    },
+    "bazelisk": {
+      "$ref": "#/definitions/bazelisk"
+    },
+    "bbAutoResolvePrTasks": {
+      "$ref": "#/definitions/bbAutoResolvePrTasks"
+    },
+    "bbUseDefaultReviewers": {
+      "$ref": "#/definitions/bbUseDefaultReviewers"
+    },
+    "bicep": {
+      "$ref": "#/definitions/bicep"
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#/definitions/bitbucket-pipelines"
+    },
+    "bitrise": {
+      "$ref": "#/definitions/bitrise"
+    },
+    "branchConcurrentLimit": {
+      "$ref": "#/definitions/branchConcurrentLimit"
+    },
+    "branchName": {
+      "$ref": "#/definitions/branchName"
+    },
+    "branchNameStrict": {
+      "$ref": "#/definitions/branchNameStrict"
+    },
+    "branchPrefix": {
+      "$ref": "#/definitions/branchPrefix"
+    },
+    "branchPrefixOld": {
+      "$ref": "#/definitions/branchPrefixOld"
+    },
+    "branchTopic": {
+      "$ref": "#/definitions/branchTopic"
+    },
+    "buildkite": {
+      "$ref": "#/definitions/buildkite"
+    },
+    "buildpacks": {
+      "$ref": "#/definitions/buildpacks"
+    },
+    "bumpVersion": {
+      "$ref": "#/definitions/bumpVersion"
+    },
+    "bumpVersions": {
+      "$ref": "#/definitions/bumpVersions"
+    },
+    "bun": {
+      "$ref": "#/definitions/bun"
+    },
+    "bun-version": {
+      "$ref": "#/definitions/bun-version"
+    },
+    "bundler": {
+      "$ref": "#/definitions/bundler"
+    },
+    "cake": {
+      "$ref": "#/definitions/cake"
+    },
+    "cargo": {
+      "$ref": "#/definitions/cargo"
+    },
+    "cdnurl": {
+      "$ref": "#/definitions/cdnurl"
+    },
+    "circleci": {
+      "$ref": "#/definitions/circleci"
+    },
+    "cloneSubmodules": {
+      "$ref": "#/definitions/cloneSubmodules"
+    },
+    "cloneSubmodulesFilter": {
+      "$ref": "#/definitions/cloneSubmodulesFilter"
+    },
+    "cloudbuild": {
+      "$ref": "#/definitions/cloudbuild"
+    },
+    "cocoapods": {
+      "$ref": "#/definitions/cocoapods"
+    },
+    "commitBody": {
+      "$ref": "#/definitions/commitBody"
+    },
+    "commitBodyTable": {
+      "$ref": "#/definitions/commitBodyTable"
+    },
+    "commitHourlyLimit": {
+      "$ref": "#/definitions/commitHourlyLimit"
+    },
+    "commitMessage": {
+      "$ref": "#/definitions/commitMessage"
+    },
+    "commitMessageAction": {
+      "$ref": "#/definitions/commitMessageAction"
+    },
+    "commitMessageExtra": {
+      "$ref": "#/definitions/commitMessageExtra"
+    },
+    "commitMessageLowerCase": {
+      "$ref": "#/definitions/commitMessageLowerCase"
+    },
+    "commitMessagePrefix": {
+      "$ref": "#/definitions/commitMessagePrefix"
+    },
+    "commitMessageSuffix": {
+      "$ref": "#/definitions/commitMessageSuffix"
+    },
+    "commitMessageTopic": {
+      "$ref": "#/definitions/commitMessageTopic"
+    },
+    "commitTrailers": {
+      "$ref": "#/definitions/commitTrailers"
+    },
+    "composer": {
+      "$ref": "#/definitions/composer"
+    },
+    "composerIgnorePlatformReqs": {
+      "$ref": "#/definitions/composerIgnorePlatformReqs"
+    },
+    "conan": {
+      "$ref": "#/definitions/conan"
+    },
+    "confidential": {
+      "$ref": "#/definitions/confidential"
+    },
+    "configMigration": {
+      "$ref": "#/definitions/configMigration"
+    },
+    "configWarningReuseIssue": {
+      "$ref": "#/definitions/configWarningReuseIssue"
+    },
+    "constraints": {
+      "$ref": "#/definitions/constraints"
+    },
+    "constraintsFiltering": {
+      "$ref": "#/definitions/constraintsFiltering"
+    },
+    "constraintsVersioning": {
+      "$ref": "#/definitions/constraintsVersioning"
+    },
+    "copier": {
+      "$ref": "#/definitions/copier"
+    },
+    "cpanfile": {
+      "$ref": "#/definitions/cpanfile"
+    },
+    "crossplane": {
+      "$ref": "#/definitions/crossplane"
+    },
+    "crow": {
+      "$ref": "#/definitions/crow"
+    },
+    "customDatasources": {
+      "$ref": "#/definitions/customDatasources"
+    },
+    "customManagers": {
+      "$ref": "#/definitions/customManagers"
+    },
+    "customizeDashboard": {
+      "$ref": "#/definitions/customizeDashboard"
+    },
+    "defaultRegistryUrls": {
+      "$ref": "#/definitions/defaultRegistryUrls"
+    },
+    "deno": {
+      "$ref": "#/definitions/deno"
+    },
+    "dependencyDashboard": {
+      "$ref": "#/definitions/dependencyDashboard"
+    },
+    "dependencyDashboardApproval": {
+      "$ref": "#/definitions/dependencyDashboardApproval"
+    },
+    "dependencyDashboardAutoclose": {
+      "$ref": "#/definitions/dependencyDashboardAutoclose"
+    },
+    "dependencyDashboardCategory": {
+      "$ref": "#/definitions/dependencyDashboardCategory"
+    },
+    "dependencyDashboardFooter": {
+      "$ref": "#/definitions/dependencyDashboardFooter"
+    },
+    "dependencyDashboardHeader": {
+      "$ref": "#/definitions/dependencyDashboardHeader"
+    },
+    "dependencyDashboardLabels": {
+      "$ref": "#/definitions/dependencyDashboardLabels"
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "$ref": "#/definitions/dependencyDashboardOSVVulnerabilitySummary"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "$ref": "#/definitions/dependencyDashboardReportAbandonment"
+    },
+    "dependencyDashboardTitle": {
+      "$ref": "#/definitions/dependencyDashboardTitle"
+    },
+    "deps-edn": {
+      "$ref": "#/definitions/deps-edn"
+    },
+    "description": {
+      "$ref": "#/definitions/description"
+    },
+    "devbox": {
+      "$ref": "#/definitions/devbox"
+    },
+    "devcontainer": {
+      "$ref": "#/definitions/devcontainer"
+    },
+    "digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "docker-compose": {
+      "$ref": "#/definitions/docker-compose"
+    },
+    "dockerfile": {
+      "$ref": "#/definitions/dockerfile"
+    },
+    "draftPR": {
+      "$ref": "#/definitions/draftPR"
+    },
+    "droneci": {
+      "$ref": "#/definitions/droneci"
+    },
+    "enabled": {
+      "$ref": "#/definitions/enabled"
+    },
+    "enabledManagers": {
+      "$ref": "#/definitions/enabledManagers"
+    },
+    "encrypted": {
+      "$ref": "#/definitions/encrypted"
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "excludeCommitPaths": {
+      "$ref": "#/definitions/excludeCommitPaths"
+    },
+    "expandCodeOwnersGroups": {
+      "$ref": "#/definitions/expandCodeOwnersGroups"
+    },
+    "extends": {
+      "$ref": "#/definitions/extends"
+    },
+    "extractVersion": {
+      "$ref": "#/definitions/extractVersion"
+    },
+    "fetchChangeLogs": {
+      "$ref": "#/definitions/fetchChangeLogs"
+    },
+    "filterUnavailableUsers": {
+      "$ref": "#/definitions/filterUnavailableUsers"
+    },
+    "fleet": {
+      "$ref": "#/definitions/fleet"
+    },
+    "flux": {
+      "$ref": "#/definitions/flux"
+    },
+    "followTag": {
+      "$ref": "#/definitions/followTag"
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "$ref": "#/definitions/forkModeDisallowMaintainerEdits"
+    },
+    "forkProcessing": {
+      "$ref": "#/definitions/forkProcessing"
+    },
+    "fvm": {
+      "$ref": "#/definitions/fvm"
+    },
+    "git-submodules": {
+      "$ref": "#/definitions/git-submodules"
+    },
+    "gitAuthor": {
+      "$ref": "#/definitions/gitAuthor"
+    },
+    "gitIgnoredAuthors": {
+      "$ref": "#/definitions/gitIgnoredAuthors"
+    },
+    "gitLabIgnoreApprovals": {
+      "$ref": "#/definitions/gitLabIgnoreApprovals"
+    },
+    "github-actions": {
+      "$ref": "#/definitions/github-actions"
+    },
+    "gitlabci": {
+      "$ref": "#/definitions/gitlabci"
+    },
+    "gitlabci-include": {
+      "$ref": "#/definitions/gitlabci-include"
+    },
+    "glasskube": {
+      "$ref": "#/definitions/glasskube"
+    },
+    "gleam": {
+      "$ref": "#/definitions/gleam"
+    },
+    "goGetDirs": {
+      "$ref": "#/definitions/goGetDirs"
+    },
+    "gomod": {
+      "$ref": "#/definitions/gomod"
+    },
+    "gradle": {
+      "$ref": "#/definitions/gradle"
+    },
+    "gradle-wrapper": {
+      "$ref": "#/definitions/gradle-wrapper"
+    },
+    "group": {
+      "$ref": "#/definitions/group"
+    },
+    "groupName": {
+      "$ref": "#/definitions/groupName"
+    },
+    "groupSingleUpdates": {
+      "$ref": "#/definitions/groupSingleUpdates"
+    },
+    "groupSlug": {
+      "$ref": "#/definitions/groupSlug"
+    },
+    "hashedBranchLength": {
+      "$ref": "#/definitions/hashedBranchLength"
+    },
+    "haskell-cabal": {
+      "$ref": "#/definitions/haskell-cabal"
+    },
+    "helm-requirements": {
+      "$ref": "#/definitions/helm-requirements"
+    },
+    "helm-values": {
+      "$ref": "#/definitions/helm-values"
+    },
+    "helmfile": {
+      "$ref": "#/definitions/helmfile"
+    },
+    "helmsman": {
+      "$ref": "#/definitions/helmsman"
+    },
+    "helmv3": {
+      "$ref": "#/definitions/helmv3"
+    },
+    "hermit": {
+      "$ref": "#/definitions/hermit"
+    },
+    "homeassistant-manifest": {
+      "$ref": "#/definitions/homeassistant-manifest"
+    },
+    "homebrew": {
+      "$ref": "#/definitions/homebrew"
+    },
+    "hostRules": {
+      "$ref": "#/definitions/hostRules"
+    },
+    "html": {
+      "$ref": "#/definitions/html"
+    },
+    "ignoreDeprecated": {
+      "$ref": "#/definitions/ignoreDeprecated"
+    },
+    "ignoreDeps": {
+      "$ref": "#/definitions/ignoreDeps"
+    },
+    "ignorePaths": {
+      "$ref": "#/definitions/ignorePaths"
+    },
+    "ignorePlugins": {
+      "$ref": "#/definitions/ignorePlugins"
+    },
+    "ignorePresets": {
+      "$ref": "#/definitions/ignorePresets"
+    },
+    "ignoreReviewers": {
+      "$ref": "#/definitions/ignoreReviewers"
+    },
+    "ignoreScripts": {
+      "$ref": "#/definitions/ignoreScripts"
+    },
+    "ignoreTests": {
+      "$ref": "#/definitions/ignoreTests"
+    },
+    "ignoreUnstable": {
+      "$ref": "#/definitions/ignoreUnstable"
+    },
+    "includePaths": {
+      "$ref": "#/definitions/includePaths"
+    },
+    "internalChecksAsSuccess": {
+      "$ref": "#/definitions/internalChecksAsSuccess"
+    },
+    "internalChecksFilter": {
+      "$ref": "#/definitions/internalChecksFilter"
+    },
+    "jenkins": {
+      "$ref": "#/definitions/jenkins"
+    },
+    "jsonata": {
+      "$ref": "#/definitions/jsonata"
+    },
+    "jsonnet-bundler": {
+      "$ref": "#/definitions/jsonnet-bundler"
+    },
+    "keepUpdatedLabel": {
+      "$ref": "#/definitions/keepUpdatedLabel"
+    },
+    "kotlin-script": {
+      "$ref": "#/definitions/kotlin-script"
+    },
+    "kubernetes": {
+      "$ref": "#/definitions/kubernetes"
+    },
+    "kustomize": {
+      "$ref": "#/definitions/kustomize"
+    },
+    "labels": {
+      "$ref": "#/definitions/labels"
+    },
+    "leiningen": {
+      "$ref": "#/definitions/leiningen"
+    },
+    "lockFileMaintenance": {
+      "$ref": "#/definitions/lockFileMaintenance"
+    },
+    "logLevelRemap": {
+      "$ref": "#/definitions/logLevelRemap"
+    },
+    "major": {
+      "$ref": "#/definitions/major"
+    },
+    "maven": {
+      "$ref": "#/definitions/maven"
+    },
+    "maven-wrapper": {
+      "$ref": "#/definitions/maven-wrapper"
+    },
+    "maxMajorIncrement": {
+      "$ref": "#/definitions/maxMajorIncrement"
+    },
+    "meteor": {
+      "$ref": "#/definitions/meteor"
+    },
+    "milestone": {
+      "$ref": "#/definitions/milestone"
+    },
+    "minimumGroupSize": {
+      "$ref": "#/definitions/minimumGroupSize"
+    },
+    "minimumReleaseAge": {
+      "$ref": "#/definitions/minimumReleaseAge"
+    },
+    "minimumReleaseAgeBehaviour": {
+      "$ref": "#/definitions/minimumReleaseAgeBehaviour"
+    },
+    "minor": {
+      "$ref": "#/definitions/minor"
+    },
+    "mint": {
+      "$ref": "#/definitions/mint"
+    },
+    "mise": {
+      "$ref": "#/definitions/mise"
+    },
+    "mix": {
+      "$ref": "#/definitions/mix"
+    },
+    "mode": {
+      "$ref": "#/definitions/mode"
+    },
+    "nix": {
+      "$ref": "#/definitions/nix"
+    },
+    "nodenv": {
+      "$ref": "#/definitions/nodenv"
+    },
+    "npm": {
+      "$ref": "#/definitions/npm"
+    },
+    "npmToken": {
+      "$ref": "#/definitions/npmToken"
+    },
+    "npmrc": {
+      "$ref": "#/definitions/npmrc"
+    },
+    "npmrcMerge": {
+      "$ref": "#/definitions/npmrcMerge"
+    },
+    "nuget": {
+      "$ref": "#/definitions/nuget"
+    },
+    "nvm": {
+      "$ref": "#/definitions/nvm"
+    },
+    "ocb": {
+      "$ref": "#/definitions/ocb"
+    },
+    "osgi": {
+      "$ref": "#/definitions/osgi"
+    },
+    "osvVulnerabilityAlerts": {
+      "$ref": "#/definitions/osvVulnerabilityAlerts"
+    },
+    "packageRules": {
+      "$ref": "#/definitions/packageRules"
+    },
+    "patch": {
+      "$ref": "#/definitions/patch"
+    },
+    "pep621": {
+      "$ref": "#/definitions/pep621"
+    },
+    "pep723": {
+      "$ref": "#/definitions/pep723"
+    },
+    "pin": {
+      "$ref": "#/definitions/pin"
+    },
+    "pinDigest": {
+      "$ref": "#/definitions/pinDigest"
+    },
+    "pinDigests": {
+      "$ref": "#/definitions/pinDigests"
+    },
+    "pip-compile": {
+      "$ref": "#/definitions/pip-compile"
+    },
+    "pip_requirements": {
+      "$ref": "#/definitions/pip_requirements"
+    },
+    "pip_setup": {
+      "$ref": "#/definitions/pip_setup"
+    },
+    "pipenv": {
+      "$ref": "#/definitions/pipenv"
+    },
+    "pixi": {
+      "$ref": "#/definitions/pixi"
+    },
+    "platformAutomerge": {
+      "$ref": "#/definitions/platformAutomerge"
+    },
+    "platformCommit": {
+      "$ref": "#/definitions/platformCommit"
+    },
+    "poetry": {
+      "$ref": "#/definitions/poetry"
+    },
+    "postUpdateOptions": {
+      "$ref": "#/definitions/postUpdateOptions"
+    },
+    "postUpgradeTasks": {
+      "$ref": "#/definitions/postUpgradeTasks"
+    },
+    "prBodyColumns": {
+      "$ref": "#/definitions/prBodyColumns"
+    },
+    "prBodyDefinitions": {
+      "$ref": "#/definitions/prBodyDefinitions"
+    },
+    "prBodyHeadingDefinitions": {
+      "$ref": "#/definitions/prBodyHeadingDefinitions"
+    },
+    "prBodyNotes": {
+      "$ref": "#/definitions/prBodyNotes"
+    },
+    "prBodyTemplate": {
+      "$ref": "#/definitions/prBodyTemplate"
+    },
+    "prConcurrentLimit": {
+      "$ref": "#/definitions/prConcurrentLimit"
+    },
+    "prCreation": {
+      "$ref": "#/definitions/prCreation"
+    },
+    "prFooter": {
+      "$ref": "#/definitions/prFooter"
+    },
+    "prHeader": {
+      "$ref": "#/definitions/prHeader"
+    },
+    "prHourlyLimit": {
+      "$ref": "#/definitions/prHourlyLimit"
+    },
+    "prNotPendingHours": {
+      "$ref": "#/definitions/prNotPendingHours"
+    },
+    "prTitle": {
+      "$ref": "#/definitions/prTitle"
+    },
+    "prTitleStrict": {
+      "$ref": "#/definitions/prTitleStrict"
+    },
+    "pre-commit": {
+      "$ref": "#/definitions/pre-commit"
+    },
+    "printConfig": {
+      "$ref": "#/definitions/printConfig"
+    },
+    "proto": {
+      "$ref": "#/definitions/proto"
+    },
+    "pruneBranchAfterAutomerge": {
+      "$ref": "#/definitions/pruneBranchAfterAutomerge"
+    },
+    "pruneStaleBranches": {
+      "$ref": "#/definitions/pruneStaleBranches"
+    },
+    "pub": {
+      "$ref": "#/definitions/pub"
+    },
+    "puppet": {
+      "$ref": "#/definitions/puppet"
+    },
+    "pyenv": {
+      "$ref": "#/definitions/pyenv"
+    },
+    "quadlet": {
+      "$ref": "#/definitions/quadlet"
+    },
+    "rangeStrategy": {
+      "$ref": "#/definitions/rangeStrategy"
+    },
+    "rebaseLabel": {
+      "$ref": "#/definitions/rebaseLabel"
+    },
+    "rebaseWhen": {
+      "$ref": "#/definitions/rebaseWhen"
+    },
+    "recreateWhen": {
+      "$ref": "#/definitions/recreateWhen"
+    },
+    "regex": {
+      "$ref": "#/definitions/regex"
+    },
+    "registryAliases": {
+      "$ref": "#/definitions/registryAliases"
+    },
+    "registryUrls": {
+      "$ref": "#/definitions/registryUrls"
+    },
+    "renovate-config": {
+      "$ref": "#/definitions/renovate-config"
+    },
+    "replacement": {
+      "$ref": "#/definitions/replacement"
+    },
+    "replacementApproach": {
+      "$ref": "#/definitions/replacementApproach"
+    },
+    "respectLatest": {
+      "$ref": "#/definitions/respectLatest"
+    },
+    "reviewers": {
+      "$ref": "#/definitions/reviewers"
+    },
+    "reviewersFromCodeOwners": {
+      "$ref": "#/definitions/reviewersFromCodeOwners"
+    },
+    "reviewersSampleSize": {
+      "$ref": "#/definitions/reviewersSampleSize"
+    },
+    "rollback": {
+      "$ref": "#/definitions/rollback"
+    },
+    "rollbackPrs": {
+      "$ref": "#/definitions/rollbackPrs"
+    },
+    "ruby-version": {
+      "$ref": "#/definitions/ruby-version"
+    },
+    "runtime-version": {
+      "$ref": "#/definitions/runtime-version"
+    },
+    "rust-toolchain": {
+      "$ref": "#/definitions/rust-toolchain"
+    },
+    "sbt": {
+      "$ref": "#/definitions/sbt"
+    },
+    "scalafmt": {
+      "$ref": "#/definitions/scalafmt"
+    },
+    "schedule": {
+      "$ref": "#/definitions/schedule"
+    },
+    "semanticCommitScope": {
+      "$ref": "#/definitions/semanticCommitScope"
+    },
+    "semanticCommitType": {
+      "$ref": "#/definitions/semanticCommitType"
+    },
+    "semanticCommits": {
+      "$ref": "#/definitions/semanticCommits"
+    },
+    "separateMajorMinor": {
+      "$ref": "#/definitions/separateMajorMinor"
+    },
+    "separateMinorPatch": {
+      "$ref": "#/definitions/separateMinorPatch"
+    },
+    "separateMultipleMajor": {
+      "$ref": "#/definitions/separateMultipleMajor"
+    },
+    "separateMultipleMinor": {
+      "$ref": "#/definitions/separateMultipleMinor"
+    },
+    "setup-cfg": {
+      "$ref": "#/definitions/setup-cfg"
+    },
+    "skipArtifactsUpdate": {
+      "$ref": "#/definitions/skipArtifactsUpdate"
+    },
+    "skipInstalls": {
+      "$ref": "#/definitions/skipInstalls"
+    },
+    "smithy": {
+      "$ref": "#/definitions/smithy"
+    },
+    "statusCheckNames": {
+      "$ref": "#/definitions/statusCheckNames"
+    },
+    "statusCheckWhen": {
+      "$ref": "#/definitions/statusCheckWhen"
+    },
+    "stopUpdatingLabel": {
+      "$ref": "#/definitions/stopUpdatingLabel"
+    },
+    "suppressNotifications": {
+      "$ref": "#/definitions/suppressNotifications"
+    },
+    "sveltos": {
+      "$ref": "#/definitions/sveltos"
+    },
+    "swift": {
+      "$ref": "#/definitions/swift"
+    },
+    "tekton": {
+      "$ref": "#/definitions/tekton"
+    },
+    "terraform": {
+      "$ref": "#/definitions/terraform"
+    },
+    "terraform-version": {
+      "$ref": "#/definitions/terraform-version"
+    },
+    "terragrunt": {
+      "$ref": "#/definitions/terragrunt"
+    },
+    "terragrunt-version": {
+      "$ref": "#/definitions/terragrunt-version"
+    },
+    "tflint-plugin": {
+      "$ref": "#/definitions/tflint-plugin"
+    },
+    "timezone": {
+      "$ref": "#/definitions/timezone"
+    },
+    "toolSettings": {
+      "$ref": "#/definitions/toolSettings"
+    },
+    "travis": {
+      "$ref": "#/definitions/travis"
+    },
+    "typst": {
+      "$ref": "#/definitions/typst"
+    },
+    "unity3d": {
+      "$ref": "#/definitions/unity3d"
+    },
+    "updateInternalDeps": {
+      "$ref": "#/definitions/updateInternalDeps"
+    },
+    "updateNotScheduled": {
+      "$ref": "#/definitions/updateNotScheduled"
+    },
+    "updatePinnedDependencies": {
+      "$ref": "#/definitions/updatePinnedDependencies"
+    },
+    "useBaseBranchConfig": {
+      "$ref": "#/definitions/useBaseBranchConfig"
+    },
+    "userStrings": {
+      "$ref": "#/definitions/userStrings"
+    },
+    "velaci": {
+      "$ref": "#/definitions/velaci"
+    },
+    "vendir": {
+      "$ref": "#/definitions/vendir"
+    },
+    "versionCompatibility": {
+      "$ref": "#/definitions/versionCompatibility"
+    },
+    "versioning": {
+      "$ref": "#/definitions/versioning"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#/definitions/vulnerabilityAlerts"
+    },
+    "woodpecker": {
+      "$ref": "#/definitions/woodpecker"
+    },
+    "xcodegen": {
+      "$ref": "#/definitions/xcodegen"
+    }
+  },
+  "not": {
+    "anyOf": [
+      {
+        "required": ["allowedHeaders"]
+      },
+      {
+        "required": ["autodiscoverRepoOrder"]
+      },
+      {
+        "required": ["autodiscoverRepoSort"]
+      },
+      {
+        "required": ["allowedEnv"]
+      },
+      {
+        "required": ["detectGlobalManagerConfig"]
+      },
+      {
+        "required": ["detectHostRulesFromEnv"]
+      },
+      {
+        "required": ["mergeConfidenceEndpoint"]
+      },
+      {
+        "required": ["mergeConfidenceDatasources"]
+      },
+      {
+        "required": ["useCloudMetadataServices"]
+      },
+      {
+        "required": ["userAgent"]
+      },
+      {
+        "required": ["allowedCommands"]
+      },
+      {
+        "required": ["onboardingBranch"]
+      },
+      {
+        "required": ["onboardingAutoCloseAge"]
+      },
+      {
+        "required": ["onboardingCommitMessage"]
+      },
+      {
+        "required": ["configFileNames"]
+      },
+      {
+        "required": ["onboardingConfigFileName"]
+      },
+      {
+        "required": ["onboardingNoDeps"]
+      },
+      {
+        "required": ["onboardingPrTitle"]
+      },
+      {
+        "required": ["productLinks"]
+      },
+      {
+        "required": ["secrets"]
+      },
+      {
+        "required": ["variables"]
+      },
+      {
+        "required": ["migratePresets"]
+      },
+      {
+        "required": ["presetCachePersistence"]
+      },
+      {
+        "required": ["globalExtends"]
+      },
+      {
+        "required": ["repositoryCache"]
+      },
+      {
+        "required": ["repositoryCacheType"]
+      },
+      {
+        "required": ["repositoryCacheForceLocal"]
+      },
+      {
+        "required": ["reportType"]
+      },
+      {
+        "required": ["reportPath"]
+      },
+      {
+        "required": ["reportFormatting"]
+      },
+      {
+        "required": ["force"]
+      },
+      {
+        "required": ["forceCli"]
+      },
+      {
+        "required": ["dryRun"]
+      },
+      {
+        "required": ["binarySource"]
+      },
+      {
+        "required": ["redisUrl"]
+      },
+      {
+        "required": ["redisPrefix"]
+      },
+      {
+        "required": ["baseDir"]
+      },
+      {
+        "required": ["cacheDir"]
+      },
+      {
+        "required": ["containerbaseDir"]
+      },
+      {
+        "required": ["customEnvVariables"]
+      },
+      {
+        "required": ["dockerChildPrefix"]
+      },
+      {
+        "required": ["dockerCliOptions"]
+      },
+      {
+        "required": ["dockerSidecarImage"]
+      },
+      {
+        "required": ["dockerUser"]
+      },
+      {
+        "required": ["logContext"]
+      },
+      {
+        "required": ["onboarding"]
+      },
+      {
+        "required": ["onboardingConfig"]
+      },
+      {
+        "required": ["onboardingRebaseCheckbox"]
+      },
+      {
+        "required": ["includeMirrors"]
+      },
+      {
+        "required": ["forkCreation"]
+      },
+      {
+        "required": ["forkToken"]
+      },
+      {
+        "required": ["forkOrg"]
+      },
+      {
+        "required": ["githubTokenWarn"]
+      },
+      {
+        "required": ["encryptedWarning"]
+      },
+      {
+        "required": ["inheritConfig"]
+      },
+      {
+        "required": ["inheritConfigRepoName"]
+      },
+      {
+        "required": ["inheritConfigFileName"]
+      },
+      {
+        "required": ["inheritConfigStrict"]
+      },
+      {
+        "required": ["requireConfig"]
+      },
+      {
+        "required": ["optimizeForDisabled"]
+      },
+      {
+        "required": ["privateKey"]
+      },
+      {
+        "required": ["privateKeyOld"]
+      },
+      {
+        "required": ["privateKeyPath"]
+      },
+      {
+        "required": ["privateKeyPathOld"]
+      },
+      {
+        "required": ["persistRepoData"]
+      },
+      {
+        "required": ["exposeAllEnv"]
+      },
+      {
+        "required": ["allowPlugins"]
+      },
+      {
+        "required": ["allowScripts"]
+      },
+      {
+        "required": ["allowShellExecutorForPostUpgradeCommands"]
+      },
+      {
+        "required": ["allowCustomCrateRegistries"]
+      },
+      {
+        "required": ["platform"]
+      },
+      {
+        "required": ["endpoint"]
+      },
+      {
+        "required": ["token"]
+      },
+      {
+        "required": ["username"]
+      },
+      {
+        "required": ["password"]
+      },
+      {
+        "required": ["autodiscover"]
+      },
+      {
+        "required": ["autodiscoverFilter"]
+      },
+      {
+        "required": ["autodiscoverNamespaces"]
+      },
+      {
+        "required": ["autodiscoverProjects"]
+      },
+      {
+        "required": ["autodiscoverTopics"]
+      },
+      {
+        "required": ["prCommitsPerRunLimit"]
+      },
+      {
+        "required": ["repositories"]
+      },
+      {
+        "required": ["gitPrivateKey"]
+      },
+      {
+        "required": ["gitPrivateKeyPassphrase"]
+      },
+      {
+        "required": ["gitTimeout"]
+      },
+      {
+        "required": ["executionTimeout"]
+      },
+      {
+        "required": ["processEnv"]
+      },
+      {
+        "required": ["bbUseDevelopmentBranch"]
+      },
+      {
+        "required": ["cacheHardTtlMinutes"]
+      },
+      {
+        "required": ["cacheTtlOverride"]
+      },
+      {
+        "required": ["unicodeEmoji"]
+      },
+      {
+        "required": ["ignorePrAuthor"]
+      },
+      {
+        "required": ["allowedUnsafeExecutions"]
+      },
+      {
+        "required": ["gitNoVerify"]
+      },
+      {
+        "required": ["gitUrl"]
+      },
+      {
+        "required": ["writeDiscoveredRepos"]
+      },
+      {
+        "required": ["checkedBranches"]
+      },
+      {
+        "required": ["rebaseAllOpenBranches"]
+      },
+      {
+        "required": ["httpCacheTtlDays"]
+      },
+      {
+        "required": ["prCacheSyncMaxPages"]
+      },
+      {
+        "required": ["dockerMaxPages"]
+      },
+      {
+        "required": ["deleteConfigFile"]
+      },
+      {
+        "required": ["deleteAdditionalConfigFile"]
+      },
+      {
+        "required": ["s3Endpoint"]
+      },
+      {
+        "required": ["s3PathStyle"]
+      },
+      {
+        "required": ["cachePrivatePackages"]
+      },
+      {
+        "required": ["configValidationError"]
+      }
+    ]
+  }
+}

--- a/src/schemas/json/renovate-global-schema-43.json
+++ b/src/schemas/json/renovate-global-schema-43.json
@@ -1,0 +1,10079 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/renovate-global-schema-43.json",
+  "title": "JSON schema for Renovate 43.288.0 global self-hosting configuration (https://renovatebot.com/)",
+  "x-renovate-version": "43.288.0",
+  "allowComments": true,
+  "type": "object",
+  "definitions": {
+    "abandonmentThreshold": {
+      "description": "Flags packages that have not been updated within this period as abandoned.\nSee also: https://docs.renovatebot.com/configuration-options/#abandonmentthreshold",
+      "markdownDescription": "Flags packages that have not been updated within this period as abandoned.\n\nSee also: [abandonmentThreshold](https://docs.renovatebot.com/configuration-options/#abandonmentthreshold)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "abortIgnoreStatusCodes": {
+      "description": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes",
+      "markdownDescription": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\n\nSee also: [abortIgnoreStatusCodes](https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes)",
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "abortOnError": {
+      "description": "If enabled, Renovate aborts its run when HTTP request errors occur.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror",
+      "markdownDescription": "If enabled, Renovate aborts its run when HTTP request errors occur.\n\nSee also: [abortOnError](https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror)",
+      "type": "boolean",
+      "default": false
+    },
+    "addLabels": {
+      "description": "Labels to add to Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#addlabels",
+      "markdownDescription": "Labels to add to Pull Request.\n\nSee also: [addLabels](https://docs.renovatebot.com/configuration-options/#addlabels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additionalBranchPrefix": {
+      "description": "Additional string value to be appended to `branchPrefix`.\nSee also: https://docs.renovatebot.com/configuration-options/#additionalbranchprefix",
+      "markdownDescription": "Additional string value to be appended to `branchPrefix`.\n\nSee also: [additionalBranchPrefix](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix)",
+      "type": "string",
+      "default": ""
+    },
+    "additionalReviewers": {
+      "description": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\nSee also: https://docs.renovatebot.com/configuration-options/#additionalreviewers",
+      "markdownDescription": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\n\nSee also: [additionalReviewers](https://docs.renovatebot.com/configuration-options/#additionalreviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "allowCustomCrateRegistries": {
+      "description": "Set this to `true` to allow custom crate registries.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowcustomcrateregistries",
+      "markdownDescription": "Set this to `true` to allow custom crate registries.\n\nSee also: [allowCustomCrateRegistries](https://docs.renovatebot.com/self-hosted-configuration/#allowcustomcrateregistries)",
+      "type": "boolean",
+      "default": false
+    },
+    "allowPlugins": {
+      "description": "Set this to `true` if repositories are allowed to run install plugins.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowplugins",
+      "markdownDescription": "Set this to `true` if repositories are allowed to run install plugins.\n\nSee also: [allowPlugins](https://docs.renovatebot.com/self-hosted-configuration/#allowplugins)",
+      "type": "boolean",
+      "default": false
+    },
+    "allowScripts": {
+      "description": "Set this to `true` if repositories are allowed to run install scripts.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowscripts",
+      "markdownDescription": "Set this to `true` if repositories are allowed to run install scripts.\n\nSee also: [allowScripts](https://docs.renovatebot.com/self-hosted-configuration/#allowscripts)",
+      "type": "boolean",
+      "default": false
+    },
+    "allowShellExecutorForPostUpgradeCommands": {
+      "description": "Whether to run commands for `postUpgradeTasks` inside a shell. This has security implications, as it means that they can call out to other commands or access shell variables. It is difficult to craft an `allowedCommands` regex to restrict this.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowshellexecutorforpostupgradecommands",
+      "markdownDescription": "Whether to run commands for `postUpgradeTasks` inside a shell. This has security implications, as it means that they can call out to other commands or access shell variables. It is difficult to craft an `allowedCommands` regex to restrict this.\n\nSee also: [allowShellExecutorForPostUpgradeCommands](https://docs.renovatebot.com/self-hosted-configuration/#allowshellexecutorforpostupgradecommands)",
+      "type": "boolean",
+      "default": false
+    },
+    "allowedCommands": {
+      "description": "A list of regular expressions that decide which commands are allowed in post-upgrade tasks.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands",
+      "markdownDescription": "A list of regular expressions that decide which commands are allowed in post-upgrade tasks.\n\nSee also: [allowedCommands](https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "allowedEnv": {
+      "description": "List of allowed patterns for environment variable names in repository env config.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowedenv",
+      "markdownDescription": "List of allowed patterns for environment variable names in repository env config.\n\nSee also: [allowedEnv](https://docs.renovatebot.com/self-hosted-configuration/#allowedenv)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "allowedHeaders": {
+      "description": "List of allowed patterns for header names in repository hostRules config.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowedheaders",
+      "markdownDescription": "List of allowed patterns for header names in repository hostRules config.\n\nSee also: [allowedHeaders](https://docs.renovatebot.com/self-hosted-configuration/#allowedheaders)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["X-*"]
+    },
+    "allowedUnsafeExecutions": {
+      "description": "List of possibly unsafe executions which are permitted to run. This enables global control over any implicit commands\n        which are run as part of a renovate run. This is similar to `allowedCommands` but is specifically used to control executions\n        which run automatically, and are not explicitly added in `postUpgradeTasks`\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#allowedunsafeexecutions",
+      "markdownDescription": "List of possibly unsafe executions which are permitted to run. This enables global control over any implicit commands\n        which are run as part of a renovate run. This is similar to `allowedCommands` but is specifically used to control executions\n        which run automatically, and are not explicitly added in `postUpgradeTasks`\n\nSee also: [allowedUnsafeExecutions](https://docs.renovatebot.com/self-hosted-configuration/#allowedunsafeexecutions)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["bazelModDeps", "goGenerate", "gradleWrapper", "mise", "pixi"]
+      },
+      "default": []
+    },
+    "allowedVersions": {
+      "description": "A version range or regex pattern capturing allowed versions for dependencies.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions",
+      "markdownDescription": "A version range or regex pattern capturing allowed versions for dependencies.\n\nSee also: [allowedVersions](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)",
+      "type": "string"
+    },
+    "ansible": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible",
+      "markdownDescription": "Configuration object for the ansible manager\n\nSee also: [ansible](https://docs.renovatebot.com/configuration-options/#ansible)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)tasks/[^/]+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ansible-galaxy": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible-galaxy manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible-galaxy",
+      "markdownDescription": "Configuration object for the ansible-galaxy manager\n\nSee also: [ansible-galaxy](https://docs.renovatebot.com/configuration-options/#ansible-galaxy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(galaxy|requirements)(\\.ansible)?\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ant": {
+      "$ref": "#",
+      "description": "Configuration object for the ant manager\nSee also: https://docs.renovatebot.com/configuration-options/#ant",
+      "markdownDescription": "Configuration object for the ant manager\n\nSee also: [ant](https://docs.renovatebot.com/configuration-options/#ant)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/build.xml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "argocd": {
+      "$ref": "#",
+      "description": "Configuration object for the argocd manager\nSee also: https://docs.renovatebot.com/configuration-options/#argocd",
+      "markdownDescription": "Configuration object for the argocd manager\n\nSee also: [argocd](https://docs.renovatebot.com/configuration-options/#argocd)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "artifactAuth": {
+      "description": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth",
+      "markdownDescription": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\n\nSee also: [artifactAuth](https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "enum": ["composer"]
+      },
+      "default": null
+    },
+    "asdf": {
+      "$ref": "#",
+      "description": "Configuration object for the asdf manager\nSee also: https://docs.renovatebot.com/configuration-options/#asdf",
+      "markdownDescription": "Configuration object for the asdf manager\n\nSee also: [asdf](https://docs.renovatebot.com/configuration-options/#asdf)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.tool-versions$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "assignAutomerge": {
+      "description": "Assign reviewers and assignees even if the PR is to be automerged.\nSee also: https://docs.renovatebot.com/configuration-options/#assignautomerge",
+      "markdownDescription": "Assign reviewers and assignees even if the PR is to be automerged.\n\nSee also: [assignAutomerge](https://docs.renovatebot.com/configuration-options/#assignautomerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "assignees": {
+      "description": "Assignees for Pull Request (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#assignees",
+      "markdownDescription": "Assignees for Pull Request (either username or email address depending on the platform).\n\nSee also: [assignees](https://docs.renovatebot.com/configuration-options/#assignees)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "assigneesFromCodeOwners": {
+      "description": "Determine assignees based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners",
+      "markdownDescription": "Determine assignees based on configured code owners and changes in PR.\n\nSee also: [assigneesFromCodeOwners](https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "assigneesSampleSize": {
+      "description": "Take a random sample of given size from `assignees`.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneessamplesize",
+      "markdownDescription": "Take a random sample of given size from `assignees`.\n\nSee also: [assigneesSampleSize](https://docs.renovatebot.com/configuration-options/#assigneessamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "authType": {
+      "description": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesauthtype",
+      "markdownDescription": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\n\nSee also: [authType](https://docs.renovatebot.com/configuration-options/#hostrulesauthtype)",
+      "type": "string",
+      "default": "Bearer"
+    },
+    "autoApprove": {
+      "description": "Set to `true` to automatically approve PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#autoapprove",
+      "markdownDescription": "Set to `true` to automatically approve PRs.\n\nSee also: [autoApprove](https://docs.renovatebot.com/configuration-options/#autoapprove)",
+      "type": "boolean",
+      "default": false
+    },
+    "autoReplaceGlobalMatch": {
+      "description": "Control whether replacement regular expressions are global matches or only the first match.\nSee also: https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch",
+      "markdownDescription": "Control whether replacement regular expressions are global matches or only the first match.\n\nSee also: [autoReplaceGlobalMatch](https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch)",
+      "type": "boolean",
+      "default": true
+    },
+    "autoReplaceStringTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [autoReplaceStringTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate)",
+      "type": "string"
+    },
+    "autodiscover": {
+      "description": "Autodiscover all repositories.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscover",
+      "markdownDescription": "Autodiscover all repositories.\n\nSee also: [autodiscover](https://docs.renovatebot.com/self-hosted-configuration/#autodiscover)",
+      "type": "boolean",
+      "default": false
+    },
+    "autodiscoverFilter": {
+      "description": "Filter the list of autodiscovered repositories.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter",
+      "markdownDescription": "Filter the list of autodiscovered repositories.\n\nSee also: [autodiscoverFilter](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": null,
+      "type": ["array", "null"]
+    },
+    "autodiscoverNamespaces": {
+      "description": "Filter the list of autodiscovered repositories by namespaces.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscovernamespaces",
+      "markdownDescription": "Filter the list of autodiscovered repositories by namespaces.\n\nSee also: [autodiscoverNamespaces](https://docs.renovatebot.com/self-hosted-configuration/#autodiscovernamespaces)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "autodiscoverProjects": {
+      "description": "Filter the list of autodiscovered repositories by project names.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverprojects",
+      "markdownDescription": "Filter the list of autodiscovered repositories by project names.\n\nSee also: [autodiscoverProjects](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverprojects)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "autodiscoverRepoOrder": {
+      "description": "The order method for autodiscover server side repository search.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverrepoorder",
+      "markdownDescription": "The order method for autodiscover server side repository search.\n\nSee also: [autodiscoverRepoOrder](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverrepoorder)",
+      "type": ["string", "null"],
+      "enum": ["asc", "desc"],
+      "default": null
+    },
+    "autodiscoverRepoSort": {
+      "description": "The sort method for autodiscover server side repository search.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverreposort",
+      "markdownDescription": "The sort method for autodiscover server side repository search.\n\nSee also: [autodiscoverRepoSort](https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverreposort)",
+      "type": ["string", "null"],
+      "enum": [
+        "alpha",
+        "created",
+        "created_at",
+        "updated",
+        "updated_at",
+        "size",
+        "id"
+      ],
+      "default": null
+    },
+    "autodiscoverTopics": {
+      "description": "Filter the list of autodiscovered repositories by topics.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#autodiscovertopics",
+      "markdownDescription": "Filter the list of autodiscovered repositories by topics.\n\nSee also: [autodiscoverTopics](https://docs.renovatebot.com/self-hosted-configuration/#autodiscovertopics)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "automerge": {
+      "description": "Whether to automerge branches/PRs automatically, without human intervention.\nSee also: https://docs.renovatebot.com/configuration-options/#automerge",
+      "markdownDescription": "Whether to automerge branches/PRs automatically, without human intervention.\n\nSee also: [automerge](https://docs.renovatebot.com/configuration-options/#automerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "automergeComment": {
+      "description": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergecomment",
+      "markdownDescription": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\n\nSee also: [automergeComment](https://docs.renovatebot.com/configuration-options/#automergecomment)",
+      "type": "string",
+      "default": "automergeComment"
+    },
+    "automergeSchedule": {
+      "description": "Limit automerge to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#automergeschedule",
+      "markdownDescription": "Limit automerge to these times of day or week.\n\nSee also: [automergeSchedule](https://docs.renovatebot.com/configuration-options/#automergeschedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "automergeStrategy": {
+      "description": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergestrategy",
+      "markdownDescription": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\n\nSee also: [automergeStrategy](https://docs.renovatebot.com/configuration-options/#automergestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "fast-forward",
+        "merge-commit",
+        "rebase",
+        "rebase-merge",
+        "squash"
+      ],
+      "default": "auto"
+    },
+    "automergeType": {
+      "description": "How to automerge, if enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#automergetype",
+      "markdownDescription": "How to automerge, if enabled.\n\nSee also: [automergeType](https://docs.renovatebot.com/configuration-options/#automergetype)",
+      "type": "string",
+      "enum": ["branch", "pr", "pr-comment"],
+      "default": "pr"
+    },
+    "azure-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the azure-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#azure-pipelines",
+      "markdownDescription": "Configuration object for the azure-pipelines manager\n\nSee also: [azure-pipelines](https://docs.renovatebot.com/configuration-options/#azure-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/).azuredevops/.+\\.ya?ml$/",
+          "/azure.*pipelines?.*\\.ya?ml$/"
+        ],
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "azureWorkItemId": {
+      "description": "The id of an existing work item on Azure Boards to link to each PR.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemid",
+      "markdownDescription": "The id of an existing work item on Azure Boards to link to each PR.\n\nSee also: [azureWorkItemId](https://docs.renovatebot.com/configuration-options/#azureworkitemid)",
+      "type": "integer",
+      "default": 0
+    },
+    "azureWorkItemType": {
+      "description": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemtype",
+      "markdownDescription": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\n\nSee also: [azureWorkItemType](https://docs.renovatebot.com/configuration-options/#azureworkitemtype)",
+      "type": "string",
+      "default": "Issue"
+    },
+    "baseBranchPatterns": {
+      "description": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\nSee also: https://docs.renovatebot.com/configuration-options/#basebranchpatterns",
+      "markdownDescription": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\n\nSee also: [baseBranchPatterns](https://docs.renovatebot.com/configuration-options/#basebranchpatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "baseDir": {
+      "description": "The base directory for Renovate to store local files, including repository files and cache. If left empty, Renovate will create its own temporary directory to use.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#basedir",
+      "markdownDescription": "The base directory for Renovate to store local files, including repository files and cache. If left empty, Renovate will create its own temporary directory to use.\n\nSee also: [baseDir](https://docs.renovatebot.com/self-hosted-configuration/#basedir)",
+      "type": "string"
+    },
+    "batect": {
+      "$ref": "#",
+      "description": "Configuration object for the batect manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect",
+      "markdownDescription": "Configuration object for the batect manager\n\nSee also: [batect](https://docs.renovatebot.com/configuration-options/#batect)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect(-bundle)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "batect-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the batect-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect-wrapper",
+      "markdownDescription": "Configuration object for the batect-wrapper manager\n\nSee also: [batect-wrapper](https://docs.renovatebot.com/configuration-options/#batect-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect$/"],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel",
+      "markdownDescription": "Configuration object for the bazel manager\n\nSee also: [bazel](https://docs.renovatebot.com/configuration-options/#bazel)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)WORKSPACE(|\\.bazel|\\.bzlmod)$/",
+          "/\\.WORKSPACE\\.bazel$/",
+          "/\\.bzl$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel-module": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel-module manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel-module",
+      "markdownDescription": "Configuration object for the bazel-module manager\n\nSee also: [bazel-module](https://docs.renovatebot.com/configuration-options/#bazel-module)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/|\\.)MODULE\\.bazel$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazelisk": {
+      "$ref": "#",
+      "description": "Configuration object for the bazelisk manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazelisk",
+      "markdownDescription": "Configuration object for the bazelisk manager\n\nSee also: [bazelisk](https://docs.renovatebot.com/configuration-options/#bazelisk)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bazelversion$/"],
+        "pinDigests": false,
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bbAutoResolvePrTasks": {
+      "description": "The PR tasks will be automatically completed after the PR is raised.\nSee also: https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks",
+      "markdownDescription": "The PR tasks will be automatically completed after the PR is raised.\n\nSee also: [bbAutoResolvePrTasks](https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks)",
+      "type": "boolean",
+      "default": false
+    },
+    "bbUseDefaultReviewers": {
+      "description": "Use the default reviewers (Bitbucket only).\nSee also: https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers",
+      "markdownDescription": "Use the default reviewers (Bitbucket only).\n\nSee also: [bbUseDefaultReviewers](https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers)",
+      "type": "boolean",
+      "default": true
+    },
+    "bbUseDevelopmentBranch": {
+      "description": "Use the repository's [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as the repository's default branch.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#bbusedevelopmentbranch",
+      "markdownDescription": "Use the repository's [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as the repository's default branch.\n\nSee also: [bbUseDevelopmentBranch](https://docs.renovatebot.com/self-hosted-configuration/#bbusedevelopmentbranch)",
+      "type": "boolean",
+      "default": false
+    },
+    "bicep": {
+      "$ref": "#",
+      "description": "Configuration object for the bicep manager\nSee also: https://docs.renovatebot.com/configuration-options/#bicep",
+      "markdownDescription": "Configuration object for the bicep manager\n\nSee also: [bicep](https://docs.renovatebot.com/configuration-options/#bicep)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.bicep$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "binarySource": {
+      "description": "Controls how third-party tools like npm or Gradle are called: directly, via Docker sidecar containers, or via dynamic install.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#binarysource",
+      "markdownDescription": "Controls how third-party tools like npm or Gradle are called: directly, via Docker sidecar containers, or via dynamic install.\n\nSee also: [binarySource](https://docs.renovatebot.com/self-hosted-configuration/#binarysource)",
+      "type": "string",
+      "enum": ["global", "docker", "install", "hermit"],
+      "default": "install"
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the bitbucket-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines",
+      "markdownDescription": "Configuration object for the bitbucket-pipelines manager\n\nSee also: [bitbucket-pipelines](https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/*-pipelines.yml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bitrise": {
+      "$ref": "#",
+      "description": "Configuration object for the bitrise manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitrise",
+      "markdownDescription": "Configuration object for the bitrise manager\n\nSee also: [bitrise](https://docs.renovatebot.com/configuration-options/#bitrise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bitrise\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "branchConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\nSee also: https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\n\nSee also: [branchConcurrentLimit](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "branchName": {
+      "description": "Branch name template.\nSee also: https://docs.renovatebot.com/configuration-options/#branchname",
+      "markdownDescription": "Branch name template.\n\nSee also: [branchName](https://docs.renovatebot.com/configuration-options/#branchname)",
+      "type": "string",
+      "default": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}"
+    },
+    "branchNameStrict": {
+      "description": "Whether to be strict about the use of special characters within the branch name.\nSee also: https://docs.renovatebot.com/configuration-options/#branchnamestrict",
+      "markdownDescription": "Whether to be strict about the use of special characters within the branch name.\n\nSee also: [branchNameStrict](https://docs.renovatebot.com/configuration-options/#branchnamestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "branchPrefix": {
+      "description": "Prefix to use for all branch names.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefix",
+      "markdownDescription": "Prefix to use for all branch names.\n\nSee also: [branchPrefix](https://docs.renovatebot.com/configuration-options/#branchprefix)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchPrefixOld": {
+      "description": "Old branchPrefix value to check for existing PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefixold",
+      "markdownDescription": "Old branchPrefix value to check for existing PRs.\n\nSee also: [branchPrefixOld](https://docs.renovatebot.com/configuration-options/#branchprefixold)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchTopic": {
+      "description": "Branch topic.\nSee also: https://docs.renovatebot.com/configuration-options/#branchtopic",
+      "markdownDescription": "Branch topic.\n\nSee also: [branchTopic](https://docs.renovatebot.com/configuration-options/#branchtopic)",
+      "type": "string",
+      "default": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}.{{{newMinor}}}{{/if}}{{/if}}{{#if separateMultipleMinor}}{{#if isMinor}}.{{{newMinor}}}{{/if}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}"
+    },
+    "buildkite": {
+      "$ref": "#",
+      "description": "Configuration object for the buildkite manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildkite",
+      "markdownDescription": "Configuration object for the buildkite manager\n\nSee also: [buildkite](https://docs.renovatebot.com/configuration-options/#buildkite)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/buildkite\\.ya?ml/",
+          "/\\.buildkite/.+\\.ya?ml$/"
+        ],
+        "commitMessageTopic": "buildkite plugin {{depName}}",
+        "commitMessageExtra": "to {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{{newValue}}}{{/if}}"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "buildpacks": {
+      "$ref": "#",
+      "description": "Configuration object for the buildpacks manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildpacks",
+      "markdownDescription": "Configuration object for the buildpacks manager\n\nSee also: [buildpacks](https://docs.renovatebot.com/configuration-options/#buildpacks)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "buildpack {{depName}}",
+        "managerFilePatterns": ["/(^|/)project\\.toml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bumpType": {
+      "description": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype",
+      "markdownDescription": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\n\nSee also: [bumpType](https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype)",
+      "type": "string",
+      "anyOf": [
+        {
+          "enum": ["major", "minor", "patch", "sync"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "bumpVersion": {
+      "description": "Bump the version in the package file being updated.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversion",
+      "markdownDescription": "Bump the version in the package file being updated.\n\nSee also: [bumpVersion](https://docs.renovatebot.com/configuration-options/#bumpversion)",
+      "type": "string",
+      "enum": ["major", "minor", "patch", "prerelease"]
+    },
+    "bumpVersions": {
+      "description": "A list of bumpVersion config options to bump generic version numbers.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversions",
+      "markdownDescription": "A list of bumpVersion config options to bump generic version numbers.\n\nSee also: [bumpVersions](https://docs.renovatebot.com/configuration-options/#bumpversions)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "bumpType": {
+                "$ref": "#/definitions/bumpType"
+              },
+              "filePatterns": {
+                "$ref": "#/definitions/filePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "name": {
+                "$ref": "#/definitions/name"
+              }
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "bun": {
+      "$ref": "#",
+      "description": "Configuration object for the bun manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun",
+      "markdownDescription": "Configuration object for the bun manager\n\nSee also: [bun](https://docs.renovatebot.com/configuration-options/#bun)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)bun\\.lockb?$/",
+          "/(^|/)package\\.json$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bun-version": {
+      "$ref": "#",
+      "description": "Configuration object for the bun-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun-version",
+      "markdownDescription": "Configuration object for the bun-version manager\n\nSee also: [bun-version](https://docs.renovatebot.com/configuration-options/#bun-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bun-version$/"],
+        "versioning": "npm"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#bundler",
+      "markdownDescription": "Configuration object for the bundler manager\n\nSee also: [bundler](https://docs.renovatebot.com/configuration-options/#bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Gemfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cacheDir": {
+      "description": "The directory where Renovate stores its cache. If left empty, Renovate creates a subdirectory within the `baseDir`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#cachedir",
+      "markdownDescription": "The directory where Renovate stores its cache. If left empty, Renovate creates a subdirectory within the `baseDir`.\n\nSee also: [cacheDir](https://docs.renovatebot.com/self-hosted-configuration/#cachedir)",
+      "type": "string"
+    },
+    "cacheHardTtlMinutes": {
+      "description": "Maximum duration in minutes to keep datasource cache entries.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#cachehardttlminutes",
+      "markdownDescription": "Maximum duration in minutes to keep datasource cache entries.\n\nSee also: [cacheHardTtlMinutes](https://docs.renovatebot.com/self-hosted-configuration/#cachehardttlminutes)",
+      "type": "integer",
+      "default": 10080
+    },
+    "cachePrivatePackages": {
+      "description": "Cache private packages in the datasource cache. This is useful for self-hosted setups\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#cacheprivatepackages",
+      "markdownDescription": "Cache private packages in the datasource cache. This is useful for self-hosted setups\n\nSee also: [cachePrivatePackages](https://docs.renovatebot.com/self-hosted-configuration/#cacheprivatepackages)",
+      "type": "boolean",
+      "default": false
+    },
+    "cacheTtlOverride": {
+      "$ref": "#",
+      "description": "An object that contains cache namespace TTL override values.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#cachettloverride",
+      "markdownDescription": "An object that contains cache namespace TTL override values.\n\nSee also: [cacheTtlOverride](https://docs.renovatebot.com/self-hosted-configuration/#cachettloverride)",
+      "type": "object",
+      "default": {}
+    },
+    "cake": {
+      "$ref": "#",
+      "description": "Configuration object for the cake manager\nSee also: https://docs.renovatebot.com/configuration-options/#cake",
+      "markdownDescription": "Configuration object for the cake manager\n\nSee also: [cake](https://docs.renovatebot.com/configuration-options/#cake)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cake$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cargo": {
+      "$ref": "#",
+      "description": "Configuration object for the cargo manager\nSee also: https://docs.renovatebot.com/configuration-options/#cargo",
+      "markdownDescription": "Configuration object for the cargo manager\n\nSee also: [cargo](https://docs.renovatebot.com/configuration-options/#cargo)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust crate {{depName}}",
+        "managerFilePatterns": ["/(^|/)Cargo\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cdnurl": {
+      "$ref": "#",
+      "description": "Configuration object for the cdnurl manager\nSee also: https://docs.renovatebot.com/configuration-options/#cdnurl",
+      "markdownDescription": "Configuration object for the cdnurl manager\n\nSee also: [cdnurl](https://docs.renovatebot.com/configuration-options/#cdnurl)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "changelogUrl": {
+      "description": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\nSee also: https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl",
+      "markdownDescription": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\n\nSee also: [changelogUrl](https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl)",
+      "type": "string"
+    },
+    "checkedBranches": {
+      "description": "A list of branch names to mark for creation or rebasing as if it was selected in the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#checkedbranches",
+      "markdownDescription": "A list of branch names to mark for creation or rebasing as if it was selected in the Dependency Dashboard issue.\n\nSee also: [checkedBranches](https://docs.renovatebot.com/self-hosted-configuration/#checkedbranches)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "circleci": {
+      "$ref": "#",
+      "description": "Configuration object for the circleci manager\nSee also: https://docs.renovatebot.com/configuration-options/#circleci",
+      "markdownDescription": "Configuration object for the circleci manager\n\nSee also: [circleci](https://docs.renovatebot.com/configuration-options/#circleci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.circleci/.+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cloneSubmodules": {
+      "description": "Set to `true` to initialize submodules during repository clone.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodules",
+      "markdownDescription": "Set to `true` to initialize submodules during repository clone.\n\nSee also: [cloneSubmodules](https://docs.renovatebot.com/configuration-options/#clonesubmodules)",
+      "type": "boolean",
+      "default": false
+    },
+    "cloneSubmodulesFilter": {
+      "description": "List of submodules names or patterns to clone when cloneSubmodules=true.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter",
+      "markdownDescription": "List of submodules names or patterns to clone when cloneSubmodules=true.\n\nSee also: [cloneSubmodulesFilter](https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["*"]
+    },
+    "cloudbuild": {
+      "$ref": "#",
+      "description": "Configuration object for the cloudbuild manager\nSee also: https://docs.renovatebot.com/configuration-options/#cloudbuild",
+      "markdownDescription": "Configuration object for the cloudbuild manager\n\nSee also: [cloudbuild](https://docs.renovatebot.com/configuration-options/#cloudbuild)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cloudbuild\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cocoapods": {
+      "$ref": "#",
+      "description": "Configuration object for the cocoapods manager\nSee also: https://docs.renovatebot.com/configuration-options/#cocoapods",
+      "markdownDescription": "Configuration object for the cocoapods manager\n\nSee also: [cocoapods](https://docs.renovatebot.com/configuration-options/#cocoapods)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Podfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "commands": {
+      "description": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands",
+      "markdownDescription": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\n\nSee also: [commands](https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "commitBody": {
+      "description": "Commit message body template. Will be appended to commit message, separated by two line returns.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbody",
+      "markdownDescription": "Commit message body template. Will be appended to commit message, separated by two line returns.\n\nSee also: [commitBody](https://docs.renovatebot.com/configuration-options/#commitbody)",
+      "type": "string"
+    },
+    "commitBodyTable": {
+      "description": "If enabled, append a table in the commit message body describing all updates in the commit.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbodytable",
+      "markdownDescription": "If enabled, append a table in the commit message body describing all updates in the commit.\n\nSee also: [commitBodyTable](https://docs.renovatebot.com/configuration-options/#commitbodytable)",
+      "type": "boolean",
+      "default": false
+    },
+    "commitHourlyLimit": {
+      "description": "Rate limit commits to maximum x per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#commithourlylimit",
+      "markdownDescription": "Rate limit commits to maximum x per hour. 0 means no limit.\n\nSee also: [commitHourlyLimit](https://docs.renovatebot.com/configuration-options/#commithourlylimit)",
+      "type": "integer",
+      "default": 0
+    },
+    "commitMessage": {
+      "description": "Message to use for commit messages and pull request titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessage",
+      "markdownDescription": "Message to use for commit messages and pull request titles.\n\nSee also: [commitMessage](https://docs.renovatebot.com/configuration-options/#commitmessage)",
+      "type": "string",
+      "default": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}"
+    },
+    "commitMessageAction": {
+      "description": "Action verb to use in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageaction",
+      "markdownDescription": "Action verb to use in commit messages and PR titles.\n\nSee also: [commitMessageAction](https://docs.renovatebot.com/configuration-options/#commitmessageaction)",
+      "type": "string",
+      "default": "Update"
+    },
+    "commitMessageExtra": {
+      "description": "Extra description used after the commit message topic - typically the version.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageextra",
+      "markdownDescription": "Extra description used after the commit message topic - typically the version.\n\nSee also: [commitMessageExtra](https://docs.renovatebot.com/configuration-options/#commitmessageextra)",
+      "type": "string",
+      "default": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}"
+    },
+    "commitMessageLowerCase": {
+      "description": "Lowercase PR- and commit titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagelowercase",
+      "markdownDescription": "Lowercase PR- and commit titles.\n\nSee also: [commitMessageLowerCase](https://docs.renovatebot.com/configuration-options/#commitmessagelowercase)",
+      "type": "string",
+      "enum": ["auto", "never"],
+      "default": "auto"
+    },
+    "commitMessagePrefix": {
+      "description": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageprefix",
+      "markdownDescription": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\n\nSee also: [commitMessagePrefix](https://docs.renovatebot.com/configuration-options/#commitmessageprefix)",
+      "type": "string"
+    },
+    "commitMessageSuffix": {
+      "description": "Suffix to add to end of commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagesuffix",
+      "markdownDescription": "Suffix to add to end of commit messages and PR titles.\n\nSee also: [commitMessageSuffix](https://docs.renovatebot.com/configuration-options/#commitmessagesuffix)",
+      "type": "string"
+    },
+    "commitMessageTopic": {
+      "description": "The upgrade topic/noun used in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagetopic",
+      "markdownDescription": "The upgrade topic/noun used in commit messages and PR titles.\n\nSee also: [commitMessageTopic](https://docs.renovatebot.com/configuration-options/#commitmessagetopic)",
+      "type": "string",
+      "default": "dependency {{depName}}"
+    },
+    "commitTrailers": {
+      "description": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\nSee also: https://docs.renovatebot.com/configuration-options/#committrailers",
+      "markdownDescription": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\n\nSee also: [commitTrailers](https://docs.renovatebot.com/configuration-options/#committrailers)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "composer": {
+      "$ref": "#",
+      "description": "Configuration object for the composer manager\nSee also: https://docs.renovatebot.com/configuration-options/#composer",
+      "markdownDescription": "Configuration object for the composer manager\n\nSee also: [composer](https://docs.renovatebot.com/configuration-options/#composer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)([\\w-]*)composer\\.json$/"],
+        "versioning": "composer"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "composerIgnorePlatformReqs": {
+      "description": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\nSee also: https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs",
+      "markdownDescription": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\n\nSee also: [composerIgnorePlatformReqs](https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "conan": {
+      "$ref": "#",
+      "description": "Configuration object for the conan manager\nSee also: https://docs.renovatebot.com/configuration-options/#conan",
+      "markdownDescription": "Configuration object for the conan manager\n\nSee also: [conan](https://docs.renovatebot.com/configuration-options/#conan)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)conanfile\\.(txt|py)$/"],
+        "datasource": "conan",
+        "versioning": "conan"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "concurrentRequestLimit": {
+      "description": "Limit concurrent requests per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit",
+      "markdownDescription": "Limit concurrent requests per host.\n\nSee also: [concurrentRequestLimit](https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "confidential": {
+      "description": "If enabled, issues created by Renovate are set as confidential.\nSee also: https://docs.renovatebot.com/configuration-options/#confidential",
+      "markdownDescription": "If enabled, issues created by Renovate are set as confidential.\n\nSee also: [confidential](https://docs.renovatebot.com/configuration-options/#confidential)",
+      "type": "boolean",
+      "default": false
+    },
+    "configFileNames": {
+      "description": "List of filenames where repository config will be stored.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#configfilenames",
+      "markdownDescription": "List of filenames where repository config will be stored.\n\nSee also: [configFileNames](https://docs.renovatebot.com/self-hosted-configuration/#configfilenames)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "configMigration": {
+      "description": "Enable this to get config migration PRs when needed.\nSee also: https://docs.renovatebot.com/configuration-options/#configmigration",
+      "markdownDescription": "Enable this to get config migration PRs when needed.\n\nSee also: [configMigration](https://docs.renovatebot.com/configuration-options/#configmigration)",
+      "type": "boolean",
+      "default": false
+    },
+    "configValidationError": {
+      "description": "If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#configvalidationerror",
+      "markdownDescription": "If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.\n\nSee also: [configValidationError](https://docs.renovatebot.com/self-hosted-configuration/#configvalidationerror)",
+      "type": "boolean",
+      "default": false
+    },
+    "configWarningReuseIssue": {
+      "description": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\nSee also: https://docs.renovatebot.com/configuration-options/#configwarningreuseissue",
+      "markdownDescription": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\n\nSee also: [configWarningReuseIssue](https://docs.renovatebot.com/configuration-options/#configwarningreuseissue)",
+      "type": "boolean",
+      "default": false
+    },
+    "constraints": {
+      "description": "Configuration object to define language or manager version constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraints",
+      "markdownDescription": "Configuration object to define language or manager version constraints.\n\nSee also: [constraints](https://docs.renovatebot.com/configuration-options/#constraints)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "string",
+          "description": "A constraint for the `bazelisk` Containerbase tool"
+        },
+        "bun": {
+          "type": "string",
+          "description": "A constraint for the `bun` Containerbase tool"
+        },
+        "bundler": {
+          "type": "string",
+          "description": "A constraint for the `bundler` Containerbase tool"
+        },
+        "cocoapods": {
+          "type": "string",
+          "description": "A constraint for the `cocoapods` Containerbase tool"
+        },
+        "composer": {
+          "type": "string",
+          "description": "A constraint for the `composer` Containerbase tool"
+        },
+        "conan": {
+          "type": "string",
+          "description": "A constraint for the `conan` Containerbase tool"
+        },
+        "copier": {
+          "type": "string",
+          "description": "A constraint for the `copier` Containerbase tool"
+        },
+        "corepack": {
+          "type": "string",
+          "description": "A constraint for the `corepack` Containerbase tool"
+        },
+        "deno": {
+          "type": "string",
+          "description": "A constraint for the `deno` Containerbase tool"
+        },
+        "devbox": {
+          "type": "string",
+          "description": "A constraint for the `devbox` Containerbase tool"
+        },
+        "dotnet": {
+          "type": "string",
+          "description": "A constraint for the `dotnet` Containerbase tool"
+        },
+        "erlang": {
+          "type": "string",
+          "description": "A constraint for the `erlang` Containerbase tool"
+        },
+        "elixir": {
+          "type": "string",
+          "description": "A constraint for the `elixir` Containerbase tool"
+        },
+        "flux": {
+          "type": "string",
+          "description": "A constraint for the `flux` Containerbase tool"
+        },
+        "gleam": {
+          "type": "string",
+          "description": "A constraint for the `gleam` Containerbase tool"
+        },
+        "golang": {
+          "type": "string",
+          "description": "A constraint for the `golang` Containerbase tool"
+        },
+        "gradle": {
+          "type": "string",
+          "description": "A constraint for the `gradle` Containerbase tool"
+        },
+        "hashin": {
+          "type": "string",
+          "description": "A constraint for the `hashin` Containerbase tool"
+        },
+        "helm": {
+          "type": "string",
+          "description": "A constraint for the `helm` Containerbase tool"
+        },
+        "helmfile": {
+          "type": "string",
+          "description": "A constraint for the `helmfile` Containerbase tool"
+        },
+        "java": {
+          "type": "string",
+          "description": "A constraint for the `java` Containerbase tool"
+        },
+        "java-maven": {
+          "type": "string",
+          "description": "A constraint for the `java-maven` Containerbase tool"
+        },
+        "jb": {
+          "type": "string",
+          "description": "A constraint for the `jb` Containerbase tool"
+        },
+        "kustomize": {
+          "type": "string",
+          "description": "A constraint for the `kustomize` Containerbase tool"
+        },
+        "maven": {
+          "type": "string",
+          "description": "A constraint for the `maven` Containerbase tool"
+        },
+        "mise": {
+          "type": "string",
+          "description": "A constraint for the `mise` Containerbase tool"
+        },
+        "nix": {
+          "type": "string",
+          "description": "A constraint for the `nix` Containerbase tool"
+        },
+        "node": {
+          "type": "string",
+          "description": "A constraint for the `node` Containerbase tool"
+        },
+        "npm": {
+          "type": "string",
+          "description": "A constraint for the `npm` Containerbase tool"
+        },
+        "pdm": {
+          "type": "string",
+          "description": "A constraint for the `pdm` Containerbase tool"
+        },
+        "php": {
+          "type": "string",
+          "description": "A constraint for the `php` Containerbase tool"
+        },
+        "pip-tools": {
+          "type": "string",
+          "description": "A constraint for the `pip-tools` Containerbase tool"
+        },
+        "pipenv": {
+          "type": "string",
+          "description": "A constraint for the `pipenv` Containerbase tool"
+        },
+        "pnpm": {
+          "type": "string",
+          "description": "A constraint for the `pnpm` Containerbase tool"
+        },
+        "pixi": {
+          "type": "string",
+          "description": "A constraint for the `pixi` Containerbase tool"
+        },
+        "poetry": {
+          "type": "string",
+          "description": "A constraint for the `poetry` Containerbase tool"
+        },
+        "python": {
+          "type": "string",
+          "description": "A constraint for the `python` Containerbase tool"
+        },
+        "ruby": {
+          "type": "string",
+          "description": "A constraint for the `ruby` Containerbase tool. Also used in the `rubygems` Datasource"
+        },
+        "rust": {
+          "type": "string",
+          "description": "A constraint for the `rust` Containerbase tool"
+        },
+        "uv": {
+          "type": "string",
+          "description": "A constraint for the `uv` Containerbase tool"
+        },
+        "yarn": {
+          "type": "string",
+          "description": "A constraint for the `yarn` Containerbase tool"
+        },
+        "yarn-slim": {
+          "type": "string",
+          "description": "A constraint for the `yarn-slim` Containerbase tool"
+        },
+        "dart": {
+          "type": "string",
+          "description": "A constraint for the `dart` Containerbase tool"
+        },
+        "flutter": {
+          "type": "string",
+          "description": "A constraint for the `flutter` Containerbase tool"
+        },
+        "vendir": {
+          "type": "string",
+          "description": "A constraint for the `vendir` Containerbase tool"
+        },
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "constraintsFiltering": {
+      "description": "Perform release filtering based on language constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsfiltering",
+      "markdownDescription": "Perform release filtering based on language constraints.\n\nSee also: [constraintsFiltering](https://docs.renovatebot.com/configuration-options/#constraintsfiltering)",
+      "type": "string",
+      "enum": ["none", "strict"],
+      "default": "none"
+    },
+    "constraintsVersioning": {
+      "description": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsversioning",
+      "markdownDescription": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\n\nSee also: [constraintsVersioning](https://docs.renovatebot.com/configuration-options/#constraintsversioning)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "containerbaseDir": {
+      "description": "The directory where Renovate stores its containerbase cache. If left empty, Renovate creates a subdirectory within the `cacheDir`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#containerbasedir",
+      "markdownDescription": "The directory where Renovate stores its containerbase cache. If left empty, Renovate creates a subdirectory within the `cacheDir`.\n\nSee also: [containerbaseDir](https://docs.renovatebot.com/self-hosted-configuration/#containerbasedir)",
+      "type": "string"
+    },
+    "copier": {
+      "$ref": "#",
+      "description": "Configuration object for the copier manager\nSee also: https://docs.renovatebot.com/configuration-options/#copier",
+      "markdownDescription": "Configuration object for the copier manager\n\nSee also: [copier](https://docs.renovatebot.com/configuration-options/#copier)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.copier-answers(\\..+)?\\.ya?ml/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cpanfile": {
+      "$ref": "#",
+      "description": "Configuration object for the cpanfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#cpanfile",
+      "markdownDescription": "Configuration object for the cpanfile manager\n\nSee also: [cpanfile](https://docs.renovatebot.com/configuration-options/#cpanfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cpanfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crossplane": {
+      "$ref": "#",
+      "description": "Configuration object for the crossplane manager\nSee also: https://docs.renovatebot.com/configuration-options/#crossplane",
+      "markdownDescription": "Configuration object for the crossplane manager\n\nSee also: [crossplane](https://docs.renovatebot.com/configuration-options/#crossplane)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crow": {
+      "$ref": "#",
+      "description": "Configuration object for the crow manager\nSee also: https://docs.renovatebot.com/configuration-options/#crow",
+      "markdownDescription": "Configuration object for the crow manager\n\nSee also: [crow](https://docs.renovatebot.com/configuration-options/#crow)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.crow(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "currentValueTemplate": {
+      "description": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate",
+      "markdownDescription": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [currentValueTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate)",
+      "type": "string"
+    },
+    "customDatasources": {
+      "$ref": "#",
+      "description": "Defines custom datasources for usage by managers.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasources",
+      "markdownDescription": "Defines custom datasources for usage by managers.\n\nSee also: [customDatasources](https://docs.renovatebot.com/configuration-options/#customdatasources)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "defaultRegistryUrlTemplate": {
+                "$ref": "#/definitions/defaultRegistryUrlTemplate"
+              },
+              "format": {
+                "$ref": "#/definitions/format"
+              },
+              "transformTemplates": {
+                "$ref": "#/definitions/transformTemplates"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "customEnvVariables": {
+      "$ref": "#",
+      "description": "Custom environment variables for child processes and sidecar Docker containers.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#customenvvariables",
+      "markdownDescription": "Custom environment variables for child processes and sidecar Docker containers.\n\nSee also: [customEnvVariables](https://docs.renovatebot.com/self-hosted-configuration/#customenvvariables)",
+      "type": "object",
+      "default": {}
+    },
+    "customManagers": {
+      "description": "Custom managers using regex matching.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagers",
+      "markdownDescription": "Custom managers using regex matching.\n\nSee also: [customManagers](https://docs.renovatebot.com/configuration-options/#custommanagers)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "autoReplaceStringTemplate": {
+                "$ref": "#/definitions/autoReplaceStringTemplate"
+              },
+              "currentValueTemplate": {
+                "$ref": "#/definitions/currentValueTemplate"
+              },
+              "customType": {
+                "$ref": "#/definitions/customType"
+              },
+              "datasourceTemplate": {
+                "$ref": "#/definitions/datasourceTemplate"
+              },
+              "depNameTemplate": {
+                "$ref": "#/definitions/depNameTemplate"
+              },
+              "depTypeTemplate": {
+                "$ref": "#/definitions/depTypeTemplate"
+              },
+              "extractVersionTemplate": {
+                "$ref": "#/definitions/extractVersionTemplate"
+              },
+              "fileFormat": {
+                "$ref": "#/definitions/fileFormat"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "matchStringsStrategy": {
+                "$ref": "#/definitions/matchStringsStrategy"
+              },
+              "packageNameTemplate": {
+                "$ref": "#/definitions/packageNameTemplate"
+              },
+              "registryUrlTemplate": {
+                "$ref": "#/definitions/registryUrlTemplate"
+              },
+              "versioningTemplate": {
+                "$ref": "#/definitions/versioningTemplate"
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "customType": {
+                  "const": "jsonata"
+                }
+              },
+              "required": ["customType"]
+            },
+            "then": {
+              "required": ["fileFormat"]
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "customType": {
+      "description": "Custom manager to use. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype",
+      "markdownDescription": "Custom manager to use. Valid only within a `customManagers` object.\n\nSee also: [customType](https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype)",
+      "type": "string",
+      "enum": ["jsonata", "regex"]
+    },
+    "customizeDashboard": {
+      "description": "Customize sections in the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#customizedashboard",
+      "markdownDescription": "Customize sections in the Dependency Dashboard issue.\n\nSee also: [customizeDashboard](https://docs.renovatebot.com/configuration-options/#customizedashboard)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dataFileTemplate": {
+      "description": "A template to create post-upgrade command data file from.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate",
+      "markdownDescription": "A template to create post-upgrade command data file from.\n\nSee also: [dataFileTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate)",
+      "type": "string"
+    },
+    "datasourceTemplate": {
+      "description": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate",
+      "markdownDescription": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [datasourceTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate)",
+      "type": "string"
+    },
+    "defaultRegistryUrlTemplate": {
+      "description": "Template for generating a `defaultRegistryUrl` for custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate",
+      "markdownDescription": "Template for generating a `defaultRegistryUrl` for custom datasource.\n\nSee also: [defaultRegistryUrlTemplate](https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate)",
+      "type": "string",
+      "default": ""
+    },
+    "defaultRegistryUrls": {
+      "description": "List of registry URLs to use as the default for a datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#defaultregistryurls",
+      "markdownDescription": "List of registry URLs to use as the default for a datasource.\n\nSee also: [defaultRegistryUrls](https://docs.renovatebot.com/configuration-options/#defaultregistryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "deleteAdditionalConfigFile": {
+      "description": "If set to `true`, Renovate tries to delete the additional self-hosted config file after reading it.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#deleteadditionalconfigfile",
+      "markdownDescription": "If set to `true`, Renovate tries to delete the additional self-hosted config file after reading it.\n\nSee also: [deleteAdditionalConfigFile](https://docs.renovatebot.com/self-hosted-configuration/#deleteadditionalconfigfile)",
+      "type": "boolean",
+      "default": false
+    },
+    "deleteConfigFile": {
+      "description": "If set to `true`, Renovate tries to delete the self-hosted config file after reading it.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#deleteconfigfile",
+      "markdownDescription": "If set to `true`, Renovate tries to delete the self-hosted config file after reading it.\n\nSee also: [deleteConfigFile](https://docs.renovatebot.com/self-hosted-configuration/#deleteconfigfile)",
+      "type": "boolean",
+      "default": false
+    },
+    "deno": {
+      "$ref": "#",
+      "description": "Configuration object for the deno manager\nSee also: https://docs.renovatebot.com/configuration-options/#deno",
+      "markdownDescription": "Configuration object for the deno manager\n\nSee also: [deno](https://docs.renovatebot.com/configuration-options/#deno)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)deno\\.lock$/",
+          "/(^|/)deno\\.(json|jsonc)$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "{{#if (equals datasource \"npm\")}}[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}}){{else}}{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}{{/if}}"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "depNameTemplate": {
+      "description": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate",
+      "markdownDescription": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate)",
+      "type": "string"
+    },
+    "depTypeTemplate": {
+      "description": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate",
+      "markdownDescription": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depTypeTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate)",
+      "type": "string"
+    },
+    "dependencyDashboard": {
+      "description": "Whether to create a \"Dependency Dashboard\" issue in the repository.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboard",
+      "markdownDescription": "Whether to create a \"Dependency Dashboard\" issue in the repository.\n\nSee also: [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardApproval": {
+      "description": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval",
+      "markdownDescription": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\n\nSee also: [dependencyDashboardApproval](https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardAutoclose": {
+      "description": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose",
+      "markdownDescription": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\n\nSee also: [dependencyDashboardAutoclose](https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardCategory": {
+      "description": "The category to group branches on the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory",
+      "markdownDescription": "The category to group branches on the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardCategory](https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "dependencyDashboardFooter": {
+      "description": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter",
+      "markdownDescription": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\n\nSee also: [dependencyDashboardFooter](https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter)",
+      "type": "string"
+    },
+    "dependencyDashboardHeader": {
+      "description": "Any text added here will be placed first in the Dependency Dashboard issue body.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardheader",
+      "markdownDescription": "Any text added here will be placed first in the Dependency Dashboard issue body.\n\nSee also: [dependencyDashboardHeader](https://docs.renovatebot.com/configuration-options/#dependencydashboardheader)",
+      "type": "string",
+      "default": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more."
+    },
+    "dependencyDashboardLabels": {
+      "description": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels",
+      "markdownDescription": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\n\nSee also: [dependencyDashboardLabels](https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "description": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary",
+      "markdownDescription": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\n\nSee also: [dependencyDashboardOSVVulnerabilitySummary](https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary)",
+      "type": "string",
+      "enum": ["none", "all", "unresolved"],
+      "default": "none"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "description": "Controls whether abandoned packages are reported in the dependency dashboard.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment",
+      "markdownDescription": "Controls whether abandoned packages are reported in the dependency dashboard.\n\nSee also: [dependencyDashboardReportAbandonment](https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment)",
+      "type": "boolean",
+      "default": true
+    },
+    "dependencyDashboardTitle": {
+      "description": "Title for the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle",
+      "markdownDescription": "Title for the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardTitle](https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle)",
+      "type": "string",
+      "default": "Dependency Dashboard"
+    },
+    "deps-edn": {
+      "$ref": "#",
+      "description": "Configuration object for the deps-edn manager\nSee also: https://docs.renovatebot.com/configuration-options/#deps-edn",
+      "markdownDescription": "Configuration object for the deps-edn manager\n\nSee also: [deps-edn](https://docs.renovatebot.com/configuration-options/#deps-edn)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:deps|bb)\\.edn$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "description": {
+      "description": "Plain text description for a config or preset.\nSee also: https://docs.renovatebot.com/configuration-options/#description",
+      "markdownDescription": "Plain text description for a config or preset.\n\nSee also: [description](https://docs.renovatebot.com/configuration-options/#description)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "detectGlobalManagerConfig": {
+      "description": "If `true`, Renovate tries to detect global manager configuration from the file system.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#detectglobalmanagerconfig",
+      "markdownDescription": "If `true`, Renovate tries to detect global manager configuration from the file system.\n\nSee also: [detectGlobalManagerConfig](https://docs.renovatebot.com/self-hosted-configuration/#detectglobalmanagerconfig)",
+      "type": "boolean",
+      "default": false
+    },
+    "detectHostRulesFromEnv": {
+      "description": "If `true`, Renovate tries to detect host rules from environment variables.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#detecthostrulesfromenv",
+      "markdownDescription": "If `true`, Renovate tries to detect host rules from environment variables.\n\nSee also: [detectHostRulesFromEnv](https://docs.renovatebot.com/self-hosted-configuration/#detecthostrulesfromenv)",
+      "type": "boolean",
+      "default": false
+    },
+    "devbox": {
+      "$ref": "#",
+      "description": "Configuration object for the devbox manager\nSee also: https://docs.renovatebot.com/configuration-options/#devbox",
+      "markdownDescription": "Configuration object for the devbox manager\n\nSee also: [devbox](https://docs.renovatebot.com/configuration-options/#devbox)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)devbox\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "devcontainer": {
+      "$ref": "#",
+      "description": "Configuration object for the devcontainer manager\nSee also: https://docs.renovatebot.com/configuration-options/#devcontainer",
+      "markdownDescription": "Configuration object for the devcontainer manager\n\nSee also: [devcontainer](https://docs.renovatebot.com/configuration-options/#devcontainer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/^.devcontainer/devcontainer.json$/",
+          "/^.devcontainer.json$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "digest": {
+      "$ref": "#",
+      "description": "Configuration to apply when updating a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#digest",
+      "markdownDescription": "Configuration to apply when updating a digest (no change in tag/version).\n\nSee also: [digest](https://docs.renovatebot.com/configuration-options/#digest)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-digest",
+        "commitMessageExtra": "to {{newDigestShort}}",
+        "commitMessageTopic": "{{{depName}}} digest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dnsCache": {
+      "description": "Enable got DNS cache.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesdnscache",
+      "markdownDescription": "Enable got DNS cache.\n\nSee also: [dnsCache](https://docs.renovatebot.com/configuration-options/#hostrulesdnscache)",
+      "type": "boolean",
+      "default": false
+    },
+    "docker-compose": {
+      "$ref": "#",
+      "description": "Configuration object for the docker-compose manager\nSee also: https://docs.renovatebot.com/configuration-options/#docker-compose",
+      "markdownDescription": "Configuration object for the docker-compose manager\n\nSee also: [docker-compose](https://docs.renovatebot.com/configuration-options/#docker-compose)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dockerChildPrefix": {
+      "description": "Change this value to add a prefix to the Renovate Docker sidecar container names and labels.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dockerchildprefix",
+      "markdownDescription": "Change this value to add a prefix to the Renovate Docker sidecar container names and labels.\n\nSee also: [dockerChildPrefix](https://docs.renovatebot.com/self-hosted-configuration/#dockerchildprefix)",
+      "type": "string",
+      "default": "renovate_"
+    },
+    "dockerCliOptions": {
+      "description": "Pass CLI flags to `docker run` command when `binarySource=docker`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dockerclioptions",
+      "markdownDescription": "Pass CLI flags to `docker run` command when `binarySource=docker`.\n\nSee also: [dockerCliOptions](https://docs.renovatebot.com/self-hosted-configuration/#dockerclioptions)",
+      "type": "string"
+    },
+    "dockerMaxPages": {
+      "description": "By default, Renovate fetches up to 20 pages of Docker tags from registries. But you can set your own limit with this config option.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dockermaxpages",
+      "markdownDescription": "By default, Renovate fetches up to 20 pages of Docker tags from registries. But you can set your own limit with this config option.\n\nSee also: [dockerMaxPages](https://docs.renovatebot.com/self-hosted-configuration/#dockermaxpages)",
+      "type": "integer",
+      "default": 20
+    },
+    "dockerSidecarImage": {
+      "description": "Change this value to override the default Renovate sidecar image.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dockersidecarimage",
+      "markdownDescription": "Change this value to override the default Renovate sidecar image.\n\nSee also: [dockerSidecarImage](https://docs.renovatebot.com/self-hosted-configuration/#dockersidecarimage)",
+      "type": "string",
+      "default": "ghcr.io/renovatebot/base-image:13.78.1"
+    },
+    "dockerUser": {
+      "description": "Set the `UID` and `GID` for Docker-based binaries if you use `binarySource=docker`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dockeruser",
+      "markdownDescription": "Set the `UID` and `GID` for Docker-based binaries if you use `binarySource=docker`.\n\nSee also: [dockerUser](https://docs.renovatebot.com/self-hosted-configuration/#dockeruser)",
+      "type": "string",
+      "default": "12021"
+    },
+    "dockerfile": {
+      "$ref": "#",
+      "description": "Configuration object for the dockerfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#dockerfile",
+      "markdownDescription": "Configuration object for the dockerfile manager\n\nSee also: [dockerfile](https://docs.renovatebot.com/configuration-options/#dockerfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/",
+          "/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "draftPR": {
+      "description": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#draftpr",
+      "markdownDescription": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\n\nSee also: [draftPR](https://docs.renovatebot.com/configuration-options/#draftpr)",
+      "type": "boolean",
+      "default": false
+    },
+    "droneci": {
+      "$ref": "#",
+      "description": "Configuration object for the droneci manager\nSee also: https://docs.renovatebot.com/configuration-options/#droneci",
+      "markdownDescription": "Configuration object for the droneci manager\n\nSee also: [droneci](https://docs.renovatebot.com/configuration-options/#droneci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.drone\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dryRun": {
+      "description": "If enabled, perform a dry run by logging messages instead of creating/updating/deleting branches and PRs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#dryrun",
+      "markdownDescription": "If enabled, perform a dry run by logging messages instead of creating/updating/deleting branches and PRs.\n\nSee also: [dryRun](https://docs.renovatebot.com/self-hosted-configuration/#dryrun)",
+      "type": ["string", "null"],
+      "enum": ["extract", "lookup", "full"],
+      "default": null
+    },
+    "enableHttp2": {
+      "description": "Enable got HTTP/2 support.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2",
+      "markdownDescription": "Enable got HTTP/2 support.\n\nSee also: [enableHttp2](https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2)",
+      "type": "boolean",
+      "default": false
+    },
+    "enabled": {
+      "description": "Enable or disable corresponding functionality.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesenabled",
+      "markdownDescription": "Enable or disable corresponding functionality.\n\nSee also: [enabled](https://docs.renovatebot.com/configuration-options/#packagerulesenabled)",
+      "type": "boolean",
+      "default": true
+    },
+    "enabledManagers": {
+      "description": "A list of package managers to enable. Only managers on the list are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#enabledmanagers",
+      "markdownDescription": "A list of package managers to enable. Only managers on the list are enabled.\n\nSee also: [enabledManagers](https://docs.renovatebot.com/configuration-options/#enabledmanagers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "encrypted": {
+      "$ref": "#",
+      "description": "An object containing configuration encrypted with project key.\nSee also: https://docs.renovatebot.com/configuration-options/#encrypted",
+      "markdownDescription": "An object containing configuration encrypted with project key.\n\nSee also: [encrypted](https://docs.renovatebot.com/configuration-options/#encrypted)",
+      "type": ["object", "null"],
+      "default": null
+    },
+    "encryptedWarning": {
+      "description": "Warning text to use if encrypted config is found.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#encryptedwarning",
+      "markdownDescription": "Warning text to use if encrypted config is found.\n\nSee also: [encryptedWarning](https://docs.renovatebot.com/self-hosted-configuration/#encryptedwarning)",
+      "type": "string"
+    },
+    "endpoint": {
+      "description": "Custom endpoint to use.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#endpoint",
+      "markdownDescription": "Custom endpoint to use.\n\nSee also: [endpoint](https://docs.renovatebot.com/self-hosted-configuration/#endpoint)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "env": {
+      "$ref": "#",
+      "description": "Environment variables that Renovate uses when executing package manager commands.\nSee also: https://docs.renovatebot.com/configuration-options/#env",
+      "markdownDescription": "Environment variables that Renovate uses when executing package manager commands.\n\nSee also: [env](https://docs.renovatebot.com/configuration-options/#env)",
+      "type": "object",
+      "default": {}
+    },
+    "excludeCommitPaths": {
+      "description": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\nSee also: https://docs.renovatebot.com/configuration-options/#excludecommitpaths",
+      "markdownDescription": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\n\nSee also: [excludeCommitPaths](https://docs.renovatebot.com/configuration-options/#excludecommitpaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "executionMode": {
+      "description": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode",
+      "markdownDescription": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\n\nSee also: [executionMode](https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode)",
+      "type": "string",
+      "enum": ["update", "branch"],
+      "default": "update"
+    },
+    "executionTimeout": {
+      "description": "Default execution timeout in minutes for child processes Renovate creates.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#executiontimeout",
+      "markdownDescription": "Default execution timeout in minutes for child processes Renovate creates.\n\nSee also: [executionTimeout](https://docs.renovatebot.com/self-hosted-configuration/#executiontimeout)",
+      "type": "integer",
+      "default": 15
+    },
+    "expandCodeOwnersGroups": {
+      "description": "Expand the configured code owner groups into a full list of group members.\nSee also: https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups",
+      "markdownDescription": "Expand the configured code owner groups into a full list of group members.\n\nSee also: [expandCodeOwnersGroups](https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups)",
+      "type": "boolean",
+      "default": false
+    },
+    "exposeAllEnv": {
+      "description": "Set this to `true` to allow passing of all environment variables to package managers.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#exposeallenv",
+      "markdownDescription": "Set this to `true` to allow passing of all environment variables to package managers.\n\nSee also: [exposeAllEnv](https://docs.renovatebot.com/self-hosted-configuration/#exposeallenv)",
+      "type": "boolean",
+      "default": false
+    },
+    "extends": {
+      "description": "Configuration presets to use or extend.\nSee also: https://docs.renovatebot.com/configuration-options/#extends",
+      "markdownDescription": "Configuration presets to use or extend.\n\nSee also: [extends](https://docs.renovatebot.com/configuration-options/#extends)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "enum": [
+                  "config:best-practices",
+                  "config:recommended",
+                  "mergeConfidence:all-badges",
+                  "abandonments:recommended",
+                  "group:all",
+                  "replacements:all",
+                  "security:minimumReleaseAgeNpm",
+                  "security:only-security-updates"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "extractVersion": {
+      "description": "A regex (`re2`) to extract a version from a datasource's raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#extractversion",
+      "markdownDescription": "A regex (`re2`) to extract a version from a datasource's raw version string.\n\nSee also: [extractVersion](https://docs.renovatebot.com/configuration-options/#extractversion)",
+      "type": "string",
+      "format": "regex"
+    },
+    "extractVersionTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [extractVersionTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate)",
+      "type": "string"
+    },
+    "fetchChangeLogs": {
+      "description": "Controls if and when changelogs/release notes are fetched.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs",
+      "markdownDescription": "Controls if and when changelogs/release notes are fetched.\n\nSee also: [fetchChangeLogs](https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs)",
+      "type": "string",
+      "enum": ["off", "branch", "pr"],
+      "default": "pr"
+    },
+    "fileFilters": {
+      "description": "Files that match the glob pattern will be committed after running a post-upgrade task.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters",
+      "markdownDescription": "Files that match the glob pattern will be committed after running a post-upgrade task.\n\nSee also: [fileFilters](https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/*"]
+    },
+    "fileFormat": {
+      "description": "It specifies the syntax of the package file being managed by the custom JSONata manager.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersfileformat",
+      "markdownDescription": "It specifies the syntax of the package file being managed by the custom JSONata manager.\n\nSee also: [fileFormat](https://docs.renovatebot.com/configuration-options/#custommanagersfileformat)",
+      "type": "string",
+      "enum": ["json", "toml", "yaml"]
+    },
+    "filePatterns": {
+      "description": "A list of patterns to match files that contain the version string.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns",
+      "markdownDescription": "A list of patterns to match files that contain the version string.\n\nSee also: [filePatterns](https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "filterUnavailableUsers": {
+      "description": "Filter reviewers and assignees based on their availability.\nSee also: https://docs.renovatebot.com/configuration-options/#filterunavailableusers",
+      "markdownDescription": "Filter reviewers and assignees based on their availability.\n\nSee also: [filterUnavailableUsers](https://docs.renovatebot.com/configuration-options/#filterunavailableusers)",
+      "type": "boolean",
+      "default": false
+    },
+    "fleet": {
+      "$ref": "#",
+      "description": "Configuration object for the fleet manager\nSee also: https://docs.renovatebot.com/configuration-options/#fleet",
+      "markdownDescription": "Configuration object for the fleet manager\n\nSee also: [fleet](https://docs.renovatebot.com/configuration-options/#fleet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)fleet\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "flux": {
+      "$ref": "#",
+      "description": "Configuration object for the flux manager\nSee also: https://docs.renovatebot.com/configuration-options/#flux",
+      "markdownDescription": "Configuration object for the flux manager\n\nSee also: [flux](https://docs.renovatebot.com/configuration-options/#flux)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(?:^|/)gotk-components\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "followTag": {
+      "description": "If defined, packages will follow this release tag exactly.\nSee also: https://docs.renovatebot.com/configuration-options/#followtag",
+      "markdownDescription": "If defined, packages will follow this release tag exactly.\n\nSee also: [followTag](https://docs.renovatebot.com/configuration-options/#followtag)",
+      "type": "string"
+    },
+    "force": {
+      "$ref": "#",
+      "description": "Any configuration set in this object will force override existing settings.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#force",
+      "markdownDescription": "Any configuration set in this object will force override existing settings.\n\nSee also: [force](https://docs.renovatebot.com/self-hosted-configuration/#force)",
+      "type": "object"
+    },
+    "forceCli": {
+      "description": "Decides if CLI configuration options are moved to the `force` config section.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#forcecli",
+      "markdownDescription": "Decides if CLI configuration options are moved to the `force` config section.\n\nSee also: [forceCli](https://docs.renovatebot.com/self-hosted-configuration/#forcecli)",
+      "type": "boolean",
+      "default": true
+    },
+    "forkCreation": {
+      "description": "Whether to create forks as needed at runtime when running in \"fork mode\".\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#forkcreation",
+      "markdownDescription": "Whether to create forks as needed at runtime when running in \"fork mode\".\n\nSee also: [forkCreation](https://docs.renovatebot.com/self-hosted-configuration/#forkcreation)",
+      "type": "boolean",
+      "default": true
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "description": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits",
+      "markdownDescription": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\n\nSee also: [forkModeDisallowMaintainerEdits](https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits)",
+      "type": "boolean",
+      "default": false
+    },
+    "forkOrg": {
+      "description": "The preferred organization to create or find forked repositories, when in fork mode.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#forkorg",
+      "markdownDescription": "The preferred organization to create or find forked repositories, when in fork mode.\n\nSee also: [forkOrg](https://docs.renovatebot.com/self-hosted-configuration/#forkorg)",
+      "type": "string"
+    },
+    "forkProcessing": {
+      "description": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkprocessing",
+      "markdownDescription": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\n\nSee also: [forkProcessing](https://docs.renovatebot.com/configuration-options/#forkprocessing)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "forkToken": {
+      "description": "Set a personal access token here to enable \"fork mode\".\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#forktoken",
+      "markdownDescription": "Set a personal access token here to enable \"fork mode\".\n\nSee also: [forkToken](https://docs.renovatebot.com/self-hosted-configuration/#forktoken)",
+      "type": "string"
+    },
+    "format": {
+      "description": "Format of the custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesformat",
+      "markdownDescription": "Format of the custom datasource.\n\nSee also: [format](https://docs.renovatebot.com/configuration-options/#customdatasourcesformat)",
+      "type": "string",
+      "enum": ["json", "plain"],
+      "default": "json"
+    },
+    "fvm": {
+      "$ref": "#",
+      "description": "Configuration object for the fvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#fvm",
+      "markdownDescription": "Configuration object for the fvm manager\n\nSee also: [fvm](https://docs.renovatebot.com/configuration-options/#fvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)\\.fvm/fvm_config\\.json$/",
+          "/(^|/)\\.fvmrc$/"
+        ],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "git-submodules": {
+      "$ref": "#",
+      "description": "Configuration object for the git-submodules manager\nSee also: https://docs.renovatebot.com/configuration-options/#git-submodules",
+      "markdownDescription": "Configuration object for the git-submodules manager\n\nSee also: [git-submodules](https://docs.renovatebot.com/configuration-options/#git-submodules)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "versioning": "git",
+        "managerFilePatterns": ["/(^|/)\\.gitmodules$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitAuthor": {
+      "description": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitauthor",
+      "markdownDescription": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitAuthor](https://docs.renovatebot.com/configuration-options/#gitauthor)",
+      "type": "string"
+    },
+    "gitIgnoredAuthors": {
+      "description": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitignoredauthors",
+      "markdownDescription": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitIgnoredAuthors](https://docs.renovatebot.com/configuration-options/#gitignoredauthors)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gitLabIgnoreApprovals": {
+      "description": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals",
+      "markdownDescription": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\n\nSee also: [gitLabIgnoreApprovals](https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals)",
+      "type": "boolean",
+      "default": false
+    },
+    "gitNoVerify": {
+      "description": "Which Git commands will be run with the `--no-verify` option.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#gitnoverify",
+      "markdownDescription": "Which Git commands will be run with the `--no-verify` option.\n\nSee also: [gitNoVerify](https://docs.renovatebot.com/self-hosted-configuration/#gitnoverify)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": ["commit", "push"]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": ["commit", "push"]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "default": ["commit", "push"]
+    },
+    "gitPrivateKey": {
+      "description": "PGP key to use for signing Git commits.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#gitprivatekey",
+      "markdownDescription": "PGP key to use for signing Git commits.\n\nSee also: [gitPrivateKey](https://docs.renovatebot.com/self-hosted-configuration/#gitprivatekey)",
+      "type": "string"
+    },
+    "gitPrivateKeyPassphrase": {
+      "description": "Passphrase for the `gitPrivateKey`\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#gitprivatekeypassphrase",
+      "markdownDescription": "Passphrase for the `gitPrivateKey`\n\nSee also: [gitPrivateKeyPassphrase](https://docs.renovatebot.com/self-hosted-configuration/#gitprivatekeypassphrase)",
+      "type": "string"
+    },
+    "gitTimeout": {
+      "description": "Configure the timeout with a number of milliseconds to wait for a Git task.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#gittimeout",
+      "markdownDescription": "Configure the timeout with a number of milliseconds to wait for a Git task.\n\nSee also: [gitTimeout](https://docs.renovatebot.com/self-hosted-configuration/#gittimeout)",
+      "type": "integer",
+      "default": 0
+    },
+    "gitUrl": {
+      "description": "Overrides the default resolution for Git remote, e.g. to switch GitLab from HTTPS to SSH-based.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#giturl",
+      "markdownDescription": "Overrides the default resolution for Git remote, e.g. to switch GitLab from HTTPS to SSH-based.\n\nSee also: [gitUrl](https://docs.renovatebot.com/self-hosted-configuration/#giturl)",
+      "type": "string",
+      "enum": ["default", "ssh", "endpoint"],
+      "default": "default"
+    },
+    "github-actions": {
+      "$ref": "#",
+      "description": "Configuration object for the github-actions manager\nSee also: https://docs.renovatebot.com/configuration-options/#github-actions",
+      "markdownDescription": "Configuration object for the github-actions manager\n\nSee also: [github-actions](https://docs.renovatebot.com/configuration-options/#github-actions)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+          "/(^|/)action\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "githubTokenWarn": {
+      "description": "Display warnings about GitHub token not being set.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#githubtokenwarn",
+      "markdownDescription": "Display warnings about GitHub token not being set.\n\nSee also: [githubTokenWarn](https://docs.renovatebot.com/self-hosted-configuration/#githubtokenwarn)",
+      "type": "boolean",
+      "default": true
+    },
+    "gitlabci": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci",
+      "markdownDescription": "Configuration object for the gitlabci manager\n\nSee also: [gitlabci](https://docs.renovatebot.com/configuration-options/#gitlabci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitlabci-include": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci-include manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci-include",
+      "markdownDescription": "Configuration object for the gitlabci-include manager\n\nSee also: [gitlabci-include](https://docs.renovatebot.com/configuration-options/#gitlabci-include)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "glasskube": {
+      "$ref": "#",
+      "description": "Configuration object for the glasskube manager\nSee also: https://docs.renovatebot.com/configuration-options/#glasskube",
+      "markdownDescription": "Configuration object for the glasskube manager\n\nSee also: [glasskube](https://docs.renovatebot.com/configuration-options/#glasskube)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gleam": {
+      "$ref": "#",
+      "description": "Configuration object for the gleam manager\nSee also: https://docs.renovatebot.com/configuration-options/#gleam",
+      "markdownDescription": "Configuration object for the gleam manager\n\nSee also: [gleam](https://docs.renovatebot.com/configuration-options/#gleam)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)gleam.toml$/"],
+        "versioning": "hex"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "globalExtends": {
+      "description": "Configuration presets to use or extend for a self-hosted config.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#globalextends",
+      "markdownDescription": "Configuration presets to use or extend for a self-hosted config.\n\nSee also: [globalExtends](https://docs.renovatebot.com/self-hosted-configuration/#globalextends)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "goGetDirs": {
+      "description": "Directory pattern to run `go get` on.\nSee also: https://docs.renovatebot.com/configuration-options/#gogetdirs",
+      "markdownDescription": "Directory pattern to run `go get` on.\n\nSee also: [goGetDirs](https://docs.renovatebot.com/configuration-options/#gogetdirs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["./..."]
+    },
+    "gomod": {
+      "$ref": "#",
+      "description": "Configuration object for the gomod manager\nSee also: https://docs.renovatebot.com/configuration-options/#gomod",
+      "markdownDescription": "Configuration object for the gomod manager\n\nSee also: [gomod](https://docs.renovatebot.com/configuration-options/#gomod)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)go\\.mod$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle",
+      "markdownDescription": "Configuration object for the gradle manager\n\nSee also: [gradle](https://docs.renovatebot.com/configuration-options/#gradle)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.gradle(\\.kts)?$/",
+          "/(^|/)gradle\\.properties$/",
+          "/(^|/)gradle/.+\\.toml$/",
+          "/(^|/)buildSrc/.+\\.kt$/",
+          "/\\.versions\\.toml$/",
+          "/(^|/)versions.props$/",
+          "/(^|/)versions.lock$/"
+        ],
+        "timeout": 600,
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle-wrapper",
+      "markdownDescription": "Configuration object for the gradle-wrapper manager\n\nSee also: [gradle-wrapper](https://docs.renovatebot.com/configuration-options/#gradle-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)gradle/wrapper/gradle-wrapper\\.properties$/"
+        ],
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "group": {
+      "$ref": "#",
+      "description": "Config if `groupName` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#group",
+      "markdownDescription": "Config if `groupName` is enabled.\n\nSee also: [group](https://docs.renovatebot.com/configuration-options/#group)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{groupSlug}}}",
+        "commitMessageTopic": "{{{groupName}}}"
+      }
+    },
+    "groupName": {
+      "description": "Human understandable name for the dependency group.\nSee also: https://docs.renovatebot.com/configuration-options/#groupname",
+      "markdownDescription": "Human understandable name for the dependency group.\n\nSee also: [groupName](https://docs.renovatebot.com/configuration-options/#groupname)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "groupSingleUpdates": {
+      "description": "Apply group settings even when the group contains only one update.\nSee also: https://docs.renovatebot.com/configuration-options/#groupsingleupdates",
+      "markdownDescription": "Apply group settings even when the group contains only one update.\n\nSee also: [groupSingleUpdates](https://docs.renovatebot.com/configuration-options/#groupsingleupdates)",
+      "type": "boolean",
+      "default": false
+    },
+    "groupSlug": {
+      "description": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#groupslug",
+      "markdownDescription": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\n\nSee also: [groupSlug](https://docs.renovatebot.com/configuration-options/#groupslug)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "hashedBranchLength": {
+      "description": "If enabled, branch names will use a hashing function to ensure each branch has that length.\nSee also: https://docs.renovatebot.com/configuration-options/#hashedbranchlength",
+      "markdownDescription": "If enabled, branch names will use a hashing function to ensure each branch has that length.\n\nSee also: [hashedBranchLength](https://docs.renovatebot.com/configuration-options/#hashedbranchlength)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "haskell-cabal": {
+      "$ref": "#",
+      "description": "Configuration object for the haskell-cabal manager\nSee also: https://docs.renovatebot.com/configuration-options/#haskell-cabal",
+      "markdownDescription": "Configuration object for the haskell-cabal manager\n\nSee also: [haskell-cabal](https://docs.renovatebot.com/configuration-options/#haskell-cabal)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cabal$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "headers": {
+      "$ref": "#",
+      "description": "Put fields to be forwarded to the HTTP request headers in the headers config option.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesheaders",
+      "markdownDescription": "Put fields to be forwarded to the HTTP request headers in the headers config option.\n\nSee also: [headers](https://docs.renovatebot.com/configuration-options/#hostrulesheaders)",
+      "type": "object"
+    },
+    "helm-requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-requirements",
+      "markdownDescription": "Configuration object for the helm-requirements manager\n\nSee also: [helm-requirements](https://docs.renovatebot.com/configuration-options/#helm-requirements)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)requirements\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helm-values": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-values manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-values",
+      "markdownDescription": "Configuration object for the helm-values manager\n\nSee also: [helm-values](https://docs.renovatebot.com/configuration-options/#helm-values)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "helm values {{depName}}",
+        "managerFilePatterns": ["/(^|/)values\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmfile": {
+      "$ref": "#",
+      "description": "Configuration object for the helmfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmfile",
+      "markdownDescription": "Configuration object for the helmfile manager\n\nSee also: [helmfile](https://docs.renovatebot.com/configuration-options/#helmfile)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": [
+          "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?$/",
+          "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmsman": {
+      "$ref": "#",
+      "description": "Configuration object for the helmsman manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmsman",
+      "markdownDescription": "Configuration object for the helmsman manager\n\nSee also: [helmsman](https://docs.renovatebot.com/configuration-options/#helmsman)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmv3": {
+      "$ref": "#",
+      "description": "Configuration object for the helmv3 manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmv3",
+      "markdownDescription": "Configuration object for the helmv3 manager\n\nSee also: [helmv3](https://docs.renovatebot.com/configuration-options/#helmv3)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)Chart\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hermit": {
+      "$ref": "#",
+      "description": "Configuration object for the hermit manager\nSee also: https://docs.renovatebot.com/configuration-options/#hermit",
+      "markdownDescription": "Configuration object for the hermit manager\n\nSee also: [hermit](https://docs.renovatebot.com/configuration-options/#hermit)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bin/hermit$/"],
+        "excludeCommitPaths": ["**/bin/hermit"],
+        "versioning": "hermit"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homeassistant-manifest": {
+      "$ref": "#",
+      "description": "Configuration object for the homeassistant-manifest manager\nSee also: https://docs.renovatebot.com/configuration-options/#homeassistant-manifest",
+      "markdownDescription": "Configuration object for the homeassistant-manifest manager\n\nSee also: [homeassistant-manifest](https://docs.renovatebot.com/configuration-options/#homeassistant-manifest)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)manifest\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homebrew": {
+      "$ref": "#",
+      "description": "Configuration object for the homebrew manager\nSee also: https://docs.renovatebot.com/configuration-options/#homebrew",
+      "markdownDescription": "Configuration object for the homebrew manager\n\nSee also: [homebrew](https://docs.renovatebot.com/configuration-options/#homebrew)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Homebrew Formula {{depName}}",
+        "managerFilePatterns": ["/^Formula/\\w*/?[^/]+[.]rb$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostRules": {
+      "description": "Host rules/configuration including credentials.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrules",
+      "markdownDescription": "Host rules/configuration including credentials.\n\nSee also: [hostRules](https://docs.renovatebot.com/configuration-options/#hostrules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "abortIgnoreStatusCodes": {
+                "$ref": "#/definitions/abortIgnoreStatusCodes"
+              },
+              "abortOnError": {
+                "$ref": "#/definitions/abortOnError"
+              },
+              "artifactAuth": {
+                "$ref": "#/definitions/artifactAuth"
+              },
+              "authType": {
+                "$ref": "#/definitions/authType"
+              },
+              "concurrentRequestLimit": {
+                "$ref": "#/definitions/concurrentRequestLimit"
+              },
+              "dnsCache": {
+                "$ref": "#/definitions/dnsCache"
+              },
+              "enableHttp2": {
+                "$ref": "#/definitions/enableHttp2"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "headers": {
+                "$ref": "#/definitions/headers"
+              },
+              "hostType": {
+                "$ref": "#/definitions/hostType"
+              },
+              "httpsCertificate": {
+                "$ref": "#/definitions/httpsCertificate"
+              },
+              "httpsCertificateAuthority": {
+                "$ref": "#/definitions/httpsCertificateAuthority"
+              },
+              "httpsPrivateKey": {
+                "$ref": "#/definitions/httpsPrivateKey"
+              },
+              "insecureRegistry": {
+                "$ref": "#/definitions/insecureRegistry"
+              },
+              "keepAlive": {
+                "$ref": "#/definitions/keepAlive"
+              },
+              "matchHost": {
+                "$ref": "#/definitions/matchHost"
+              },
+              "maxRequestsPerSecond": {
+                "$ref": "#/definitions/maxRequestsPerSecond"
+              },
+              "maxRetryAfter": {
+                "$ref": "#/definitions/maxRetryAfter"
+              },
+              "readOnly": {
+                "$ref": "#/definitions/readOnly"
+              },
+              "timeout": {
+                "$ref": "#/definitions/timeout"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostType": {
+      "description": "hostType for a package rule. Can be a platform name or a datasource name.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshosttype",
+      "markdownDescription": "hostType for a package rule. Can be a platform name or a datasource name.\n\nSee also: [hostType](https://docs.renovatebot.com/configuration-options/#hostruleshosttype)",
+      "type": "string"
+    },
+    "html": {
+      "$ref": "#",
+      "description": "Configuration object for the html manager\nSee also: https://docs.renovatebot.com/configuration-options/#html",
+      "markdownDescription": "Configuration object for the html manager\n\nSee also: [html](https://docs.renovatebot.com/configuration-options/#html)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.html?$/"],
+        "versioning": "semver",
+        "digest": {
+          "enabled": false
+        },
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "httpCacheTtlDays": {
+      "description": "Maximum duration in days to keep HTTP cache entries.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#httpcachettldays",
+      "markdownDescription": "Maximum duration in days to keep HTTP cache entries.\n\nSee also: [httpCacheTtlDays](https://docs.renovatebot.com/self-hosted-configuration/#httpcachettldays)",
+      "type": "integer",
+      "default": 90
+    },
+    "httpsCertificate": {
+      "description": "The certificate chains in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate",
+      "markdownDescription": "The certificate chains in PEM format.\n\nSee also: [httpsCertificate](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsCertificateAuthority": {
+      "description": "The overriding trusted CA certificate.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority",
+      "markdownDescription": "The overriding trusted CA certificate.\n\nSee also: [httpsCertificateAuthority](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsPrivateKey": {
+      "description": "The private key in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey",
+      "markdownDescription": "The private key in PEM format.\n\nSee also: [httpsPrivateKey](https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "ignoreDeprecated": {
+      "description": "Avoid upgrading from a non-deprecated version to a deprecated one.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeprecated",
+      "markdownDescription": "Avoid upgrading from a non-deprecated version to a deprecated one.\n\nSee also: [ignoreDeprecated](https://docs.renovatebot.com/configuration-options/#ignoredeprecated)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreDeps": {
+      "description": "Dependencies to ignore.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeps",
+      "markdownDescription": "Dependencies to ignore.\n\nSee also: [ignoreDeps](https://docs.renovatebot.com/configuration-options/#ignoredeps)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignorePaths": {
+      "description": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepaths",
+      "markdownDescription": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\n\nSee also: [ignorePaths](https://docs.renovatebot.com/configuration-options/#ignorepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/node_modules/**", "**/bower_components/**"]
+    },
+    "ignorePlugins": {
+      "description": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreplugins",
+      "markdownDescription": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\n\nSee also: [ignorePlugins](https://docs.renovatebot.com/configuration-options/#ignoreplugins)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignorePrAuthor": {
+      "description": "Set to `true` to fetch the entire list of PRs instead of only those authored by the Renovate user.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#ignoreprauthor",
+      "markdownDescription": "Set to `true` to fetch the entire list of PRs instead of only those authored by the Renovate user.\n\nSee also: [ignorePrAuthor](https://docs.renovatebot.com/self-hosted-configuration/#ignoreprauthor)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignorePresets": {
+      "description": "A list of presets to ignore, including any that are nested inside an `extends` array.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepresets",
+      "markdownDescription": "A list of presets to ignore, including any that are nested inside an `extends` array.\n\nSee also: [ignorePresets](https://docs.renovatebot.com/configuration-options/#ignorepresets)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ignoreReviewers": {
+      "description": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#ignorereviewers",
+      "markdownDescription": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\n\nSee also: [ignoreReviewers](https://docs.renovatebot.com/configuration-options/#ignorereviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignoreScripts": {
+      "description": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorescripts",
+      "markdownDescription": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\n\nSee also: [ignoreScripts](https://docs.renovatebot.com/configuration-options/#ignorescripts)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreTests": {
+      "description": "Set to `true` to enable automerging without tests.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoretests",
+      "markdownDescription": "Set to `true` to enable automerging without tests.\n\nSee also: [ignoreTests](https://docs.renovatebot.com/configuration-options/#ignoretests)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignoreUnstable": {
+      "description": "Ignore versions with unstable SemVer.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreunstable",
+      "markdownDescription": "Ignore versions with unstable SemVer.\n\nSee also: [ignoreUnstable](https://docs.renovatebot.com/configuration-options/#ignoreunstable)",
+      "type": "boolean",
+      "default": true
+    },
+    "includeMirrors": {
+      "description": "Whether to process repositories that are mirrors. By default, repositories that are mirrors are skipped.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#includemirrors",
+      "markdownDescription": "Whether to process repositories that are mirrors. By default, repositories that are mirrors are skipped.\n\nSee also: [includeMirrors](https://docs.renovatebot.com/self-hosted-configuration/#includemirrors)",
+      "type": "boolean",
+      "default": false
+    },
+    "includePaths": {
+      "description": "Include package files only within these defined paths.\nSee also: https://docs.renovatebot.com/configuration-options/#includepaths",
+      "markdownDescription": "Include package files only within these defined paths.\n\nSee also: [includePaths](https://docs.renovatebot.com/configuration-options/#includepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "inheritConfig": {
+      "description": "If `true`, Renovate will inherit configuration from the `inheritConfigFileName` file in `inheritConfigRepoName`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#inheritconfig",
+      "markdownDescription": "If `true`, Renovate will inherit configuration from the `inheritConfigFileName` file in `inheritConfigRepoName`.\n\nSee also: [inheritConfig](https://docs.renovatebot.com/self-hosted-configuration/#inheritconfig)",
+      "type": "boolean",
+      "default": false
+    },
+    "inheritConfigFileName": {
+      "description": "Renovate will look for this config file name in the `inheritConfigRepoName`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigfilename",
+      "markdownDescription": "Renovate will look for this config file name in the `inheritConfigRepoName`.\n\nSee also: [inheritConfigFileName](https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigfilename)",
+      "type": "string",
+      "default": "org-inherited-config.json"
+    },
+    "inheritConfigRepoName": {
+      "description": "Renovate will look in this repo for the `inheritConfigFileName`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigreponame",
+      "markdownDescription": "Renovate will look in this repo for the `inheritConfigFileName`.\n\nSee also: [inheritConfigRepoName](https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigreponame)",
+      "type": "string",
+      "default": "{{parentOrg}}/renovate-config"
+    },
+    "inheritConfigStrict": {
+      "description": "If `true`, any `inheritedConfig` fetch error will result in an aborted run.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigstrict",
+      "markdownDescription": "If `true`, any `inheritedConfig` fetch error will result in an aborted run.\n\nSee also: [inheritConfigStrict](https://docs.renovatebot.com/self-hosted-configuration/#inheritconfigstrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "insecureRegistry": {
+      "description": "Explicitly turn on insecure Docker registry access (HTTP).\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry",
+      "markdownDescription": "Explicitly turn on insecure Docker registry access (HTTP).\n\nSee also: [insecureRegistry](https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry)",
+      "type": "boolean",
+      "default": false
+    },
+    "installTools": {
+      "description": "Install tools before executing commands\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools",
+      "markdownDescription": "Install tools before executing commands\n\nSee also: [installTools](https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "object",
+          "description": "Install the `bazelisk` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bun": {
+          "type": "object",
+          "description": "Install the `bun` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bundler": {
+          "type": "object",
+          "description": "Install the `bundler` Containerbase tool",
+          "additionalProperties": false
+        },
+        "cocoapods": {
+          "type": "object",
+          "description": "Install the `cocoapods` Containerbase tool",
+          "additionalProperties": false
+        },
+        "composer": {
+          "type": "object",
+          "description": "Install the `composer` Containerbase tool",
+          "additionalProperties": false
+        },
+        "conan": {
+          "type": "object",
+          "description": "Install the `conan` Containerbase tool",
+          "additionalProperties": false
+        },
+        "copier": {
+          "type": "object",
+          "description": "Install the `copier` Containerbase tool",
+          "additionalProperties": false
+        },
+        "corepack": {
+          "type": "object",
+          "description": "Install the `corepack` Containerbase tool",
+          "additionalProperties": false
+        },
+        "deno": {
+          "type": "object",
+          "description": "Install the `deno` Containerbase tool",
+          "additionalProperties": false
+        },
+        "devbox": {
+          "type": "object",
+          "description": "Install the `devbox` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dotnet": {
+          "type": "object",
+          "description": "Install the `dotnet` Containerbase tool",
+          "additionalProperties": false
+        },
+        "erlang": {
+          "type": "object",
+          "description": "Install the `erlang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "elixir": {
+          "type": "object",
+          "description": "Install the `elixir` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flux": {
+          "type": "object",
+          "description": "Install the `flux` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gleam": {
+          "type": "object",
+          "description": "Install the `gleam` Containerbase tool",
+          "additionalProperties": false
+        },
+        "golang": {
+          "type": "object",
+          "description": "Install the `golang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gradle": {
+          "type": "object",
+          "description": "Install the `gradle` Containerbase tool",
+          "additionalProperties": false
+        },
+        "hashin": {
+          "type": "object",
+          "description": "Install the `hashin` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helm": {
+          "type": "object",
+          "description": "Install the `helm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helmfile": {
+          "type": "object",
+          "description": "Install the `helmfile` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java": {
+          "type": "object",
+          "description": "Install the `java` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java-maven": {
+          "type": "object",
+          "description": "Install the `java-maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "jb": {
+          "type": "object",
+          "description": "Install the `jb` Containerbase tool",
+          "additionalProperties": false
+        },
+        "kustomize": {
+          "type": "object",
+          "description": "Install the `kustomize` Containerbase tool",
+          "additionalProperties": false
+        },
+        "maven": {
+          "type": "object",
+          "description": "Install the `maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "mise": {
+          "type": "object",
+          "description": "Install the `mise` Containerbase tool",
+          "additionalProperties": false
+        },
+        "nix": {
+          "type": "object",
+          "description": "Install the `nix` Containerbase tool",
+          "additionalProperties": false
+        },
+        "node": {
+          "type": "object",
+          "description": "Install the `node` Containerbase tool",
+          "additionalProperties": false
+        },
+        "npm": {
+          "type": "object",
+          "description": "Install the `npm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pdm": {
+          "type": "object",
+          "description": "Install the `pdm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "php": {
+          "type": "object",
+          "description": "Install the `php` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pip-tools": {
+          "type": "object",
+          "description": "Install the `pip-tools` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pipenv": {
+          "type": "object",
+          "description": "Install the `pipenv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pnpm": {
+          "type": "object",
+          "description": "Install the `pnpm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pixi": {
+          "type": "object",
+          "description": "Install the `pixi` Containerbase tool",
+          "additionalProperties": false
+        },
+        "poetry": {
+          "type": "object",
+          "description": "Install the `poetry` Containerbase tool",
+          "additionalProperties": false
+        },
+        "python": {
+          "type": "object",
+          "description": "Install the `python` Containerbase tool",
+          "additionalProperties": false
+        },
+        "ruby": {
+          "type": "object",
+          "description": "Install the `ruby` Containerbase tool. Also used in the `rubygems` Datasource",
+          "additionalProperties": false
+        },
+        "rust": {
+          "type": "object",
+          "description": "Install the `rust` Containerbase tool",
+          "additionalProperties": false
+        },
+        "uv": {
+          "type": "object",
+          "description": "Install the `uv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn": {
+          "type": "object",
+          "description": "Install the `yarn` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn-slim": {
+          "type": "object",
+          "description": "Install the `yarn-slim` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dart": {
+          "type": "object",
+          "description": "Install the `dart` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flutter": {
+          "type": "object",
+          "description": "Install the `flutter` Containerbase tool",
+          "additionalProperties": false
+        },
+        "vendir": {
+          "type": "object",
+          "description": "Install the `vendir` Containerbase tool",
+          "additionalProperties": false
+        }
+      }
+    },
+    "internalChecksAsSuccess": {
+      "description": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksassuccess",
+      "markdownDescription": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\n\nSee also: [internalChecksAsSuccess](https://docs.renovatebot.com/configuration-options/#internalchecksassuccess)",
+      "type": "boolean",
+      "default": false
+    },
+    "internalChecksFilter": {
+      "description": "When and how to filter based on internal checks.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksfilter",
+      "markdownDescription": "When and how to filter based on internal checks.\n\nSee also: [internalChecksFilter](https://docs.renovatebot.com/configuration-options/#internalchecksfilter)",
+      "type": "string",
+      "enum": ["strict", "flexible", "none"],
+      "default": "strict"
+    },
+    "jenkins": {
+      "$ref": "#",
+      "description": "Configuration object for the jenkins manager\nSee also: https://docs.renovatebot.com/configuration-options/#jenkins",
+      "markdownDescription": "Configuration object for the jenkins manager\n\nSee also: [jenkins](https://docs.renovatebot.com/configuration-options/#jenkins)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)plugins\\.(txt|ya?ml)$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jsonata": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonata manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonata",
+      "markdownDescription": "Configuration object for the jsonata manager\n\nSee also: [jsonata](https://docs.renovatebot.com/configuration-options/#jsonata)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "jsonnet-bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonnet-bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonnet-bundler",
+      "markdownDescription": "Configuration object for the jsonnet-bundler manager\n\nSee also: [jsonnet-bundler](https://docs.renovatebot.com/configuration-options/#jsonnet-bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)jsonnetfile\\.json$/"],
+        "datasource": "git-tags"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jvmMaxMemory": {
+      "description": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory",
+      "markdownDescription": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory)",
+      "type": "integer"
+    },
+    "jvmMemory": {
+      "description": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory",
+      "markdownDescription": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory)",
+      "type": "integer"
+    },
+    "keepAlive": {
+      "description": "Enable HTTP keep-alive for hosts.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleskeepalive",
+      "markdownDescription": "Enable HTTP keep-alive for hosts.\n\nSee also: [keepAlive](https://docs.renovatebot.com/configuration-options/#hostruleskeepalive)",
+      "type": "boolean",
+      "default": false
+    },
+    "keepUpdatedLabel": {
+      "description": "If set, users can add this label to PRs to request they be kept updated with the base branch.\nSee also: https://docs.renovatebot.com/configuration-options/#keepupdatedlabel",
+      "markdownDescription": "If set, users can add this label to PRs to request they be kept updated with the base branch.\n\nSee also: [keepUpdatedLabel](https://docs.renovatebot.com/configuration-options/#keepupdatedlabel)",
+      "type": "string"
+    },
+    "kotlin-script": {
+      "$ref": "#",
+      "description": "Configuration object for the kotlin-script manager\nSee also: https://docs.renovatebot.com/configuration-options/#kotlin-script",
+      "markdownDescription": "Configuration object for the kotlin-script manager\n\nSee also: [kotlin-script](https://docs.renovatebot.com/configuration-options/#kotlin-script)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^.+\\.main\\.kts$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kubernetes": {
+      "$ref": "#",
+      "description": "Configuration object for the kubernetes manager\nSee also: https://docs.renovatebot.com/configuration-options/#kubernetes",
+      "markdownDescription": "Configuration object for the kubernetes manager\n\nSee also: [kubernetes](https://docs.renovatebot.com/configuration-options/#kubernetes)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kustomize": {
+      "$ref": "#",
+      "description": "Configuration object for the kustomize manager\nSee also: https://docs.renovatebot.com/configuration-options/#kustomize",
+      "markdownDescription": "Configuration object for the kustomize manager\n\nSee also: [kustomize](https://docs.renovatebot.com/configuration-options/#kustomize)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)kustomization\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "labels": {
+      "description": "Labels to set in Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#labels",
+      "markdownDescription": "Labels to set in Pull Request.\n\nSee also: [labels](https://docs.renovatebot.com/configuration-options/#labels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "leiningen": {
+      "$ref": "#",
+      "description": "Configuration object for the leiningen manager\nSee also: https://docs.renovatebot.com/configuration-options/#leiningen",
+      "markdownDescription": "Configuration object for the leiningen manager\n\nSee also: [leiningen](https://docs.renovatebot.com/configuration-options/#leiningen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)project\\.clj$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "lockFileMaintenance": {
+      "$ref": "#",
+      "description": "Configuration for lock file maintenance.\nSee also: https://docs.renovatebot.com/configuration-options/#lockfilemaintenance",
+      "markdownDescription": "Configuration for lock file maintenance.\n\nSee also: [lockFileMaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "recreateWhen": "always",
+        "branchTopic": "lock-file-maintenance",
+        "commitMessageAction": "Lock file maintenance",
+        "commitMessageTopic": null,
+        "commitMessageExtra": null,
+        "schedule": ["before 4am on monday"],
+        "groupName": null,
+        "prBodyDefinitions": {
+          "Change": "All locks refreshed"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "logContext": {
+      "description": "Add a global or per-repo log context to each log entry.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#logcontext",
+      "markdownDescription": "Add a global or per-repo log context to each log entry.\n\nSee also: [logContext](https://docs.renovatebot.com/self-hosted-configuration/#logcontext)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "logLevelRemap": {
+      "description": "Remap log levels to different levels.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremap",
+      "markdownDescription": "Remap log levels to different levels.\n\nSee also: [logLevelRemap](https://docs.renovatebot.com/configuration-options/#loglevelremap)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "matchMessage": {
+                "$ref": "#/definitions/matchMessage"
+              },
+              "newLogLevel": {
+                "$ref": "#/definitions/newLogLevel"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "major": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `major`.\nSee also: https://docs.renovatebot.com/configuration-options/#major",
+      "markdownDescription": "Configuration to apply when an update type is `major`.\n\nSee also: [major](https://docs.renovatebot.com/configuration-options/#major)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "managerFilePatterns": {
+      "description": "RegEx (`re2`) and glob patterns for matching manager files.\nSee also: https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns",
+      "markdownDescription": "RegEx (`re2`) and glob patterns for matching manager files.\n\nSee also: [managerFilePatterns](https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchBaseBranches": {
+      "description": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches",
+      "markdownDescription": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchBaseBranches](https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchCategories": {
+      "description": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories",
+      "markdownDescription": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchCategories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchConfidence": {
+      "description": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence",
+      "markdownDescription": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\n\nSee also: [matchConfidence](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": ["low", "neutral", "high", "very high"]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": ["low", "neutral", "high", "very high"]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "matchCurrentAge": {
+      "description": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage",
+      "markdownDescription": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentAge](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage)",
+      "type": "string"
+    },
+    "matchCurrentValue": {
+      "description": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue)",
+      "type": "string"
+    },
+    "matchCurrentVersion": {
+      "description": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion",
+      "markdownDescription": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentVersion](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion)",
+      "type": "string"
+    },
+    "matchDatasources": {
+      "description": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources",
+      "markdownDescription": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchDatasources](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepNames": {
+      "description": "Dep names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames",
+      "markdownDescription": "Dep names to match. Valid only within a `packageRules` object.\n\nSee also: [matchDepNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepTypes": {
+      "description": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes",
+      "markdownDescription": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\n\nSee also: [matchDepTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchFileNames": {
+      "description": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames",
+      "markdownDescription": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\n\nSee also: [matchFileNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchHost": {
+      "description": "A domain name, host name or base URL to match against.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost",
+      "markdownDescription": "A domain name, host name or base URL to match against.\n\nSee also: [matchHost](https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost)",
+      "type": "string"
+    },
+    "matchJsonata": {
+      "description": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata",
+      "markdownDescription": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\n\nSee also: [matchJsonata](https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchManagers": {
+      "description": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers",
+      "markdownDescription": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchManagers](https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchMessage": {
+      "description": "Regex/minimatch expression to match against log message.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage",
+      "markdownDescription": "Regex/minimatch expression to match against log message.\n\nSee also: [matchMessage](https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage)",
+      "type": "string"
+    },
+    "matchNewValue": {
+      "description": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchNewValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue)",
+      "type": "string"
+    },
+    "matchPackageNames": {
+      "description": "Package names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames",
+      "markdownDescription": "Package names to match. Valid only within a `packageRules` object.\n\nSee also: [matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRegistryUrls": {
+      "description": "A list of URLs (or URL patterns) to match against registryUrls.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls",
+      "markdownDescription": "A list of URLs (or URL patterns) to match against registryUrls.\n\nSee also: [matchRegistryUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRepositories": {
+      "description": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories",
+      "markdownDescription": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchRepositories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchSourceUrls": {
+      "description": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls",
+      "markdownDescription": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\n\nSee also: [matchSourceUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchStrings": {
+      "description": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings",
+      "markdownDescription": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\n\nSee also: [matchStrings](https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchStringsStrategy": {
+      "description": "Strategy how to interpret matchStrings.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy",
+      "markdownDescription": "Strategy how to interpret matchStrings.\n\nSee also: [matchStringsStrategy](https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy)",
+      "type": "string",
+      "enum": ["any", "recursive", "combination"],
+      "default": "any"
+    },
+    "matchUpdateTypes": {
+      "description": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes",
+      "markdownDescription": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\n\nSee also: [matchUpdateTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "major",
+                  "minor",
+                  "patch",
+                  "pin",
+                  "pinDigest",
+                  "digest",
+                  "lockFileMaintenance",
+                  "rollback",
+                  "bump",
+                  "replacement"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "major",
+                "minor",
+                "patch",
+                "pin",
+                "pinDigest",
+                "digest",
+                "lockFileMaintenance",
+                "rollback",
+                "bump",
+                "replacement"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "maven": {
+      "$ref": "#",
+      "description": "Configuration object for the maven manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven",
+      "markdownDescription": "Configuration object for the maven manager\n\nSee also: [maven](https://docs.renovatebot.com/configuration-options/#maven)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)pom\\.xml$/",
+          "/(^|/)pom\\.template\\.xml$/",
+          "/^(((\\.mvn)|(\\.m2))/)?settings\\.xml$/",
+          "/(^|/)\\.mvn/extensions\\.xml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maven-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the maven-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven-wrapper",
+      "markdownDescription": "Configuration object for the maven-wrapper manager\n\nSee also: [maven-wrapper](https://docs.renovatebot.com/configuration-options/#maven-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|\\/).mvn/wrapper/maven-wrapper.properties$/",
+          "/(^|\\/)mvnw(.cmd)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maxMajorIncrement": {
+      "description": "Limit the maximum major version increment allowed. Set to 0 to disable.\nSee also: https://docs.renovatebot.com/configuration-options/#maxmajorincrement",
+      "markdownDescription": "Limit the maximum major version increment allowed. Set to 0 to disable.\n\nSee also: [maxMajorIncrement](https://docs.renovatebot.com/configuration-options/#maxmajorincrement)",
+      "type": "integer",
+      "default": 500
+    },
+    "maxRequestsPerSecond": {
+      "description": "Limit requests rate per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond",
+      "markdownDescription": "Limit requests rate per host.\n\nSee also: [maxRequestsPerSecond](https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond)",
+      "type": "integer",
+      "default": 0
+    },
+    "maxRetryAfter": {
+      "description": "Maximum retry-after header value to wait for before retrying a failed request.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter",
+      "markdownDescription": "Maximum retry-after header value to wait for before retrying a failed request.\n\nSee also: [maxRetryAfter](https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter)",
+      "type": "integer",
+      "default": 60
+    },
+    "mergeConfidenceDatasources": {
+      "description": "If set, Renovate will query the merge-confidence JSON API only for datasources that are part of this list.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#mergeconfidencedatasources",
+      "markdownDescription": "If set, Renovate will query the merge-confidence JSON API only for datasources that are part of this list.\n\nSee also: [mergeConfidenceDatasources](https://docs.renovatebot.com/self-hosted-configuration/#mergeconfidencedatasources)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["go", "maven", "npm", "nuget", "packagist", "pypi", "rubygems"]
+      },
+      "default": [
+        "go",
+        "maven",
+        "npm",
+        "nuget",
+        "packagist",
+        "pypi",
+        "rubygems"
+      ]
+    },
+    "mergeConfidenceEndpoint": {
+      "description": "If set, Renovate will query this API for Merge Confidence data.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#mergeconfidenceendpoint",
+      "markdownDescription": "If set, Renovate will query this API for Merge Confidence data.\n\nSee also: [mergeConfidenceEndpoint](https://docs.renovatebot.com/self-hosted-configuration/#mergeconfidenceendpoint)",
+      "type": "string",
+      "default": "https://developer.mend.io/"
+    },
+    "meteor": {
+      "$ref": "#",
+      "description": "Configuration object for the meteor manager\nSee also: https://docs.renovatebot.com/configuration-options/#meteor",
+      "markdownDescription": "Configuration object for the meteor manager\n\nSee also: [meteor](https://docs.renovatebot.com/configuration-options/#meteor)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)package\\.js$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "migratePresets": {
+      "$ref": "#",
+      "description": "Define presets here which have been removed or renamed and should be migrated automatically.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#migratepresets",
+      "markdownDescription": "Define presets here which have been removed or renamed and should be migrated automatically.\n\nSee also: [migratePresets](https://docs.renovatebot.com/self-hosted-configuration/#migratepresets)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "milestone": {
+      "description": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\nSee also: https://docs.renovatebot.com/configuration-options/#milestone",
+      "markdownDescription": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\n\nSee also: [milestone](https://docs.renovatebot.com/configuration-options/#milestone)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "minimumGroupSize": {
+      "description": "The minimum number of updates which must be in a group for branches to be created.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumgroupsize",
+      "markdownDescription": "The minimum number of updates which must be in a group for branches to be created.\n\nSee also: [minimumGroupSize](https://docs.renovatebot.com/configuration-options/#minimumgroupsize)",
+      "type": "integer",
+      "default": 1
+    },
+    "minimumReleaseAge": {
+      "description": "Time required before a new release is considered stable.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseage",
+      "markdownDescription": "Time required before a new release is considered stable.\n\nSee also: [minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "minimumReleaseAgeBehaviour": {
+      "description": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour",
+      "markdownDescription": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\n\nSee also: [minimumReleaseAgeBehaviour](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour)",
+      "type": "string",
+      "enum": ["timestamp-required", "timestamp-optional"],
+      "default": "timestamp-required"
+    },
+    "minor": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `minor`.\nSee also: https://docs.renovatebot.com/configuration-options/#minor",
+      "markdownDescription": "Configuration to apply when an update type is `minor`.\n\nSee also: [minor](https://docs.renovatebot.com/configuration-options/#minor)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mint": {
+      "$ref": "#",
+      "description": "Configuration object for the mint manager\nSee also: https://docs.renovatebot.com/configuration-options/#mint",
+      "markdownDescription": "Configuration object for the mint manager\n\nSee also: [mint](https://docs.renovatebot.com/configuration-options/#mint)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Mintfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mise": {
+      "$ref": "#",
+      "description": "Configuration object for the mise manager\nSee also: https://docs.renovatebot.com/configuration-options/#mise",
+      "markdownDescription": "Configuration object for the mise manager\n\nSee also: [mise](https://docs.renovatebot.com/configuration-options/#mise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "**/{,.}mise{,.*}.toml",
+          "**/{,.}mise/config{,.*}.toml",
+          "**/.config/mise{,.*}.toml",
+          "**/.config/mise/{mise,config}{,.*}.toml",
+          "**/.config/mise/conf.d/*.toml",
+          "**/.rtx{,.*}.toml"
+        ],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mix": {
+      "$ref": "#",
+      "description": "Configuration object for the mix manager\nSee also: https://docs.renovatebot.com/configuration-options/#mix",
+      "markdownDescription": "Configuration object for the mix manager\n\nSee also: [mix](https://docs.renovatebot.com/configuration-options/#mix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)mix\\.exs$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mode": {
+      "description": "Mode of operation.\nSee also: https://docs.renovatebot.com/configuration-options/#mode",
+      "markdownDescription": "Mode of operation.\n\nSee also: [mode](https://docs.renovatebot.com/configuration-options/#mode)",
+      "type": "string",
+      "enum": ["full", "silent"],
+      "default": "full"
+    },
+    "name": {
+      "description": "A name for the bumpVersion config. This is used for logging and debugging.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsname",
+      "markdownDescription": "A name for the bumpVersion config. This is used for logging and debugging.\n\nSee also: [name](https://docs.renovatebot.com/configuration-options/#bumpversionsname)",
+      "type": "string"
+    },
+    "newLogLevel": {
+      "description": "New log level to use if matchMessage matches.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel",
+      "markdownDescription": "New log level to use if matchMessage matches.\n\nSee also: [newLogLevel](https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel)",
+      "type": "string",
+      "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+    },
+    "nix": {
+      "$ref": "#",
+      "description": "Configuration object for the nix manager\nSee also: https://docs.renovatebot.com/configuration-options/#nix",
+      "markdownDescription": "Configuration object for the nix manager\n\nSee also: [nix](https://docs.renovatebot.com/configuration-options/#nix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)flake\\.nix$/"],
+        "commitMessageTopic": "nix",
+        "commitMessageExtra": "to {{newValue}}",
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nodeMaxMemory": {
+      "description": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory",
+      "markdownDescription": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\n\nSee also: [nodeMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory)",
+      "type": "integer"
+    },
+    "nodenv": {
+      "$ref": "#",
+      "description": "Configuration object for the nodenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#nodenv",
+      "markdownDescription": "Configuration object for the nodenv manager\n\nSee also: [nodenv](https://docs.renovatebot.com/configuration-options/#nodenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.node-version$/"],
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npm": {
+      "$ref": "#",
+      "description": "Configuration object for the npm manager\nSee also: https://docs.renovatebot.com/configuration-options/#npm",
+      "markdownDescription": "Configuration object for the npm manager\n\nSee also: [npm](https://docs.renovatebot.com/configuration-options/#npm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)package\\.json$/",
+          "/(^|/)pnpm-workspace\\.yaml$/",
+          "/(^|/)\\.yarnrc\\.yml$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npmToken": {
+      "description": "npm token used to authenticate with the default registry.\nSee also: https://docs.renovatebot.com/configuration-options/#npmtoken",
+      "markdownDescription": "npm token used to authenticate with the default registry.\n\nSee also: [npmToken](https://docs.renovatebot.com/configuration-options/#npmtoken)",
+      "type": "string"
+    },
+    "npmrc": {
+      "description": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrc",
+      "markdownDescription": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\n\nSee also: [npmrc](https://docs.renovatebot.com/configuration-options/#npmrc)",
+      "type": "string"
+    },
+    "npmrcMerge": {
+      "description": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrcmerge",
+      "markdownDescription": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\n\nSee also: [npmrcMerge](https://docs.renovatebot.com/configuration-options/#npmrcmerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "nuget": {
+      "$ref": "#",
+      "description": "Configuration object for the nuget manager\nSee also: https://docs.renovatebot.com/configuration-options/#nuget",
+      "markdownDescription": "Configuration object for the nuget manager\n\nSee also: [nuget](https://docs.renovatebot.com/configuration-options/#nuget)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.(?:cs|fs|vb|sql)proj$/",
+          "/\\.(?:props|targets)$/",
+          "/(^|/)dotnet-tools\\.json$/",
+          "/(^|/)global\\.json$/"
+        ],
+        "rangeStrategy": "bump",
+        "packageRules": [
+          {
+            "matchDepTypes": ["msbuild-sdk"],
+            "rangeStrategy": "bump"
+          }
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nvm": {
+      "$ref": "#",
+      "description": "Configuration object for the nvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#nvm",
+      "markdownDescription": "Configuration object for the nvm manager\n\nSee also: [nvm](https://docs.renovatebot.com/configuration-options/#nvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.nvmrc$/"],
+        "versioning": "node",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ocb": {
+      "$ref": "#",
+      "description": "Configuration object for the ocb manager\nSee also: https://docs.renovatebot.com/configuration-options/#ocb",
+      "markdownDescription": "Configuration object for the ocb manager\n\nSee also: [ocb](https://docs.renovatebot.com/configuration-options/#ocb)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "onboarding": {
+      "description": "Require a Configuration PR first.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboarding",
+      "markdownDescription": "Require a Configuration PR first.\n\nSee also: [onboarding](https://docs.renovatebot.com/self-hosted-configuration/#onboarding)",
+      "type": "boolean"
+    },
+    "onboardingAutoCloseAge": {
+      "description": "Maximum number of days after which Renovate will stop trying to onboard the repository, and will close any existing onboarding PRs\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingautocloseage",
+      "markdownDescription": "Maximum number of days after which Renovate will stop trying to onboard the repository, and will close any existing onboarding PRs\n\nSee also: [onboardingAutoCloseAge](https://docs.renovatebot.com/self-hosted-configuration/#onboardingautocloseage)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "onboardingBranch": {
+      "description": "Change this value to override the default onboarding branch name.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingbranch",
+      "markdownDescription": "Change this value to override the default onboarding branch name.\n\nSee also: [onboardingBranch](https://docs.renovatebot.com/self-hosted-configuration/#onboardingbranch)",
+      "type": "string",
+      "default": "renovate/configure"
+    },
+    "onboardingCommitMessage": {
+      "description": "Change this value to override the default onboarding commit message.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingcommitmessage",
+      "markdownDescription": "Change this value to override the default onboarding commit message.\n\nSee also: [onboardingCommitMessage](https://docs.renovatebot.com/self-hosted-configuration/#onboardingcommitmessage)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "onboardingConfig": {
+      "$ref": "#",
+      "description": "Configuration to use for onboarding PRs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfig",
+      "markdownDescription": "Configuration to use for onboarding PRs.\n\nSee also: [onboardingConfig](https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfig)",
+      "type": "object",
+      "default": {
+        "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+      }
+    },
+    "onboardingConfigFileName": {
+      "description": "Change this value to override the default onboarding config file name.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfigfilename",
+      "markdownDescription": "Change this value to override the default onboarding config file name.\n\nSee also: [onboardingConfigFileName](https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfigfilename)",
+      "type": "string",
+      "default": "renovate.json"
+    },
+    "onboardingNoDeps": {
+      "description": "Onboard the repository even if no dependencies are found.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingnodeps",
+      "markdownDescription": "Onboard the repository even if no dependencies are found.\n\nSee also: [onboardingNoDeps](https://docs.renovatebot.com/self-hosted-configuration/#onboardingnodeps)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "onboardingPrTitle": {
+      "description": "Change this value to override the default onboarding PR title.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingprtitle",
+      "markdownDescription": "Change this value to override the default onboarding PR title.\n\nSee also: [onboardingPrTitle](https://docs.renovatebot.com/self-hosted-configuration/#onboardingprtitle)",
+      "type": "string",
+      "default": "Configure Renovate"
+    },
+    "onboardingRebaseCheckbox": {
+      "description": "Set to enable rebase/retry markdown checkbox for onboarding PRs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingrebasecheckbox",
+      "markdownDescription": "Set to enable rebase/retry markdown checkbox for onboarding PRs.\n\nSee also: [onboardingRebaseCheckbox](https://docs.renovatebot.com/self-hosted-configuration/#onboardingrebasecheckbox)",
+      "type": "boolean",
+      "default": false
+    },
+    "optimizeForDisabled": {
+      "description": "Set to `true` to perform a check for disabled config prior to cloning.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#optimizefordisabled",
+      "markdownDescription": "Set to `true` to perform a check for disabled config prior to cloning.\n\nSee also: [optimizeForDisabled](https://docs.renovatebot.com/self-hosted-configuration/#optimizefordisabled)",
+      "type": "boolean",
+      "default": false
+    },
+    "osgi": {
+      "$ref": "#",
+      "description": "Configuration object for the osgi manager\nSee also: https://docs.renovatebot.com/configuration-options/#osgi",
+      "markdownDescription": "Configuration object for the osgi manager\n\nSee also: [osgi](https://docs.renovatebot.com/configuration-options/#osgi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)src/main/features/.+\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "osvVulnerabilityAlerts": {
+      "description": "Use vulnerability alerts from `osv.dev`.\nSee also: https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts",
+      "markdownDescription": "Use vulnerability alerts from `osv.dev`.\n\nSee also: [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)",
+      "type": "boolean",
+      "default": false
+    },
+    "overrideDatasource": {
+      "description": "Override the datasource value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource",
+      "markdownDescription": "Override the datasource value.\n\nSee also: [overrideDatasource](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource)",
+      "type": "string"
+    },
+    "overrideDepName": {
+      "description": "Override the depName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname",
+      "markdownDescription": "Override the depName value.\n\nSee also: [overrideDepName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname)",
+      "type": "string"
+    },
+    "overridePackageName": {
+      "description": "Override the packageName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename",
+      "markdownDescription": "Override the packageName value.\n\nSee also: [overridePackageName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename)",
+      "type": "string"
+    },
+    "packageNameTemplate": {
+      "description": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate",
+      "markdownDescription": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\n\nSee also: [packageNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate)",
+      "type": "string"
+    },
+    "packageRules": {
+      "description": "Rules for matching packages.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerules",
+      "markdownDescription": "Rules for matching packages.\n\nSee also: [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "allowedVersions": {
+                "$ref": "#/definitions/allowedVersions"
+              },
+              "changelogUrl": {
+                "$ref": "#/definitions/changelogUrl"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "fetchChangeLogs": {
+                "$ref": "#/definitions/fetchChangeLogs"
+              },
+              "matchBaseBranches": {
+                "$ref": "#/definitions/matchBaseBranches"
+              },
+              "matchCategories": {
+                "$ref": "#/definitions/matchCategories"
+              },
+              "matchConfidence": {
+                "$ref": "#/definitions/matchConfidence"
+              },
+              "matchCurrentAge": {
+                "$ref": "#/definitions/matchCurrentAge"
+              },
+              "matchCurrentValue": {
+                "$ref": "#/definitions/matchCurrentValue"
+              },
+              "matchCurrentVersion": {
+                "$ref": "#/definitions/matchCurrentVersion"
+              },
+              "matchDatasources": {
+                "$ref": "#/definitions/matchDatasources"
+              },
+              "matchDepNames": {
+                "$ref": "#/definitions/matchDepNames"
+              },
+              "matchDepTypes": {
+                "$ref": "#/definitions/matchDepTypes"
+              },
+              "matchFileNames": {
+                "$ref": "#/definitions/matchFileNames"
+              },
+              "matchJsonata": {
+                "$ref": "#/definitions/matchJsonata"
+              },
+              "matchManagers": {
+                "$ref": "#/definitions/matchManagers"
+              },
+              "matchNewValue": {
+                "$ref": "#/definitions/matchNewValue"
+              },
+              "matchPackageNames": {
+                "$ref": "#/definitions/matchPackageNames"
+              },
+              "matchRegistryUrls": {
+                "$ref": "#/definitions/matchRegistryUrls"
+              },
+              "matchRepositories": {
+                "$ref": "#/definitions/matchRepositories"
+              },
+              "matchSourceUrls": {
+                "$ref": "#/definitions/matchSourceUrls"
+              },
+              "matchUpdateTypes": {
+                "$ref": "#/definitions/matchUpdateTypes"
+              },
+              "overrideDatasource": {
+                "$ref": "#/definitions/overrideDatasource"
+              },
+              "overrideDepName": {
+                "$ref": "#/definitions/overrideDepName"
+              },
+              "overridePackageName": {
+                "$ref": "#/definitions/overridePackageName"
+              },
+              "prPriority": {
+                "$ref": "#/definitions/prPriority"
+              },
+              "replacementName": {
+                "$ref": "#/definitions/replacementName"
+              },
+              "replacementNameTemplate": {
+                "$ref": "#/definitions/replacementNameTemplate"
+              },
+              "replacementVersion": {
+                "$ref": "#/definitions/replacementVersion"
+              },
+              "replacementVersionTemplate": {
+                "$ref": "#/definitions/replacementVersionTemplate"
+              },
+              "sourceDirectory": {
+                "$ref": "#/definitions/sourceDirectory"
+              },
+              "sourceUrl": {
+                "$ref": "#/definitions/sourceUrl"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "password": {
+      "description": "Password for authentication.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#password",
+      "markdownDescription": "Password for authentication.\n\nSee also: [password](https://docs.renovatebot.com/self-hosted-configuration/#password)",
+      "type": "string"
+    },
+    "patch": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `patch`.\nSee also: https://docs.renovatebot.com/configuration-options/#patch",
+      "markdownDescription": "Configuration to apply when an update type is `patch`.\n\nSee also: [patch](https://docs.renovatebot.com/configuration-options/#patch)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep621": {
+      "$ref": "#",
+      "description": "Configuration object for the pep621 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep621",
+      "markdownDescription": "Configuration object for the pep621 manager\n\nSee also: [pep621](https://docs.renovatebot.com/configuration-options/#pep621)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep723": {
+      "$ref": "#",
+      "description": "Configuration object for the pep723 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep723",
+      "markdownDescription": "Configuration object for the pep723 manager\n\nSee also: [pep723](https://docs.renovatebot.com/configuration-options/#pep723)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "persistRepoData": {
+      "description": "If set to `true`: keep repository data between runs instead of deleting the data.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#persistrepodata",
+      "markdownDescription": "If set to `true`: keep repository data between runs instead of deleting the data.\n\nSee also: [persistRepoData](https://docs.renovatebot.com/self-hosted-configuration/#persistrepodata)",
+      "type": "boolean",
+      "default": false
+    },
+    "pin": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `pin`.\nSee also: https://docs.renovatebot.com/configuration-options/#pin",
+      "markdownDescription": "Configuration to apply when an update type is `pin`.\n\nSee also: [pin](https://docs.renovatebot.com/configuration-options/#pin)",
+      "type": "object",
+      "default": {
+        "rebaseWhen": "behind-base-branch",
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigest": {
+      "$ref": "#",
+      "description": "Configuration to apply when pinning a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#pindigest",
+      "markdownDescription": "Configuration to apply when pinning a digest (no change in tag/version).\n\nSee also: [pinDigest](https://docs.renovatebot.com/configuration-options/#pindigest)",
+      "type": "object",
+      "default": {
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigests": {
+      "description": "Whether to add digests to Dockerfile source images.\nSee also: https://docs.renovatebot.com/configuration-options/#pindigests",
+      "markdownDescription": "Whether to add digests to Dockerfile source images.\n\nSee also: [pinDigests](https://docs.renovatebot.com/configuration-options/#pindigests)",
+      "type": "boolean",
+      "default": false
+    },
+    "pip-compile": {
+      "$ref": "#",
+      "description": "Configuration object for the pip-compile manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip-compile",
+      "markdownDescription": "Configuration object for the pip-compile manager\n\nSee also: [pip-compile](https://docs.renovatebot.com/configuration-options/#pip-compile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "lockFileMaintenance": {
+          "enabled": true,
+          "branchTopic": "pip-compile-refresh",
+          "commitMessageAction": "Refresh pip-compile outputs"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_requirements",
+      "markdownDescription": "Configuration object for the pip_requirements manager\n\nSee also: [pip_requirements](https://docs.renovatebot.com/configuration-options/#pip_requirements)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)[\\w-]*requirements([-._]\\w+)?\\.(txt|pip)$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_setup": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_setup manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_setup",
+      "markdownDescription": "Configuration object for the pip_setup manager\n\nSee also: [pip_setup](https://docs.renovatebot.com/configuration-options/#pip_setup)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.py$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pipenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pipenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pipenv",
+      "markdownDescription": "Configuration object for the pipenv manager\n\nSee also: [pipenv](https://docs.renovatebot.com/configuration-options/#pipenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Pipfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pixi": {
+      "$ref": "#",
+      "description": "Configuration object for the pixi manager\nSee also: https://docs.renovatebot.com/configuration-options/#pixi",
+      "markdownDescription": "Configuration object for the pixi manager\n\nSee also: [pixi](https://docs.renovatebot.com/configuration-options/#pixi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)pyproject\\.toml$/",
+          "/(^|/)pixi\\.toml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "platform": {
+      "description": "Platform type of repository.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#platform",
+      "markdownDescription": "Platform type of repository.\n\nSee also: [platform](https://docs.renovatebot.com/self-hosted-configuration/#platform)",
+      "type": "string",
+      "enum": [
+        "azure",
+        "bitbucket",
+        "bitbucket-server",
+        "codecommit",
+        "forgejo",
+        "gerrit",
+        "gitea",
+        "github",
+        "gitlab",
+        "local",
+        "scm-manager"
+      ],
+      "default": "github"
+    },
+    "platformAutomerge": {
+      "description": "Controls if platform-native auto-merge is used.\nSee also: https://docs.renovatebot.com/configuration-options/#platformautomerge",
+      "markdownDescription": "Controls if platform-native auto-merge is used.\n\nSee also: [platformAutomerge](https://docs.renovatebot.com/configuration-options/#platformautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "platformCommit": {
+      "description": "Use platform API to perform commits instead of using Git directly.\nSee also: https://docs.renovatebot.com/configuration-options/#platformcommit",
+      "markdownDescription": "Use platform API to perform commits instead of using Git directly.\n\nSee also: [platformCommit](https://docs.renovatebot.com/configuration-options/#platformcommit)",
+      "type": "string",
+      "enum": ["auto", "disabled", "enabled"],
+      "default": "auto"
+    },
+    "poetry": {
+      "$ref": "#",
+      "description": "Configuration object for the poetry manager\nSee also: https://docs.renovatebot.com/configuration-options/#poetry",
+      "markdownDescription": "Configuration object for the poetry manager\n\nSee also: [poetry](https://docs.renovatebot.com/configuration-options/#poetry)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "postUpdateOptions": {
+      "description": "Enable post-update options to be run after package/artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#postupdateoptions",
+      "markdownDescription": "Enable post-update options to be run after package/artifact updating.\n\nSee also: [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "bundlerConservative",
+          "composerWithAll",
+          "composerNoMinimalChanges",
+          "dotnetWorkloadRestore",
+          "gomodMassage",
+          "gomodTidy",
+          "gomodTidy1.17",
+          "gomodTidyE",
+          "gomodUpdateImportPaths",
+          "gomodSkipVendor",
+          "gomodVendor",
+          "goGenerate",
+          "helmUpdateSubChartArchives",
+          "kustomizeInflateHelmCharts",
+          "npmDedupe",
+          "npmInstallTwice",
+          "pnpmDedupe",
+          "yarnDedupeFewer",
+          "yarnDedupeHighest"
+        ]
+      },
+      "default": []
+    },
+    "postUpgradeTasks": {
+      "$ref": "#",
+      "description": "Post-upgrade tasks that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasks",
+      "markdownDescription": "Post-upgrade tasks that are executed before a commit is made by Renovate.\n\nSee also: [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks)",
+      "type": "object",
+      "default": {
+        "commands": [],
+        "fileFilters": [],
+        "executionMode": "update",
+        "installTools": {}
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "commands": {
+                "$ref": "#/definitions/commands"
+              },
+              "dataFileTemplate": {
+                "$ref": "#/definitions/dataFileTemplate"
+              },
+              "executionMode": {
+                "$ref": "#/definitions/executionMode"
+              },
+              "fileFilters": {
+                "$ref": "#/definitions/fileFilters"
+              },
+              "installTools": {
+                "$ref": "#/definitions/installTools"
+              },
+              "workingDirTemplate": {
+                "$ref": "#/definitions/workingDirTemplate"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "prBodyColumns": {
+      "description": "List of columns to use in PR bodies.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodycolumns",
+      "markdownDescription": "List of columns to use in PR bodies.\n\nSee also: [prBodyColumns](https://docs.renovatebot.com/configuration-options/#prbodycolumns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["Package", "Type", "Update", "Change", "Pending"]
+    },
+    "prBodyDefinitions": {
+      "description": "Table column definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodydefinitions",
+      "markdownDescription": "Table column definitions to use in PR tables.\n\nSee also: [prBodyDefinitions](https://docs.renovatebot.com/configuration-options/#prbodydefinitions)",
+      "type": "object",
+      "default": {
+        "Package": "{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} \u2192 {{{newNameLinked}}}{{/unless}}{{/if}}",
+        "Type": "{{{depType}}}",
+        "Update": "{{{updateType}}}",
+        "Current value": "{{{currentValue}}}",
+        "New value": "{{{newValue}}}",
+        "Change": "`{{{displayFrom}}}` \u2192 `{{{displayTo}}}`",
+        "Pending": "{{{displayPending}}}",
+        "References": "{{{references}}}",
+        "Package file": "{{{packageFile}}}",
+        "Age": "{{#if newVersion}}![age](https://developer.mend.io/api/mc/badges/age/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Adoption": "{{#if newVersion}}![adoption](https://developer.mend.io/api/mc/badges/adoption/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Passing": "{{#if newVersion}}![passing](https://developer.mend.io/api/mc/badges/compatibility/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Confidence": "{{#if newVersion}}![confidence](https://developer.mend.io/api/mc/badges/confidence/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}"
+      }
+    },
+    "prBodyHeadingDefinitions": {
+      "description": "Table header definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions",
+      "markdownDescription": "Table header definitions to use in PR tables.\n\nSee also: [prBodyHeadingDefinitions](https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions)",
+      "type": "object",
+      "default": {
+        "Age": "[Age](https://docs.renovatebot.com/merge-confidence/)",
+        "Adoption": "[Adoption](https://docs.renovatebot.com/merge-confidence/)",
+        "Passing": "[Passing](https://docs.renovatebot.com/merge-confidence/)",
+        "Confidence": "[Confidence](https://docs.renovatebot.com/merge-confidence/)"
+      }
+    },
+    "prBodyNotes": {
+      "description": "List of extra notes or templates to include in the Pull Request body.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodynotes",
+      "markdownDescription": "List of extra notes or templates to include in the Pull Request body.\n\nSee also: [prBodyNotes](https://docs.renovatebot.com/configuration-options/#prbodynotes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": []
+    },
+    "prBodyTemplate": {
+      "description": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodytemplate",
+      "markdownDescription": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\n\nSee also: [prBodyTemplate](https://docs.renovatebot.com/configuration-options/#prbodytemplate)",
+      "type": "string",
+      "default": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
+    },
+    "prCacheSyncMaxPages": {
+      "description": "Maximum number of pages to fetch when syncing the pull request cache.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#prcachesyncmaxpages",
+      "markdownDescription": "Maximum number of pages to fetch when syncing the pull request cache.\n\nSee also: [prCacheSyncMaxPages](https://docs.renovatebot.com/self-hosted-configuration/#prcachesyncmaxpages)",
+      "type": "integer",
+      "default": 100
+    },
+    "prCommitsPerRunLimit": {
+      "description": "Set the maximum number of commits per Renovate run. By default there is no limit.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#prcommitsperrunlimit",
+      "markdownDescription": "Set the maximum number of commits per Renovate run. By default there is no limit.\n\nSee also: [prCommitsPerRunLimit](https://docs.renovatebot.com/self-hosted-configuration/#prcommitsperrunlimit)",
+      "type": "integer",
+      "default": 0
+    },
+    "prConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\n\nSee also: [prConcurrentLimit](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit)",
+      "type": "integer",
+      "default": 10
+    },
+    "prCreation": {
+      "description": "When to create the PR for a branch.\nSee also: https://docs.renovatebot.com/configuration-options/#prcreation",
+      "markdownDescription": "When to create the PR for a branch.\n\nSee also: [prCreation](https://docs.renovatebot.com/configuration-options/#prcreation)",
+      "type": "string",
+      "enum": ["immediate", "not-pending", "status-success", "approval"],
+      "default": "immediate"
+    },
+    "prFooter": {
+      "description": "Text added here will be placed last in the PR body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#prfooter",
+      "markdownDescription": "Text added here will be placed last in the PR body, with a divider separator before it.\n\nSee also: [prFooter](https://docs.renovatebot.com/configuration-options/#prfooter)",
+      "type": "string",
+      "default": "This PR has been generated by [Mend Renovate](https://github.com/renovatebot/renovate)."
+    },
+    "prHeader": {
+      "description": "Text added here will be placed first in the PR body.\nSee also: https://docs.renovatebot.com/configuration-options/#prheader",
+      "markdownDescription": "Text added here will be placed first in the PR body.\n\nSee also: [prHeader](https://docs.renovatebot.com/configuration-options/#prheader)",
+      "type": "string"
+    },
+    "prHourlyLimit": {
+      "description": "Rate limit PRs to maximum x created per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prhourlylimit",
+      "markdownDescription": "Rate limit PRs to maximum x created per hour. 0 means no limit.\n\nSee also: [prHourlyLimit](https://docs.renovatebot.com/configuration-options/#prhourlylimit)",
+      "type": "integer",
+      "default": 2
+    },
+    "prNotPendingHours": {
+      "description": "Timeout in hours for when `prCreation=not-pending`.\nSee also: https://docs.renovatebot.com/configuration-options/#prnotpendinghours",
+      "markdownDescription": "Timeout in hours for when `prCreation=not-pending`.\n\nSee also: [prNotPendingHours](https://docs.renovatebot.com/configuration-options/#prnotpendinghours)",
+      "type": "integer",
+      "default": 25
+    },
+    "prPriority": {
+      "description": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesprpriority",
+      "markdownDescription": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\n\nSee also: [prPriority](https://docs.renovatebot.com/configuration-options/#packagerulesprpriority)",
+      "type": "integer",
+      "default": 0
+    },
+    "prTitle": {
+      "description": "Pull Request title template. Inherits from `commitMessage` if null.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitle",
+      "markdownDescription": "Pull Request title template. Inherits from `commitMessage` if null.\n\nSee also: [prTitle](https://docs.renovatebot.com/configuration-options/#prtitle)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "prTitleStrict": {
+      "description": "Whether to bypass appending extra context to the Pull Request title.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitlestrict",
+      "markdownDescription": "Whether to bypass appending extra context to the Pull Request title.\n\nSee also: [prTitleStrict](https://docs.renovatebot.com/configuration-options/#prtitlestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "pre-commit": {
+      "$ref": "#",
+      "description": "Configuration object for the pre-commit manager\nSee also: https://docs.renovatebot.com/configuration-options/#pre-commit",
+      "markdownDescription": "Configuration object for the pre-commit manager\n\nSee also: [pre-commit](https://docs.renovatebot.com/configuration-options/#pre-commit)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "pre-commit hook {{depName}}",
+        "enabled": false,
+        "managerFilePatterns": ["/(^|/)\\.pre-commit-config\\.ya?ml$/"],
+        "prBodyNotes": [
+          "Note: The `pre-commit` manager in Renovate is not supported by the `pre-commit` maintainers or community. Please do not report any problems there, instead [create a Discussion in the Renovate repository](https://github.com/renovatebot/renovate/discussions/new) if you have any questions."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "presetCachePersistence": {
+      "description": "Cache resolved presets in package cache.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#presetcachepersistence",
+      "markdownDescription": "Cache resolved presets in package cache.\n\nSee also: [presetCachePersistence](https://docs.renovatebot.com/self-hosted-configuration/#presetcachepersistence)",
+      "type": "boolean",
+      "default": false
+    },
+    "printConfig": {
+      "description": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\nSee also: https://docs.renovatebot.com/configuration-options/#printconfig",
+      "markdownDescription": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\n\nSee also: [printConfig](https://docs.renovatebot.com/configuration-options/#printconfig)",
+      "type": "boolean",
+      "default": false
+    },
+    "privateKey": {
+      "description": "Server-side private key.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#privatekey",
+      "markdownDescription": "Server-side private key.\n\nSee also: [privateKey](https://docs.renovatebot.com/self-hosted-configuration/#privatekey)",
+      "type": "string"
+    },
+    "privateKeyOld": {
+      "description": "Secondary or old private key to try.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#privatekeyold",
+      "markdownDescription": "Secondary or old private key to try.\n\nSee also: [privateKeyOld](https://docs.renovatebot.com/self-hosted-configuration/#privatekeyold)",
+      "type": "string"
+    },
+    "privateKeyPath": {
+      "description": "Path to the Server-side private key.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#privatekeypath",
+      "markdownDescription": "Path to the Server-side private key.\n\nSee also: [privateKeyPath](https://docs.renovatebot.com/self-hosted-configuration/#privatekeypath)",
+      "type": "string"
+    },
+    "privateKeyPathOld": {
+      "description": "Path to the Server-side old private key.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#privatekeypathold",
+      "markdownDescription": "Path to the Server-side old private key.\n\nSee also: [privateKeyPathOld](https://docs.renovatebot.com/self-hosted-configuration/#privatekeypathold)",
+      "type": "string"
+    },
+    "processEnv": {
+      "$ref": "#",
+      "description": "Environment variables to be used in global config only.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#processenv",
+      "markdownDescription": "Environment variables to be used in global config only.\n\nSee also: [processEnv](https://docs.renovatebot.com/self-hosted-configuration/#processenv)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "productLinks": {
+      "$ref": "#",
+      "description": "Links which are used in PRs, issues and comments.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#productlinks",
+      "markdownDescription": "Links which are used in PRs, issues and comments.\n\nSee also: [productLinks](https://docs.renovatebot.com/self-hosted-configuration/#productlinks)",
+      "type": "object",
+      "default": {
+        "documentation": "https://docs.renovatebot.com/",
+        "help": "https://github.com/renovatebot/renovate/discussions",
+        "homepage": "https://github.com/renovatebot/renovate"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "proto": {
+      "$ref": "#",
+      "description": "Configuration object for the proto manager\nSee also: https://docs.renovatebot.com/configuration-options/#proto",
+      "markdownDescription": "Configuration object for the proto manager\n\nSee also: [proto](https://docs.renovatebot.com/configuration-options/#proto)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/.prototools"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pruneBranchAfterAutomerge": {
+      "description": "Set to `true` to enable branch pruning after automerging.\nSee also: https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge",
+      "markdownDescription": "Set to `true` to enable branch pruning after automerging.\n\nSee also: [pruneBranchAfterAutomerge](https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "pruneStaleBranches": {
+      "description": "Set to `false` to disable pruning stale branches.\nSee also: https://docs.renovatebot.com/configuration-options/#prunestalebranches",
+      "markdownDescription": "Set to `false` to disable pruning stale branches.\n\nSee also: [pruneStaleBranches](https://docs.renovatebot.com/configuration-options/#prunestalebranches)",
+      "type": "boolean",
+      "default": true
+    },
+    "pub": {
+      "$ref": "#",
+      "description": "Configuration object for the pub manager\nSee also: https://docs.renovatebot.com/configuration-options/#pub",
+      "markdownDescription": "Configuration object for the pub manager\n\nSee also: [pub](https://docs.renovatebot.com/configuration-options/#pub)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pubspec\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "puppet": {
+      "$ref": "#",
+      "description": "Configuration object for the puppet manager\nSee also: https://docs.renovatebot.com/configuration-options/#puppet",
+      "markdownDescription": "Configuration object for the puppet manager\n\nSee also: [puppet](https://docs.renovatebot.com/configuration-options/#puppet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Puppetfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pyenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pyenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pyenv",
+      "markdownDescription": "Configuration object for the pyenv manager\n\nSee also: [pyenv](https://docs.renovatebot.com/configuration-options/#pyenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.python-version$/"],
+        "versioning": "docker",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "quadlet": {
+      "$ref": "#",
+      "description": "Configuration object for the quadlet manager\nSee also: https://docs.renovatebot.com/configuration-options/#quadlet",
+      "markdownDescription": "Configuration object for the quadlet manager\n\nSee also: [quadlet](https://docs.renovatebot.com/configuration-options/#quadlet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/.+\\.container$/",
+          "/.+\\.image$/",
+          "/.+\\.volume$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rangeStrategy": {
+      "description": "Determines how to modify or update existing ranges.\nSee also: https://docs.renovatebot.com/configuration-options/#rangestrategy",
+      "markdownDescription": "Determines how to modify or update existing ranges.\n\nSee also: [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "pin",
+        "bump",
+        "replace",
+        "widen",
+        "update-lockfile",
+        "in-range-only"
+      ],
+      "default": "auto"
+    },
+    "readOnly": {
+      "description": "Match against requests that only read data and do not mutate anything.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesreadonly",
+      "markdownDescription": "Match against requests that only read data and do not mutate anything.\n\nSee also: [readOnly](https://docs.renovatebot.com/configuration-options/#hostrulesreadonly)",
+      "type": "boolean"
+    },
+    "rebaseAllOpenBranches": {
+      "description": "Rebase all open branches at once, as if the rebase-all-open-PRs checkbox was selected in the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#rebaseallopenbranches",
+      "markdownDescription": "Rebase all open branches at once, as if the rebase-all-open-PRs checkbox was selected in the Dependency Dashboard issue.\n\nSee also: [rebaseAllOpenBranches](https://docs.renovatebot.com/self-hosted-configuration/#rebaseallopenbranches)",
+      "type": "boolean",
+      "default": false
+    },
+    "rebaseLabel": {
+      "description": "Label to request a rebase from Renovate bot.\nSee also: https://docs.renovatebot.com/configuration-options/#rebaselabel",
+      "markdownDescription": "Label to request a rebase from Renovate bot.\n\nSee also: [rebaseLabel](https://docs.renovatebot.com/configuration-options/#rebaselabel)",
+      "type": "string",
+      "default": "rebase"
+    },
+    "rebaseWhen": {
+      "description": "Controls when Renovate rebases an existing branch.\nSee also: https://docs.renovatebot.com/configuration-options/#rebasewhen",
+      "markdownDescription": "Controls when Renovate rebases an existing branch.\n\nSee also: [rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "never",
+        "conflicted",
+        "behind-base-branch",
+        "automerging"
+      ],
+      "default": "auto"
+    },
+    "recreateWhen": {
+      "description": "Recreate PRs even if same ones were closed previously.\nSee also: https://docs.renovatebot.com/configuration-options/#recreatewhen",
+      "markdownDescription": "Recreate PRs even if same ones were closed previously.\n\nSee also: [recreateWhen](https://docs.renovatebot.com/configuration-options/#recreatewhen)",
+      "type": "string",
+      "enum": ["auto", "always", "never"],
+      "default": "auto"
+    },
+    "redisPrefix": {
+      "description": "Key prefix for redis cache entries.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#redisprefix",
+      "markdownDescription": "Key prefix for redis cache entries.\n\nSee also: [redisPrefix](https://docs.renovatebot.com/self-hosted-configuration/#redisprefix)",
+      "type": "string"
+    },
+    "redisUrl": {
+      "description": "If set, this Redis URL will be used for caching instead of the file system.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#redisurl",
+      "markdownDescription": "If set, this Redis URL will be used for caching instead of the file system.\n\nSee also: [redisUrl](https://docs.renovatebot.com/self-hosted-configuration/#redisurl)",
+      "type": "string"
+    },
+    "regex": {
+      "$ref": "#",
+      "description": "Configuration object for the regex manager\nSee also: https://docs.renovatebot.com/configuration-options/#regex",
+      "markdownDescription": "Configuration object for the regex manager\n\nSee also: [regex](https://docs.renovatebot.com/configuration-options/#regex)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "registryAliases": {
+      "$ref": "#",
+      "description": "Aliases for registries.\nSee also: https://docs.renovatebot.com/configuration-options/#registryaliases",
+      "markdownDescription": "Aliases for registries.\n\nSee also: [registryAliases](https://docs.renovatebot.com/configuration-options/#registryaliases)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "registryUrlTemplate": {
+      "description": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate",
+      "markdownDescription": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [registryUrlTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate)",
+      "type": "string"
+    },
+    "registryUrls": {
+      "description": "List of URLs to try for dependency lookup. Package manager specific.\nSee also: https://docs.renovatebot.com/configuration-options/#registryurls",
+      "markdownDescription": "List of URLs to try for dependency lookup. Package manager specific.\n\nSee also: [registryUrls](https://docs.renovatebot.com/configuration-options/#registryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "renovate-config": {
+      "$ref": "#",
+      "description": "Configuration object for the renovate-config manager\nSee also: https://docs.renovatebot.com/configuration-options/#renovate-config",
+      "markdownDescription": "Configuration object for the renovate-config manager\n\nSee also: [renovate-config](https://docs.renovatebot.com/configuration-options/#renovate-config)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "renovate.json",
+          "renovate.jsonc",
+          "renovate.json5",
+          ".github/renovate.json",
+          ".github/renovate.jsonc",
+          ".github/renovate.json5",
+          ".gitlab/renovate.json",
+          ".gitlab/renovate.jsonc",
+          ".gitlab/renovate.json5",
+          ".renovaterc",
+          ".renovaterc.json",
+          ".renovaterc.jsonc",
+          ".renovaterc.json5"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacement": {
+      "$ref": "#",
+      "description": "Configuration to apply when replacing a dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#replacement",
+      "markdownDescription": "Configuration to apply when replacing a dependency.\n\nSee also: [replacement](https://docs.renovatebot.com/configuration-options/#replacement)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-replacement",
+        "commitMessageAction": "Replace",
+        "commitMessageExtra": "with {{newName}} {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{#if isSingleVersion}}{{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
+        "prBodyNotes": [
+          "This is a special PR that replaces `{{{depName}}}` with the community suggested minimal stable replacement version."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacementApproach": {
+      "description": "Select whether to perform a direct replacement or alias replacement.\nSee also: https://docs.renovatebot.com/configuration-options/#replacementapproach",
+      "markdownDescription": "Select whether to perform a direct replacement or alias replacement.\n\nSee also: [replacementApproach](https://docs.renovatebot.com/configuration-options/#replacementapproach)",
+      "type": "string",
+      "enum": ["replace", "alias"],
+      "default": "replace"
+    },
+    "replacementName": {
+      "description": "The name of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname",
+      "markdownDescription": "The name of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementName](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname)",
+      "type": "string"
+    },
+    "replacementNameTemplate": {
+      "description": "Controls what the replacement package name.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate",
+      "markdownDescription": "Controls what the replacement package name.\n\nSee also: [replacementNameTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate)",
+      "type": "string",
+      "default": "{{{packageName}}}"
+    },
+    "replacementVersion": {
+      "description": "The version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion",
+      "markdownDescription": "The version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersion](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion)",
+      "type": "string"
+    },
+    "replacementVersionTemplate": {
+      "description": "Template field for the version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate",
+      "markdownDescription": "Template field for the version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersionTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate)",
+      "type": "string"
+    },
+    "reportFormatting": {
+      "description": "If set to `true`, Renovate will format the report JSON with Prettier before writing.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#reportformatting",
+      "markdownDescription": "If set to `true`, Renovate will format the report JSON with Prettier before writing.\n\nSee also: [reportFormatting](https://docs.renovatebot.com/self-hosted-configuration/#reportformatting)",
+      "type": "boolean",
+      "default": false
+    },
+    "reportPath": {
+      "description": "Path to where the file should be written. In case of `s3` this has to be a full S3 URI.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#reportpath",
+      "markdownDescription": "Path to where the file should be written. In case of `s3` this has to be a full S3 URI.\n\nSee also: [reportPath](https://docs.renovatebot.com/self-hosted-configuration/#reportpath)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "reportType": {
+      "description": "Set how, or if, reports should be generated.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#reporttype",
+      "markdownDescription": "Set how, or if, reports should be generated.\n\nSee also: [reportType](https://docs.renovatebot.com/self-hosted-configuration/#reporttype)",
+      "type": ["string", "null"],
+      "enum": ["logging", "file", "s3"],
+      "default": null
+    },
+    "repositories": {
+      "description": "List of Repositories.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#repositories",
+      "markdownDescription": "List of Repositories.\n\nSee also: [repositories](https://docs.renovatebot.com/self-hosted-configuration/#repositories)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "repositoryCache": {
+      "description": "This option decides if Renovate uses a JSON cache to speed up extractions.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#repositorycache",
+      "markdownDescription": "This option decides if Renovate uses a JSON cache to speed up extractions.\n\nSee also: [repositoryCache](https://docs.renovatebot.com/self-hosted-configuration/#repositorycache)",
+      "type": "string",
+      "enum": ["disabled", "enabled", "reset"],
+      "default": "disabled"
+    },
+    "repositoryCacheForceLocal": {
+      "description": "If set to `true`, Renovate will persist repository cache locally after uploading to S3.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#repositorycacheforcelocal",
+      "markdownDescription": "If set to `true`, Renovate will persist repository cache locally after uploading to S3.\n\nSee also: [repositoryCacheForceLocal](https://docs.renovatebot.com/self-hosted-configuration/#repositorycacheforcelocal)",
+      "type": "boolean",
+      "default": false
+    },
+    "repositoryCacheType": {
+      "description": "Set the type of renovate repository cache if `repositoryCache` is enabled.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#repositorycachetype",
+      "markdownDescription": "Set the type of renovate repository cache if `repositoryCache` is enabled.\n\nSee also: [repositoryCacheType](https://docs.renovatebot.com/self-hosted-configuration/#repositorycachetype)",
+      "type": "string",
+      "default": "local"
+    },
+    "requireConfig": {
+      "description": "Controls Renovate's behavior regarding repository config files such as `renovate.json`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#requireconfig",
+      "markdownDescription": "Controls Renovate's behavior regarding repository config files such as `renovate.json`.\n\nSee also: [requireConfig](https://docs.renovatebot.com/self-hosted-configuration/#requireconfig)",
+      "type": "string",
+      "enum": ["required", "optional", "ignored"],
+      "default": "required"
+    },
+    "respectLatest": {
+      "description": "Ignore versions newer than npm \"latest\" version.\nSee also: https://docs.renovatebot.com/configuration-options/#respectlatest",
+      "markdownDescription": "Ignore versions newer than npm \"latest\" version.\n\nSee also: [respectLatest](https://docs.renovatebot.com/configuration-options/#respectlatest)",
+      "type": "boolean",
+      "default": true
+    },
+    "reviewers": {
+      "description": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#reviewers",
+      "markdownDescription": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\n\nSee also: [reviewers](https://docs.renovatebot.com/configuration-options/#reviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reviewersFromCodeOwners": {
+      "description": "Determine reviewers based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners",
+      "markdownDescription": "Determine reviewers based on configured code owners and changes in PR.\n\nSee also: [reviewersFromCodeOwners](https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "reviewersSampleSize": {
+      "description": "Take a random sample of given size from `reviewers`.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewerssamplesize",
+      "markdownDescription": "Take a random sample of given size from `reviewers`.\n\nSee also: [reviewersSampleSize](https://docs.renovatebot.com/configuration-options/#reviewerssamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "rollback": {
+      "$ref": "#",
+      "description": "Configuration to apply when rolling back a version.\nSee also: https://docs.renovatebot.com/configuration-options/#rollback",
+      "markdownDescription": "Configuration to apply when rolling back a version.\n\nSee also: [rollback](https://docs.renovatebot.com/configuration-options/#rollback)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-rollback",
+        "commitMessageAction": "Roll back",
+        "semanticCommitType": "fix"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rollbackPrs": {
+      "description": "Create PRs to roll back versions if the current version is not found in the registry.\nSee also: https://docs.renovatebot.com/configuration-options/#rollbackprs",
+      "markdownDescription": "Create PRs to roll back versions if the current version is not found in the registry.\n\nSee also: [rollbackPrs](https://docs.renovatebot.com/configuration-options/#rollbackprs)",
+      "type": "boolean",
+      "default": false
+    },
+    "ruby-version": {
+      "$ref": "#",
+      "description": "Configuration object for the ruby-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#ruby-version",
+      "markdownDescription": "Configuration object for the ruby-version manager\n\nSee also: [ruby-version](https://docs.renovatebot.com/configuration-options/#ruby-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.ruby-version$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "runtime-version": {
+      "$ref": "#",
+      "description": "Configuration object for the runtime-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#runtime-version",
+      "markdownDescription": "Configuration object for the runtime-version manager\n\nSee also: [runtime-version](https://docs.renovatebot.com/configuration-options/#runtime-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)runtime.txt$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rust-toolchain": {
+      "$ref": "#",
+      "description": "Configuration object for the rust-toolchain manager\nSee also: https://docs.renovatebot.com/configuration-options/#rust-toolchain",
+      "markdownDescription": "Configuration object for the rust-toolchain manager\n\nSee also: [rust-toolchain](https://docs.renovatebot.com/configuration-options/#rust-toolchain)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust",
+        "managerFilePatterns": ["/(^|/)rust-toolchain(\\.toml)?$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "s3Endpoint": {
+      "description": "If set, Renovate will use this string as the `endpoint` when creating the AWS S3 client instance.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#s3endpoint",
+      "markdownDescription": "If set, Renovate will use this string as the `endpoint` when creating the AWS S3 client instance.\n\nSee also: [s3Endpoint](https://docs.renovatebot.com/self-hosted-configuration/#s3endpoint)",
+      "type": "string"
+    },
+    "s3PathStyle": {
+      "description": "If set, Renovate will enable `forcePathStyle` when creating the AWS S3 client instance.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#s3pathstyle",
+      "markdownDescription": "If set, Renovate will enable `forcePathStyle` when creating the AWS S3 client instance.\n\nSee also: [s3PathStyle](https://docs.renovatebot.com/self-hosted-configuration/#s3pathstyle)",
+      "type": "boolean",
+      "default": false
+    },
+    "sbt": {
+      "$ref": "#",
+      "description": "Configuration object for the sbt manager\nSee also: https://docs.renovatebot.com/configuration-options/#sbt",
+      "markdownDescription": "Configuration object for the sbt manager\n\nSee also: [sbt](https://docs.renovatebot.com/configuration-options/#sbt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.sbt$/",
+          "/project/[^/]*\\.scala$/",
+          "/project/build\\.properties$/",
+          "/(^|/)repositories$/"
+        ],
+        "versioning": "ivy"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "scalafmt": {
+      "$ref": "#",
+      "description": "Configuration object for the scalafmt manager\nSee also: https://docs.renovatebot.com/configuration-options/#scalafmt",
+      "markdownDescription": "Configuration object for the scalafmt manager\n\nSee also: [scalafmt](https://docs.renovatebot.com/configuration-options/#scalafmt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.scalafmt.conf$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "schedule": {
+      "description": "Limit branch creation to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#schedule",
+      "markdownDescription": "Limit branch creation to these times of day or week.\n\nSee also: [schedule](https://docs.renovatebot.com/configuration-options/#schedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "secrets": {
+      "$ref": "#",
+      "description": "Object which holds secret name/value pairs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#secrets",
+      "markdownDescription": "Object which holds secret name/value pairs.\n\nSee also: [secrets](https://docs.renovatebot.com/self-hosted-configuration/#secrets)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "semanticCommitScope": {
+      "description": "Commit scope to use if Semantic Commits are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommitscope",
+      "markdownDescription": "Commit scope to use if Semantic Commits are enabled.\n\nSee also: [semanticCommitScope](https://docs.renovatebot.com/configuration-options/#semanticcommitscope)",
+      "type": "string",
+      "default": "deps"
+    },
+    "semanticCommitType": {
+      "description": "Commit type to use if Semantic Commits is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommittype",
+      "markdownDescription": "Commit type to use if Semantic Commits is enabled.\n\nSee also: [semanticCommitType](https://docs.renovatebot.com/configuration-options/#semanticcommittype)",
+      "type": "string",
+      "default": "chore"
+    },
+    "semanticCommits": {
+      "description": "Enable Semantic Commit prefixes for commits and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommits",
+      "markdownDescription": "Enable Semantic Commit prefixes for commits and PR titles.\n\nSee also: [semanticCommits](https://docs.renovatebot.com/configuration-options/#semanticcommits)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "separateMajorMinor": {
+      "description": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemajorminor",
+      "markdownDescription": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\n\nSee also: [separateMajorMinor](https://docs.renovatebot.com/configuration-options/#separatemajorminor)",
+      "type": "boolean",
+      "default": true
+    },
+    "separateMinorPatch": {
+      "description": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separateminorpatch",
+      "markdownDescription": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\n\nSee also: [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMajor": {
+      "description": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultiplemajor",
+      "markdownDescription": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\n\nSee also: [separateMultipleMajor](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMinor": {
+      "description": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultipleminor",
+      "markdownDescription": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\n\nSee also: [separateMultipleMinor](https://docs.renovatebot.com/configuration-options/#separatemultipleminor)",
+      "type": "boolean",
+      "default": false
+    },
+    "setup-cfg": {
+      "$ref": "#",
+      "description": "Configuration object for the setup-cfg manager\nSee also: https://docs.renovatebot.com/configuration-options/#setup-cfg",
+      "markdownDescription": "Configuration object for the setup-cfg manager\n\nSee also: [setup-cfg](https://docs.renovatebot.com/configuration-options/#setup-cfg)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.cfg$/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "skipArtifactsUpdate": {
+      "description": "Skip Renovate's automatic artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#skipartifactsupdate",
+      "markdownDescription": "Skip Renovate's automatic artifact updating.\n\nSee also: [skipArtifactsUpdate](https://docs.renovatebot.com/configuration-options/#skipartifactsupdate)",
+      "type": "boolean",
+      "default": false
+    },
+    "skipInstalls": {
+      "description": "Skip installing modules/dependencies if lock file updating is possible without a full install.\nSee also: https://docs.renovatebot.com/configuration-options/#skipinstalls",
+      "markdownDescription": "Skip installing modules/dependencies if lock file updating is possible without a full install.\n\nSee also: [skipInstalls](https://docs.renovatebot.com/configuration-options/#skipinstalls)",
+      "type": ["boolean", "null"],
+      "default": null
+    },
+    "smithy": {
+      "$ref": "#",
+      "description": "Configuration object for the smithy manager\nSee also: https://docs.renovatebot.com/configuration-options/#smithy",
+      "markdownDescription": "Configuration object for the smithy manager\n\nSee also: [smithy](https://docs.renovatebot.com/configuration-options/#smithy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)smithy-build\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sourceDirectory": {
+      "description": "The source directory in which the package is present at its source.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory",
+      "markdownDescription": "The source directory in which the package is present at its source.\n\nSee also: [sourceDirectory](https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory)",
+      "type": "string"
+    },
+    "sourceUrl": {
+      "description": "The source URL of the package.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourceurl",
+      "markdownDescription": "The source URL of the package.\n\nSee also: [sourceUrl](https://docs.renovatebot.com/configuration-options/#packagerulessourceurl)",
+      "type": "string"
+    },
+    "statusCheckNames": {
+      "$ref": "#",
+      "description": "Custom strings to use as status check names.\nSee also: https://docs.renovatebot.com/configuration-options/#statuschecknames",
+      "markdownDescription": "Custom strings to use as status check names.\n\nSee also: [statusCheckNames](https://docs.renovatebot.com/configuration-options/#statuschecknames)",
+      "type": "object",
+      "default": {
+        "artifactError": "renovate/artifacts",
+        "configValidation": "renovate/config-validation",
+        "mergeConfidence": "renovate/merge-confidence",
+        "minimumReleaseAge": "renovate/stability-days"
+      }
+    },
+    "statusCheckWhen": {
+      "$ref": "#",
+      "description": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\nSee also: https://docs.renovatebot.com/configuration-options/#statuscheckwhen",
+      "markdownDescription": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\n\nSee also: [statusCheckWhen](https://docs.renovatebot.com/configuration-options/#statuscheckwhen)",
+      "type": "object",
+      "default": {
+        "artifactError": "failed",
+        "configValidation": "always",
+        "mergeConfidence": "always",
+        "minimumReleaseAge": "always"
+      }
+    },
+    "stopUpdatingLabel": {
+      "description": "Label to make Renovate stop updating a PR.\nSee also: https://docs.renovatebot.com/configuration-options/#stopupdatinglabel",
+      "markdownDescription": "Label to make Renovate stop updating a PR.\n\nSee also: [stopUpdatingLabel](https://docs.renovatebot.com/configuration-options/#stopupdatinglabel)",
+      "type": "string",
+      "default": "stop-updating"
+    },
+    "suppressNotifications": {
+      "description": "Options to suppress various types of warnings and other notifications.\nSee also: https://docs.renovatebot.com/configuration-options/#suppressnotifications",
+      "markdownDescription": "Options to suppress various types of warnings and other notifications.\n\nSee also: [suppressNotifications](https://docs.renovatebot.com/configuration-options/#suppressnotifications)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "artifactErrors",
+          "branchAutomergeFailure",
+          "configErrorIssue",
+          "dependencyLookupWarnings",
+          "lockFileErrors",
+          "missingCredentialsError",
+          "onboardingClose",
+          "prEditedNotification",
+          "prIgnoreNotification"
+        ]
+      },
+      "default": []
+    },
+    "sveltos": {
+      "$ref": "#",
+      "description": "Configuration object for the sveltos manager\nSee also: https://docs.renovatebot.com/configuration-options/#sveltos",
+      "markdownDescription": "Configuration object for the sveltos manager\n\nSee also: [sveltos](https://docs.renovatebot.com/configuration-options/#sveltos)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "swift": {
+      "$ref": "#",
+      "description": "Configuration object for the swift manager\nSee also: https://docs.renovatebot.com/configuration-options/#swift",
+      "markdownDescription": "Configuration object for the swift manager\n\nSee also: [swift](https://docs.renovatebot.com/configuration-options/#swift)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Package\\.swift/"],
+        "versioning": "swift",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tekton": {
+      "$ref": "#",
+      "description": "Configuration object for the tekton manager\nSee also: https://docs.renovatebot.com/configuration-options/#tekton",
+      "markdownDescription": "Configuration object for the tekton manager\n\nSee also: [tekton](https://docs.renovatebot.com/configuration-options/#tekton)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform",
+      "markdownDescription": "Configuration object for the terraform manager\n\nSee also: [terraform](https://docs.renovatebot.com/configuration-options/#terraform)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terraform {{depName}}",
+        "managerFilePatterns": ["**/*.tf", "**/*.tofu"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform-version",
+      "markdownDescription": "Configuration object for the terraform-version manager\n\nSee also: [terraform-version](https://docs.renovatebot.com/configuration-options/#terraform-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terraform-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt",
+      "markdownDescription": "Configuration object for the terragrunt manager\n\nSee also: [terragrunt](https://docs.renovatebot.com/configuration-options/#terragrunt)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terragrunt dependency {{depName}}",
+        "managerFilePatterns": ["/(^|/)terragrunt\\.hcl$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt-version",
+      "markdownDescription": "Configuration object for the terragrunt-version manager\n\nSee also: [terragrunt-version](https://docs.renovatebot.com/configuration-options/#terragrunt-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terragrunt-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.+)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tflint-plugin": {
+      "$ref": "#",
+      "description": "Configuration object for the tflint-plugin manager\nSee also: https://docs.renovatebot.com/configuration-options/#tflint-plugin",
+      "markdownDescription": "Configuration object for the tflint-plugin manager\n\nSee also: [tflint-plugin](https://docs.renovatebot.com/configuration-options/#tflint-plugin)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "TFLint plugin {{depName}}",
+        "managerFilePatterns": ["/\\.tflint\\.hcl$/"],
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "timeout": {
+      "description": "Timeout (in milliseconds) for queries to external endpoints.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulestimeout",
+      "markdownDescription": "Timeout (in milliseconds) for queries to external endpoints.\n\nSee also: [timeout](https://docs.renovatebot.com/configuration-options/#hostrulestimeout)",
+      "type": "integer"
+    },
+    "timezone": {
+      "description": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\nSee also: https://docs.renovatebot.com/configuration-options/#timezone",
+      "markdownDescription": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\n\nSee also: [timezone](https://docs.renovatebot.com/configuration-options/#timezone)",
+      "type": "string"
+    },
+    "token": {
+      "description": "Repository Auth Token.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#token",
+      "markdownDescription": "Repository Auth Token.\n\nSee also: [token](https://docs.renovatebot.com/self-hosted-configuration/#token)",
+      "type": "string"
+    },
+    "toolSettings": {
+      "$ref": "#",
+      "description": "Tool specific configuration. Global self-hosted configuration takes precedence.\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettings",
+      "markdownDescription": "Tool specific configuration. Global self-hosted configuration takes precedence.\n\nSee also: [toolSettings](https://docs.renovatebot.com/configuration-options/#toolsettings)",
+      "type": "object",
+      "default": {
+        "jvmMaxMemory": 512,
+        "jvmMemory": 512
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "jvmMaxMemory": {
+                "$ref": "#/definitions/jvmMaxMemory"
+              },
+              "jvmMemory": {
+                "$ref": "#/definitions/jvmMemory"
+              },
+              "nodeMaxMemory": {
+                "$ref": "#/definitions/nodeMaxMemory"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "transformTemplates": {
+      "description": "List of jsonata transformation rules.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates",
+      "markdownDescription": "List of jsonata transformation rules.\n\nSee also: [transformTemplates](https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "travis": {
+      "$ref": "#",
+      "description": "Configuration object for the travis manager\nSee also: https://docs.renovatebot.com/configuration-options/#travis",
+      "markdownDescription": "Configuration object for the travis manager\n\nSee also: [travis](https://docs.renovatebot.com/configuration-options/#travis)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.travis\\.ya?ml$/"],
+        "major": {
+          "enabled": false
+        },
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "typst": {
+      "$ref": "#",
+      "description": "Configuration object for the typst manager\nSee also: https://docs.renovatebot.com/configuration-options/#typst",
+      "markdownDescription": "Configuration object for the typst manager\n\nSee also: [typst](https://docs.renovatebot.com/configuration-options/#typst)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.typ$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "unicodeEmoji": {
+      "description": "Enable or disable Unicode emoji.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#unicodeemoji",
+      "markdownDescription": "Enable or disable Unicode emoji.\n\nSee also: [unicodeEmoji](https://docs.renovatebot.com/self-hosted-configuration/#unicodeemoji)",
+      "type": "boolean",
+      "default": true
+    },
+    "unity3d": {
+      "$ref": "#",
+      "description": "Configuration object for the unity3d manager\nSee also: https://docs.renovatebot.com/configuration-options/#unity3d",
+      "markdownDescription": "Configuration object for the unity3d manager\n\nSee also: [unity3d](https://docs.renovatebot.com/configuration-options/#unity3d)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/ProjectSettings/ProjectVersion.txt"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "updateInternalDeps": {
+      "description": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\nSee also: https://docs.renovatebot.com/configuration-options/#updateinternaldeps",
+      "markdownDescription": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\n\nSee also: [updateInternalDeps](https://docs.renovatebot.com/configuration-options/#updateinternaldeps)",
+      "type": "boolean",
+      "default": false
+    },
+    "updateNotScheduled": {
+      "description": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\nSee also: https://docs.renovatebot.com/configuration-options/#updatenotscheduled",
+      "markdownDescription": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\n\nSee also: [updateNotScheduled](https://docs.renovatebot.com/configuration-options/#updatenotscheduled)",
+      "type": "boolean",
+      "default": true
+    },
+    "updatePinnedDependencies": {
+      "description": "Whether to update pinned (single version) dependencies or not.\nSee also: https://docs.renovatebot.com/configuration-options/#updatepinneddependencies",
+      "markdownDescription": "Whether to update pinned (single version) dependencies or not.\n\nSee also: [updatePinnedDependencies](https://docs.renovatebot.com/configuration-options/#updatepinneddependencies)",
+      "type": "boolean",
+      "default": true
+    },
+    "useBaseBranchConfig": {
+      "description": "Whether to read configuration from base branches instead of only the default branch.\nSee also: https://docs.renovatebot.com/configuration-options/#usebasebranchconfig",
+      "markdownDescription": "Whether to read configuration from base branches instead of only the default branch.\n\nSee also: [useBaseBranchConfig](https://docs.renovatebot.com/configuration-options/#usebasebranchconfig)",
+      "type": "string",
+      "enum": ["merge", "none"],
+      "default": "none"
+    },
+    "useCloudMetadataServices": {
+      "description": "If `false`, Renovate does not try to access cloud metadata services.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#usecloudmetadataservices",
+      "markdownDescription": "If `false`, Renovate does not try to access cloud metadata services.\n\nSee also: [useCloudMetadataServices](https://docs.renovatebot.com/self-hosted-configuration/#usecloudmetadataservices)",
+      "type": "boolean",
+      "default": true
+    },
+    "userAgent": {
+      "description": "Sets the `user-agent` header to be sent with HTTP requests. Supports `{{renovateVersion}}` as a template variable for the current Renovate version.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#useragent",
+      "markdownDescription": "Sets the `user-agent` header to be sent with HTTP requests. Supports `{{renovateVersion}}` as a template variable for the current Renovate version.\n\nSee also: [userAgent](https://docs.renovatebot.com/self-hosted-configuration/#useragent)",
+      "type": "string",
+      "default": "Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)"
+    },
+    "userStrings": {
+      "description": "User-facing strings for the Renovate comment when a PR is closed.\nSee also: https://docs.renovatebot.com/configuration-options/#userstrings",
+      "markdownDescription": "User-facing strings for the Renovate comment when a PR is closed.\n\nSee also: [userStrings](https://docs.renovatebot.com/configuration-options/#userstrings)",
+      "type": "object",
+      "default": {
+        "ignoreTopic": "Renovate Ignore Notification",
+        "ignoreMajor": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for *any* future `{{{newMajor}}}.x` releases. But if you manually upgrade to `{{{newMajor}}}.x` then Renovate will re-enable `minor` and `patch` updates automatically.",
+        "ignoreDigest": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for the `{{{depName}}}` `{{{newDigestShort}}}` update again.",
+        "ignoreOther": "Because you closed this PR without merging, Renovate will ignore this update (`{{{newValue}}}`). You will get a PR once a newer version is released. To ignore this dependency forever, add it to the `ignoreDeps` array of your Renovate config.",
+        "artifactErrorWarning": "You probably do not want to merge this PR as-is."
+      }
+    },
+    "username": {
+      "description": "Username for authentication.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#username",
+      "markdownDescription": "Username for authentication.\n\nSee also: [username](https://docs.renovatebot.com/self-hosted-configuration/#username)",
+      "type": "string"
+    },
+    "variables": {
+      "$ref": "#",
+      "description": "Object which holds variable name/value pairs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#variables",
+      "markdownDescription": "Object which holds variable name/value pairs.\n\nSee also: [variables](https://docs.renovatebot.com/self-hosted-configuration/#variables)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "velaci": {
+      "$ref": "#",
+      "description": "Configuration object for the velaci manager\nSee also: https://docs.renovatebot.com/configuration-options/#velaci",
+      "markdownDescription": "Configuration object for the velaci manager\n\nSee also: [velaci](https://docs.renovatebot.com/configuration-options/#velaci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.vela\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vendir": {
+      "$ref": "#",
+      "description": "Configuration object for the vendir manager\nSee also: https://docs.renovatebot.com/configuration-options/#vendir",
+      "markdownDescription": "Configuration object for the vendir manager\n\nSee also: [vendir](https://docs.renovatebot.com/configuration-options/#vendir)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "vendir {{depName}}",
+        "managerFilePatterns": ["/(^|/)vendir\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "versionCompatibility": {
+      "description": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#versioncompatibility",
+      "markdownDescription": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\n\nSee also: [versionCompatibility](https://docs.renovatebot.com/configuration-options/#versioncompatibility)",
+      "type": "string",
+      "format": "regex"
+    },
+    "versioning": {
+      "description": "Versioning to use for filtering and comparisons.\nSee also: https://docs.renovatebot.com/configuration-options/#versioning",
+      "markdownDescription": "Versioning to use for filtering and comparisons.\n\nSee also: [versioning](https://docs.renovatebot.com/configuration-options/#versioning)",
+      "type": "string",
+      "oneOf": [
+        {
+          "enum": [
+            "apk",
+            "aws-eks-addon",
+            "aws-machine-image",
+            "azure-rest-api",
+            "bazel-module",
+            "cargo",
+            "composer",
+            "conan",
+            "conda",
+            "deb",
+            "debian",
+            "deno",
+            "devbox",
+            "docker",
+            "elm",
+            "exact",
+            "git",
+            "github-actions",
+            "glasskube",
+            "go-mod-directive",
+            "gradle",
+            "hashicorp",
+            "helm",
+            "hermit",
+            "hex",
+            "ivy",
+            "kubernetes-api",
+            "lambda-node",
+            "loose",
+            "maven",
+            "nixpkgs",
+            "node",
+            "npm",
+            "nuget",
+            "paket",
+            "pep440",
+            "perl",
+            "poetry",
+            "pvp",
+            "python",
+            "redhat",
+            "regex",
+            "rez",
+            "rpm",
+            "ruby",
+            "rust-release-channel",
+            "same-major",
+            "semver",
+            "semver-coerced",
+            "semver-partial",
+            "swift",
+            "ubuntu",
+            "unity3d",
+            "unity3d-packages"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^regex:"
+        }
+      ]
+    },
+    "versioningTemplate": {
+      "description": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate",
+      "markdownDescription": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [versioningTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate)",
+      "type": "string"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#",
+      "description": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
+      "markdownDescription": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\n\nSee also: [vulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)",
+      "type": "object",
+      "default": {
+        "groupName": null,
+        "schedule": [],
+        "dependencyDashboardApproval": false,
+        "minimumReleaseAge": null,
+        "rangeStrategy": "update-lockfile",
+        "commitMessageSuffix": "[SECURITY]",
+        "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+        "prCreation": "immediate",
+        "vulnerabilityFixStrategy": "lowest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "vulnerabilityFixStrategy": {
+                "$ref": "#/definitions/vulnerabilityFixStrategy"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vulnerabilityFixStrategy": {
+      "description": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy",
+      "markdownDescription": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\n\nSee also: [vulnerabilityFixStrategy](https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy)",
+      "type": "string",
+      "enum": ["lowest", "highest"],
+      "default": "lowest"
+    },
+    "woodpecker": {
+      "$ref": "#",
+      "description": "Configuration object for the woodpecker manager\nSee also: https://docs.renovatebot.com/configuration-options/#woodpecker",
+      "markdownDescription": "Configuration object for the woodpecker manager\n\nSee also: [woodpecker](https://docs.renovatebot.com/configuration-options/#woodpecker)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.woodpecker(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "workingDirTemplate": {
+      "description": "A template describing the working directory in which post-upgrade tasks should be executed.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate",
+      "markdownDescription": "A template describing the working directory in which post-upgrade tasks should be executed.\n\nSee also: [workingDirTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate)",
+      "type": "string"
+    },
+    "writeDiscoveredRepos": {
+      "description": "Writes discovered repositories to a JSON file and then exit.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#writediscoveredrepos",
+      "markdownDescription": "Writes discovered repositories to a JSON file and then exit.\n\nSee also: [writeDiscoveredRepos](https://docs.renovatebot.com/self-hosted-configuration/#writediscoveredrepos)",
+      "type": "string"
+    },
+    "xcodegen": {
+      "$ref": "#",
+      "description": "Configuration object for the xcodegen manager\nSee also: https://docs.renovatebot.com/configuration-options/#xcodegen",
+      "markdownDescription": "Configuration object for the xcodegen manager\n\nSee also: [xcodegen](https://docs.renovatebot.com/configuration-options/#xcodegen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/project.yml"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "abandonmentThreshold": {
+      "$ref": "#/definitions/abandonmentThreshold"
+    },
+    "addLabels": {
+      "$ref": "#/definitions/addLabels"
+    },
+    "additionalBranchPrefix": {
+      "$ref": "#/definitions/additionalBranchPrefix"
+    },
+    "additionalReviewers": {
+      "$ref": "#/definitions/additionalReviewers"
+    },
+    "allowCustomCrateRegistries": {
+      "$ref": "#/definitions/allowCustomCrateRegistries"
+    },
+    "allowPlugins": {
+      "$ref": "#/definitions/allowPlugins"
+    },
+    "allowScripts": {
+      "$ref": "#/definitions/allowScripts"
+    },
+    "allowShellExecutorForPostUpgradeCommands": {
+      "$ref": "#/definitions/allowShellExecutorForPostUpgradeCommands"
+    },
+    "allowedCommands": {
+      "$ref": "#/definitions/allowedCommands"
+    },
+    "allowedEnv": {
+      "$ref": "#/definitions/allowedEnv"
+    },
+    "allowedHeaders": {
+      "$ref": "#/definitions/allowedHeaders"
+    },
+    "allowedUnsafeExecutions": {
+      "$ref": "#/definitions/allowedUnsafeExecutions"
+    },
+    "ansible": {
+      "$ref": "#/definitions/ansible"
+    },
+    "ansible-galaxy": {
+      "$ref": "#/definitions/ansible-galaxy"
+    },
+    "ant": {
+      "$ref": "#/definitions/ant"
+    },
+    "argocd": {
+      "$ref": "#/definitions/argocd"
+    },
+    "asdf": {
+      "$ref": "#/definitions/asdf"
+    },
+    "assignAutomerge": {
+      "$ref": "#/definitions/assignAutomerge"
+    },
+    "assignees": {
+      "$ref": "#/definitions/assignees"
+    },
+    "assigneesFromCodeOwners": {
+      "$ref": "#/definitions/assigneesFromCodeOwners"
+    },
+    "assigneesSampleSize": {
+      "$ref": "#/definitions/assigneesSampleSize"
+    },
+    "autoApprove": {
+      "$ref": "#/definitions/autoApprove"
+    },
+    "autoReplaceGlobalMatch": {
+      "$ref": "#/definitions/autoReplaceGlobalMatch"
+    },
+    "autodiscover": {
+      "$ref": "#/definitions/autodiscover"
+    },
+    "autodiscoverFilter": {
+      "$ref": "#/definitions/autodiscoverFilter"
+    },
+    "autodiscoverNamespaces": {
+      "$ref": "#/definitions/autodiscoverNamespaces"
+    },
+    "autodiscoverProjects": {
+      "$ref": "#/definitions/autodiscoverProjects"
+    },
+    "autodiscoverRepoOrder": {
+      "$ref": "#/definitions/autodiscoverRepoOrder"
+    },
+    "autodiscoverRepoSort": {
+      "$ref": "#/definitions/autodiscoverRepoSort"
+    },
+    "autodiscoverTopics": {
+      "$ref": "#/definitions/autodiscoverTopics"
+    },
+    "automerge": {
+      "$ref": "#/definitions/automerge"
+    },
+    "automergeComment": {
+      "$ref": "#/definitions/automergeComment"
+    },
+    "automergeSchedule": {
+      "$ref": "#/definitions/automergeSchedule"
+    },
+    "automergeStrategy": {
+      "$ref": "#/definitions/automergeStrategy"
+    },
+    "automergeType": {
+      "$ref": "#/definitions/automergeType"
+    },
+    "azure-pipelines": {
+      "$ref": "#/definitions/azure-pipelines"
+    },
+    "azureWorkItemId": {
+      "$ref": "#/definitions/azureWorkItemId"
+    },
+    "azureWorkItemType": {
+      "$ref": "#/definitions/azureWorkItemType"
+    },
+    "baseBranchPatterns": {
+      "$ref": "#/definitions/baseBranchPatterns"
+    },
+    "baseDir": {
+      "$ref": "#/definitions/baseDir"
+    },
+    "batect": {
+      "$ref": "#/definitions/batect"
+    },
+    "batect-wrapper": {
+      "$ref": "#/definitions/batect-wrapper"
+    },
+    "bazel": {
+      "$ref": "#/definitions/bazel"
+    },
+    "bazel-module": {
+      "$ref": "#/definitions/bazel-module"
+    },
+    "bazelisk": {
+      "$ref": "#/definitions/bazelisk"
+    },
+    "bbAutoResolvePrTasks": {
+      "$ref": "#/definitions/bbAutoResolvePrTasks"
+    },
+    "bbUseDefaultReviewers": {
+      "$ref": "#/definitions/bbUseDefaultReviewers"
+    },
+    "bbUseDevelopmentBranch": {
+      "$ref": "#/definitions/bbUseDevelopmentBranch"
+    },
+    "bicep": {
+      "$ref": "#/definitions/bicep"
+    },
+    "binarySource": {
+      "$ref": "#/definitions/binarySource"
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#/definitions/bitbucket-pipelines"
+    },
+    "bitrise": {
+      "$ref": "#/definitions/bitrise"
+    },
+    "branchConcurrentLimit": {
+      "$ref": "#/definitions/branchConcurrentLimit"
+    },
+    "branchName": {
+      "$ref": "#/definitions/branchName"
+    },
+    "branchNameStrict": {
+      "$ref": "#/definitions/branchNameStrict"
+    },
+    "branchPrefix": {
+      "$ref": "#/definitions/branchPrefix"
+    },
+    "branchPrefixOld": {
+      "$ref": "#/definitions/branchPrefixOld"
+    },
+    "branchTopic": {
+      "$ref": "#/definitions/branchTopic"
+    },
+    "buildkite": {
+      "$ref": "#/definitions/buildkite"
+    },
+    "buildpacks": {
+      "$ref": "#/definitions/buildpacks"
+    },
+    "bumpVersion": {
+      "$ref": "#/definitions/bumpVersion"
+    },
+    "bumpVersions": {
+      "$ref": "#/definitions/bumpVersions"
+    },
+    "bun": {
+      "$ref": "#/definitions/bun"
+    },
+    "bun-version": {
+      "$ref": "#/definitions/bun-version"
+    },
+    "bundler": {
+      "$ref": "#/definitions/bundler"
+    },
+    "cacheDir": {
+      "$ref": "#/definitions/cacheDir"
+    },
+    "cacheHardTtlMinutes": {
+      "$ref": "#/definitions/cacheHardTtlMinutes"
+    },
+    "cachePrivatePackages": {
+      "$ref": "#/definitions/cachePrivatePackages"
+    },
+    "cacheTtlOverride": {
+      "$ref": "#/definitions/cacheTtlOverride"
+    },
+    "cake": {
+      "$ref": "#/definitions/cake"
+    },
+    "cargo": {
+      "$ref": "#/definitions/cargo"
+    },
+    "cdnurl": {
+      "$ref": "#/definitions/cdnurl"
+    },
+    "checkedBranches": {
+      "$ref": "#/definitions/checkedBranches"
+    },
+    "circleci": {
+      "$ref": "#/definitions/circleci"
+    },
+    "cloneSubmodules": {
+      "$ref": "#/definitions/cloneSubmodules"
+    },
+    "cloneSubmodulesFilter": {
+      "$ref": "#/definitions/cloneSubmodulesFilter"
+    },
+    "cloudbuild": {
+      "$ref": "#/definitions/cloudbuild"
+    },
+    "cocoapods": {
+      "$ref": "#/definitions/cocoapods"
+    },
+    "commitBody": {
+      "$ref": "#/definitions/commitBody"
+    },
+    "commitBodyTable": {
+      "$ref": "#/definitions/commitBodyTable"
+    },
+    "commitHourlyLimit": {
+      "$ref": "#/definitions/commitHourlyLimit"
+    },
+    "commitMessage": {
+      "$ref": "#/definitions/commitMessage"
+    },
+    "commitMessageAction": {
+      "$ref": "#/definitions/commitMessageAction"
+    },
+    "commitMessageExtra": {
+      "$ref": "#/definitions/commitMessageExtra"
+    },
+    "commitMessageLowerCase": {
+      "$ref": "#/definitions/commitMessageLowerCase"
+    },
+    "commitMessagePrefix": {
+      "$ref": "#/definitions/commitMessagePrefix"
+    },
+    "commitMessageSuffix": {
+      "$ref": "#/definitions/commitMessageSuffix"
+    },
+    "commitMessageTopic": {
+      "$ref": "#/definitions/commitMessageTopic"
+    },
+    "commitTrailers": {
+      "$ref": "#/definitions/commitTrailers"
+    },
+    "composer": {
+      "$ref": "#/definitions/composer"
+    },
+    "composerIgnorePlatformReqs": {
+      "$ref": "#/definitions/composerIgnorePlatformReqs"
+    },
+    "conan": {
+      "$ref": "#/definitions/conan"
+    },
+    "confidential": {
+      "$ref": "#/definitions/confidential"
+    },
+    "configFileNames": {
+      "$ref": "#/definitions/configFileNames"
+    },
+    "configMigration": {
+      "$ref": "#/definitions/configMigration"
+    },
+    "configValidationError": {
+      "$ref": "#/definitions/configValidationError"
+    },
+    "configWarningReuseIssue": {
+      "$ref": "#/definitions/configWarningReuseIssue"
+    },
+    "constraints": {
+      "$ref": "#/definitions/constraints"
+    },
+    "constraintsFiltering": {
+      "$ref": "#/definitions/constraintsFiltering"
+    },
+    "constraintsVersioning": {
+      "$ref": "#/definitions/constraintsVersioning"
+    },
+    "containerbaseDir": {
+      "$ref": "#/definitions/containerbaseDir"
+    },
+    "copier": {
+      "$ref": "#/definitions/copier"
+    },
+    "cpanfile": {
+      "$ref": "#/definitions/cpanfile"
+    },
+    "crossplane": {
+      "$ref": "#/definitions/crossplane"
+    },
+    "crow": {
+      "$ref": "#/definitions/crow"
+    },
+    "customDatasources": {
+      "$ref": "#/definitions/customDatasources"
+    },
+    "customEnvVariables": {
+      "$ref": "#/definitions/customEnvVariables"
+    },
+    "customManagers": {
+      "$ref": "#/definitions/customManagers"
+    },
+    "customizeDashboard": {
+      "$ref": "#/definitions/customizeDashboard"
+    },
+    "defaultRegistryUrls": {
+      "$ref": "#/definitions/defaultRegistryUrls"
+    },
+    "deleteAdditionalConfigFile": {
+      "$ref": "#/definitions/deleteAdditionalConfigFile"
+    },
+    "deleteConfigFile": {
+      "$ref": "#/definitions/deleteConfigFile"
+    },
+    "deno": {
+      "$ref": "#/definitions/deno"
+    },
+    "dependencyDashboard": {
+      "$ref": "#/definitions/dependencyDashboard"
+    },
+    "dependencyDashboardApproval": {
+      "$ref": "#/definitions/dependencyDashboardApproval"
+    },
+    "dependencyDashboardAutoclose": {
+      "$ref": "#/definitions/dependencyDashboardAutoclose"
+    },
+    "dependencyDashboardCategory": {
+      "$ref": "#/definitions/dependencyDashboardCategory"
+    },
+    "dependencyDashboardFooter": {
+      "$ref": "#/definitions/dependencyDashboardFooter"
+    },
+    "dependencyDashboardHeader": {
+      "$ref": "#/definitions/dependencyDashboardHeader"
+    },
+    "dependencyDashboardLabels": {
+      "$ref": "#/definitions/dependencyDashboardLabels"
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "$ref": "#/definitions/dependencyDashboardOSVVulnerabilitySummary"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "$ref": "#/definitions/dependencyDashboardReportAbandonment"
+    },
+    "dependencyDashboardTitle": {
+      "$ref": "#/definitions/dependencyDashboardTitle"
+    },
+    "deps-edn": {
+      "$ref": "#/definitions/deps-edn"
+    },
+    "description": {
+      "$ref": "#/definitions/description"
+    },
+    "detectGlobalManagerConfig": {
+      "$ref": "#/definitions/detectGlobalManagerConfig"
+    },
+    "detectHostRulesFromEnv": {
+      "$ref": "#/definitions/detectHostRulesFromEnv"
+    },
+    "devbox": {
+      "$ref": "#/definitions/devbox"
+    },
+    "devcontainer": {
+      "$ref": "#/definitions/devcontainer"
+    },
+    "digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "docker-compose": {
+      "$ref": "#/definitions/docker-compose"
+    },
+    "dockerChildPrefix": {
+      "$ref": "#/definitions/dockerChildPrefix"
+    },
+    "dockerCliOptions": {
+      "$ref": "#/definitions/dockerCliOptions"
+    },
+    "dockerMaxPages": {
+      "$ref": "#/definitions/dockerMaxPages"
+    },
+    "dockerSidecarImage": {
+      "$ref": "#/definitions/dockerSidecarImage"
+    },
+    "dockerUser": {
+      "$ref": "#/definitions/dockerUser"
+    },
+    "dockerfile": {
+      "$ref": "#/definitions/dockerfile"
+    },
+    "draftPR": {
+      "$ref": "#/definitions/draftPR"
+    },
+    "droneci": {
+      "$ref": "#/definitions/droneci"
+    },
+    "dryRun": {
+      "$ref": "#/definitions/dryRun"
+    },
+    "enabled": {
+      "$ref": "#/definitions/enabled"
+    },
+    "enabledManagers": {
+      "$ref": "#/definitions/enabledManagers"
+    },
+    "encrypted": {
+      "$ref": "#/definitions/encrypted"
+    },
+    "encryptedWarning": {
+      "$ref": "#/definitions/encryptedWarning"
+    },
+    "endpoint": {
+      "$ref": "#/definitions/endpoint"
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "excludeCommitPaths": {
+      "$ref": "#/definitions/excludeCommitPaths"
+    },
+    "executionTimeout": {
+      "$ref": "#/definitions/executionTimeout"
+    },
+    "expandCodeOwnersGroups": {
+      "$ref": "#/definitions/expandCodeOwnersGroups"
+    },
+    "exposeAllEnv": {
+      "$ref": "#/definitions/exposeAllEnv"
+    },
+    "extends": {
+      "$ref": "#/definitions/extends"
+    },
+    "extractVersion": {
+      "$ref": "#/definitions/extractVersion"
+    },
+    "fetchChangeLogs": {
+      "$ref": "#/definitions/fetchChangeLogs"
+    },
+    "filterUnavailableUsers": {
+      "$ref": "#/definitions/filterUnavailableUsers"
+    },
+    "fleet": {
+      "$ref": "#/definitions/fleet"
+    },
+    "flux": {
+      "$ref": "#/definitions/flux"
+    },
+    "followTag": {
+      "$ref": "#/definitions/followTag"
+    },
+    "force": {
+      "$ref": "#/definitions/force"
+    },
+    "forceCli": {
+      "$ref": "#/definitions/forceCli"
+    },
+    "forkCreation": {
+      "$ref": "#/definitions/forkCreation"
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "$ref": "#/definitions/forkModeDisallowMaintainerEdits"
+    },
+    "forkOrg": {
+      "$ref": "#/definitions/forkOrg"
+    },
+    "forkProcessing": {
+      "$ref": "#/definitions/forkProcessing"
+    },
+    "forkToken": {
+      "$ref": "#/definitions/forkToken"
+    },
+    "fvm": {
+      "$ref": "#/definitions/fvm"
+    },
+    "git-submodules": {
+      "$ref": "#/definitions/git-submodules"
+    },
+    "gitAuthor": {
+      "$ref": "#/definitions/gitAuthor"
+    },
+    "gitIgnoredAuthors": {
+      "$ref": "#/definitions/gitIgnoredAuthors"
+    },
+    "gitLabIgnoreApprovals": {
+      "$ref": "#/definitions/gitLabIgnoreApprovals"
+    },
+    "gitNoVerify": {
+      "$ref": "#/definitions/gitNoVerify"
+    },
+    "gitPrivateKey": {
+      "$ref": "#/definitions/gitPrivateKey"
+    },
+    "gitPrivateKeyPassphrase": {
+      "$ref": "#/definitions/gitPrivateKeyPassphrase"
+    },
+    "gitTimeout": {
+      "$ref": "#/definitions/gitTimeout"
+    },
+    "gitUrl": {
+      "$ref": "#/definitions/gitUrl"
+    },
+    "github-actions": {
+      "$ref": "#/definitions/github-actions"
+    },
+    "githubTokenWarn": {
+      "$ref": "#/definitions/githubTokenWarn"
+    },
+    "gitlabci": {
+      "$ref": "#/definitions/gitlabci"
+    },
+    "gitlabci-include": {
+      "$ref": "#/definitions/gitlabci-include"
+    },
+    "glasskube": {
+      "$ref": "#/definitions/glasskube"
+    },
+    "gleam": {
+      "$ref": "#/definitions/gleam"
+    },
+    "globalExtends": {
+      "$ref": "#/definitions/globalExtends"
+    },
+    "goGetDirs": {
+      "$ref": "#/definitions/goGetDirs"
+    },
+    "gomod": {
+      "$ref": "#/definitions/gomod"
+    },
+    "gradle": {
+      "$ref": "#/definitions/gradle"
+    },
+    "gradle-wrapper": {
+      "$ref": "#/definitions/gradle-wrapper"
+    },
+    "group": {
+      "$ref": "#/definitions/group"
+    },
+    "groupName": {
+      "$ref": "#/definitions/groupName"
+    },
+    "groupSingleUpdates": {
+      "$ref": "#/definitions/groupSingleUpdates"
+    },
+    "groupSlug": {
+      "$ref": "#/definitions/groupSlug"
+    },
+    "hashedBranchLength": {
+      "$ref": "#/definitions/hashedBranchLength"
+    },
+    "haskell-cabal": {
+      "$ref": "#/definitions/haskell-cabal"
+    },
+    "helm-requirements": {
+      "$ref": "#/definitions/helm-requirements"
+    },
+    "helm-values": {
+      "$ref": "#/definitions/helm-values"
+    },
+    "helmfile": {
+      "$ref": "#/definitions/helmfile"
+    },
+    "helmsman": {
+      "$ref": "#/definitions/helmsman"
+    },
+    "helmv3": {
+      "$ref": "#/definitions/helmv3"
+    },
+    "hermit": {
+      "$ref": "#/definitions/hermit"
+    },
+    "homeassistant-manifest": {
+      "$ref": "#/definitions/homeassistant-manifest"
+    },
+    "homebrew": {
+      "$ref": "#/definitions/homebrew"
+    },
+    "hostRules": {
+      "$ref": "#/definitions/hostRules"
+    },
+    "html": {
+      "$ref": "#/definitions/html"
+    },
+    "httpCacheTtlDays": {
+      "$ref": "#/definitions/httpCacheTtlDays"
+    },
+    "ignoreDeprecated": {
+      "$ref": "#/definitions/ignoreDeprecated"
+    },
+    "ignoreDeps": {
+      "$ref": "#/definitions/ignoreDeps"
+    },
+    "ignorePaths": {
+      "$ref": "#/definitions/ignorePaths"
+    },
+    "ignorePlugins": {
+      "$ref": "#/definitions/ignorePlugins"
+    },
+    "ignorePrAuthor": {
+      "$ref": "#/definitions/ignorePrAuthor"
+    },
+    "ignorePresets": {
+      "$ref": "#/definitions/ignorePresets"
+    },
+    "ignoreReviewers": {
+      "$ref": "#/definitions/ignoreReviewers"
+    },
+    "ignoreScripts": {
+      "$ref": "#/definitions/ignoreScripts"
+    },
+    "ignoreTests": {
+      "$ref": "#/definitions/ignoreTests"
+    },
+    "ignoreUnstable": {
+      "$ref": "#/definitions/ignoreUnstable"
+    },
+    "includeMirrors": {
+      "$ref": "#/definitions/includeMirrors"
+    },
+    "includePaths": {
+      "$ref": "#/definitions/includePaths"
+    },
+    "inheritConfig": {
+      "$ref": "#/definitions/inheritConfig"
+    },
+    "inheritConfigFileName": {
+      "$ref": "#/definitions/inheritConfigFileName"
+    },
+    "inheritConfigRepoName": {
+      "$ref": "#/definitions/inheritConfigRepoName"
+    },
+    "inheritConfigStrict": {
+      "$ref": "#/definitions/inheritConfigStrict"
+    },
+    "internalChecksAsSuccess": {
+      "$ref": "#/definitions/internalChecksAsSuccess"
+    },
+    "internalChecksFilter": {
+      "$ref": "#/definitions/internalChecksFilter"
+    },
+    "jenkins": {
+      "$ref": "#/definitions/jenkins"
+    },
+    "jsonata": {
+      "$ref": "#/definitions/jsonata"
+    },
+    "jsonnet-bundler": {
+      "$ref": "#/definitions/jsonnet-bundler"
+    },
+    "keepUpdatedLabel": {
+      "$ref": "#/definitions/keepUpdatedLabel"
+    },
+    "kotlin-script": {
+      "$ref": "#/definitions/kotlin-script"
+    },
+    "kubernetes": {
+      "$ref": "#/definitions/kubernetes"
+    },
+    "kustomize": {
+      "$ref": "#/definitions/kustomize"
+    },
+    "labels": {
+      "$ref": "#/definitions/labels"
+    },
+    "leiningen": {
+      "$ref": "#/definitions/leiningen"
+    },
+    "lockFileMaintenance": {
+      "$ref": "#/definitions/lockFileMaintenance"
+    },
+    "logContext": {
+      "$ref": "#/definitions/logContext"
+    },
+    "logLevelRemap": {
+      "$ref": "#/definitions/logLevelRemap"
+    },
+    "major": {
+      "$ref": "#/definitions/major"
+    },
+    "maven": {
+      "$ref": "#/definitions/maven"
+    },
+    "maven-wrapper": {
+      "$ref": "#/definitions/maven-wrapper"
+    },
+    "maxMajorIncrement": {
+      "$ref": "#/definitions/maxMajorIncrement"
+    },
+    "mergeConfidenceDatasources": {
+      "$ref": "#/definitions/mergeConfidenceDatasources"
+    },
+    "mergeConfidenceEndpoint": {
+      "$ref": "#/definitions/mergeConfidenceEndpoint"
+    },
+    "meteor": {
+      "$ref": "#/definitions/meteor"
+    },
+    "migratePresets": {
+      "$ref": "#/definitions/migratePresets"
+    },
+    "milestone": {
+      "$ref": "#/definitions/milestone"
+    },
+    "minimumGroupSize": {
+      "$ref": "#/definitions/minimumGroupSize"
+    },
+    "minimumReleaseAge": {
+      "$ref": "#/definitions/minimumReleaseAge"
+    },
+    "minimumReleaseAgeBehaviour": {
+      "$ref": "#/definitions/minimumReleaseAgeBehaviour"
+    },
+    "minor": {
+      "$ref": "#/definitions/minor"
+    },
+    "mint": {
+      "$ref": "#/definitions/mint"
+    },
+    "mise": {
+      "$ref": "#/definitions/mise"
+    },
+    "mix": {
+      "$ref": "#/definitions/mix"
+    },
+    "mode": {
+      "$ref": "#/definitions/mode"
+    },
+    "nix": {
+      "$ref": "#/definitions/nix"
+    },
+    "nodenv": {
+      "$ref": "#/definitions/nodenv"
+    },
+    "npm": {
+      "$ref": "#/definitions/npm"
+    },
+    "npmToken": {
+      "$ref": "#/definitions/npmToken"
+    },
+    "npmrc": {
+      "$ref": "#/definitions/npmrc"
+    },
+    "npmrcMerge": {
+      "$ref": "#/definitions/npmrcMerge"
+    },
+    "nuget": {
+      "$ref": "#/definitions/nuget"
+    },
+    "nvm": {
+      "$ref": "#/definitions/nvm"
+    },
+    "ocb": {
+      "$ref": "#/definitions/ocb"
+    },
+    "onboarding": {
+      "$ref": "#/definitions/onboarding"
+    },
+    "onboardingAutoCloseAge": {
+      "$ref": "#/definitions/onboardingAutoCloseAge"
+    },
+    "onboardingBranch": {
+      "$ref": "#/definitions/onboardingBranch"
+    },
+    "onboardingCommitMessage": {
+      "$ref": "#/definitions/onboardingCommitMessage"
+    },
+    "onboardingConfig": {
+      "$ref": "#/definitions/onboardingConfig"
+    },
+    "onboardingConfigFileName": {
+      "$ref": "#/definitions/onboardingConfigFileName"
+    },
+    "onboardingNoDeps": {
+      "$ref": "#/definitions/onboardingNoDeps"
+    },
+    "onboardingPrTitle": {
+      "$ref": "#/definitions/onboardingPrTitle"
+    },
+    "onboardingRebaseCheckbox": {
+      "$ref": "#/definitions/onboardingRebaseCheckbox"
+    },
+    "optimizeForDisabled": {
+      "$ref": "#/definitions/optimizeForDisabled"
+    },
+    "osgi": {
+      "$ref": "#/definitions/osgi"
+    },
+    "osvVulnerabilityAlerts": {
+      "$ref": "#/definitions/osvVulnerabilityAlerts"
+    },
+    "packageRules": {
+      "$ref": "#/definitions/packageRules"
+    },
+    "password": {
+      "$ref": "#/definitions/password"
+    },
+    "patch": {
+      "$ref": "#/definitions/patch"
+    },
+    "pep621": {
+      "$ref": "#/definitions/pep621"
+    },
+    "pep723": {
+      "$ref": "#/definitions/pep723"
+    },
+    "persistRepoData": {
+      "$ref": "#/definitions/persistRepoData"
+    },
+    "pin": {
+      "$ref": "#/definitions/pin"
+    },
+    "pinDigest": {
+      "$ref": "#/definitions/pinDigest"
+    },
+    "pinDigests": {
+      "$ref": "#/definitions/pinDigests"
+    },
+    "pip-compile": {
+      "$ref": "#/definitions/pip-compile"
+    },
+    "pip_requirements": {
+      "$ref": "#/definitions/pip_requirements"
+    },
+    "pip_setup": {
+      "$ref": "#/definitions/pip_setup"
+    },
+    "pipenv": {
+      "$ref": "#/definitions/pipenv"
+    },
+    "pixi": {
+      "$ref": "#/definitions/pixi"
+    },
+    "platform": {
+      "$ref": "#/definitions/platform"
+    },
+    "platformAutomerge": {
+      "$ref": "#/definitions/platformAutomerge"
+    },
+    "platformCommit": {
+      "$ref": "#/definitions/platformCommit"
+    },
+    "poetry": {
+      "$ref": "#/definitions/poetry"
+    },
+    "postUpdateOptions": {
+      "$ref": "#/definitions/postUpdateOptions"
+    },
+    "postUpgradeTasks": {
+      "$ref": "#/definitions/postUpgradeTasks"
+    },
+    "prBodyColumns": {
+      "$ref": "#/definitions/prBodyColumns"
+    },
+    "prBodyDefinitions": {
+      "$ref": "#/definitions/prBodyDefinitions"
+    },
+    "prBodyHeadingDefinitions": {
+      "$ref": "#/definitions/prBodyHeadingDefinitions"
+    },
+    "prBodyNotes": {
+      "$ref": "#/definitions/prBodyNotes"
+    },
+    "prBodyTemplate": {
+      "$ref": "#/definitions/prBodyTemplate"
+    },
+    "prCacheSyncMaxPages": {
+      "$ref": "#/definitions/prCacheSyncMaxPages"
+    },
+    "prCommitsPerRunLimit": {
+      "$ref": "#/definitions/prCommitsPerRunLimit"
+    },
+    "prConcurrentLimit": {
+      "$ref": "#/definitions/prConcurrentLimit"
+    },
+    "prCreation": {
+      "$ref": "#/definitions/prCreation"
+    },
+    "prFooter": {
+      "$ref": "#/definitions/prFooter"
+    },
+    "prHeader": {
+      "$ref": "#/definitions/prHeader"
+    },
+    "prHourlyLimit": {
+      "$ref": "#/definitions/prHourlyLimit"
+    },
+    "prNotPendingHours": {
+      "$ref": "#/definitions/prNotPendingHours"
+    },
+    "prTitle": {
+      "$ref": "#/definitions/prTitle"
+    },
+    "prTitleStrict": {
+      "$ref": "#/definitions/prTitleStrict"
+    },
+    "pre-commit": {
+      "$ref": "#/definitions/pre-commit"
+    },
+    "presetCachePersistence": {
+      "$ref": "#/definitions/presetCachePersistence"
+    },
+    "printConfig": {
+      "$ref": "#/definitions/printConfig"
+    },
+    "privateKey": {
+      "$ref": "#/definitions/privateKey"
+    },
+    "privateKeyOld": {
+      "$ref": "#/definitions/privateKeyOld"
+    },
+    "privateKeyPath": {
+      "$ref": "#/definitions/privateKeyPath"
+    },
+    "privateKeyPathOld": {
+      "$ref": "#/definitions/privateKeyPathOld"
+    },
+    "processEnv": {
+      "$ref": "#/definitions/processEnv"
+    },
+    "productLinks": {
+      "$ref": "#/definitions/productLinks"
+    },
+    "proto": {
+      "$ref": "#/definitions/proto"
+    },
+    "pruneBranchAfterAutomerge": {
+      "$ref": "#/definitions/pruneBranchAfterAutomerge"
+    },
+    "pruneStaleBranches": {
+      "$ref": "#/definitions/pruneStaleBranches"
+    },
+    "pub": {
+      "$ref": "#/definitions/pub"
+    },
+    "puppet": {
+      "$ref": "#/definitions/puppet"
+    },
+    "pyenv": {
+      "$ref": "#/definitions/pyenv"
+    },
+    "quadlet": {
+      "$ref": "#/definitions/quadlet"
+    },
+    "rangeStrategy": {
+      "$ref": "#/definitions/rangeStrategy"
+    },
+    "rebaseAllOpenBranches": {
+      "$ref": "#/definitions/rebaseAllOpenBranches"
+    },
+    "rebaseLabel": {
+      "$ref": "#/definitions/rebaseLabel"
+    },
+    "rebaseWhen": {
+      "$ref": "#/definitions/rebaseWhen"
+    },
+    "recreateWhen": {
+      "$ref": "#/definitions/recreateWhen"
+    },
+    "redisPrefix": {
+      "$ref": "#/definitions/redisPrefix"
+    },
+    "redisUrl": {
+      "$ref": "#/definitions/redisUrl"
+    },
+    "regex": {
+      "$ref": "#/definitions/regex"
+    },
+    "registryAliases": {
+      "$ref": "#/definitions/registryAliases"
+    },
+    "registryUrls": {
+      "$ref": "#/definitions/registryUrls"
+    },
+    "renovate-config": {
+      "$ref": "#/definitions/renovate-config"
+    },
+    "replacement": {
+      "$ref": "#/definitions/replacement"
+    },
+    "replacementApproach": {
+      "$ref": "#/definitions/replacementApproach"
+    },
+    "reportFormatting": {
+      "$ref": "#/definitions/reportFormatting"
+    },
+    "reportPath": {
+      "$ref": "#/definitions/reportPath"
+    },
+    "reportType": {
+      "$ref": "#/definitions/reportType"
+    },
+    "repositories": {
+      "$ref": "#/definitions/repositories"
+    },
+    "repositoryCache": {
+      "$ref": "#/definitions/repositoryCache"
+    },
+    "repositoryCacheForceLocal": {
+      "$ref": "#/definitions/repositoryCacheForceLocal"
+    },
+    "repositoryCacheType": {
+      "$ref": "#/definitions/repositoryCacheType"
+    },
+    "requireConfig": {
+      "$ref": "#/definitions/requireConfig"
+    },
+    "respectLatest": {
+      "$ref": "#/definitions/respectLatest"
+    },
+    "reviewers": {
+      "$ref": "#/definitions/reviewers"
+    },
+    "reviewersFromCodeOwners": {
+      "$ref": "#/definitions/reviewersFromCodeOwners"
+    },
+    "reviewersSampleSize": {
+      "$ref": "#/definitions/reviewersSampleSize"
+    },
+    "rollback": {
+      "$ref": "#/definitions/rollback"
+    },
+    "rollbackPrs": {
+      "$ref": "#/definitions/rollbackPrs"
+    },
+    "ruby-version": {
+      "$ref": "#/definitions/ruby-version"
+    },
+    "runtime-version": {
+      "$ref": "#/definitions/runtime-version"
+    },
+    "rust-toolchain": {
+      "$ref": "#/definitions/rust-toolchain"
+    },
+    "s3Endpoint": {
+      "$ref": "#/definitions/s3Endpoint"
+    },
+    "s3PathStyle": {
+      "$ref": "#/definitions/s3PathStyle"
+    },
+    "sbt": {
+      "$ref": "#/definitions/sbt"
+    },
+    "scalafmt": {
+      "$ref": "#/definitions/scalafmt"
+    },
+    "schedule": {
+      "$ref": "#/definitions/schedule"
+    },
+    "secrets": {
+      "$ref": "#/definitions/secrets"
+    },
+    "semanticCommitScope": {
+      "$ref": "#/definitions/semanticCommitScope"
+    },
+    "semanticCommitType": {
+      "$ref": "#/definitions/semanticCommitType"
+    },
+    "semanticCommits": {
+      "$ref": "#/definitions/semanticCommits"
+    },
+    "separateMajorMinor": {
+      "$ref": "#/definitions/separateMajorMinor"
+    },
+    "separateMinorPatch": {
+      "$ref": "#/definitions/separateMinorPatch"
+    },
+    "separateMultipleMajor": {
+      "$ref": "#/definitions/separateMultipleMajor"
+    },
+    "separateMultipleMinor": {
+      "$ref": "#/definitions/separateMultipleMinor"
+    },
+    "setup-cfg": {
+      "$ref": "#/definitions/setup-cfg"
+    },
+    "skipArtifactsUpdate": {
+      "$ref": "#/definitions/skipArtifactsUpdate"
+    },
+    "skipInstalls": {
+      "$ref": "#/definitions/skipInstalls"
+    },
+    "smithy": {
+      "$ref": "#/definitions/smithy"
+    },
+    "statusCheckNames": {
+      "$ref": "#/definitions/statusCheckNames"
+    },
+    "statusCheckWhen": {
+      "$ref": "#/definitions/statusCheckWhen"
+    },
+    "stopUpdatingLabel": {
+      "$ref": "#/definitions/stopUpdatingLabel"
+    },
+    "suppressNotifications": {
+      "$ref": "#/definitions/suppressNotifications"
+    },
+    "sveltos": {
+      "$ref": "#/definitions/sveltos"
+    },
+    "swift": {
+      "$ref": "#/definitions/swift"
+    },
+    "tekton": {
+      "$ref": "#/definitions/tekton"
+    },
+    "terraform": {
+      "$ref": "#/definitions/terraform"
+    },
+    "terraform-version": {
+      "$ref": "#/definitions/terraform-version"
+    },
+    "terragrunt": {
+      "$ref": "#/definitions/terragrunt"
+    },
+    "terragrunt-version": {
+      "$ref": "#/definitions/terragrunt-version"
+    },
+    "tflint-plugin": {
+      "$ref": "#/definitions/tflint-plugin"
+    },
+    "timezone": {
+      "$ref": "#/definitions/timezone"
+    },
+    "token": {
+      "$ref": "#/definitions/token"
+    },
+    "toolSettings": {
+      "$ref": "#/definitions/toolSettings"
+    },
+    "travis": {
+      "$ref": "#/definitions/travis"
+    },
+    "typst": {
+      "$ref": "#/definitions/typst"
+    },
+    "unicodeEmoji": {
+      "$ref": "#/definitions/unicodeEmoji"
+    },
+    "unity3d": {
+      "$ref": "#/definitions/unity3d"
+    },
+    "updateInternalDeps": {
+      "$ref": "#/definitions/updateInternalDeps"
+    },
+    "updateNotScheduled": {
+      "$ref": "#/definitions/updateNotScheduled"
+    },
+    "updatePinnedDependencies": {
+      "$ref": "#/definitions/updatePinnedDependencies"
+    },
+    "useBaseBranchConfig": {
+      "$ref": "#/definitions/useBaseBranchConfig"
+    },
+    "useCloudMetadataServices": {
+      "$ref": "#/definitions/useCloudMetadataServices"
+    },
+    "userAgent": {
+      "$ref": "#/definitions/userAgent"
+    },
+    "userStrings": {
+      "$ref": "#/definitions/userStrings"
+    },
+    "username": {
+      "$ref": "#/definitions/username"
+    },
+    "variables": {
+      "$ref": "#/definitions/variables"
+    },
+    "velaci": {
+      "$ref": "#/definitions/velaci"
+    },
+    "vendir": {
+      "$ref": "#/definitions/vendir"
+    },
+    "versionCompatibility": {
+      "$ref": "#/definitions/versionCompatibility"
+    },
+    "versioning": {
+      "$ref": "#/definitions/versioning"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#/definitions/vulnerabilityAlerts"
+    },
+    "woodpecker": {
+      "$ref": "#/definitions/woodpecker"
+    },
+    "writeDiscoveredRepos": {
+      "$ref": "#/definitions/writeDiscoveredRepos"
+    },
+    "xcodegen": {
+      "$ref": "#/definitions/xcodegen"
+    }
+  }
+}

--- a/src/schemas/json/renovate-inherited-schema-43.json
+++ b/src/schemas/json/renovate-inherited-schema-43.json
@@ -1,0 +1,9394 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/renovate-inherited-schema-43.json",
+  "title": "JSON schema for Renovate 43.288.0 config files (with Inherit Config options) (https://renovatebot.com/)",
+  "x-renovate-version": "43.288.0",
+  "allowComments": true,
+  "type": "object",
+  "definitions": {
+    "abandonmentThreshold": {
+      "description": "Flags packages that have not been updated within this period as abandoned.\nSee also: https://docs.renovatebot.com/configuration-options/#abandonmentthreshold",
+      "markdownDescription": "Flags packages that have not been updated within this period as abandoned.\n\nSee also: [abandonmentThreshold](https://docs.renovatebot.com/configuration-options/#abandonmentthreshold)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "abortIgnoreStatusCodes": {
+      "description": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes",
+      "markdownDescription": "A list of HTTP status codes safe to ignore even when `abortOnError=true`.\n\nSee also: [abortIgnoreStatusCodes](https://docs.renovatebot.com/configuration-options/#hostrulesabortignorestatuscodes)",
+      "type": "array",
+      "items": {
+        "type": "number"
+      }
+    },
+    "abortOnError": {
+      "description": "If enabled, Renovate aborts its run when HTTP request errors occur.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror",
+      "markdownDescription": "If enabled, Renovate aborts its run when HTTP request errors occur.\n\nSee also: [abortOnError](https://docs.renovatebot.com/configuration-options/#hostrulesabortonerror)",
+      "type": "boolean",
+      "default": false
+    },
+    "addLabels": {
+      "description": "Labels to add to Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#addlabels",
+      "markdownDescription": "Labels to add to Pull Request.\n\nSee also: [addLabels](https://docs.renovatebot.com/configuration-options/#addlabels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "additionalBranchPrefix": {
+      "description": "Additional string value to be appended to `branchPrefix`.\nSee also: https://docs.renovatebot.com/configuration-options/#additionalbranchprefix",
+      "markdownDescription": "Additional string value to be appended to `branchPrefix`.\n\nSee also: [additionalBranchPrefix](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix)",
+      "type": "string",
+      "default": ""
+    },
+    "additionalReviewers": {
+      "description": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\nSee also: https://docs.renovatebot.com/configuration-options/#additionalreviewers",
+      "markdownDescription": "Additional reviewers for Pull Requests (in contrast to `reviewers`, this option adds to the existing reviewer list, rather than replacing it).\n\nSee also: [additionalReviewers](https://docs.renovatebot.com/configuration-options/#additionalreviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "allowedVersions": {
+      "description": "A version range or regex pattern capturing allowed versions for dependencies.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions",
+      "markdownDescription": "A version range or regex pattern capturing allowed versions for dependencies.\n\nSee also: [allowedVersions](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)",
+      "type": "string"
+    },
+    "ansible": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible",
+      "markdownDescription": "Configuration object for the ansible manager\n\nSee also: [ansible](https://docs.renovatebot.com/configuration-options/#ansible)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)tasks/[^/]+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ansible-galaxy": {
+      "$ref": "#",
+      "description": "Configuration object for the ansible-galaxy manager\nSee also: https://docs.renovatebot.com/configuration-options/#ansible-galaxy",
+      "markdownDescription": "Configuration object for the ansible-galaxy manager\n\nSee also: [ansible-galaxy](https://docs.renovatebot.com/configuration-options/#ansible-galaxy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(galaxy|requirements)(\\.ansible)?\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ant": {
+      "$ref": "#",
+      "description": "Configuration object for the ant manager\nSee also: https://docs.renovatebot.com/configuration-options/#ant",
+      "markdownDescription": "Configuration object for the ant manager\n\nSee also: [ant](https://docs.renovatebot.com/configuration-options/#ant)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/build.xml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "argocd": {
+      "$ref": "#",
+      "description": "Configuration object for the argocd manager\nSee also: https://docs.renovatebot.com/configuration-options/#argocd",
+      "markdownDescription": "Configuration object for the argocd manager\n\nSee also: [argocd](https://docs.renovatebot.com/configuration-options/#argocd)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "artifactAuth": {
+      "description": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth",
+      "markdownDescription": "A list of package managers to enable artifact auth. Only managers on the list are enabled. All are enabled if `null`.\n\nSee also: [artifactAuth](https://docs.renovatebot.com/configuration-options/#hostrulesartifactauth)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "enum": ["composer"]
+      },
+      "default": null
+    },
+    "asdf": {
+      "$ref": "#",
+      "description": "Configuration object for the asdf manager\nSee also: https://docs.renovatebot.com/configuration-options/#asdf",
+      "markdownDescription": "Configuration object for the asdf manager\n\nSee also: [asdf](https://docs.renovatebot.com/configuration-options/#asdf)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.tool-versions$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "assignAutomerge": {
+      "description": "Assign reviewers and assignees even if the PR is to be automerged.\nSee also: https://docs.renovatebot.com/configuration-options/#assignautomerge",
+      "markdownDescription": "Assign reviewers and assignees even if the PR is to be automerged.\n\nSee also: [assignAutomerge](https://docs.renovatebot.com/configuration-options/#assignautomerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "assignees": {
+      "description": "Assignees for Pull Request (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#assignees",
+      "markdownDescription": "Assignees for Pull Request (either username or email address depending on the platform).\n\nSee also: [assignees](https://docs.renovatebot.com/configuration-options/#assignees)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "assigneesFromCodeOwners": {
+      "description": "Determine assignees based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners",
+      "markdownDescription": "Determine assignees based on configured code owners and changes in PR.\n\nSee also: [assigneesFromCodeOwners](https://docs.renovatebot.com/configuration-options/#assigneesfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "assigneesSampleSize": {
+      "description": "Take a random sample of given size from `assignees`.\nSee also: https://docs.renovatebot.com/configuration-options/#assigneessamplesize",
+      "markdownDescription": "Take a random sample of given size from `assignees`.\n\nSee also: [assigneesSampleSize](https://docs.renovatebot.com/configuration-options/#assigneessamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "authType": {
+      "description": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesauthtype",
+      "markdownDescription": "Authentication type for HTTP header. e.g. `\"Bearer\"` or `\"Basic\"`. Use `\"Token-Only\"` to use only the token without an authorization type.\n\nSee also: [authType](https://docs.renovatebot.com/configuration-options/#hostrulesauthtype)",
+      "type": "string",
+      "default": "Bearer"
+    },
+    "autoApprove": {
+      "description": "Set to `true` to automatically approve PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#autoapprove",
+      "markdownDescription": "Set to `true` to automatically approve PRs.\n\nSee also: [autoApprove](https://docs.renovatebot.com/configuration-options/#autoapprove)",
+      "type": "boolean",
+      "default": false
+    },
+    "autoReplaceGlobalMatch": {
+      "description": "Control whether replacement regular expressions are global matches or only the first match.\nSee also: https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch",
+      "markdownDescription": "Control whether replacement regular expressions are global matches or only the first match.\n\nSee also: [autoReplaceGlobalMatch](https://docs.renovatebot.com/configuration-options/#autoreplaceglobalmatch)",
+      "type": "boolean",
+      "default": true
+    },
+    "autoReplaceStringTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [autoReplaceStringTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersautoreplacestringtemplate)",
+      "type": "string"
+    },
+    "automerge": {
+      "description": "Whether to automerge branches/PRs automatically, without human intervention.\nSee also: https://docs.renovatebot.com/configuration-options/#automerge",
+      "markdownDescription": "Whether to automerge branches/PRs automatically, without human intervention.\n\nSee also: [automerge](https://docs.renovatebot.com/configuration-options/#automerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "automergeComment": {
+      "description": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergecomment",
+      "markdownDescription": "PR comment to add to trigger automerge. Only used if `automergeType=pr-comment`.\n\nSee also: [automergeComment](https://docs.renovatebot.com/configuration-options/#automergecomment)",
+      "type": "string",
+      "default": "automergeComment"
+    },
+    "automergeSchedule": {
+      "description": "Limit automerge to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#automergeschedule",
+      "markdownDescription": "Limit automerge to these times of day or week.\n\nSee also: [automergeSchedule](https://docs.renovatebot.com/configuration-options/#automergeschedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "automergeStrategy": {
+      "description": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\nSee also: https://docs.renovatebot.com/configuration-options/#automergestrategy",
+      "markdownDescription": "The merge strategy to use when automerging PRs. Used only if `automergeType=pr`.\n\nSee also: [automergeStrategy](https://docs.renovatebot.com/configuration-options/#automergestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "fast-forward",
+        "merge-commit",
+        "rebase",
+        "rebase-merge",
+        "squash"
+      ],
+      "default": "auto"
+    },
+    "automergeType": {
+      "description": "How to automerge, if enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#automergetype",
+      "markdownDescription": "How to automerge, if enabled.\n\nSee also: [automergeType](https://docs.renovatebot.com/configuration-options/#automergetype)",
+      "type": "string",
+      "enum": ["branch", "pr", "pr-comment"],
+      "default": "pr"
+    },
+    "azure-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the azure-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#azure-pipelines",
+      "markdownDescription": "Configuration object for the azure-pipelines manager\n\nSee also: [azure-pipelines](https://docs.renovatebot.com/configuration-options/#azure-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/).azuredevops/.+\\.ya?ml$/",
+          "/azure.*pipelines?.*\\.ya?ml$/"
+        ],
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "azureWorkItemId": {
+      "description": "The id of an existing work item on Azure Boards to link to each PR.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemid",
+      "markdownDescription": "The id of an existing work item on Azure Boards to link to each PR.\n\nSee also: [azureWorkItemId](https://docs.renovatebot.com/configuration-options/#azureworkitemid)",
+      "type": "integer",
+      "default": 0
+    },
+    "azureWorkItemType": {
+      "description": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\nSee also: https://docs.renovatebot.com/configuration-options/#azureworkitemtype",
+      "markdownDescription": "The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on Azure DevOps.\n\nSee also: [azureWorkItemType](https://docs.renovatebot.com/configuration-options/#azureworkitemtype)",
+      "type": "string",
+      "default": "Issue"
+    },
+    "baseBranchPatterns": {
+      "description": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\nSee also: https://docs.renovatebot.com/configuration-options/#basebranchpatterns",
+      "markdownDescription": "List of one or more custom base branches defined as exact strings and/or via regex expressions.\n\nSee also: [baseBranchPatterns](https://docs.renovatebot.com/configuration-options/#basebranchpatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "batect": {
+      "$ref": "#",
+      "description": "Configuration object for the batect manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect",
+      "markdownDescription": "Configuration object for the batect manager\n\nSee also: [batect](https://docs.renovatebot.com/configuration-options/#batect)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect(-bundle)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "batect-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the batect-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#batect-wrapper",
+      "markdownDescription": "Configuration object for the batect-wrapper manager\n\nSee also: [batect-wrapper](https://docs.renovatebot.com/configuration-options/#batect-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)batect$/"],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel",
+      "markdownDescription": "Configuration object for the bazel manager\n\nSee also: [bazel](https://docs.renovatebot.com/configuration-options/#bazel)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)WORKSPACE(|\\.bazel|\\.bzlmod)$/",
+          "/\\.WORKSPACE\\.bazel$/",
+          "/\\.bzl$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazel-module": {
+      "$ref": "#",
+      "description": "Configuration object for the bazel-module manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazel-module",
+      "markdownDescription": "Configuration object for the bazel-module manager\n\nSee also: [bazel-module](https://docs.renovatebot.com/configuration-options/#bazel-module)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/|\\.)MODULE\\.bazel$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bazelisk": {
+      "$ref": "#",
+      "description": "Configuration object for the bazelisk manager\nSee also: https://docs.renovatebot.com/configuration-options/#bazelisk",
+      "markdownDescription": "Configuration object for the bazelisk manager\n\nSee also: [bazelisk](https://docs.renovatebot.com/configuration-options/#bazelisk)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bazelversion$/"],
+        "pinDigests": false,
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bbAutoResolvePrTasks": {
+      "description": "The PR tasks will be automatically completed after the PR is raised.\nSee also: https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks",
+      "markdownDescription": "The PR tasks will be automatically completed after the PR is raised.\n\nSee also: [bbAutoResolvePrTasks](https://docs.renovatebot.com/configuration-options/#bbautoresolveprtasks)",
+      "type": "boolean",
+      "default": false
+    },
+    "bbUseDefaultReviewers": {
+      "description": "Use the default reviewers (Bitbucket only).\nSee also: https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers",
+      "markdownDescription": "Use the default reviewers (Bitbucket only).\n\nSee also: [bbUseDefaultReviewers](https://docs.renovatebot.com/configuration-options/#bbusedefaultreviewers)",
+      "type": "boolean",
+      "default": true
+    },
+    "bbUseDevelopmentBranch": {
+      "description": "Use the repository's [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as the repository's default branch.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#bbusedevelopmentbranch",
+      "markdownDescription": "Use the repository's [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as the repository's default branch.\n\nSee also: [bbUseDevelopmentBranch](https://docs.renovatebot.com/self-hosted-configuration/#bbusedevelopmentbranch)",
+      "type": "boolean",
+      "default": false
+    },
+    "bicep": {
+      "$ref": "#",
+      "description": "Configuration object for the bicep manager\nSee also: https://docs.renovatebot.com/configuration-options/#bicep",
+      "markdownDescription": "Configuration object for the bicep manager\n\nSee also: [bicep](https://docs.renovatebot.com/configuration-options/#bicep)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.bicep$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#",
+      "description": "Configuration object for the bitbucket-pipelines manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines",
+      "markdownDescription": "Configuration object for the bitbucket-pipelines manager\n\nSee also: [bitbucket-pipelines](https://docs.renovatebot.com/configuration-options/#bitbucket-pipelines)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/*-pipelines.yml"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bitrise": {
+      "$ref": "#",
+      "description": "Configuration object for the bitrise manager\nSee also: https://docs.renovatebot.com/configuration-options/#bitrise",
+      "markdownDescription": "Configuration object for the bitrise manager\n\nSee also: [bitrise](https://docs.renovatebot.com/configuration-options/#bitrise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bitrise\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "branchConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\nSee also: https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches. 0 means no limit, `null` (default) inherits value from `prConcurrentLimit`.\n\nSee also: [branchConcurrentLimit](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "branchName": {
+      "description": "Branch name template.\nSee also: https://docs.renovatebot.com/configuration-options/#branchname",
+      "markdownDescription": "Branch name template.\n\nSee also: [branchName](https://docs.renovatebot.com/configuration-options/#branchname)",
+      "type": "string",
+      "default": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}"
+    },
+    "branchNameStrict": {
+      "description": "Whether to be strict about the use of special characters within the branch name.\nSee also: https://docs.renovatebot.com/configuration-options/#branchnamestrict",
+      "markdownDescription": "Whether to be strict about the use of special characters within the branch name.\n\nSee also: [branchNameStrict](https://docs.renovatebot.com/configuration-options/#branchnamestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "branchPrefix": {
+      "description": "Prefix to use for all branch names.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefix",
+      "markdownDescription": "Prefix to use for all branch names.\n\nSee also: [branchPrefix](https://docs.renovatebot.com/configuration-options/#branchprefix)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchPrefixOld": {
+      "description": "Old branchPrefix value to check for existing PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#branchprefixold",
+      "markdownDescription": "Old branchPrefix value to check for existing PRs.\n\nSee also: [branchPrefixOld](https://docs.renovatebot.com/configuration-options/#branchprefixold)",
+      "type": "string",
+      "default": "renovate/"
+    },
+    "branchTopic": {
+      "description": "Branch topic.\nSee also: https://docs.renovatebot.com/configuration-options/#branchtopic",
+      "markdownDescription": "Branch topic.\n\nSee also: [branchTopic](https://docs.renovatebot.com/configuration-options/#branchtopic)",
+      "type": "string",
+      "default": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}.{{{newMinor}}}{{/if}}{{/if}}{{#if separateMultipleMinor}}{{#if isMinor}}.{{{newMinor}}}{{/if}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}"
+    },
+    "buildkite": {
+      "$ref": "#",
+      "description": "Configuration object for the buildkite manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildkite",
+      "markdownDescription": "Configuration object for the buildkite manager\n\nSee also: [buildkite](https://docs.renovatebot.com/configuration-options/#buildkite)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/buildkite\\.ya?ml/",
+          "/\\.buildkite/.+\\.ya?ml$/"
+        ],
+        "commitMessageTopic": "buildkite plugin {{depName}}",
+        "commitMessageExtra": "to {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{{newValue}}}{{/if}}"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "buildpacks": {
+      "$ref": "#",
+      "description": "Configuration object for the buildpacks manager\nSee also: https://docs.renovatebot.com/configuration-options/#buildpacks",
+      "markdownDescription": "Configuration object for the buildpacks manager\n\nSee also: [buildpacks](https://docs.renovatebot.com/configuration-options/#buildpacks)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "buildpack {{depName}}",
+        "managerFilePatterns": ["/(^|/)project\\.toml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bumpType": {
+      "description": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype",
+      "markdownDescription": "The semver level to use when bumping versions. This is used by the `bumpVersions` feature.\n\nSee also: [bumpType](https://docs.renovatebot.com/configuration-options/#bumpversionsbumptype)",
+      "type": "string",
+      "anyOf": [
+        {
+          "enum": ["major", "minor", "patch", "sync"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "bumpVersion": {
+      "description": "Bump the version in the package file being updated.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversion",
+      "markdownDescription": "Bump the version in the package file being updated.\n\nSee also: [bumpVersion](https://docs.renovatebot.com/configuration-options/#bumpversion)",
+      "type": "string",
+      "enum": ["major", "minor", "patch", "prerelease"]
+    },
+    "bumpVersions": {
+      "description": "A list of bumpVersion config options to bump generic version numbers.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversions",
+      "markdownDescription": "A list of bumpVersion config options to bump generic version numbers.\n\nSee also: [bumpVersions](https://docs.renovatebot.com/configuration-options/#bumpversions)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "bumpType": {
+                "$ref": "#/definitions/bumpType"
+              },
+              "filePatterns": {
+                "$ref": "#/definitions/filePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "name": {
+                "$ref": "#/definitions/name"
+              }
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "bun": {
+      "$ref": "#",
+      "description": "Configuration object for the bun manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun",
+      "markdownDescription": "Configuration object for the bun manager\n\nSee also: [bun](https://docs.renovatebot.com/configuration-options/#bun)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)bun\\.lockb?$/",
+          "/(^|/)package\\.json$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bun-version": {
+      "$ref": "#",
+      "description": "Configuration object for the bun-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#bun-version",
+      "markdownDescription": "Configuration object for the bun-version manager\n\nSee also: [bun-version](https://docs.renovatebot.com/configuration-options/#bun-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.bun-version$/"],
+        "versioning": "npm"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#bundler",
+      "markdownDescription": "Configuration object for the bundler manager\n\nSee also: [bundler](https://docs.renovatebot.com/configuration-options/#bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Gemfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cake": {
+      "$ref": "#",
+      "description": "Configuration object for the cake manager\nSee also: https://docs.renovatebot.com/configuration-options/#cake",
+      "markdownDescription": "Configuration object for the cake manager\n\nSee also: [cake](https://docs.renovatebot.com/configuration-options/#cake)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cake$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cargo": {
+      "$ref": "#",
+      "description": "Configuration object for the cargo manager\nSee also: https://docs.renovatebot.com/configuration-options/#cargo",
+      "markdownDescription": "Configuration object for the cargo manager\n\nSee also: [cargo](https://docs.renovatebot.com/configuration-options/#cargo)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust crate {{depName}}",
+        "managerFilePatterns": ["/(^|/)Cargo\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cdnurl": {
+      "$ref": "#",
+      "description": "Configuration object for the cdnurl manager\nSee also: https://docs.renovatebot.com/configuration-options/#cdnurl",
+      "markdownDescription": "Configuration object for the cdnurl manager\n\nSee also: [cdnurl](https://docs.renovatebot.com/configuration-options/#cdnurl)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "changelogUrl": {
+      "description": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\nSee also: https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl",
+      "markdownDescription": "Set a custom URL for the changelog. Renovate will put this URL in the PR body text.\n\nSee also: [changelogUrl](https://docs.renovatebot.com/configuration-options/#packageruleschangelogurl)",
+      "type": "string"
+    },
+    "circleci": {
+      "$ref": "#",
+      "description": "Configuration object for the circleci manager\nSee also: https://docs.renovatebot.com/configuration-options/#circleci",
+      "markdownDescription": "Configuration object for the circleci manager\n\nSee also: [circleci](https://docs.renovatebot.com/configuration-options/#circleci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.circleci/.+\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cloneSubmodules": {
+      "description": "Set to `true` to initialize submodules during repository clone.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodules",
+      "markdownDescription": "Set to `true` to initialize submodules during repository clone.\n\nSee also: [cloneSubmodules](https://docs.renovatebot.com/configuration-options/#clonesubmodules)",
+      "type": "boolean",
+      "default": false
+    },
+    "cloneSubmodulesFilter": {
+      "description": "List of submodules names or patterns to clone when cloneSubmodules=true.\nSee also: https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter",
+      "markdownDescription": "List of submodules names or patterns to clone when cloneSubmodules=true.\n\nSee also: [cloneSubmodulesFilter](https://docs.renovatebot.com/configuration-options/#clonesubmodulesfilter)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["*"]
+    },
+    "cloudbuild": {
+      "$ref": "#",
+      "description": "Configuration object for the cloudbuild manager\nSee also: https://docs.renovatebot.com/configuration-options/#cloudbuild",
+      "markdownDescription": "Configuration object for the cloudbuild manager\n\nSee also: [cloudbuild](https://docs.renovatebot.com/configuration-options/#cloudbuild)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cloudbuild\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cocoapods": {
+      "$ref": "#",
+      "description": "Configuration object for the cocoapods manager\nSee also: https://docs.renovatebot.com/configuration-options/#cocoapods",
+      "markdownDescription": "Configuration object for the cocoapods manager\n\nSee also: [cocoapods](https://docs.renovatebot.com/configuration-options/#cocoapods)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Podfile$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "commands": {
+      "description": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands",
+      "markdownDescription": "A list of post-upgrade commands that are executed before a commit is made by Renovate.\n\nSee also: [commands](https://docs.renovatebot.com/configuration-options/#postupgradetaskscommands)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "commitBody": {
+      "description": "Commit message body template. Will be appended to commit message, separated by two line returns.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbody",
+      "markdownDescription": "Commit message body template. Will be appended to commit message, separated by two line returns.\n\nSee also: [commitBody](https://docs.renovatebot.com/configuration-options/#commitbody)",
+      "type": "string"
+    },
+    "commitBodyTable": {
+      "description": "If enabled, append a table in the commit message body describing all updates in the commit.\nSee also: https://docs.renovatebot.com/configuration-options/#commitbodytable",
+      "markdownDescription": "If enabled, append a table in the commit message body describing all updates in the commit.\n\nSee also: [commitBodyTable](https://docs.renovatebot.com/configuration-options/#commitbodytable)",
+      "type": "boolean",
+      "default": false
+    },
+    "commitHourlyLimit": {
+      "description": "Rate limit commits to maximum x per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#commithourlylimit",
+      "markdownDescription": "Rate limit commits to maximum x per hour. 0 means no limit.\n\nSee also: [commitHourlyLimit](https://docs.renovatebot.com/configuration-options/#commithourlylimit)",
+      "type": "integer",
+      "default": 0
+    },
+    "commitMessage": {
+      "description": "Message to use for commit messages and pull request titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessage",
+      "markdownDescription": "Message to use for commit messages and pull request titles.\n\nSee also: [commitMessage](https://docs.renovatebot.com/configuration-options/#commitmessage)",
+      "type": "string",
+      "default": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}"
+    },
+    "commitMessageAction": {
+      "description": "Action verb to use in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageaction",
+      "markdownDescription": "Action verb to use in commit messages and PR titles.\n\nSee also: [commitMessageAction](https://docs.renovatebot.com/configuration-options/#commitmessageaction)",
+      "type": "string",
+      "default": "Update"
+    },
+    "commitMessageExtra": {
+      "description": "Extra description used after the commit message topic - typically the version.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageextra",
+      "markdownDescription": "Extra description used after the commit message topic - typically the version.\n\nSee also: [commitMessageExtra](https://docs.renovatebot.com/configuration-options/#commitmessageextra)",
+      "type": "string",
+      "default": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}"
+    },
+    "commitMessageLowerCase": {
+      "description": "Lowercase PR- and commit titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagelowercase",
+      "markdownDescription": "Lowercase PR- and commit titles.\n\nSee also: [commitMessageLowerCase](https://docs.renovatebot.com/configuration-options/#commitmessagelowercase)",
+      "type": "string",
+      "enum": ["auto", "never"],
+      "default": "auto"
+    },
+    "commitMessagePrefix": {
+      "description": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessageprefix",
+      "markdownDescription": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if `semanticCommits` is enabled.\n\nSee also: [commitMessagePrefix](https://docs.renovatebot.com/configuration-options/#commitmessageprefix)",
+      "type": "string"
+    },
+    "commitMessageSuffix": {
+      "description": "Suffix to add to end of commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagesuffix",
+      "markdownDescription": "Suffix to add to end of commit messages and PR titles.\n\nSee also: [commitMessageSuffix](https://docs.renovatebot.com/configuration-options/#commitmessagesuffix)",
+      "type": "string"
+    },
+    "commitMessageTopic": {
+      "description": "The upgrade topic/noun used in commit messages and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#commitmessagetopic",
+      "markdownDescription": "The upgrade topic/noun used in commit messages and PR titles.\n\nSee also: [commitMessageTopic](https://docs.renovatebot.com/configuration-options/#commitmessagetopic)",
+      "type": "string",
+      "default": "dependency {{depName}}"
+    },
+    "commitTrailers": {
+      "description": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\nSee also: https://docs.renovatebot.com/configuration-options/#committrailers",
+      "markdownDescription": "Structured git trailers (`Key: value` lines) to add in the final block of the commit message.\n\nSee also: [commitTrailers](https://docs.renovatebot.com/configuration-options/#committrailers)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "composer": {
+      "$ref": "#",
+      "description": "Configuration object for the composer manager\nSee also: https://docs.renovatebot.com/configuration-options/#composer",
+      "markdownDescription": "Configuration object for the composer manager\n\nSee also: [composer](https://docs.renovatebot.com/configuration-options/#composer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)([\\w-]*)composer\\.json$/"],
+        "versioning": "composer"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "composerIgnorePlatformReqs": {
+      "description": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\nSee also: https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs",
+      "markdownDescription": "Configure use of `--ignore-platform-reqs` or `--ignore-platform-req` for the Composer package manager.\n\nSee also: [composerIgnorePlatformReqs](https://docs.renovatebot.com/configuration-options/#composerignoreplatformreqs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "conan": {
+      "$ref": "#",
+      "description": "Configuration object for the conan manager\nSee also: https://docs.renovatebot.com/configuration-options/#conan",
+      "markdownDescription": "Configuration object for the conan manager\n\nSee also: [conan](https://docs.renovatebot.com/configuration-options/#conan)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)conanfile\\.(txt|py)$/"],
+        "datasource": "conan",
+        "versioning": "conan"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "concurrentRequestLimit": {
+      "description": "Limit concurrent requests per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit",
+      "markdownDescription": "Limit concurrent requests per host.\n\nSee also: [concurrentRequestLimit](https://docs.renovatebot.com/configuration-options/#hostrulesconcurrentrequestlimit)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "confidential": {
+      "description": "If enabled, issues created by Renovate are set as confidential.\nSee also: https://docs.renovatebot.com/configuration-options/#confidential",
+      "markdownDescription": "If enabled, issues created by Renovate are set as confidential.\n\nSee also: [confidential](https://docs.renovatebot.com/configuration-options/#confidential)",
+      "type": "boolean",
+      "default": false
+    },
+    "configFileNames": {
+      "description": "List of filenames where repository config will be stored.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#configfilenames",
+      "markdownDescription": "List of filenames where repository config will be stored.\n\nSee also: [configFileNames](https://docs.renovatebot.com/self-hosted-configuration/#configfilenames)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "configMigration": {
+      "description": "Enable this to get config migration PRs when needed.\nSee also: https://docs.renovatebot.com/configuration-options/#configmigration",
+      "markdownDescription": "Enable this to get config migration PRs when needed.\n\nSee also: [configMigration](https://docs.renovatebot.com/configuration-options/#configmigration)",
+      "type": "boolean",
+      "default": false
+    },
+    "configWarningReuseIssue": {
+      "description": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\nSee also: https://docs.renovatebot.com/configuration-options/#configwarningreuseissue",
+      "markdownDescription": "Set this to `true` to make Renovate reuse/reopen an existing closed Config Warning issue, instead of opening a new one each time.\n\nSee also: [configWarningReuseIssue](https://docs.renovatebot.com/configuration-options/#configwarningreuseissue)",
+      "type": "boolean",
+      "default": false
+    },
+    "constraints": {
+      "description": "Configuration object to define language or manager version constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraints",
+      "markdownDescription": "Configuration object to define language or manager version constraints.\n\nSee also: [constraints](https://docs.renovatebot.com/configuration-options/#constraints)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "string",
+          "description": "A constraint for the `bazelisk` Containerbase tool"
+        },
+        "bun": {
+          "type": "string",
+          "description": "A constraint for the `bun` Containerbase tool"
+        },
+        "bundler": {
+          "type": "string",
+          "description": "A constraint for the `bundler` Containerbase tool"
+        },
+        "cocoapods": {
+          "type": "string",
+          "description": "A constraint for the `cocoapods` Containerbase tool"
+        },
+        "composer": {
+          "type": "string",
+          "description": "A constraint for the `composer` Containerbase tool"
+        },
+        "conan": {
+          "type": "string",
+          "description": "A constraint for the `conan` Containerbase tool"
+        },
+        "copier": {
+          "type": "string",
+          "description": "A constraint for the `copier` Containerbase tool"
+        },
+        "corepack": {
+          "type": "string",
+          "description": "A constraint for the `corepack` Containerbase tool"
+        },
+        "deno": {
+          "type": "string",
+          "description": "A constraint for the `deno` Containerbase tool"
+        },
+        "devbox": {
+          "type": "string",
+          "description": "A constraint for the `devbox` Containerbase tool"
+        },
+        "dotnet": {
+          "type": "string",
+          "description": "A constraint for the `dotnet` Containerbase tool"
+        },
+        "erlang": {
+          "type": "string",
+          "description": "A constraint for the `erlang` Containerbase tool"
+        },
+        "elixir": {
+          "type": "string",
+          "description": "A constraint for the `elixir` Containerbase tool"
+        },
+        "flux": {
+          "type": "string",
+          "description": "A constraint for the `flux` Containerbase tool"
+        },
+        "gleam": {
+          "type": "string",
+          "description": "A constraint for the `gleam` Containerbase tool"
+        },
+        "golang": {
+          "type": "string",
+          "description": "A constraint for the `golang` Containerbase tool"
+        },
+        "gradle": {
+          "type": "string",
+          "description": "A constraint for the `gradle` Containerbase tool"
+        },
+        "hashin": {
+          "type": "string",
+          "description": "A constraint for the `hashin` Containerbase tool"
+        },
+        "helm": {
+          "type": "string",
+          "description": "A constraint for the `helm` Containerbase tool"
+        },
+        "helmfile": {
+          "type": "string",
+          "description": "A constraint for the `helmfile` Containerbase tool"
+        },
+        "java": {
+          "type": "string",
+          "description": "A constraint for the `java` Containerbase tool"
+        },
+        "java-maven": {
+          "type": "string",
+          "description": "A constraint for the `java-maven` Containerbase tool"
+        },
+        "jb": {
+          "type": "string",
+          "description": "A constraint for the `jb` Containerbase tool"
+        },
+        "kustomize": {
+          "type": "string",
+          "description": "A constraint for the `kustomize` Containerbase tool"
+        },
+        "maven": {
+          "type": "string",
+          "description": "A constraint for the `maven` Containerbase tool"
+        },
+        "mise": {
+          "type": "string",
+          "description": "A constraint for the `mise` Containerbase tool"
+        },
+        "nix": {
+          "type": "string",
+          "description": "A constraint for the `nix` Containerbase tool"
+        },
+        "node": {
+          "type": "string",
+          "description": "A constraint for the `node` Containerbase tool"
+        },
+        "npm": {
+          "type": "string",
+          "description": "A constraint for the `npm` Containerbase tool"
+        },
+        "pdm": {
+          "type": "string",
+          "description": "A constraint for the `pdm` Containerbase tool"
+        },
+        "php": {
+          "type": "string",
+          "description": "A constraint for the `php` Containerbase tool"
+        },
+        "pip-tools": {
+          "type": "string",
+          "description": "A constraint for the `pip-tools` Containerbase tool"
+        },
+        "pipenv": {
+          "type": "string",
+          "description": "A constraint for the `pipenv` Containerbase tool"
+        },
+        "pnpm": {
+          "type": "string",
+          "description": "A constraint for the `pnpm` Containerbase tool"
+        },
+        "pixi": {
+          "type": "string",
+          "description": "A constraint for the `pixi` Containerbase tool"
+        },
+        "poetry": {
+          "type": "string",
+          "description": "A constraint for the `poetry` Containerbase tool"
+        },
+        "python": {
+          "type": "string",
+          "description": "A constraint for the `python` Containerbase tool"
+        },
+        "ruby": {
+          "type": "string",
+          "description": "A constraint for the `ruby` Containerbase tool. Also used in the `rubygems` Datasource"
+        },
+        "rust": {
+          "type": "string",
+          "description": "A constraint for the `rust` Containerbase tool"
+        },
+        "uv": {
+          "type": "string",
+          "description": "A constraint for the `uv` Containerbase tool"
+        },
+        "yarn": {
+          "type": "string",
+          "description": "A constraint for the `yarn` Containerbase tool"
+        },
+        "yarn-slim": {
+          "type": "string",
+          "description": "A constraint for the `yarn-slim` Containerbase tool"
+        },
+        "dart": {
+          "type": "string",
+          "description": "A constraint for the `dart` Containerbase tool"
+        },
+        "flutter": {
+          "type": "string",
+          "description": "A constraint for the `flutter` Containerbase tool"
+        },
+        "vendir": {
+          "type": "string",
+          "description": "A constraint for the `vendir` Containerbase tool"
+        },
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "constraintsFiltering": {
+      "description": "Perform release filtering based on language constraints.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsfiltering",
+      "markdownDescription": "Perform release filtering based on language constraints.\n\nSee also: [constraintsFiltering](https://docs.renovatebot.com/configuration-options/#constraintsfiltering)",
+      "type": "string",
+      "enum": ["none", "strict"],
+      "default": "none"
+    },
+    "constraintsVersioning": {
+      "description": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\nSee also: https://docs.renovatebot.com/configuration-options/#constraintsversioning",
+      "markdownDescription": "Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.\n\nSee also: [constraintsVersioning](https://docs.renovatebot.com/configuration-options/#constraintsversioning)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "go": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify the version of the Go toolchain to use.\n\nIn precedence order:\n\n1. config: `constraints.go`\n1. `go.mod`: `toolchain` directive\n1. `go.mod`: `go` directive\n\nNOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)\n  "
+        },
+        "gomodMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to specify a tag for [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).\n\nMust be prefixed with `v`."
+        },
+        "jenkins": {
+          "type": "string",
+          "description": "Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support."
+        },
+        "pipTools": {
+          "type": "string",
+          "description": "Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599"
+        },
+        "platform": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports."
+        },
+        "rubygems": {
+          "type": "string",
+          "description": "Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem."
+        },
+        "vscode": {
+          "type": "string",
+          "description": "Used in the `npm` manager to track the version of VSCode that the package is compatible with."
+        },
+        "dotnet-sdk": {
+          "type": "string",
+          "description": "Used in the `nuget` manager to track .NET SDK version required."
+        },
+        "perl": {
+          "type": "string",
+          "description": "Used in the `cpanfile` manager to track Perl version required."
+        },
+        "%goMod": {
+          "type": "string",
+          "description": "Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows."
+        }
+      }
+    },
+    "copier": {
+      "$ref": "#",
+      "description": "Configuration object for the copier manager\nSee also: https://docs.renovatebot.com/configuration-options/#copier",
+      "markdownDescription": "Configuration object for the copier manager\n\nSee also: [copier](https://docs.renovatebot.com/configuration-options/#copier)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.copier-answers(\\..+)?\\.ya?ml/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "cpanfile": {
+      "$ref": "#",
+      "description": "Configuration object for the cpanfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#cpanfile",
+      "markdownDescription": "Configuration object for the cpanfile manager\n\nSee also: [cpanfile](https://docs.renovatebot.com/configuration-options/#cpanfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)cpanfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crossplane": {
+      "$ref": "#",
+      "description": "Configuration object for the crossplane manager\nSee also: https://docs.renovatebot.com/configuration-options/#crossplane",
+      "markdownDescription": "Configuration object for the crossplane manager\n\nSee also: [crossplane](https://docs.renovatebot.com/configuration-options/#crossplane)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "crow": {
+      "$ref": "#",
+      "description": "Configuration object for the crow manager\nSee also: https://docs.renovatebot.com/configuration-options/#crow",
+      "markdownDescription": "Configuration object for the crow manager\n\nSee also: [crow](https://docs.renovatebot.com/configuration-options/#crow)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.crow(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "currentValueTemplate": {
+      "description": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate",
+      "markdownDescription": "Optional `currentValue` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [currentValueTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerscurrentvaluetemplate)",
+      "type": "string"
+    },
+    "customDatasources": {
+      "$ref": "#",
+      "description": "Defines custom datasources for usage by managers.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasources",
+      "markdownDescription": "Defines custom datasources for usage by managers.\n\nSee also: [customDatasources](https://docs.renovatebot.com/configuration-options/#customdatasources)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "defaultRegistryUrlTemplate": {
+                "$ref": "#/definitions/defaultRegistryUrlTemplate"
+              },
+              "format": {
+                "$ref": "#/definitions/format"
+              },
+              "transformTemplates": {
+                "$ref": "#/definitions/transformTemplates"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "customManagers": {
+      "description": "Custom managers using regex matching.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagers",
+      "markdownDescription": "Custom managers using regex matching.\n\nSee also: [customManagers](https://docs.renovatebot.com/configuration-options/#custommanagers)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "autoReplaceStringTemplate": {
+                "$ref": "#/definitions/autoReplaceStringTemplate"
+              },
+              "currentValueTemplate": {
+                "$ref": "#/definitions/currentValueTemplate"
+              },
+              "customType": {
+                "$ref": "#/definitions/customType"
+              },
+              "datasourceTemplate": {
+                "$ref": "#/definitions/datasourceTemplate"
+              },
+              "depNameTemplate": {
+                "$ref": "#/definitions/depNameTemplate"
+              },
+              "depTypeTemplate": {
+                "$ref": "#/definitions/depTypeTemplate"
+              },
+              "extractVersionTemplate": {
+                "$ref": "#/definitions/extractVersionTemplate"
+              },
+              "fileFormat": {
+                "$ref": "#/definitions/fileFormat"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              },
+              "matchStrings": {
+                "$ref": "#/definitions/matchStrings"
+              },
+              "matchStringsStrategy": {
+                "$ref": "#/definitions/matchStringsStrategy"
+              },
+              "packageNameTemplate": {
+                "$ref": "#/definitions/packageNameTemplate"
+              },
+              "registryUrlTemplate": {
+                "$ref": "#/definitions/registryUrlTemplate"
+              },
+              "versioningTemplate": {
+                "$ref": "#/definitions/versioningTemplate"
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "customType": {
+                  "const": "jsonata"
+                }
+              },
+              "required": ["customType"]
+            },
+            "then": {
+              "required": ["fileFormat"]
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "customType": {
+      "description": "Custom manager to use. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype",
+      "markdownDescription": "Custom manager to use. Valid only within a `customManagers` object.\n\nSee also: [customType](https://docs.renovatebot.com/configuration-options/#custommanagerscustomtype)",
+      "type": "string",
+      "enum": ["jsonata", "regex"]
+    },
+    "customizeDashboard": {
+      "description": "Customize sections in the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#customizedashboard",
+      "markdownDescription": "Customize sections in the Dependency Dashboard issue.\n\nSee also: [customizeDashboard](https://docs.renovatebot.com/configuration-options/#customizedashboard)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dataFileTemplate": {
+      "description": "A template to create post-upgrade command data file from.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate",
+      "markdownDescription": "A template to create post-upgrade command data file from.\n\nSee also: [dataFileTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksdatafiletemplate)",
+      "type": "string"
+    },
+    "datasourceTemplate": {
+      "description": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate",
+      "markdownDescription": "Optional datasource for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [datasourceTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdatasourcetemplate)",
+      "type": "string"
+    },
+    "defaultRegistryUrlTemplate": {
+      "description": "Template for generating a `defaultRegistryUrl` for custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate",
+      "markdownDescription": "Template for generating a `defaultRegistryUrl` for custom datasource.\n\nSee also: [defaultRegistryUrlTemplate](https://docs.renovatebot.com/configuration-options/#customdatasourcesdefaultregistryurltemplate)",
+      "type": "string",
+      "default": ""
+    },
+    "defaultRegistryUrls": {
+      "description": "List of registry URLs to use as the default for a datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#defaultregistryurls",
+      "markdownDescription": "List of registry URLs to use as the default for a datasource.\n\nSee also: [defaultRegistryUrls](https://docs.renovatebot.com/configuration-options/#defaultregistryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "deno": {
+      "$ref": "#",
+      "description": "Configuration object for the deno manager\nSee also: https://docs.renovatebot.com/configuration-options/#deno",
+      "markdownDescription": "Configuration object for the deno manager\n\nSee also: [deno](https://docs.renovatebot.com/configuration-options/#deno)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)deno\\.lock$/",
+          "/(^|/)deno\\.(json|jsonc)$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "{{#if (equals datasource \"npm\")}}[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}}){{else}}{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}{{/if}}"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "depNameTemplate": {
+      "description": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate",
+      "markdownDescription": "Optional depName for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdepnametemplate)",
+      "type": "string"
+    },
+    "depTypeTemplate": {
+      "description": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate",
+      "markdownDescription": "Optional `depType` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [depTypeTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersdeptypetemplate)",
+      "type": "string"
+    },
+    "dependencyDashboard": {
+      "description": "Whether to create a \"Dependency Dashboard\" issue in the repository.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboard",
+      "markdownDescription": "Whether to create a \"Dependency Dashboard\" issue in the repository.\n\nSee also: [dependencyDashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardApproval": {
+      "description": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval",
+      "markdownDescription": "Controls if updates need manual approval from the Dependency Dashboard issue before PRs are created.\n\nSee also: [dependencyDashboardApproval](https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardAutoclose": {
+      "description": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose",
+      "markdownDescription": "Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.\n\nSee also: [dependencyDashboardAutoclose](https://docs.renovatebot.com/configuration-options/#dependencydashboardautoclose)",
+      "type": "boolean",
+      "default": false
+    },
+    "dependencyDashboardCategory": {
+      "description": "The category to group branches on the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory",
+      "markdownDescription": "The category to group branches on the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardCategory](https://docs.renovatebot.com/configuration-options/#dependencydashboardcategory)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "dependencyDashboardFooter": {
+      "description": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter",
+      "markdownDescription": "Any text added here will be placed last in the Dependency Dashboard issue body, with a divider separator before it.\n\nSee also: [dependencyDashboardFooter](https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter)",
+      "type": "string"
+    },
+    "dependencyDashboardHeader": {
+      "description": "Any text added here will be placed first in the Dependency Dashboard issue body.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardheader",
+      "markdownDescription": "Any text added here will be placed first in the Dependency Dashboard issue body.\n\nSee also: [dependencyDashboardHeader](https://docs.renovatebot.com/configuration-options/#dependencydashboardheader)",
+      "type": "string",
+      "default": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more."
+    },
+    "dependencyDashboardLabels": {
+      "description": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels",
+      "markdownDescription": "These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.\n\nSee also: [dependencyDashboardLabels](https://docs.renovatebot.com/configuration-options/#dependencydashboardlabels)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "description": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary",
+      "markdownDescription": "Control if the Dependency Dashboard issue lists CVEs supplied by [osv.dev](https://osv.dev).\n\nSee also: [dependencyDashboardOSVVulnerabilitySummary](https://docs.renovatebot.com/configuration-options/#dependencydashboardosvvulnerabilitysummary)",
+      "type": "string",
+      "enum": ["none", "all", "unresolved"],
+      "default": "none"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "description": "Controls whether abandoned packages are reported in the dependency dashboard.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment",
+      "markdownDescription": "Controls whether abandoned packages are reported in the dependency dashboard.\n\nSee also: [dependencyDashboardReportAbandonment](https://docs.renovatebot.com/configuration-options/#dependencydashboardreportabandonment)",
+      "type": "boolean",
+      "default": true
+    },
+    "dependencyDashboardTitle": {
+      "description": "Title for the Dependency Dashboard issue.\nSee also: https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle",
+      "markdownDescription": "Title for the Dependency Dashboard issue.\n\nSee also: [dependencyDashboardTitle](https://docs.renovatebot.com/configuration-options/#dependencydashboardtitle)",
+      "type": "string",
+      "default": "Dependency Dashboard"
+    },
+    "deps-edn": {
+      "$ref": "#",
+      "description": "Configuration object for the deps-edn manager\nSee also: https://docs.renovatebot.com/configuration-options/#deps-edn",
+      "markdownDescription": "Configuration object for the deps-edn manager\n\nSee also: [deps-edn](https://docs.renovatebot.com/configuration-options/#deps-edn)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:deps|bb)\\.edn$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "description": {
+      "description": "Plain text description for a config or preset.\nSee also: https://docs.renovatebot.com/configuration-options/#description",
+      "markdownDescription": "Plain text description for a config or preset.\n\nSee also: [description](https://docs.renovatebot.com/configuration-options/#description)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "devbox": {
+      "$ref": "#",
+      "description": "Configuration object for the devbox manager\nSee also: https://docs.renovatebot.com/configuration-options/#devbox",
+      "markdownDescription": "Configuration object for the devbox manager\n\nSee also: [devbox](https://docs.renovatebot.com/configuration-options/#devbox)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)devbox\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "devcontainer": {
+      "$ref": "#",
+      "description": "Configuration object for the devcontainer manager\nSee also: https://docs.renovatebot.com/configuration-options/#devcontainer",
+      "markdownDescription": "Configuration object for the devcontainer manager\n\nSee also: [devcontainer](https://docs.renovatebot.com/configuration-options/#devcontainer)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/^.devcontainer/devcontainer.json$/",
+          "/^.devcontainer.json$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "digest": {
+      "$ref": "#",
+      "description": "Configuration to apply when updating a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#digest",
+      "markdownDescription": "Configuration to apply when updating a digest (no change in tag/version).\n\nSee also: [digest](https://docs.renovatebot.com/configuration-options/#digest)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-digest",
+        "commitMessageExtra": "to {{newDigestShort}}",
+        "commitMessageTopic": "{{{depName}}} digest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dnsCache": {
+      "description": "Enable got DNS cache.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesdnscache",
+      "markdownDescription": "Enable got DNS cache.\n\nSee also: [dnsCache](https://docs.renovatebot.com/configuration-options/#hostrulesdnscache)",
+      "type": "boolean",
+      "default": false
+    },
+    "docker-compose": {
+      "$ref": "#",
+      "description": "Configuration object for the docker-compose manager\nSee also: https://docs.renovatebot.com/configuration-options/#docker-compose",
+      "markdownDescription": "Configuration object for the docker-compose manager\n\nSee also: [docker-compose](https://docs.renovatebot.com/configuration-options/#docker-compose)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "dockerfile": {
+      "$ref": "#",
+      "description": "Configuration object for the dockerfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#dockerfile",
+      "markdownDescription": "Configuration object for the dockerfile manager\n\nSee also: [dockerfile](https://docs.renovatebot.com/configuration-options/#dockerfile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/",
+          "/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "draftPR": {
+      "description": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\nSee also: https://docs.renovatebot.com/configuration-options/#draftpr",
+      "markdownDescription": "If set to `true` then Renovate creates draft PRs, instead of normal status PRs.\n\nSee also: [draftPR](https://docs.renovatebot.com/configuration-options/#draftpr)",
+      "type": "boolean",
+      "default": false
+    },
+    "droneci": {
+      "$ref": "#",
+      "description": "Configuration object for the droneci manager\nSee also: https://docs.renovatebot.com/configuration-options/#droneci",
+      "markdownDescription": "Configuration object for the droneci manager\n\nSee also: [droneci](https://docs.renovatebot.com/configuration-options/#droneci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.drone\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "enableHttp2": {
+      "description": "Enable got HTTP/2 support.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2",
+      "markdownDescription": "Enable got HTTP/2 support.\n\nSee also: [enableHttp2](https://docs.renovatebot.com/configuration-options/#hostrulesenablehttp2)",
+      "type": "boolean",
+      "default": false
+    },
+    "enabled": {
+      "description": "Enable or disable corresponding functionality.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesenabled",
+      "markdownDescription": "Enable or disable corresponding functionality.\n\nSee also: [enabled](https://docs.renovatebot.com/configuration-options/#packagerulesenabled)",
+      "type": "boolean",
+      "default": true
+    },
+    "enabledManagers": {
+      "description": "A list of package managers to enable. Only managers on the list are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#enabledmanagers",
+      "markdownDescription": "A list of package managers to enable. Only managers on the list are enabled.\n\nSee also: [enabledManagers](https://docs.renovatebot.com/configuration-options/#enabledmanagers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "encrypted": {
+      "$ref": "#",
+      "description": "An object containing configuration encrypted with project key.\nSee also: https://docs.renovatebot.com/configuration-options/#encrypted",
+      "markdownDescription": "An object containing configuration encrypted with project key.\n\nSee also: [encrypted](https://docs.renovatebot.com/configuration-options/#encrypted)",
+      "type": ["object", "null"],
+      "default": null
+    },
+    "env": {
+      "$ref": "#",
+      "description": "Environment variables that Renovate uses when executing package manager commands.\nSee also: https://docs.renovatebot.com/configuration-options/#env",
+      "markdownDescription": "Environment variables that Renovate uses when executing package manager commands.\n\nSee also: [env](https://docs.renovatebot.com/configuration-options/#env)",
+      "type": "object",
+      "default": {}
+    },
+    "excludeCommitPaths": {
+      "description": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\nSee also: https://docs.renovatebot.com/configuration-options/#excludecommitpaths",
+      "markdownDescription": "A file matching any of these glob patterns will not be committed, even if the file has been updated.\n\nSee also: [excludeCommitPaths](https://docs.renovatebot.com/configuration-options/#excludecommitpaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "executionMode": {
+      "description": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode",
+      "markdownDescription": "Controls when the post upgrade tasks run: on every update, or once per upgrade branch.\n\nSee also: [executionMode](https://docs.renovatebot.com/configuration-options/#postupgradetasksexecutionmode)",
+      "type": "string",
+      "enum": ["update", "branch"],
+      "default": "update"
+    },
+    "expandCodeOwnersGroups": {
+      "description": "Expand the configured code owner groups into a full list of group members.\nSee also: https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups",
+      "markdownDescription": "Expand the configured code owner groups into a full list of group members.\n\nSee also: [expandCodeOwnersGroups](https://docs.renovatebot.com/configuration-options/#expandcodeownersgroups)",
+      "type": "boolean",
+      "default": false
+    },
+    "extends": {
+      "description": "Configuration presets to use or extend.\nSee also: https://docs.renovatebot.com/configuration-options/#extends",
+      "markdownDescription": "Configuration presets to use or extend.\n\nSee also: [extends](https://docs.renovatebot.com/configuration-options/#extends)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "enum": [
+                  "config:best-practices",
+                  "config:recommended",
+                  "mergeConfidence:all-badges",
+                  "abandonments:recommended",
+                  "group:all",
+                  "replacements:all",
+                  "security:minimumReleaseAgeNpm",
+                  "security:only-security-updates"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "extractVersion": {
+      "description": "A regex (`re2`) to extract a version from a datasource's raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#extractversion",
+      "markdownDescription": "A regex (`re2`) to extract a version from a datasource's raw version string.\n\nSee also: [extractVersion](https://docs.renovatebot.com/configuration-options/#extractversion)",
+      "type": "string",
+      "format": "regex"
+    },
+    "extractVersionTemplate": {
+      "description": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate",
+      "markdownDescription": "Optional `extractVersion` for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [extractVersionTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersextractversiontemplate)",
+      "type": "string"
+    },
+    "fetchChangeLogs": {
+      "description": "Controls if and when changelogs/release notes are fetched.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs",
+      "markdownDescription": "Controls if and when changelogs/release notes are fetched.\n\nSee also: [fetchChangeLogs](https://docs.renovatebot.com/configuration-options/#packagerulesfetchchangelogs)",
+      "type": "string",
+      "enum": ["off", "branch", "pr"],
+      "default": "pr"
+    },
+    "fileFilters": {
+      "description": "Files that match the glob pattern will be committed after running a post-upgrade task.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters",
+      "markdownDescription": "Files that match the glob pattern will be committed after running a post-upgrade task.\n\nSee also: [fileFilters](https://docs.renovatebot.com/configuration-options/#postupgradetasksfilefilters)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/*"]
+    },
+    "fileFormat": {
+      "description": "It specifies the syntax of the package file being managed by the custom JSONata manager.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersfileformat",
+      "markdownDescription": "It specifies the syntax of the package file being managed by the custom JSONata manager.\n\nSee also: [fileFormat](https://docs.renovatebot.com/configuration-options/#custommanagersfileformat)",
+      "type": "string",
+      "enum": ["json", "toml", "yaml"]
+    },
+    "filePatterns": {
+      "description": "A list of patterns to match files that contain the version string.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns",
+      "markdownDescription": "A list of patterns to match files that contain the version string.\n\nSee also: [filePatterns](https://docs.renovatebot.com/configuration-options/#bumpversionsfilepatterns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "filterUnavailableUsers": {
+      "description": "Filter reviewers and assignees based on their availability.\nSee also: https://docs.renovatebot.com/configuration-options/#filterunavailableusers",
+      "markdownDescription": "Filter reviewers and assignees based on their availability.\n\nSee also: [filterUnavailableUsers](https://docs.renovatebot.com/configuration-options/#filterunavailableusers)",
+      "type": "boolean",
+      "default": false
+    },
+    "fleet": {
+      "$ref": "#",
+      "description": "Configuration object for the fleet manager\nSee also: https://docs.renovatebot.com/configuration-options/#fleet",
+      "markdownDescription": "Configuration object for the fleet manager\n\nSee also: [fleet](https://docs.renovatebot.com/configuration-options/#fleet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)fleet\\.ya?ml/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "flux": {
+      "$ref": "#",
+      "description": "Configuration object for the flux manager\nSee also: https://docs.renovatebot.com/configuration-options/#flux",
+      "markdownDescription": "Configuration object for the flux manager\n\nSee also: [flux](https://docs.renovatebot.com/configuration-options/#flux)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(?:^|/)gotk-components\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "followTag": {
+      "description": "If defined, packages will follow this release tag exactly.\nSee also: https://docs.renovatebot.com/configuration-options/#followtag",
+      "markdownDescription": "If defined, packages will follow this release tag exactly.\n\nSee also: [followTag](https://docs.renovatebot.com/configuration-options/#followtag)",
+      "type": "string"
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "description": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits",
+      "markdownDescription": "Disallow maintainers to push to Renovate pull requests when running in fork mode.\n\nSee also: [forkModeDisallowMaintainerEdits](https://docs.renovatebot.com/configuration-options/#forkmodedisallowmaintaineredits)",
+      "type": "boolean",
+      "default": false
+    },
+    "forkProcessing": {
+      "description": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\nSee also: https://docs.renovatebot.com/configuration-options/#forkprocessing",
+      "markdownDescription": "Whether to process forked repositories. By default, all forked repositories are skipped when in `autodiscover` mode.\n\nSee also: [forkProcessing](https://docs.renovatebot.com/configuration-options/#forkprocessing)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "format": {
+      "description": "Format of the custom datasource.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcesformat",
+      "markdownDescription": "Format of the custom datasource.\n\nSee also: [format](https://docs.renovatebot.com/configuration-options/#customdatasourcesformat)",
+      "type": "string",
+      "enum": ["json", "plain"],
+      "default": "json"
+    },
+    "fvm": {
+      "$ref": "#",
+      "description": "Configuration object for the fvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#fvm",
+      "markdownDescription": "Configuration object for the fvm manager\n\nSee also: [fvm](https://docs.renovatebot.com/configuration-options/#fvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)\\.fvm/fvm_config\\.json$/",
+          "/(^|/)\\.fvmrc$/"
+        ],
+        "versioning": "semver"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "git-submodules": {
+      "$ref": "#",
+      "description": "Configuration object for the git-submodules manager\nSee also: https://docs.renovatebot.com/configuration-options/#git-submodules",
+      "markdownDescription": "Configuration object for the git-submodules manager\n\nSee also: [git-submodules](https://docs.renovatebot.com/configuration-options/#git-submodules)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "versioning": "git",
+        "managerFilePatterns": ["/(^|/)\\.gitmodules$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitAuthor": {
+      "description": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitauthor",
+      "markdownDescription": "Author to use for Git commits. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitAuthor](https://docs.renovatebot.com/configuration-options/#gitauthor)",
+      "type": "string"
+    },
+    "gitIgnoredAuthors": {
+      "description": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\nSee also: https://docs.renovatebot.com/configuration-options/#gitignoredauthors",
+      "markdownDescription": "Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).\n\nSee also: [gitIgnoredAuthors](https://docs.renovatebot.com/configuration-options/#gitignoredauthors)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gitLabIgnoreApprovals": {
+      "description": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals",
+      "markdownDescription": "Ignore approval rules for MRs created by Renovate, which is useful for automerge.\n\nSee also: [gitLabIgnoreApprovals](https://docs.renovatebot.com/configuration-options/#gitlabignoreapprovals)",
+      "type": "boolean",
+      "default": false
+    },
+    "github-actions": {
+      "$ref": "#",
+      "description": "Configuration object for the github-actions manager\nSee also: https://docs.renovatebot.com/configuration-options/#github-actions",
+      "markdownDescription": "Configuration object for the github-actions manager\n\nSee also: [github-actions](https://docs.renovatebot.com/configuration-options/#github-actions)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+          "/(^|/)action\\.ya?ml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitlabci": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci",
+      "markdownDescription": "Configuration object for the gitlabci manager\n\nSee also: [gitlabci](https://docs.renovatebot.com/configuration-options/#gitlabci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gitlabci-include": {
+      "$ref": "#",
+      "description": "Configuration object for the gitlabci-include manager\nSee also: https://docs.renovatebot.com/configuration-options/#gitlabci-include",
+      "markdownDescription": "Configuration object for the gitlabci-include manager\n\nSee also: [gitlabci-include](https://docs.renovatebot.com/configuration-options/#gitlabci-include)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.gitlab-ci\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "glasskube": {
+      "$ref": "#",
+      "description": "Configuration object for the glasskube manager\nSee also: https://docs.renovatebot.com/configuration-options/#glasskube",
+      "markdownDescription": "Configuration object for the glasskube manager\n\nSee also: [glasskube](https://docs.renovatebot.com/configuration-options/#glasskube)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gleam": {
+      "$ref": "#",
+      "description": "Configuration object for the gleam manager\nSee also: https://docs.renovatebot.com/configuration-options/#gleam",
+      "markdownDescription": "Configuration object for the gleam manager\n\nSee also: [gleam](https://docs.renovatebot.com/configuration-options/#gleam)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)gleam.toml$/"],
+        "versioning": "hex"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "goGetDirs": {
+      "description": "Directory pattern to run `go get` on.\nSee also: https://docs.renovatebot.com/configuration-options/#gogetdirs",
+      "markdownDescription": "Directory pattern to run `go get` on.\n\nSee also: [goGetDirs](https://docs.renovatebot.com/configuration-options/#gogetdirs)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["./..."]
+    },
+    "gomod": {
+      "$ref": "#",
+      "description": "Configuration object for the gomod manager\nSee also: https://docs.renovatebot.com/configuration-options/#gomod",
+      "markdownDescription": "Configuration object for the gomod manager\n\nSee also: [gomod](https://docs.renovatebot.com/configuration-options/#gomod)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)go\\.mod$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle",
+      "markdownDescription": "Configuration object for the gradle manager\n\nSee also: [gradle](https://docs.renovatebot.com/configuration-options/#gradle)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.gradle(\\.kts)?$/",
+          "/(^|/)gradle\\.properties$/",
+          "/(^|/)gradle/.+\\.toml$/",
+          "/(^|/)buildSrc/.+\\.kt$/",
+          "/\\.versions\\.toml$/",
+          "/(^|/)versions.props$/",
+          "/(^|/)versions.lock$/"
+        ],
+        "timeout": 600,
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gradle-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the gradle-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#gradle-wrapper",
+      "markdownDescription": "Configuration object for the gradle-wrapper manager\n\nSee also: [gradle-wrapper](https://docs.renovatebot.com/configuration-options/#gradle-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)gradle/wrapper/gradle-wrapper\\.properties$/"
+        ],
+        "versioning": "gradle"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "group": {
+      "$ref": "#",
+      "description": "Config if `groupName` is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#group",
+      "markdownDescription": "Config if `groupName` is enabled.\n\nSee also: [group](https://docs.renovatebot.com/configuration-options/#group)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{groupSlug}}}",
+        "commitMessageTopic": "{{{groupName}}}"
+      }
+    },
+    "groupName": {
+      "description": "Human understandable name for the dependency group.\nSee also: https://docs.renovatebot.com/configuration-options/#groupname",
+      "markdownDescription": "Human understandable name for the dependency group.\n\nSee also: [groupName](https://docs.renovatebot.com/configuration-options/#groupname)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "groupSingleUpdates": {
+      "description": "Apply group settings even when the group contains only one update.\nSee also: https://docs.renovatebot.com/configuration-options/#groupsingleupdates",
+      "markdownDescription": "Apply group settings even when the group contains only one update.\n\nSee also: [groupSingleUpdates](https://docs.renovatebot.com/configuration-options/#groupsingleupdates)",
+      "type": "boolean",
+      "default": false
+    },
+    "groupSlug": {
+      "description": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\nSee also: https://docs.renovatebot.com/configuration-options/#groupslug",
+      "markdownDescription": "Slug to use for group (e.g. in branch name). Slug is calculated from `groupName` if `null`.\n\nSee also: [groupSlug](https://docs.renovatebot.com/configuration-options/#groupslug)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "hashedBranchLength": {
+      "description": "If enabled, branch names will use a hashing function to ensure each branch has that length.\nSee also: https://docs.renovatebot.com/configuration-options/#hashedbranchlength",
+      "markdownDescription": "If enabled, branch names will use a hashing function to ensure each branch has that length.\n\nSee also: [hashedBranchLength](https://docs.renovatebot.com/configuration-options/#hashedbranchlength)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "haskell-cabal": {
+      "$ref": "#",
+      "description": "Configuration object for the haskell-cabal manager\nSee also: https://docs.renovatebot.com/configuration-options/#haskell-cabal",
+      "markdownDescription": "Configuration object for the haskell-cabal manager\n\nSee also: [haskell-cabal](https://docs.renovatebot.com/configuration-options/#haskell-cabal)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.cabal$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "headers": {
+      "$ref": "#",
+      "description": "Put fields to be forwarded to the HTTP request headers in the headers config option.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesheaders",
+      "markdownDescription": "Put fields to be forwarded to the HTTP request headers in the headers config option.\n\nSee also: [headers](https://docs.renovatebot.com/configuration-options/#hostrulesheaders)",
+      "type": "object"
+    },
+    "helm-requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-requirements",
+      "markdownDescription": "Configuration object for the helm-requirements manager\n\nSee also: [helm-requirements](https://docs.renovatebot.com/configuration-options/#helm-requirements)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)requirements\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helm-values": {
+      "$ref": "#",
+      "description": "Configuration object for the helm-values manager\nSee also: https://docs.renovatebot.com/configuration-options/#helm-values",
+      "markdownDescription": "Configuration object for the helm-values manager\n\nSee also: [helm-values](https://docs.renovatebot.com/configuration-options/#helm-values)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "helm values {{depName}}",
+        "managerFilePatterns": ["/(^|/)values\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmfile": {
+      "$ref": "#",
+      "description": "Configuration object for the helmfile manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmfile",
+      "markdownDescription": "Configuration object for the helmfile manager\n\nSee also: [helmfile](https://docs.renovatebot.com/configuration-options/#helmfile)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": [
+          "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?$/",
+          "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmsman": {
+      "$ref": "#",
+      "description": "Configuration object for the helmsman manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmsman",
+      "markdownDescription": "Configuration object for the helmsman manager\n\nSee also: [helmsman](https://docs.renovatebot.com/configuration-options/#helmsman)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "helmv3": {
+      "$ref": "#",
+      "description": "Configuration object for the helmv3 manager\nSee also: https://docs.renovatebot.com/configuration-options/#helmv3",
+      "markdownDescription": "Configuration object for the helmv3 manager\n\nSee also: [helmv3](https://docs.renovatebot.com/configuration-options/#helmv3)",
+      "type": "object",
+      "default": {
+        "registryAliases": {
+          "stable": "https://charts.helm.sh/stable"
+        },
+        "commitMessageTopic": "helm chart {{depName}}",
+        "managerFilePatterns": ["/(^|/)Chart\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hermit": {
+      "$ref": "#",
+      "description": "Configuration object for the hermit manager\nSee also: https://docs.renovatebot.com/configuration-options/#hermit",
+      "markdownDescription": "Configuration object for the hermit manager\n\nSee also: [hermit](https://docs.renovatebot.com/configuration-options/#hermit)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)bin/hermit$/"],
+        "excludeCommitPaths": ["**/bin/hermit"],
+        "versioning": "hermit"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homeassistant-manifest": {
+      "$ref": "#",
+      "description": "Configuration object for the homeassistant-manifest manager\nSee also: https://docs.renovatebot.com/configuration-options/#homeassistant-manifest",
+      "markdownDescription": "Configuration object for the homeassistant-manifest manager\n\nSee also: [homeassistant-manifest](https://docs.renovatebot.com/configuration-options/#homeassistant-manifest)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)manifest\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "homebrew": {
+      "$ref": "#",
+      "description": "Configuration object for the homebrew manager\nSee also: https://docs.renovatebot.com/configuration-options/#homebrew",
+      "markdownDescription": "Configuration object for the homebrew manager\n\nSee also: [homebrew](https://docs.renovatebot.com/configuration-options/#homebrew)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Homebrew Formula {{depName}}",
+        "managerFilePatterns": ["/^Formula/\\w*/?[^/]+[.]rb$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostRules": {
+      "description": "Host rules/configuration including credentials.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrules",
+      "markdownDescription": "Host rules/configuration including credentials.\n\nSee also: [hostRules](https://docs.renovatebot.com/configuration-options/#hostrules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "abortIgnoreStatusCodes": {
+                "$ref": "#/definitions/abortIgnoreStatusCodes"
+              },
+              "abortOnError": {
+                "$ref": "#/definitions/abortOnError"
+              },
+              "artifactAuth": {
+                "$ref": "#/definitions/artifactAuth"
+              },
+              "authType": {
+                "$ref": "#/definitions/authType"
+              },
+              "concurrentRequestLimit": {
+                "$ref": "#/definitions/concurrentRequestLimit"
+              },
+              "dnsCache": {
+                "$ref": "#/definitions/dnsCache"
+              },
+              "enableHttp2": {
+                "$ref": "#/definitions/enableHttp2"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "headers": {
+                "$ref": "#/definitions/headers"
+              },
+              "hostType": {
+                "$ref": "#/definitions/hostType"
+              },
+              "httpsCertificate": {
+                "$ref": "#/definitions/httpsCertificate"
+              },
+              "httpsCertificateAuthority": {
+                "$ref": "#/definitions/httpsCertificateAuthority"
+              },
+              "httpsPrivateKey": {
+                "$ref": "#/definitions/httpsPrivateKey"
+              },
+              "insecureRegistry": {
+                "$ref": "#/definitions/insecureRegistry"
+              },
+              "keepAlive": {
+                "$ref": "#/definitions/keepAlive"
+              },
+              "matchHost": {
+                "$ref": "#/definitions/matchHost"
+              },
+              "maxRequestsPerSecond": {
+                "$ref": "#/definitions/maxRequestsPerSecond"
+              },
+              "maxRetryAfter": {
+                "$ref": "#/definitions/maxRetryAfter"
+              },
+              "readOnly": {
+                "$ref": "#/definitions/readOnly"
+              },
+              "timeout": {
+                "$ref": "#/definitions/timeout"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "hostType": {
+      "description": "hostType for a package rule. Can be a platform name or a datasource name.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshosttype",
+      "markdownDescription": "hostType for a package rule. Can be a platform name or a datasource name.\n\nSee also: [hostType](https://docs.renovatebot.com/configuration-options/#hostruleshosttype)",
+      "type": "string"
+    },
+    "html": {
+      "$ref": "#",
+      "description": "Configuration object for the html manager\nSee also: https://docs.renovatebot.com/configuration-options/#html",
+      "markdownDescription": "Configuration object for the html manager\n\nSee also: [html](https://docs.renovatebot.com/configuration-options/#html)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.html?$/"],
+        "versioning": "semver",
+        "digest": {
+          "enabled": false
+        },
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "httpsCertificate": {
+      "description": "The certificate chains in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate",
+      "markdownDescription": "The certificate chains in PEM format.\n\nSee also: [httpsCertificate](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificate)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsCertificateAuthority": {
+      "description": "The overriding trusted CA certificate.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority",
+      "markdownDescription": "The overriding trusted CA certificate.\n\nSee also: [httpsCertificateAuthority](https://docs.renovatebot.com/configuration-options/#hostruleshttpscertificateauthority)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "httpsPrivateKey": {
+      "description": "The private key in PEM format.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey",
+      "markdownDescription": "The private key in PEM format.\n\nSee also: [httpsPrivateKey](https://docs.renovatebot.com/configuration-options/#hostruleshttpsprivatekey)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "ignoreDeprecated": {
+      "description": "Avoid upgrading from a non-deprecated version to a deprecated one.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeprecated",
+      "markdownDescription": "Avoid upgrading from a non-deprecated version to a deprecated one.\n\nSee also: [ignoreDeprecated](https://docs.renovatebot.com/configuration-options/#ignoredeprecated)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreDeps": {
+      "description": "Dependencies to ignore.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoredeps",
+      "markdownDescription": "Dependencies to ignore.\n\nSee also: [ignoreDeps](https://docs.renovatebot.com/configuration-options/#ignoredeps)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignorePaths": {
+      "description": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepaths",
+      "markdownDescription": "Skip any package file whose path matches one of these. Can be a string or glob pattern.\n\nSee also: [ignorePaths](https://docs.renovatebot.com/configuration-options/#ignorepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/node_modules/**", "**/bower_components/**"]
+    },
+    "ignorePlugins": {
+      "description": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreplugins",
+      "markdownDescription": "Set this to `true` if `allowPlugins=true` but you wish to skip running plugins when updating lock files.\n\nSee also: [ignorePlugins](https://docs.renovatebot.com/configuration-options/#ignoreplugins)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignorePresets": {
+      "description": "A list of presets to ignore, including any that are nested inside an `extends` array.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorepresets",
+      "markdownDescription": "A list of presets to ignore, including any that are nested inside an `extends` array.\n\nSee also: [ignorePresets](https://docs.renovatebot.com/configuration-options/#ignorepresets)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "ignoreReviewers": {
+      "description": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#ignorereviewers",
+      "markdownDescription": "Reviewers to be ignored in PR reviewers presence (either username or email address depending on the platform).\n\nSee also: [ignoreReviewers](https://docs.renovatebot.com/configuration-options/#ignorereviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignoreScripts": {
+      "description": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\nSee also: https://docs.renovatebot.com/configuration-options/#ignorescripts",
+      "markdownDescription": "Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.\n\nSee also: [ignoreScripts](https://docs.renovatebot.com/configuration-options/#ignorescripts)",
+      "type": "boolean",
+      "default": true
+    },
+    "ignoreTests": {
+      "description": "Set to `true` to enable automerging without tests.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoretests",
+      "markdownDescription": "Set to `true` to enable automerging without tests.\n\nSee also: [ignoreTests](https://docs.renovatebot.com/configuration-options/#ignoretests)",
+      "type": "boolean",
+      "default": false
+    },
+    "ignoreUnstable": {
+      "description": "Ignore versions with unstable SemVer.\nSee also: https://docs.renovatebot.com/configuration-options/#ignoreunstable",
+      "markdownDescription": "Ignore versions with unstable SemVer.\n\nSee also: [ignoreUnstable](https://docs.renovatebot.com/configuration-options/#ignoreunstable)",
+      "type": "boolean",
+      "default": true
+    },
+    "includePaths": {
+      "description": "Include package files only within these defined paths.\nSee also: https://docs.renovatebot.com/configuration-options/#includepaths",
+      "markdownDescription": "Include package files only within these defined paths.\n\nSee also: [includePaths](https://docs.renovatebot.com/configuration-options/#includepaths)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "insecureRegistry": {
+      "description": "Explicitly turn on insecure Docker registry access (HTTP).\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry",
+      "markdownDescription": "Explicitly turn on insecure Docker registry access (HTTP).\n\nSee also: [insecureRegistry](https://docs.renovatebot.com/configuration-options/#hostrulesinsecureregistry)",
+      "type": "boolean",
+      "default": false
+    },
+    "installTools": {
+      "description": "Install tools before executing commands\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools",
+      "markdownDescription": "Install tools before executing commands\n\nSee also: [installTools](https://docs.renovatebot.com/configuration-options/#postupgradetasksinstalltools)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "bazelisk": {
+          "type": "object",
+          "description": "Install the `bazelisk` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bun": {
+          "type": "object",
+          "description": "Install the `bun` Containerbase tool",
+          "additionalProperties": false
+        },
+        "bundler": {
+          "type": "object",
+          "description": "Install the `bundler` Containerbase tool",
+          "additionalProperties": false
+        },
+        "cocoapods": {
+          "type": "object",
+          "description": "Install the `cocoapods` Containerbase tool",
+          "additionalProperties": false
+        },
+        "composer": {
+          "type": "object",
+          "description": "Install the `composer` Containerbase tool",
+          "additionalProperties": false
+        },
+        "conan": {
+          "type": "object",
+          "description": "Install the `conan` Containerbase tool",
+          "additionalProperties": false
+        },
+        "copier": {
+          "type": "object",
+          "description": "Install the `copier` Containerbase tool",
+          "additionalProperties": false
+        },
+        "corepack": {
+          "type": "object",
+          "description": "Install the `corepack` Containerbase tool",
+          "additionalProperties": false
+        },
+        "deno": {
+          "type": "object",
+          "description": "Install the `deno` Containerbase tool",
+          "additionalProperties": false
+        },
+        "devbox": {
+          "type": "object",
+          "description": "Install the `devbox` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dotnet": {
+          "type": "object",
+          "description": "Install the `dotnet` Containerbase tool",
+          "additionalProperties": false
+        },
+        "erlang": {
+          "type": "object",
+          "description": "Install the `erlang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "elixir": {
+          "type": "object",
+          "description": "Install the `elixir` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flux": {
+          "type": "object",
+          "description": "Install the `flux` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gleam": {
+          "type": "object",
+          "description": "Install the `gleam` Containerbase tool",
+          "additionalProperties": false
+        },
+        "golang": {
+          "type": "object",
+          "description": "Install the `golang` Containerbase tool",
+          "additionalProperties": false
+        },
+        "gradle": {
+          "type": "object",
+          "description": "Install the `gradle` Containerbase tool",
+          "additionalProperties": false
+        },
+        "hashin": {
+          "type": "object",
+          "description": "Install the `hashin` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helm": {
+          "type": "object",
+          "description": "Install the `helm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "helmfile": {
+          "type": "object",
+          "description": "Install the `helmfile` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java": {
+          "type": "object",
+          "description": "Install the `java` Containerbase tool",
+          "additionalProperties": false
+        },
+        "java-maven": {
+          "type": "object",
+          "description": "Install the `java-maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "jb": {
+          "type": "object",
+          "description": "Install the `jb` Containerbase tool",
+          "additionalProperties": false
+        },
+        "kustomize": {
+          "type": "object",
+          "description": "Install the `kustomize` Containerbase tool",
+          "additionalProperties": false
+        },
+        "maven": {
+          "type": "object",
+          "description": "Install the `maven` Containerbase tool",
+          "additionalProperties": false
+        },
+        "mise": {
+          "type": "object",
+          "description": "Install the `mise` Containerbase tool",
+          "additionalProperties": false
+        },
+        "nix": {
+          "type": "object",
+          "description": "Install the `nix` Containerbase tool",
+          "additionalProperties": false
+        },
+        "node": {
+          "type": "object",
+          "description": "Install the `node` Containerbase tool",
+          "additionalProperties": false
+        },
+        "npm": {
+          "type": "object",
+          "description": "Install the `npm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pdm": {
+          "type": "object",
+          "description": "Install the `pdm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "php": {
+          "type": "object",
+          "description": "Install the `php` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pip-tools": {
+          "type": "object",
+          "description": "Install the `pip-tools` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pipenv": {
+          "type": "object",
+          "description": "Install the `pipenv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pnpm": {
+          "type": "object",
+          "description": "Install the `pnpm` Containerbase tool",
+          "additionalProperties": false
+        },
+        "pixi": {
+          "type": "object",
+          "description": "Install the `pixi` Containerbase tool",
+          "additionalProperties": false
+        },
+        "poetry": {
+          "type": "object",
+          "description": "Install the `poetry` Containerbase tool",
+          "additionalProperties": false
+        },
+        "python": {
+          "type": "object",
+          "description": "Install the `python` Containerbase tool",
+          "additionalProperties": false
+        },
+        "ruby": {
+          "type": "object",
+          "description": "Install the `ruby` Containerbase tool. Also used in the `rubygems` Datasource",
+          "additionalProperties": false
+        },
+        "rust": {
+          "type": "object",
+          "description": "Install the `rust` Containerbase tool",
+          "additionalProperties": false
+        },
+        "uv": {
+          "type": "object",
+          "description": "Install the `uv` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn": {
+          "type": "object",
+          "description": "Install the `yarn` Containerbase tool",
+          "additionalProperties": false
+        },
+        "yarn-slim": {
+          "type": "object",
+          "description": "Install the `yarn-slim` Containerbase tool",
+          "additionalProperties": false
+        },
+        "dart": {
+          "type": "object",
+          "description": "Install the `dart` Containerbase tool",
+          "additionalProperties": false
+        },
+        "flutter": {
+          "type": "object",
+          "description": "Install the `flutter` Containerbase tool",
+          "additionalProperties": false
+        },
+        "vendir": {
+          "type": "object",
+          "description": "Install the `vendir` Containerbase tool",
+          "additionalProperties": false
+        }
+      }
+    },
+    "internalChecksAsSuccess": {
+      "description": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksassuccess",
+      "markdownDescription": "Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.\n\nSee also: [internalChecksAsSuccess](https://docs.renovatebot.com/configuration-options/#internalchecksassuccess)",
+      "type": "boolean",
+      "default": false
+    },
+    "internalChecksFilter": {
+      "description": "When and how to filter based on internal checks.\nSee also: https://docs.renovatebot.com/configuration-options/#internalchecksfilter",
+      "markdownDescription": "When and how to filter based on internal checks.\n\nSee also: [internalChecksFilter](https://docs.renovatebot.com/configuration-options/#internalchecksfilter)",
+      "type": "string",
+      "enum": ["strict", "flexible", "none"],
+      "default": "strict"
+    },
+    "jenkins": {
+      "$ref": "#",
+      "description": "Configuration object for the jenkins manager\nSee also: https://docs.renovatebot.com/configuration-options/#jenkins",
+      "markdownDescription": "Configuration object for the jenkins manager\n\nSee also: [jenkins](https://docs.renovatebot.com/configuration-options/#jenkins)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)plugins\\.(txt|ya?ml)$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jsonata": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonata manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonata",
+      "markdownDescription": "Configuration object for the jsonata manager\n\nSee also: [jsonata](https://docs.renovatebot.com/configuration-options/#jsonata)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "jsonnet-bundler": {
+      "$ref": "#",
+      "description": "Configuration object for the jsonnet-bundler manager\nSee also: https://docs.renovatebot.com/configuration-options/#jsonnet-bundler",
+      "markdownDescription": "Configuration object for the jsonnet-bundler manager\n\nSee also: [jsonnet-bundler](https://docs.renovatebot.com/configuration-options/#jsonnet-bundler)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)jsonnetfile\\.json$/"],
+        "datasource": "git-tags"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "jvmMaxMemory": {
+      "description": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory",
+      "markdownDescription": "Maximum JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to 512. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmaxmemory)",
+      "type": "integer"
+    },
+    "jvmMemory": {
+      "description": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory",
+      "markdownDescription": "Initial JVM memory in MB to use for updates that use a Java VM, like the Gradle Wrapper, defaults to `jvmMaxMemory`. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.jvmMaxMemory`\n\nSee also: [jvmMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsjvmmemory)",
+      "type": "integer"
+    },
+    "keepAlive": {
+      "description": "Enable HTTP keep-alive for hosts.\nSee also: https://docs.renovatebot.com/configuration-options/#hostruleskeepalive",
+      "markdownDescription": "Enable HTTP keep-alive for hosts.\n\nSee also: [keepAlive](https://docs.renovatebot.com/configuration-options/#hostruleskeepalive)",
+      "type": "boolean",
+      "default": false
+    },
+    "keepUpdatedLabel": {
+      "description": "If set, users can add this label to PRs to request they be kept updated with the base branch.\nSee also: https://docs.renovatebot.com/configuration-options/#keepupdatedlabel",
+      "markdownDescription": "If set, users can add this label to PRs to request they be kept updated with the base branch.\n\nSee also: [keepUpdatedLabel](https://docs.renovatebot.com/configuration-options/#keepupdatedlabel)",
+      "type": "string"
+    },
+    "kotlin-script": {
+      "$ref": "#",
+      "description": "Configuration object for the kotlin-script manager\nSee also: https://docs.renovatebot.com/configuration-options/#kotlin-script",
+      "markdownDescription": "Configuration object for the kotlin-script manager\n\nSee also: [kotlin-script](https://docs.renovatebot.com/configuration-options/#kotlin-script)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^.+\\.main\\.kts$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kubernetes": {
+      "$ref": "#",
+      "description": "Configuration object for the kubernetes manager\nSee also: https://docs.renovatebot.com/configuration-options/#kubernetes",
+      "markdownDescription": "Configuration object for the kubernetes manager\n\nSee also: [kubernetes](https://docs.renovatebot.com/configuration-options/#kubernetes)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kustomize": {
+      "$ref": "#",
+      "description": "Configuration object for the kustomize manager\nSee also: https://docs.renovatebot.com/configuration-options/#kustomize",
+      "markdownDescription": "Configuration object for the kustomize manager\n\nSee also: [kustomize](https://docs.renovatebot.com/configuration-options/#kustomize)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)kustomization\\.ya?ml$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "labels": {
+      "description": "Labels to set in Pull Request.\nSee also: https://docs.renovatebot.com/configuration-options/#labels",
+      "markdownDescription": "Labels to set in Pull Request.\n\nSee also: [labels](https://docs.renovatebot.com/configuration-options/#labels)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "leiningen": {
+      "$ref": "#",
+      "description": "Configuration object for the leiningen manager\nSee also: https://docs.renovatebot.com/configuration-options/#leiningen",
+      "markdownDescription": "Configuration object for the leiningen manager\n\nSee also: [leiningen](https://docs.renovatebot.com/configuration-options/#leiningen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)project\\.clj$/"],
+        "versioning": "maven"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "lockFileMaintenance": {
+      "$ref": "#",
+      "description": "Configuration for lock file maintenance.\nSee also: https://docs.renovatebot.com/configuration-options/#lockfilemaintenance",
+      "markdownDescription": "Configuration for lock file maintenance.\n\nSee also: [lockFileMaintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)",
+      "type": "object",
+      "default": {
+        "enabled": false,
+        "recreateWhen": "always",
+        "branchTopic": "lock-file-maintenance",
+        "commitMessageAction": "Lock file maintenance",
+        "commitMessageTopic": null,
+        "commitMessageExtra": null,
+        "schedule": ["before 4am on monday"],
+        "groupName": null,
+        "prBodyDefinitions": {
+          "Change": "All locks refreshed"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "logLevelRemap": {
+      "description": "Remap log levels to different levels.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremap",
+      "markdownDescription": "Remap log levels to different levels.\n\nSee also: [logLevelRemap](https://docs.renovatebot.com/configuration-options/#loglevelremap)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "matchMessage": {
+                "$ref": "#/definitions/matchMessage"
+              },
+              "newLogLevel": {
+                "$ref": "#/definitions/newLogLevel"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "major": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `major`.\nSee also: https://docs.renovatebot.com/configuration-options/#major",
+      "markdownDescription": "Configuration to apply when an update type is `major`.\n\nSee also: [major](https://docs.renovatebot.com/configuration-options/#major)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "managerFilePatterns": {
+      "description": "RegEx (`re2`) and glob patterns for matching manager files.\nSee also: https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns",
+      "markdownDescription": "RegEx (`re2`) and glob patterns for matching manager files.\n\nSee also: [managerFilePatterns](https://docs.renovatebot.com/configuration-options/#ansiblemanagerfilepatterns)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchBaseBranches": {
+      "description": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches",
+      "markdownDescription": "List of strings containing exact matches (e.g. `[\"main\"]`) and/or regex expressions (e.g. `[\"/^release/.*/\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchBaseBranches](https://docs.renovatebot.com/configuration-options/#packagerulesmatchbasebranches)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchCategories": {
+      "description": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories",
+      "markdownDescription": "List of categories to match (for example: `[\"python\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchCategories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcategories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchConfidence": {
+      "description": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence",
+      "markdownDescription": "Merge confidence levels to match against (`low`, `neutral`, `high`, `very high`). Valid only within `packageRules` object.\n\nSee also: [matchConfidence](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": ["low", "neutral", "high", "very high"]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": ["low", "neutral", "high", "very high"]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "matchCurrentAge": {
+      "description": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage",
+      "markdownDescription": "Matches the current age of the package derived from its release timestamp. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentAge](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentage)",
+      "type": "string"
+    },
+    "matchCurrentValue": {
+      "description": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentvalue)",
+      "type": "string"
+    },
+    "matchCurrentVersion": {
+      "description": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion",
+      "markdownDescription": "A version, or range of versions, to match against the current version of a package. Valid only within a `packageRules` object.\n\nSee also: [matchCurrentVersion](https://docs.renovatebot.com/configuration-options/#packagerulesmatchcurrentversion)",
+      "type": "string"
+    },
+    "matchDatasources": {
+      "description": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources",
+      "markdownDescription": "List of datasources to match (e.g. `[\"orb\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchDatasources](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdatasources)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepNames": {
+      "description": "Dep names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames",
+      "markdownDescription": "Dep names to match. Valid only within a `packageRules` object.\n\nSee also: [matchDepNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdepnames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchDepTypes": {
+      "description": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes",
+      "markdownDescription": "List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object.\n\nSee also: [matchDepTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchdeptypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchFileNames": {
+      "description": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames",
+      "markdownDescription": "List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.\n\nSee also: [matchFileNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchfilenames)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchHost": {
+      "description": "A domain name, host name or base URL to match against.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost",
+      "markdownDescription": "A domain name, host name or base URL to match against.\n\nSee also: [matchHost](https://docs.renovatebot.com/configuration-options/#hostrulesmatchhost)",
+      "type": "string"
+    },
+    "matchJsonata": {
+      "description": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata",
+      "markdownDescription": "A JSONata expression to match against the full config object. Valid only within a `packageRules` object.\n\nSee also: [matchJsonata](https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchManagers": {
+      "description": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers",
+      "markdownDescription": "List of package managers to match (e.g. `[\"pipenv\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchManagers](https://docs.renovatebot.com/configuration-options/#packagerulesmatchmanagers)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchMessage": {
+      "description": "Regex/minimatch expression to match against log message.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage",
+      "markdownDescription": "Regex/minimatch expression to match against log message.\n\nSee also: [matchMessage](https://docs.renovatebot.com/configuration-options/#loglevelremapmatchmessage)",
+      "type": "string"
+    },
+    "matchNewValue": {
+      "description": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue",
+      "markdownDescription": "A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.\n\nSee also: [matchNewValue](https://docs.renovatebot.com/configuration-options/#packagerulesmatchnewvalue)",
+      "type": "string"
+    },
+    "matchPackageNames": {
+      "description": "Package names to match. Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames",
+      "markdownDescription": "Package names to match. Valid only within a `packageRules` object.\n\nSee also: [matchPackageNames](https://docs.renovatebot.com/configuration-options/#packagerulesmatchpackagenames)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRegistryUrls": {
+      "description": "A list of URLs (or URL patterns) to match against registryUrls.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls",
+      "markdownDescription": "A list of URLs (or URL patterns) to match against registryUrls.\n\nSee also: [matchRegistryUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchregistryurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchRepositories": {
+      "description": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories",
+      "markdownDescription": "List of repositories to match (e.g. `[\"**/*-archived\"]`). Valid only within a `packageRules` object.\n\nSee also: [matchRepositories](https://docs.renovatebot.com/configuration-options/#packagerulesmatchrepositories)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchSourceUrls": {
+      "description": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls",
+      "markdownDescription": "A list of exact match URLs (or URL patterns) to match sourceUrl against.\n\nSee also: [matchSourceUrls](https://docs.renovatebot.com/configuration-options/#packagerulesmatchsourceurls)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "matchStrings": {
+      "description": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings",
+      "markdownDescription": "Queries to use. Valid only within `bumpVersions` or `customManagers` object. Templating is supported within `bumpVersions` only.\n\nSee also: [matchStrings](https://docs.renovatebot.com/configuration-options/#bumpversionsmatchstrings)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "matchStringsStrategy": {
+      "description": "Strategy how to interpret matchStrings.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy",
+      "markdownDescription": "Strategy how to interpret matchStrings.\n\nSee also: [matchStringsStrategy](https://docs.renovatebot.com/configuration-options/#custommanagersmatchstringsstrategy)",
+      "type": "string",
+      "enum": ["any", "recursive", "combination"],
+      "default": "any"
+    },
+    "matchUpdateTypes": {
+      "description": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes",
+      "markdownDescription": "Update types to match against (`major`, `minor`, `pin`, `pinDigest`, etc). Valid only within `packageRules` object.\n\nSee also: [matchUpdateTypes](https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "major",
+                  "minor",
+                  "patch",
+                  "pin",
+                  "pinDigest",
+                  "digest",
+                  "lockFileMaintenance",
+                  "rollback",
+                  "bump",
+                  "replacement"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                "major",
+                "minor",
+                "patch",
+                "pin",
+                "pinDigest",
+                "digest",
+                "lockFileMaintenance",
+                "rollback",
+                "bump",
+                "replacement"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    "maven": {
+      "$ref": "#",
+      "description": "Configuration object for the maven manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven",
+      "markdownDescription": "Configuration object for the maven manager\n\nSee also: [maven](https://docs.renovatebot.com/configuration-options/#maven)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/|\\.)pom\\.xml$/",
+          "/(^|/)pom\\.template\\.xml$/",
+          "/^(((\\.mvn)|(\\.m2))/)?settings\\.xml$/",
+          "/(^|/)\\.mvn/extensions\\.xml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maven-wrapper": {
+      "$ref": "#",
+      "description": "Configuration object for the maven-wrapper manager\nSee also: https://docs.renovatebot.com/configuration-options/#maven-wrapper",
+      "markdownDescription": "Configuration object for the maven-wrapper manager\n\nSee also: [maven-wrapper](https://docs.renovatebot.com/configuration-options/#maven-wrapper)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|\\/).mvn/wrapper/maven-wrapper.properties$/",
+          "/(^|\\/)mvnw(.cmd)?$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "maxMajorIncrement": {
+      "description": "Limit the maximum major version increment allowed. Set to 0 to disable.\nSee also: https://docs.renovatebot.com/configuration-options/#maxmajorincrement",
+      "markdownDescription": "Limit the maximum major version increment allowed. Set to 0 to disable.\n\nSee also: [maxMajorIncrement](https://docs.renovatebot.com/configuration-options/#maxmajorincrement)",
+      "type": "integer",
+      "default": 500
+    },
+    "maxRequestsPerSecond": {
+      "description": "Limit requests rate per host.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond",
+      "markdownDescription": "Limit requests rate per host.\n\nSee also: [maxRequestsPerSecond](https://docs.renovatebot.com/configuration-options/#hostrulesmaxrequestspersecond)",
+      "type": "integer",
+      "default": 0
+    },
+    "maxRetryAfter": {
+      "description": "Maximum retry-after header value to wait for before retrying a failed request.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter",
+      "markdownDescription": "Maximum retry-after header value to wait for before retrying a failed request.\n\nSee also: [maxRetryAfter](https://docs.renovatebot.com/configuration-options/#hostrulesmaxretryafter)",
+      "type": "integer",
+      "default": 60
+    },
+    "meteor": {
+      "$ref": "#",
+      "description": "Configuration object for the meteor manager\nSee also: https://docs.renovatebot.com/configuration-options/#meteor",
+      "markdownDescription": "Configuration object for the meteor manager\n\nSee also: [meteor](https://docs.renovatebot.com/configuration-options/#meteor)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)package\\.js$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "milestone": {
+      "description": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\nSee also: https://docs.renovatebot.com/configuration-options/#milestone",
+      "markdownDescription": "The number of a milestone. If set, the milestone will be set when Renovate creates the PR.\n\nSee also: [milestone](https://docs.renovatebot.com/configuration-options/#milestone)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "minimumGroupSize": {
+      "description": "The minimum number of updates which must be in a group for branches to be created.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumgroupsize",
+      "markdownDescription": "The minimum number of updates which must be in a group for branches to be created.\n\nSee also: [minimumGroupSize](https://docs.renovatebot.com/configuration-options/#minimumgroupsize)",
+      "type": "integer",
+      "default": 1
+    },
+    "minimumReleaseAge": {
+      "description": "Time required before a new release is considered stable.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseage",
+      "markdownDescription": "Time required before a new release is considered stable.\n\nSee also: [minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "minimumReleaseAgeBehaviour": {
+      "description": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\nSee also: https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour",
+      "markdownDescription": "When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.\n\nSee also: [minimumReleaseAgeBehaviour](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour)",
+      "type": "string",
+      "enum": ["timestamp-required", "timestamp-optional"],
+      "default": "timestamp-required"
+    },
+    "minor": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `minor`.\nSee also: https://docs.renovatebot.com/configuration-options/#minor",
+      "markdownDescription": "Configuration to apply when an update type is `minor`.\n\nSee also: [minor](https://docs.renovatebot.com/configuration-options/#minor)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mint": {
+      "$ref": "#",
+      "description": "Configuration object for the mint manager\nSee also: https://docs.renovatebot.com/configuration-options/#mint",
+      "markdownDescription": "Configuration object for the mint manager\n\nSee also: [mint](https://docs.renovatebot.com/configuration-options/#mint)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Mintfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mise": {
+      "$ref": "#",
+      "description": "Configuration object for the mise manager\nSee also: https://docs.renovatebot.com/configuration-options/#mise",
+      "markdownDescription": "Configuration object for the mise manager\n\nSee also: [mise](https://docs.renovatebot.com/configuration-options/#mise)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "**/{,.}mise{,.*}.toml",
+          "**/{,.}mise/config{,.*}.toml",
+          "**/.config/mise{,.*}.toml",
+          "**/.config/mise/{mise,config}{,.*}.toml",
+          "**/.config/mise/conf.d/*.toml",
+          "**/.rtx{,.*}.toml"
+        ],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mix": {
+      "$ref": "#",
+      "description": "Configuration object for the mix manager\nSee also: https://docs.renovatebot.com/configuration-options/#mix",
+      "markdownDescription": "Configuration object for the mix manager\n\nSee also: [mix](https://docs.renovatebot.com/configuration-options/#mix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)mix\\.exs$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "mode": {
+      "description": "Mode of operation.\nSee also: https://docs.renovatebot.com/configuration-options/#mode",
+      "markdownDescription": "Mode of operation.\n\nSee also: [mode](https://docs.renovatebot.com/configuration-options/#mode)",
+      "type": "string",
+      "enum": ["full", "silent"],
+      "default": "full"
+    },
+    "name": {
+      "description": "A name for the bumpVersion config. This is used for logging and debugging.\nSee also: https://docs.renovatebot.com/configuration-options/#bumpversionsname",
+      "markdownDescription": "A name for the bumpVersion config. This is used for logging and debugging.\n\nSee also: [name](https://docs.renovatebot.com/configuration-options/#bumpversionsname)",
+      "type": "string"
+    },
+    "newLogLevel": {
+      "description": "New log level to use if matchMessage matches.\nSee also: https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel",
+      "markdownDescription": "New log level to use if matchMessage matches.\n\nSee also: [newLogLevel](https://docs.renovatebot.com/configuration-options/#loglevelremapnewloglevel)",
+      "type": "string",
+      "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+    },
+    "nix": {
+      "$ref": "#",
+      "description": "Configuration object for the nix manager\nSee also: https://docs.renovatebot.com/configuration-options/#nix",
+      "markdownDescription": "Configuration object for the nix manager\n\nSee also: [nix](https://docs.renovatebot.com/configuration-options/#nix)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)flake\\.nix$/"],
+        "commitMessageTopic": "nix",
+        "commitMessageExtra": "to {{newValue}}",
+        "enabled": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nodeMaxMemory": {
+      "description": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory",
+      "markdownDescription": "Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`\n\nSee also: [nodeMaxMemory](https://docs.renovatebot.com/configuration-options/#toolsettingsnodemaxmemory)",
+      "type": "integer"
+    },
+    "nodenv": {
+      "$ref": "#",
+      "description": "Configuration object for the nodenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#nodenv",
+      "markdownDescription": "Configuration object for the nodenv manager\n\nSee also: [nodenv](https://docs.renovatebot.com/configuration-options/#nodenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.node-version$/"],
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npm": {
+      "$ref": "#",
+      "description": "Configuration object for the npm manager\nSee also: https://docs.renovatebot.com/configuration-options/#npm",
+      "markdownDescription": "Configuration object for the npm manager\n\nSee also: [npm](https://docs.renovatebot.com/configuration-options/#npm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)package\\.json$/",
+          "/(^|/)pnpm-workspace\\.yaml$/",
+          "/(^|/)\\.yarnrc\\.yml$/"
+        ],
+        "digest": {
+          "prBodyDefinitions": {
+            "Change": "{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+          }
+        },
+        "prBodyDefinitions": {
+          "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` \u2192 {{else}}{{#if currentValue}}`{{{currentValue}}}` \u2192 {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "npmToken": {
+      "description": "npm token used to authenticate with the default registry.\nSee also: https://docs.renovatebot.com/configuration-options/#npmtoken",
+      "markdownDescription": "npm token used to authenticate with the default registry.\n\nSee also: [npmToken](https://docs.renovatebot.com/configuration-options/#npmtoken)",
+      "type": "string"
+    },
+    "npmrc": {
+      "description": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrc",
+      "markdownDescription": "String copy of `.npmrc` file. Use `\\n` instead of line breaks.\n\nSee also: [npmrc](https://docs.renovatebot.com/configuration-options/#npmrc)",
+      "type": "string"
+    },
+    "npmrcMerge": {
+      "description": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\nSee also: https://docs.renovatebot.com/configuration-options/#npmrcmerge",
+      "markdownDescription": "Whether to merge `config.npmrc` with repo `.npmrc` content if both are found.\n\nSee also: [npmrcMerge](https://docs.renovatebot.com/configuration-options/#npmrcmerge)",
+      "type": "boolean",
+      "default": false
+    },
+    "nuget": {
+      "$ref": "#",
+      "description": "Configuration object for the nuget manager\nSee also: https://docs.renovatebot.com/configuration-options/#nuget",
+      "markdownDescription": "Configuration object for the nuget manager\n\nSee also: [nuget](https://docs.renovatebot.com/configuration-options/#nuget)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.(?:cs|fs|vb|sql)proj$/",
+          "/\\.(?:props|targets)$/",
+          "/(^|/)dotnet-tools\\.json$/",
+          "/(^|/)global\\.json$/"
+        ],
+        "rangeStrategy": "bump",
+        "packageRules": [
+          {
+            "matchDepTypes": ["msbuild-sdk"],
+            "rangeStrategy": "bump"
+          }
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "nvm": {
+      "$ref": "#",
+      "description": "Configuration object for the nvm manager\nSee also: https://docs.renovatebot.com/configuration-options/#nvm",
+      "markdownDescription": "Configuration object for the nvm manager\n\nSee also: [nvm](https://docs.renovatebot.com/configuration-options/#nvm)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.nvmrc$/"],
+        "versioning": "node",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "ocb": {
+      "$ref": "#",
+      "description": "Configuration object for the ocb manager\nSee also: https://docs.renovatebot.com/configuration-options/#ocb",
+      "markdownDescription": "Configuration object for the ocb manager\n\nSee also: [ocb](https://docs.renovatebot.com/configuration-options/#ocb)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "onboarding": {
+      "description": "Require a Configuration PR first.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboarding",
+      "markdownDescription": "Require a Configuration PR first.\n\nSee also: [onboarding](https://docs.renovatebot.com/self-hosted-configuration/#onboarding)",
+      "type": "boolean"
+    },
+    "onboardingAutoCloseAge": {
+      "description": "Maximum number of days after which Renovate will stop trying to onboard the repository, and will close any existing onboarding PRs\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingautocloseage",
+      "markdownDescription": "Maximum number of days after which Renovate will stop trying to onboard the repository, and will close any existing onboarding PRs\n\nSee also: [onboardingAutoCloseAge](https://docs.renovatebot.com/self-hosted-configuration/#onboardingautocloseage)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "onboardingBranch": {
+      "description": "Change this value to override the default onboarding branch name.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingbranch",
+      "markdownDescription": "Change this value to override the default onboarding branch name.\n\nSee also: [onboardingBranch](https://docs.renovatebot.com/self-hosted-configuration/#onboardingbranch)",
+      "type": "string",
+      "default": "renovate/configure"
+    },
+    "onboardingCommitMessage": {
+      "description": "Change this value to override the default onboarding commit message.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingcommitmessage",
+      "markdownDescription": "Change this value to override the default onboarding commit message.\n\nSee also: [onboardingCommitMessage](https://docs.renovatebot.com/self-hosted-configuration/#onboardingcommitmessage)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "onboardingConfig": {
+      "$ref": "#",
+      "description": "Configuration to use for onboarding PRs.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfig",
+      "markdownDescription": "Configuration to use for onboarding PRs.\n\nSee also: [onboardingConfig](https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfig)",
+      "type": "object",
+      "default": {
+        "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+      }
+    },
+    "onboardingConfigFileName": {
+      "description": "Change this value to override the default onboarding config file name.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfigfilename",
+      "markdownDescription": "Change this value to override the default onboarding config file name.\n\nSee also: [onboardingConfigFileName](https://docs.renovatebot.com/self-hosted-configuration/#onboardingconfigfilename)",
+      "type": "string",
+      "default": "renovate.json"
+    },
+    "onboardingNoDeps": {
+      "description": "Onboard the repository even if no dependencies are found.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingnodeps",
+      "markdownDescription": "Onboard the repository even if no dependencies are found.\n\nSee also: [onboardingNoDeps](https://docs.renovatebot.com/self-hosted-configuration/#onboardingnodeps)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "onboardingPrTitle": {
+      "description": "Change this value to override the default onboarding PR title.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#onboardingprtitle",
+      "markdownDescription": "Change this value to override the default onboarding PR title.\n\nSee also: [onboardingPrTitle](https://docs.renovatebot.com/self-hosted-configuration/#onboardingprtitle)",
+      "type": "string",
+      "default": "Configure Renovate"
+    },
+    "osgi": {
+      "$ref": "#",
+      "description": "Configuration object for the osgi manager\nSee also: https://docs.renovatebot.com/configuration-options/#osgi",
+      "markdownDescription": "Configuration object for the osgi manager\n\nSee also: [osgi](https://docs.renovatebot.com/configuration-options/#osgi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)src/main/features/.+\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "osvVulnerabilityAlerts": {
+      "description": "Use vulnerability alerts from `osv.dev`.\nSee also: https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts",
+      "markdownDescription": "Use vulnerability alerts from `osv.dev`.\n\nSee also: [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)",
+      "type": "boolean",
+      "default": false
+    },
+    "overrideDatasource": {
+      "description": "Override the datasource value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource",
+      "markdownDescription": "Override the datasource value.\n\nSee also: [overrideDatasource](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedatasource)",
+      "type": "string"
+    },
+    "overrideDepName": {
+      "description": "Override the depName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname",
+      "markdownDescription": "Override the depName value.\n\nSee also: [overrideDepName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridedepname)",
+      "type": "string"
+    },
+    "overridePackageName": {
+      "description": "Override the packageName value.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename",
+      "markdownDescription": "Override the packageName value.\n\nSee also: [overridePackageName](https://docs.renovatebot.com/configuration-options/#packagerulesoverridepackagename)",
+      "type": "string"
+    },
+    "packageNameTemplate": {
+      "description": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate",
+      "markdownDescription": "Optional packageName for extracted dependencies, else defaults to `depName` value. Valid only within a `customManagers` object.\n\nSee also: [packageNameTemplate](https://docs.renovatebot.com/configuration-options/#custommanagerspackagenametemplate)",
+      "type": "string"
+    },
+    "packageRules": {
+      "description": "Rules for matching packages.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerules",
+      "markdownDescription": "Rules for matching packages.\n\nSee also: [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)",
+      "type": "array",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "allowedVersions": {
+                "$ref": "#/definitions/allowedVersions"
+              },
+              "changelogUrl": {
+                "$ref": "#/definitions/changelogUrl"
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "fetchChangeLogs": {
+                "$ref": "#/definitions/fetchChangeLogs"
+              },
+              "matchBaseBranches": {
+                "$ref": "#/definitions/matchBaseBranches"
+              },
+              "matchCategories": {
+                "$ref": "#/definitions/matchCategories"
+              },
+              "matchConfidence": {
+                "$ref": "#/definitions/matchConfidence"
+              },
+              "matchCurrentAge": {
+                "$ref": "#/definitions/matchCurrentAge"
+              },
+              "matchCurrentValue": {
+                "$ref": "#/definitions/matchCurrentValue"
+              },
+              "matchCurrentVersion": {
+                "$ref": "#/definitions/matchCurrentVersion"
+              },
+              "matchDatasources": {
+                "$ref": "#/definitions/matchDatasources"
+              },
+              "matchDepNames": {
+                "$ref": "#/definitions/matchDepNames"
+              },
+              "matchDepTypes": {
+                "$ref": "#/definitions/matchDepTypes"
+              },
+              "matchFileNames": {
+                "$ref": "#/definitions/matchFileNames"
+              },
+              "matchJsonata": {
+                "$ref": "#/definitions/matchJsonata"
+              },
+              "matchManagers": {
+                "$ref": "#/definitions/matchManagers"
+              },
+              "matchNewValue": {
+                "$ref": "#/definitions/matchNewValue"
+              },
+              "matchPackageNames": {
+                "$ref": "#/definitions/matchPackageNames"
+              },
+              "matchRegistryUrls": {
+                "$ref": "#/definitions/matchRegistryUrls"
+              },
+              "matchRepositories": {
+                "$ref": "#/definitions/matchRepositories"
+              },
+              "matchSourceUrls": {
+                "$ref": "#/definitions/matchSourceUrls"
+              },
+              "matchUpdateTypes": {
+                "$ref": "#/definitions/matchUpdateTypes"
+              },
+              "overrideDatasource": {
+                "$ref": "#/definitions/overrideDatasource"
+              },
+              "overrideDepName": {
+                "$ref": "#/definitions/overrideDepName"
+              },
+              "overridePackageName": {
+                "$ref": "#/definitions/overridePackageName"
+              },
+              "prPriority": {
+                "$ref": "#/definitions/prPriority"
+              },
+              "replacementName": {
+                "$ref": "#/definitions/replacementName"
+              },
+              "replacementNameTemplate": {
+                "$ref": "#/definitions/replacementNameTemplate"
+              },
+              "replacementVersion": {
+                "$ref": "#/definitions/replacementVersion"
+              },
+              "replacementVersionTemplate": {
+                "$ref": "#/definitions/replacementVersionTemplate"
+              },
+              "sourceDirectory": {
+                "$ref": "#/definitions/sourceDirectory"
+              },
+              "sourceUrl": {
+                "$ref": "#/definitions/sourceUrl"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "patch": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `patch`.\nSee also: https://docs.renovatebot.com/configuration-options/#patch",
+      "markdownDescription": "Configuration to apply when an update type is `patch`.\n\nSee also: [patch](https://docs.renovatebot.com/configuration-options/#patch)",
+      "type": "object",
+      "default": {},
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep621": {
+      "$ref": "#",
+      "description": "Configuration object for the pep621 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep621",
+      "markdownDescription": "Configuration object for the pep621 manager\n\nSee also: [pep621](https://docs.renovatebot.com/configuration-options/#pep621)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pep723": {
+      "$ref": "#",
+      "description": "Configuration object for the pep723 manager\nSee also: https://docs.renovatebot.com/configuration-options/#pep723",
+      "markdownDescription": "Configuration object for the pep723 manager\n\nSee also: [pep723](https://docs.renovatebot.com/configuration-options/#pep723)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pin": {
+      "$ref": "#",
+      "description": "Configuration to apply when an update type is `pin`.\nSee also: https://docs.renovatebot.com/configuration-options/#pin",
+      "markdownDescription": "Configuration to apply when an update type is `pin`.\n\nSee also: [pin](https://docs.renovatebot.com/configuration-options/#pin)",
+      "type": "object",
+      "default": {
+        "rebaseWhen": "behind-base-branch",
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigest": {
+      "$ref": "#",
+      "description": "Configuration to apply when pinning a digest (no change in tag/version).\nSee also: https://docs.renovatebot.com/configuration-options/#pindigest",
+      "markdownDescription": "Configuration to apply when pinning a digest (no change in tag/version).\n\nSee also: [pinDigest](https://docs.renovatebot.com/configuration-options/#pindigest)",
+      "type": "object",
+      "default": {
+        "groupName": "Pin Dependencies",
+        "groupSlug": "pin-dependencies",
+        "commitMessageAction": "Pin",
+        "group": {
+          "commitMessageTopic": "dependencies",
+          "commitMessageExtra": ""
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pinDigests": {
+      "description": "Whether to add digests to Dockerfile source images.\nSee also: https://docs.renovatebot.com/configuration-options/#pindigests",
+      "markdownDescription": "Whether to add digests to Dockerfile source images.\n\nSee also: [pinDigests](https://docs.renovatebot.com/configuration-options/#pindigests)",
+      "type": "boolean",
+      "default": false
+    },
+    "pip-compile": {
+      "$ref": "#",
+      "description": "Configuration object for the pip-compile manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip-compile",
+      "markdownDescription": "Configuration object for the pip-compile manager\n\nSee also: [pip-compile](https://docs.renovatebot.com/configuration-options/#pip-compile)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [],
+        "lockFileMaintenance": {
+          "enabled": true,
+          "branchTopic": "pip-compile-refresh",
+          "commitMessageAction": "Refresh pip-compile outputs"
+        }
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_requirements": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_requirements manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_requirements",
+      "markdownDescription": "Configuration object for the pip_requirements manager\n\nSee also: [pip_requirements](https://docs.renovatebot.com/configuration-options/#pip_requirements)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)[\\w-]*requirements([-._]\\w+)?\\.(txt|pip)$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pip_setup": {
+      "$ref": "#",
+      "description": "Configuration object for the pip_setup manager\nSee also: https://docs.renovatebot.com/configuration-options/#pip_setup",
+      "markdownDescription": "Configuration object for the pip_setup manager\n\nSee also: [pip_setup](https://docs.renovatebot.com/configuration-options/#pip_setup)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.py$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pipenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pipenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pipenv",
+      "markdownDescription": "Configuration object for the pipenv manager\n\nSee also: [pipenv](https://docs.renovatebot.com/configuration-options/#pipenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Pipfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pixi": {
+      "$ref": "#",
+      "description": "Configuration object for the pixi manager\nSee also: https://docs.renovatebot.com/configuration-options/#pixi",
+      "markdownDescription": "Configuration object for the pixi manager\n\nSee also: [pixi](https://docs.renovatebot.com/configuration-options/#pixi)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/(^|/)pyproject\\.toml$/",
+          "/(^|/)pixi\\.toml$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "platformAutomerge": {
+      "description": "Controls if platform-native auto-merge is used.\nSee also: https://docs.renovatebot.com/configuration-options/#platformautomerge",
+      "markdownDescription": "Controls if platform-native auto-merge is used.\n\nSee also: [platformAutomerge](https://docs.renovatebot.com/configuration-options/#platformautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "platformCommit": {
+      "description": "Use platform API to perform commits instead of using Git directly.\nSee also: https://docs.renovatebot.com/configuration-options/#platformcommit",
+      "markdownDescription": "Use platform API to perform commits instead of using Git directly.\n\nSee also: [platformCommit](https://docs.renovatebot.com/configuration-options/#platformcommit)",
+      "type": "string",
+      "enum": ["auto", "disabled", "enabled"],
+      "default": "auto"
+    },
+    "poetry": {
+      "$ref": "#",
+      "description": "Configuration object for the poetry manager\nSee also: https://docs.renovatebot.com/configuration-options/#poetry",
+      "markdownDescription": "Configuration object for the poetry manager\n\nSee also: [poetry](https://docs.renovatebot.com/configuration-options/#poetry)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pyproject\\.toml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "postUpdateOptions": {
+      "description": "Enable post-update options to be run after package/artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#postupdateoptions",
+      "markdownDescription": "Enable post-update options to be run after package/artifact updating.\n\nSee also: [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "bundlerConservative",
+          "composerWithAll",
+          "composerNoMinimalChanges",
+          "dotnetWorkloadRestore",
+          "gomodMassage",
+          "gomodTidy",
+          "gomodTidy1.17",
+          "gomodTidyE",
+          "gomodUpdateImportPaths",
+          "gomodSkipVendor",
+          "gomodVendor",
+          "goGenerate",
+          "helmUpdateSubChartArchives",
+          "kustomizeInflateHelmCharts",
+          "npmDedupe",
+          "npmInstallTwice",
+          "pnpmDedupe",
+          "yarnDedupeFewer",
+          "yarnDedupeHighest"
+        ]
+      },
+      "default": []
+    },
+    "postUpgradeTasks": {
+      "$ref": "#",
+      "description": "Post-upgrade tasks that are executed before a commit is made by Renovate.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasks",
+      "markdownDescription": "Post-upgrade tasks that are executed before a commit is made by Renovate.\n\nSee also: [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks)",
+      "type": "object",
+      "default": {
+        "commands": [],
+        "fileFilters": [],
+        "executionMode": "update",
+        "installTools": {}
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "commands": {
+                "$ref": "#/definitions/commands"
+              },
+              "dataFileTemplate": {
+                "$ref": "#/definitions/dataFileTemplate"
+              },
+              "executionMode": {
+                "$ref": "#/definitions/executionMode"
+              },
+              "fileFilters": {
+                "$ref": "#/definitions/fileFilters"
+              },
+              "installTools": {
+                "$ref": "#/definitions/installTools"
+              },
+              "workingDirTemplate": {
+                "$ref": "#/definitions/workingDirTemplate"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "prBodyColumns": {
+      "description": "List of columns to use in PR bodies.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodycolumns",
+      "markdownDescription": "List of columns to use in PR bodies.\n\nSee also: [prBodyColumns](https://docs.renovatebot.com/configuration-options/#prbodycolumns)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["Package", "Type", "Update", "Change", "Pending"]
+    },
+    "prBodyDefinitions": {
+      "description": "Table column definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodydefinitions",
+      "markdownDescription": "Table column definitions to use in PR tables.\n\nSee also: [prBodyDefinitions](https://docs.renovatebot.com/configuration-options/#prbodydefinitions)",
+      "type": "object",
+      "default": {
+        "Package": "{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} \u2192 {{{newNameLinked}}}{{/unless}}{{/if}}",
+        "Type": "{{{depType}}}",
+        "Update": "{{{updateType}}}",
+        "Current value": "{{{currentValue}}}",
+        "New value": "{{{newValue}}}",
+        "Change": "`{{{displayFrom}}}` \u2192 `{{{displayTo}}}`",
+        "Pending": "{{{displayPending}}}",
+        "References": "{{{references}}}",
+        "Package file": "{{{packageFile}}}",
+        "Age": "{{#if newVersion}}![age](https://developer.mend.io/api/mc/badges/age/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Adoption": "{{#if newVersion}}![adoption](https://developer.mend.io/api/mc/badges/adoption/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Passing": "{{#if newVersion}}![passing](https://developer.mend.io/api/mc/badges/compatibility/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}",
+        "Confidence": "{{#if newVersion}}![confidence](https://developer.mend.io/api/mc/badges/confidence/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}"
+      }
+    },
+    "prBodyHeadingDefinitions": {
+      "description": "Table header definitions to use in PR tables.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions",
+      "markdownDescription": "Table header definitions to use in PR tables.\n\nSee also: [prBodyHeadingDefinitions](https://docs.renovatebot.com/configuration-options/#prbodyheadingdefinitions)",
+      "type": "object",
+      "default": {
+        "Age": "[Age](https://docs.renovatebot.com/merge-confidence/)",
+        "Adoption": "[Adoption](https://docs.renovatebot.com/merge-confidence/)",
+        "Passing": "[Passing](https://docs.renovatebot.com/merge-confidence/)",
+        "Confidence": "[Confidence](https://docs.renovatebot.com/merge-confidence/)"
+      }
+    },
+    "prBodyNotes": {
+      "description": "List of extra notes or templates to include in the Pull Request body.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodynotes",
+      "markdownDescription": "List of extra notes or templates to include in the Pull Request body.\n\nSee also: [prBodyNotes](https://docs.renovatebot.com/configuration-options/#prbodynotes)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": []
+    },
+    "prBodyTemplate": {
+      "description": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\nSee also: https://docs.renovatebot.com/configuration-options/#prbodytemplate",
+      "markdownDescription": "Pull Request body template. Controls which sections are rendered in the body of the pull request.\n\nSee also: [prBodyTemplate](https://docs.renovatebot.com/configuration-options/#prbodytemplate)",
+      "type": "string",
+      "default": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}"
+    },
+    "prConcurrentLimit": {
+      "description": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prconcurrentlimit",
+      "markdownDescription": "Limit to a maximum of x concurrent branches/PRs. 0 means no limit.\n\nSee also: [prConcurrentLimit](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit)",
+      "type": "integer",
+      "default": 10
+    },
+    "prCreation": {
+      "description": "When to create the PR for a branch.\nSee also: https://docs.renovatebot.com/configuration-options/#prcreation",
+      "markdownDescription": "When to create the PR for a branch.\n\nSee also: [prCreation](https://docs.renovatebot.com/configuration-options/#prcreation)",
+      "type": "string",
+      "enum": ["immediate", "not-pending", "status-success", "approval"],
+      "default": "immediate"
+    },
+    "prFooter": {
+      "description": "Text added here will be placed last in the PR body, with a divider separator before it.\nSee also: https://docs.renovatebot.com/configuration-options/#prfooter",
+      "markdownDescription": "Text added here will be placed last in the PR body, with a divider separator before it.\n\nSee also: [prFooter](https://docs.renovatebot.com/configuration-options/#prfooter)",
+      "type": "string",
+      "default": "This PR has been generated by [Mend Renovate](https://github.com/renovatebot/renovate)."
+    },
+    "prHeader": {
+      "description": "Text added here will be placed first in the PR body.\nSee also: https://docs.renovatebot.com/configuration-options/#prheader",
+      "markdownDescription": "Text added here will be placed first in the PR body.\n\nSee also: [prHeader](https://docs.renovatebot.com/configuration-options/#prheader)",
+      "type": "string"
+    },
+    "prHourlyLimit": {
+      "description": "Rate limit PRs to maximum x created per hour. 0 means no limit.\nSee also: https://docs.renovatebot.com/configuration-options/#prhourlylimit",
+      "markdownDescription": "Rate limit PRs to maximum x created per hour. 0 means no limit.\n\nSee also: [prHourlyLimit](https://docs.renovatebot.com/configuration-options/#prhourlylimit)",
+      "type": "integer",
+      "default": 2
+    },
+    "prNotPendingHours": {
+      "description": "Timeout in hours for when `prCreation=not-pending`.\nSee also: https://docs.renovatebot.com/configuration-options/#prnotpendinghours",
+      "markdownDescription": "Timeout in hours for when `prCreation=not-pending`.\n\nSee also: [prNotPendingHours](https://docs.renovatebot.com/configuration-options/#prnotpendinghours)",
+      "type": "integer",
+      "default": 25
+    },
+    "prPriority": {
+      "description": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesprpriority",
+      "markdownDescription": "Set sorting priority for PR creation. PRs with higher priority are created first, negative priority last.\n\nSee also: [prPriority](https://docs.renovatebot.com/configuration-options/#packagerulesprpriority)",
+      "type": "integer",
+      "default": 0
+    },
+    "prTitle": {
+      "description": "Pull Request title template. Inherits from `commitMessage` if null.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitle",
+      "markdownDescription": "Pull Request title template. Inherits from `commitMessage` if null.\n\nSee also: [prTitle](https://docs.renovatebot.com/configuration-options/#prtitle)",
+      "type": ["string", "null"],
+      "default": null
+    },
+    "prTitleStrict": {
+      "description": "Whether to bypass appending extra context to the Pull Request title.\nSee also: https://docs.renovatebot.com/configuration-options/#prtitlestrict",
+      "markdownDescription": "Whether to bypass appending extra context to the Pull Request title.\n\nSee also: [prTitleStrict](https://docs.renovatebot.com/configuration-options/#prtitlestrict)",
+      "type": "boolean",
+      "default": false
+    },
+    "pre-commit": {
+      "$ref": "#",
+      "description": "Configuration object for the pre-commit manager\nSee also: https://docs.renovatebot.com/configuration-options/#pre-commit",
+      "markdownDescription": "Configuration object for the pre-commit manager\n\nSee also: [pre-commit](https://docs.renovatebot.com/configuration-options/#pre-commit)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "pre-commit hook {{depName}}",
+        "enabled": false,
+        "managerFilePatterns": ["/(^|/)\\.pre-commit-config\\.ya?ml$/"],
+        "prBodyNotes": [
+          "Note: The `pre-commit` manager in Renovate is not supported by the `pre-commit` maintainers or community. Please do not report any problems there, instead [create a Discussion in the Renovate repository](https://github.com/renovatebot/renovate/discussions/new) if you have any questions."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "printConfig": {
+      "description": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\nSee also: https://docs.renovatebot.com/configuration-options/#printconfig",
+      "markdownDescription": "If enabled, Renovate logs the fully resolved config for each repository, plus the fully resolved presets.\n\nSee also: [printConfig](https://docs.renovatebot.com/configuration-options/#printconfig)",
+      "type": "boolean",
+      "default": false
+    },
+    "proto": {
+      "$ref": "#",
+      "description": "Configuration object for the proto manager\nSee also: https://docs.renovatebot.com/configuration-options/#proto",
+      "markdownDescription": "Configuration object for the proto manager\n\nSee also: [proto](https://docs.renovatebot.com/configuration-options/#proto)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/.prototools"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pruneBranchAfterAutomerge": {
+      "description": "Set to `true` to enable branch pruning after automerging.\nSee also: https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge",
+      "markdownDescription": "Set to `true` to enable branch pruning after automerging.\n\nSee also: [pruneBranchAfterAutomerge](https://docs.renovatebot.com/configuration-options/#prunebranchafterautomerge)",
+      "type": "boolean",
+      "default": true
+    },
+    "pruneStaleBranches": {
+      "description": "Set to `false` to disable pruning stale branches.\nSee also: https://docs.renovatebot.com/configuration-options/#prunestalebranches",
+      "markdownDescription": "Set to `false` to disable pruning stale branches.\n\nSee also: [pruneStaleBranches](https://docs.renovatebot.com/configuration-options/#prunestalebranches)",
+      "type": "boolean",
+      "default": true
+    },
+    "pub": {
+      "$ref": "#",
+      "description": "Configuration object for the pub manager\nSee also: https://docs.renovatebot.com/configuration-options/#pub",
+      "markdownDescription": "Configuration object for the pub manager\n\nSee also: [pub](https://docs.renovatebot.com/configuration-options/#pub)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)pubspec\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "puppet": {
+      "$ref": "#",
+      "description": "Configuration object for the puppet manager\nSee also: https://docs.renovatebot.com/configuration-options/#puppet",
+      "markdownDescription": "Configuration object for the puppet manager\n\nSee also: [puppet](https://docs.renovatebot.com/configuration-options/#puppet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Puppetfile$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "pyenv": {
+      "$ref": "#",
+      "description": "Configuration object for the pyenv manager\nSee also: https://docs.renovatebot.com/configuration-options/#pyenv",
+      "markdownDescription": "Configuration object for the pyenv manager\n\nSee also: [pyenv](https://docs.renovatebot.com/configuration-options/#pyenv)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.python-version$/"],
+        "versioning": "docker",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "quadlet": {
+      "$ref": "#",
+      "description": "Configuration object for the quadlet manager\nSee also: https://docs.renovatebot.com/configuration-options/#quadlet",
+      "markdownDescription": "Configuration object for the quadlet manager\n\nSee also: [quadlet](https://docs.renovatebot.com/configuration-options/#quadlet)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/.+\\.container$/",
+          "/.+\\.image$/",
+          "/.+\\.volume$/"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rangeStrategy": {
+      "description": "Determines how to modify or update existing ranges.\nSee also: https://docs.renovatebot.com/configuration-options/#rangestrategy",
+      "markdownDescription": "Determines how to modify or update existing ranges.\n\nSee also: [rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "pin",
+        "bump",
+        "replace",
+        "widen",
+        "update-lockfile",
+        "in-range-only"
+      ],
+      "default": "auto"
+    },
+    "readOnly": {
+      "description": "Match against requests that only read data and do not mutate anything.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulesreadonly",
+      "markdownDescription": "Match against requests that only read data and do not mutate anything.\n\nSee also: [readOnly](https://docs.renovatebot.com/configuration-options/#hostrulesreadonly)",
+      "type": "boolean"
+    },
+    "rebaseLabel": {
+      "description": "Label to request a rebase from Renovate bot.\nSee also: https://docs.renovatebot.com/configuration-options/#rebaselabel",
+      "markdownDescription": "Label to request a rebase from Renovate bot.\n\nSee also: [rebaseLabel](https://docs.renovatebot.com/configuration-options/#rebaselabel)",
+      "type": "string",
+      "default": "rebase"
+    },
+    "rebaseWhen": {
+      "description": "Controls when Renovate rebases an existing branch.\nSee also: https://docs.renovatebot.com/configuration-options/#rebasewhen",
+      "markdownDescription": "Controls when Renovate rebases an existing branch.\n\nSee also: [rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen)",
+      "type": "string",
+      "enum": [
+        "auto",
+        "never",
+        "conflicted",
+        "behind-base-branch",
+        "automerging"
+      ],
+      "default": "auto"
+    },
+    "recreateWhen": {
+      "description": "Recreate PRs even if same ones were closed previously.\nSee also: https://docs.renovatebot.com/configuration-options/#recreatewhen",
+      "markdownDescription": "Recreate PRs even if same ones were closed previously.\n\nSee also: [recreateWhen](https://docs.renovatebot.com/configuration-options/#recreatewhen)",
+      "type": "string",
+      "enum": ["auto", "always", "never"],
+      "default": "auto"
+    },
+    "regex": {
+      "$ref": "#",
+      "description": "Configuration object for the regex manager\nSee also: https://docs.renovatebot.com/configuration-options/#regex",
+      "markdownDescription": "Configuration object for the regex manager\n\nSee also: [regex](https://docs.renovatebot.com/configuration-options/#regex)",
+      "type": "object",
+      "default": {
+        "pinDigests": false
+      }
+    },
+    "registryAliases": {
+      "$ref": "#",
+      "description": "Aliases for registries.\nSee also: https://docs.renovatebot.com/configuration-options/#registryaliases",
+      "markdownDescription": "Aliases for registries.\n\nSee also: [registryAliases](https://docs.renovatebot.com/configuration-options/#registryaliases)",
+      "type": "object",
+      "default": {},
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "registryUrlTemplate": {
+      "description": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate",
+      "markdownDescription": "Optional registry URL for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [registryUrlTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersregistryurltemplate)",
+      "type": "string"
+    },
+    "registryUrls": {
+      "description": "List of URLs to try for dependency lookup. Package manager specific.\nSee also: https://docs.renovatebot.com/configuration-options/#registryurls",
+      "markdownDescription": "List of URLs to try for dependency lookup. Package manager specific.\n\nSee also: [registryUrls](https://docs.renovatebot.com/configuration-options/#registryurls)",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      },
+      "default": null
+    },
+    "renovate-config": {
+      "$ref": "#",
+      "description": "Configuration object for the renovate-config manager\nSee also: https://docs.renovatebot.com/configuration-options/#renovate-config",
+      "markdownDescription": "Configuration object for the renovate-config manager\n\nSee also: [renovate-config](https://docs.renovatebot.com/configuration-options/#renovate-config)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "renovate.json",
+          "renovate.jsonc",
+          "renovate.json5",
+          ".github/renovate.json",
+          ".github/renovate.jsonc",
+          ".github/renovate.json5",
+          ".gitlab/renovate.json",
+          ".gitlab/renovate.jsonc",
+          ".gitlab/renovate.json5",
+          ".renovaterc",
+          ".renovaterc.json",
+          ".renovaterc.jsonc",
+          ".renovaterc.json5"
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacement": {
+      "$ref": "#",
+      "description": "Configuration to apply when replacing a dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#replacement",
+      "markdownDescription": "Configuration to apply when replacing a dependency.\n\nSee also: [replacement](https://docs.renovatebot.com/configuration-options/#replacement)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-replacement",
+        "commitMessageAction": "Replace",
+        "commitMessageExtra": "with {{newName}} {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{#if isSingleVersion}}{{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
+        "prBodyNotes": [
+          "This is a special PR that replaces `{{{depName}}}` with the community suggested minimal stable replacement version."
+        ]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "replacementApproach": {
+      "description": "Select whether to perform a direct replacement or alias replacement.\nSee also: https://docs.renovatebot.com/configuration-options/#replacementapproach",
+      "markdownDescription": "Select whether to perform a direct replacement or alias replacement.\n\nSee also: [replacementApproach](https://docs.renovatebot.com/configuration-options/#replacementapproach)",
+      "type": "string",
+      "enum": ["replace", "alias"],
+      "default": "replace"
+    },
+    "replacementName": {
+      "description": "The name of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname",
+      "markdownDescription": "The name of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementName](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementname)",
+      "type": "string"
+    },
+    "replacementNameTemplate": {
+      "description": "Controls what the replacement package name.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate",
+      "markdownDescription": "Controls what the replacement package name.\n\nSee also: [replacementNameTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementnametemplate)",
+      "type": "string",
+      "default": "{{{packageName}}}"
+    },
+    "replacementVersion": {
+      "description": "The version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion",
+      "markdownDescription": "The version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersion](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversion)",
+      "type": "string"
+    },
+    "replacementVersionTemplate": {
+      "description": "Template field for the version of the new dependency that replaces the old deprecated dependency.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate",
+      "markdownDescription": "Template field for the version of the new dependency that replaces the old deprecated dependency.\n\nSee also: [replacementVersionTemplate](https://docs.renovatebot.com/configuration-options/#packagerulesreplacementversiontemplate)",
+      "type": "string"
+    },
+    "requireConfig": {
+      "description": "Controls Renovate's behavior regarding repository config files such as `renovate.json`.\nSee also: https://docs.renovatebot.com/self-hosted-configuration/#requireconfig",
+      "markdownDescription": "Controls Renovate's behavior regarding repository config files such as `renovate.json`.\n\nSee also: [requireConfig](https://docs.renovatebot.com/self-hosted-configuration/#requireconfig)",
+      "type": "string",
+      "enum": ["required", "optional", "ignored"],
+      "default": "required"
+    },
+    "respectLatest": {
+      "description": "Ignore versions newer than npm \"latest\" version.\nSee also: https://docs.renovatebot.com/configuration-options/#respectlatest",
+      "markdownDescription": "Ignore versions newer than npm \"latest\" version.\n\nSee also: [respectLatest](https://docs.renovatebot.com/configuration-options/#respectlatest)",
+      "type": "boolean",
+      "default": true
+    },
+    "reviewers": {
+      "description": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\nSee also: https://docs.renovatebot.com/configuration-options/#reviewers",
+      "markdownDescription": "Requested reviewers for Pull Requests (either username or email address depending on the platform).\n\nSee also: [reviewers](https://docs.renovatebot.com/configuration-options/#reviewers)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reviewersFromCodeOwners": {
+      "description": "Determine reviewers based on configured code owners and changes in PR.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners",
+      "markdownDescription": "Determine reviewers based on configured code owners and changes in PR.\n\nSee also: [reviewersFromCodeOwners](https://docs.renovatebot.com/configuration-options/#reviewersfromcodeowners)",
+      "type": "boolean",
+      "default": false
+    },
+    "reviewersSampleSize": {
+      "description": "Take a random sample of given size from `reviewers`.\nSee also: https://docs.renovatebot.com/configuration-options/#reviewerssamplesize",
+      "markdownDescription": "Take a random sample of given size from `reviewers`.\n\nSee also: [reviewersSampleSize](https://docs.renovatebot.com/configuration-options/#reviewerssamplesize)",
+      "type": ["integer", "null"],
+      "default": null
+    },
+    "rollback": {
+      "$ref": "#",
+      "description": "Configuration to apply when rolling back a version.\nSee also: https://docs.renovatebot.com/configuration-options/#rollback",
+      "markdownDescription": "Configuration to apply when rolling back a version.\n\nSee also: [rollback](https://docs.renovatebot.com/configuration-options/#rollback)",
+      "type": "object",
+      "default": {
+        "branchTopic": "{{{depNameSanitized}}}-rollback",
+        "commitMessageAction": "Roll back",
+        "semanticCommitType": "fix"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rollbackPrs": {
+      "description": "Create PRs to roll back versions if the current version is not found in the registry.\nSee also: https://docs.renovatebot.com/configuration-options/#rollbackprs",
+      "markdownDescription": "Create PRs to roll back versions if the current version is not found in the registry.\n\nSee also: [rollbackPrs](https://docs.renovatebot.com/configuration-options/#rollbackprs)",
+      "type": "boolean",
+      "default": false
+    },
+    "ruby-version": {
+      "$ref": "#",
+      "description": "Configuration object for the ruby-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#ruby-version",
+      "markdownDescription": "Configuration object for the ruby-version manager\n\nSee also: [ruby-version](https://docs.renovatebot.com/configuration-options/#ruby-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.ruby-version$/"],
+        "versioning": "ruby"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "runtime-version": {
+      "$ref": "#",
+      "description": "Configuration object for the runtime-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#runtime-version",
+      "markdownDescription": "Configuration object for the runtime-version manager\n\nSee also: [runtime-version](https://docs.renovatebot.com/configuration-options/#runtime-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)runtime.txt$/"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "rust-toolchain": {
+      "$ref": "#",
+      "description": "Configuration object for the rust-toolchain manager\nSee also: https://docs.renovatebot.com/configuration-options/#rust-toolchain",
+      "markdownDescription": "Configuration object for the rust-toolchain manager\n\nSee also: [rust-toolchain](https://docs.renovatebot.com/configuration-options/#rust-toolchain)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Rust",
+        "managerFilePatterns": ["/(^|/)rust-toolchain(\\.toml)?$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sbt": {
+      "$ref": "#",
+      "description": "Configuration object for the sbt manager\nSee also: https://docs.renovatebot.com/configuration-options/#sbt",
+      "markdownDescription": "Configuration object for the sbt manager\n\nSee also: [sbt](https://docs.renovatebot.com/configuration-options/#sbt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": [
+          "/\\.sbt$/",
+          "/project/[^/]*\\.scala$/",
+          "/project/build\\.properties$/",
+          "/(^|/)repositories$/"
+        ],
+        "versioning": "ivy"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "scalafmt": {
+      "$ref": "#",
+      "description": "Configuration object for the scalafmt manager\nSee also: https://docs.renovatebot.com/configuration-options/#scalafmt",
+      "markdownDescription": "Configuration object for the scalafmt manager\n\nSee also: [scalafmt](https://docs.renovatebot.com/configuration-options/#scalafmt)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.scalafmt.conf$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "schedule": {
+      "description": "Limit branch creation to these times of day or week.\nSee also: https://docs.renovatebot.com/configuration-options/#schedule",
+      "markdownDescription": "Limit branch creation to these times of day or week.\n\nSee also: [schedule](https://docs.renovatebot.com/configuration-options/#schedule)",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": ["at any time"]
+    },
+    "semanticCommitScope": {
+      "description": "Commit scope to use if Semantic Commits are enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommitscope",
+      "markdownDescription": "Commit scope to use if Semantic Commits are enabled.\n\nSee also: [semanticCommitScope](https://docs.renovatebot.com/configuration-options/#semanticcommitscope)",
+      "type": "string",
+      "default": "deps"
+    },
+    "semanticCommitType": {
+      "description": "Commit type to use if Semantic Commits is enabled.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommittype",
+      "markdownDescription": "Commit type to use if Semantic Commits is enabled.\n\nSee also: [semanticCommitType](https://docs.renovatebot.com/configuration-options/#semanticcommittype)",
+      "type": "string",
+      "default": "chore"
+    },
+    "semanticCommits": {
+      "description": "Enable Semantic Commit prefixes for commits and PR titles.\nSee also: https://docs.renovatebot.com/configuration-options/#semanticcommits",
+      "markdownDescription": "Enable Semantic Commit prefixes for commits and PR titles.\n\nSee also: [semanticCommits](https://docs.renovatebot.com/configuration-options/#semanticcommits)",
+      "type": "string",
+      "enum": ["auto", "enabled", "disabled"],
+      "default": "auto"
+    },
+    "separateMajorMinor": {
+      "description": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemajorminor",
+      "markdownDescription": "If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.\n\nSee also: [separateMajorMinor](https://docs.renovatebot.com/configuration-options/#separatemajorminor)",
+      "type": "boolean",
+      "default": true
+    },
+    "separateMinorPatch": {
+      "description": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\nSee also: https://docs.renovatebot.com/configuration-options/#separateminorpatch",
+      "markdownDescription": "If set to `true`, Renovate will separate `minor` and `patch` updates into separate branches.\n\nSee also: [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMajor": {
+      "description": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultiplemajor",
+      "markdownDescription": "If set to `true`, PRs will be raised separately for each available `major` upgrade version.\n\nSee also: [separateMultipleMajor](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor)",
+      "type": "boolean",
+      "default": false
+    },
+    "separateMultipleMinor": {
+      "description": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\nSee also: https://docs.renovatebot.com/configuration-options/#separatemultipleminor",
+      "markdownDescription": "If set to `true`, Renovate creates separate PRs for each `minor` stream.\n\nSee also: [separateMultipleMinor](https://docs.renovatebot.com/configuration-options/#separatemultipleminor)",
+      "type": "boolean",
+      "default": false
+    },
+    "setup-cfg": {
+      "$ref": "#",
+      "description": "Configuration object for the setup-cfg manager\nSee also: https://docs.renovatebot.com/configuration-options/#setup-cfg",
+      "markdownDescription": "Configuration object for the setup-cfg manager\n\nSee also: [setup-cfg](https://docs.renovatebot.com/configuration-options/#setup-cfg)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)setup\\.cfg$/"],
+        "versioning": "pep440"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "skipArtifactsUpdate": {
+      "description": "Skip Renovate's automatic artifact updating.\nSee also: https://docs.renovatebot.com/configuration-options/#skipartifactsupdate",
+      "markdownDescription": "Skip Renovate's automatic artifact updating.\n\nSee also: [skipArtifactsUpdate](https://docs.renovatebot.com/configuration-options/#skipartifactsupdate)",
+      "type": "boolean",
+      "default": false
+    },
+    "skipInstalls": {
+      "description": "Skip installing modules/dependencies if lock file updating is possible without a full install.\nSee also: https://docs.renovatebot.com/configuration-options/#skipinstalls",
+      "markdownDescription": "Skip installing modules/dependencies if lock file updating is possible without a full install.\n\nSee also: [skipInstalls](https://docs.renovatebot.com/configuration-options/#skipinstalls)",
+      "type": ["boolean", "null"],
+      "default": null
+    },
+    "smithy": {
+      "$ref": "#",
+      "description": "Configuration object for the smithy manager\nSee also: https://docs.renovatebot.com/configuration-options/#smithy",
+      "markdownDescription": "Configuration object for the smithy manager\n\nSee also: [smithy](https://docs.renovatebot.com/configuration-options/#smithy)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)smithy-build\\.json$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sourceDirectory": {
+      "description": "The source directory in which the package is present at its source.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory",
+      "markdownDescription": "The source directory in which the package is present at its source.\n\nSee also: [sourceDirectory](https://docs.renovatebot.com/configuration-options/#packagerulessourcedirectory)",
+      "type": "string"
+    },
+    "sourceUrl": {
+      "description": "The source URL of the package.\nSee also: https://docs.renovatebot.com/configuration-options/#packagerulessourceurl",
+      "markdownDescription": "The source URL of the package.\n\nSee also: [sourceUrl](https://docs.renovatebot.com/configuration-options/#packagerulessourceurl)",
+      "type": "string"
+    },
+    "statusCheckNames": {
+      "$ref": "#",
+      "description": "Custom strings to use as status check names.\nSee also: https://docs.renovatebot.com/configuration-options/#statuschecknames",
+      "markdownDescription": "Custom strings to use as status check names.\n\nSee also: [statusCheckNames](https://docs.renovatebot.com/configuration-options/#statuschecknames)",
+      "type": "object",
+      "default": {
+        "artifactError": "renovate/artifacts",
+        "configValidation": "renovate/config-validation",
+        "mergeConfidence": "renovate/merge-confidence",
+        "minimumReleaseAge": "renovate/stability-days"
+      }
+    },
+    "statusCheckWhen": {
+      "$ref": "#",
+      "description": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\nSee also: https://docs.renovatebot.com/configuration-options/#statuscheckwhen",
+      "markdownDescription": "Control when each Renovate status check is set on branches. Keys match `statusCheckNames`.\n\nSee also: [statusCheckWhen](https://docs.renovatebot.com/configuration-options/#statuscheckwhen)",
+      "type": "object",
+      "default": {
+        "artifactError": "failed",
+        "configValidation": "always",
+        "mergeConfidence": "always",
+        "minimumReleaseAge": "always"
+      }
+    },
+    "stopUpdatingLabel": {
+      "description": "Label to make Renovate stop updating a PR.\nSee also: https://docs.renovatebot.com/configuration-options/#stopupdatinglabel",
+      "markdownDescription": "Label to make Renovate stop updating a PR.\n\nSee also: [stopUpdatingLabel](https://docs.renovatebot.com/configuration-options/#stopupdatinglabel)",
+      "type": "string",
+      "default": "stop-updating"
+    },
+    "suppressNotifications": {
+      "description": "Options to suppress various types of warnings and other notifications.\nSee also: https://docs.renovatebot.com/configuration-options/#suppressnotifications",
+      "markdownDescription": "Options to suppress various types of warnings and other notifications.\n\nSee also: [suppressNotifications](https://docs.renovatebot.com/configuration-options/#suppressnotifications)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "artifactErrors",
+          "branchAutomergeFailure",
+          "configErrorIssue",
+          "dependencyLookupWarnings",
+          "lockFileErrors",
+          "missingCredentialsError",
+          "onboardingClose",
+          "prEditedNotification",
+          "prIgnoreNotification"
+        ]
+      },
+      "default": []
+    },
+    "sveltos": {
+      "$ref": "#",
+      "description": "Configuration object for the sveltos manager\nSee also: https://docs.renovatebot.com/configuration-options/#sveltos",
+      "markdownDescription": "Configuration object for the sveltos manager\n\nSee also: [sveltos](https://docs.renovatebot.com/configuration-options/#sveltos)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "swift": {
+      "$ref": "#",
+      "description": "Configuration object for the swift manager\nSee also: https://docs.renovatebot.com/configuration-options/#swift",
+      "markdownDescription": "Configuration object for the swift manager\n\nSee also: [swift](https://docs.renovatebot.com/configuration-options/#swift)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)Package\\.swift/"],
+        "versioning": "swift",
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tekton": {
+      "$ref": "#",
+      "description": "Configuration object for the tekton manager\nSee also: https://docs.renovatebot.com/configuration-options/#tekton",
+      "markdownDescription": "Configuration object for the tekton manager\n\nSee also: [tekton](https://docs.renovatebot.com/configuration-options/#tekton)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": []
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform",
+      "markdownDescription": "Configuration object for the terraform manager\n\nSee also: [terraform](https://docs.renovatebot.com/configuration-options/#terraform)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terraform {{depName}}",
+        "managerFilePatterns": ["**/*.tf", "**/*.tofu"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terraform-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terraform-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terraform-version",
+      "markdownDescription": "Configuration object for the terraform-version manager\n\nSee also: [terraform-version](https://docs.renovatebot.com/configuration-options/#terraform-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terraform-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt",
+      "markdownDescription": "Configuration object for the terragrunt manager\n\nSee also: [terragrunt](https://docs.renovatebot.com/configuration-options/#terragrunt)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "Terragrunt dependency {{depName}}",
+        "managerFilePatterns": ["/(^|/)terragrunt\\.hcl$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "terragrunt-version": {
+      "$ref": "#",
+      "description": "Configuration object for the terragrunt-version manager\nSee also: https://docs.renovatebot.com/configuration-options/#terragrunt-version",
+      "markdownDescription": "Configuration object for the terragrunt-version manager\n\nSee also: [terragrunt-version](https://docs.renovatebot.com/configuration-options/#terragrunt-version)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.terragrunt-version$/"],
+        "versioning": "hashicorp",
+        "extractVersion": "^v(?<version>.+)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "tflint-plugin": {
+      "$ref": "#",
+      "description": "Configuration object for the tflint-plugin manager\nSee also: https://docs.renovatebot.com/configuration-options/#tflint-plugin",
+      "markdownDescription": "Configuration object for the tflint-plugin manager\n\nSee also: [tflint-plugin](https://docs.renovatebot.com/configuration-options/#tflint-plugin)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "TFLint plugin {{depName}}",
+        "managerFilePatterns": ["/\\.tflint\\.hcl$/"],
+        "extractVersion": "^v(?<version>.*)$"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "timeout": {
+      "description": "Timeout (in milliseconds) for queries to external endpoints.\nSee also: https://docs.renovatebot.com/configuration-options/#hostrulestimeout",
+      "markdownDescription": "Timeout (in milliseconds) for queries to external endpoints.\n\nSee also: [timeout](https://docs.renovatebot.com/configuration-options/#hostrulestimeout)",
+      "type": "integer"
+    },
+    "timezone": {
+      "description": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\nSee also: https://docs.renovatebot.com/configuration-options/#timezone",
+      "markdownDescription": "Must conform to [IANA Time Zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) format.\n\nSee also: [timezone](https://docs.renovatebot.com/configuration-options/#timezone)",
+      "type": "string"
+    },
+    "toolSettings": {
+      "$ref": "#",
+      "description": "Tool specific configuration. Global self-hosted configuration takes precedence.\nSee also: https://docs.renovatebot.com/configuration-options/#toolsettings",
+      "markdownDescription": "Tool specific configuration. Global self-hosted configuration takes precedence.\n\nSee also: [toolSettings](https://docs.renovatebot.com/configuration-options/#toolsettings)",
+      "type": "object",
+      "default": {
+        "jvmMaxMemory": 512,
+        "jvmMemory": 512
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "jvmMaxMemory": {
+                "$ref": "#/definitions/jvmMaxMemory"
+              },
+              "jvmMemory": {
+                "$ref": "#/definitions/jvmMemory"
+              },
+              "nodeMaxMemory": {
+                "$ref": "#/definitions/nodeMaxMemory"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "transformTemplates": {
+      "description": "List of jsonata transformation rules.\nSee also: https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates",
+      "markdownDescription": "List of jsonata transformation rules.\n\nSee also: [transformTemplates](https://docs.renovatebot.com/configuration-options/#customdatasourcestransformtemplates)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "travis": {
+      "$ref": "#",
+      "description": "Configuration object for the travis manager\nSee also: https://docs.renovatebot.com/configuration-options/#travis",
+      "markdownDescription": "Configuration object for the travis manager\n\nSee also: [travis](https://docs.renovatebot.com/configuration-options/#travis)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.travis\\.ya?ml$/"],
+        "major": {
+          "enabled": false
+        },
+        "versioning": "node"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "typst": {
+      "$ref": "#",
+      "description": "Configuration object for the typst manager\nSee also: https://docs.renovatebot.com/configuration-options/#typst",
+      "markdownDescription": "Configuration object for the typst manager\n\nSee also: [typst](https://docs.renovatebot.com/configuration-options/#typst)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/\\.typ$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "unity3d": {
+      "$ref": "#",
+      "description": "Configuration object for the unity3d manager\nSee also: https://docs.renovatebot.com/configuration-options/#unity3d",
+      "markdownDescription": "Configuration object for the unity3d manager\n\nSee also: [unity3d](https://docs.renovatebot.com/configuration-options/#unity3d)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/ProjectSettings/ProjectVersion.txt"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "updateInternalDeps": {
+      "description": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\nSee also: https://docs.renovatebot.com/configuration-options/#updateinternaldeps",
+      "markdownDescription": "Whether to update internal dep versions in a monorepo. Works on Yarn Workspaces.\n\nSee also: [updateInternalDeps](https://docs.renovatebot.com/configuration-options/#updateinternaldeps)",
+      "type": "boolean",
+      "default": false
+    },
+    "updateNotScheduled": {
+      "description": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\nSee also: https://docs.renovatebot.com/configuration-options/#updatenotscheduled",
+      "markdownDescription": "Whether to update branches when not scheduled. Renovate will not create branches outside of the schedule.\n\nSee also: [updateNotScheduled](https://docs.renovatebot.com/configuration-options/#updatenotscheduled)",
+      "type": "boolean",
+      "default": true
+    },
+    "updatePinnedDependencies": {
+      "description": "Whether to update pinned (single version) dependencies or not.\nSee also: https://docs.renovatebot.com/configuration-options/#updatepinneddependencies",
+      "markdownDescription": "Whether to update pinned (single version) dependencies or not.\n\nSee also: [updatePinnedDependencies](https://docs.renovatebot.com/configuration-options/#updatepinneddependencies)",
+      "type": "boolean",
+      "default": true
+    },
+    "useBaseBranchConfig": {
+      "description": "Whether to read configuration from base branches instead of only the default branch.\nSee also: https://docs.renovatebot.com/configuration-options/#usebasebranchconfig",
+      "markdownDescription": "Whether to read configuration from base branches instead of only the default branch.\n\nSee also: [useBaseBranchConfig](https://docs.renovatebot.com/configuration-options/#usebasebranchconfig)",
+      "type": "string",
+      "enum": ["merge", "none"],
+      "default": "none"
+    },
+    "userStrings": {
+      "description": "User-facing strings for the Renovate comment when a PR is closed.\nSee also: https://docs.renovatebot.com/configuration-options/#userstrings",
+      "markdownDescription": "User-facing strings for the Renovate comment when a PR is closed.\n\nSee also: [userStrings](https://docs.renovatebot.com/configuration-options/#userstrings)",
+      "type": "object",
+      "default": {
+        "ignoreTopic": "Renovate Ignore Notification",
+        "ignoreMajor": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for *any* future `{{{newMajor}}}.x` releases. But if you manually upgrade to `{{{newMajor}}}.x` then Renovate will re-enable `minor` and `patch` updates automatically.",
+        "ignoreDigest": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for the `{{{depName}}}` `{{{newDigestShort}}}` update again.",
+        "ignoreOther": "Because you closed this PR without merging, Renovate will ignore this update (`{{{newValue}}}`). You will get a PR once a newer version is released. To ignore this dependency forever, add it to the `ignoreDeps` array of your Renovate config.",
+        "artifactErrorWarning": "You probably do not want to merge this PR as-is."
+      }
+    },
+    "velaci": {
+      "$ref": "#",
+      "description": "Configuration object for the velaci manager\nSee also: https://docs.renovatebot.com/configuration-options/#velaci",
+      "markdownDescription": "Configuration object for the velaci manager\n\nSee also: [velaci](https://docs.renovatebot.com/configuration-options/#velaci)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/(^|/)\\.vela\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vendir": {
+      "$ref": "#",
+      "description": "Configuration object for the vendir manager\nSee also: https://docs.renovatebot.com/configuration-options/#vendir",
+      "markdownDescription": "Configuration object for the vendir manager\n\nSee also: [vendir](https://docs.renovatebot.com/configuration-options/#vendir)",
+      "type": "object",
+      "default": {
+        "commitMessageTopic": "vendir {{depName}}",
+        "managerFilePatterns": ["/(^|/)vendir\\.yml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "versionCompatibility": {
+      "description": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\nSee also: https://docs.renovatebot.com/configuration-options/#versioncompatibility",
+      "markdownDescription": "A regex (`re2`) with named capture groups to show how version and compatibility are split from a raw version string.\n\nSee also: [versionCompatibility](https://docs.renovatebot.com/configuration-options/#versioncompatibility)",
+      "type": "string",
+      "format": "regex"
+    },
+    "versioning": {
+      "description": "Versioning to use for filtering and comparisons.\nSee also: https://docs.renovatebot.com/configuration-options/#versioning",
+      "markdownDescription": "Versioning to use for filtering and comparisons.\n\nSee also: [versioning](https://docs.renovatebot.com/configuration-options/#versioning)",
+      "type": "string",
+      "oneOf": [
+        {
+          "enum": [
+            "apk",
+            "aws-eks-addon",
+            "aws-machine-image",
+            "azure-rest-api",
+            "bazel-module",
+            "cargo",
+            "composer",
+            "conan",
+            "conda",
+            "deb",
+            "debian",
+            "deno",
+            "devbox",
+            "docker",
+            "elm",
+            "exact",
+            "git",
+            "github-actions",
+            "glasskube",
+            "go-mod-directive",
+            "gradle",
+            "hashicorp",
+            "helm",
+            "hermit",
+            "hex",
+            "ivy",
+            "kubernetes-api",
+            "lambda-node",
+            "loose",
+            "maven",
+            "nixpkgs",
+            "node",
+            "npm",
+            "nuget",
+            "paket",
+            "pep440",
+            "perl",
+            "poetry",
+            "pvp",
+            "python",
+            "redhat",
+            "regex",
+            "rez",
+            "rpm",
+            "ruby",
+            "rust-release-channel",
+            "same-major",
+            "semver",
+            "semver-coerced",
+            "semver-partial",
+            "swift",
+            "ubuntu",
+            "unity3d",
+            "unity3d-packages"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^regex:"
+        }
+      ]
+    },
+    "versioningTemplate": {
+      "description": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\nSee also: https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate",
+      "markdownDescription": "Optional versioning for extracted dependencies. Valid only within a `customManagers` object.\n\nSee also: [versioningTemplate](https://docs.renovatebot.com/configuration-options/#custommanagersversioningtemplate)",
+      "type": "string"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#",
+      "description": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
+      "markdownDescription": "Config to apply when a PR is needed due to a vulnerability in the existing package version.\n\nSee also: [vulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)",
+      "type": "object",
+      "default": {
+        "groupName": null,
+        "schedule": [],
+        "dependencyDashboardApproval": false,
+        "minimumReleaseAge": null,
+        "rangeStrategy": "update-lockfile",
+        "commitMessageSuffix": "[SECURITY]",
+        "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+        "prCreation": "immediate",
+        "vulnerabilityFixStrategy": "lowest"
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "vulnerabilityFixStrategy": {
+                "$ref": "#/definitions/vulnerabilityFixStrategy"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "vulnerabilityFixStrategy": {
+      "description": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\nSee also: https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy",
+      "markdownDescription": "Strategy to use when fixing vulnerabilities. `lowest` will propose the earliest version with a fix, `highest` will always pick the latest version.\n\nSee also: [vulnerabilityFixStrategy](https://docs.renovatebot.com/configuration-options/#vulnerabilityalertsvulnerabilityfixstrategy)",
+      "type": "string",
+      "enum": ["lowest", "highest"],
+      "default": "lowest"
+    },
+    "woodpecker": {
+      "$ref": "#",
+      "description": "Configuration object for the woodpecker manager\nSee also: https://docs.renovatebot.com/configuration-options/#woodpecker",
+      "markdownDescription": "Configuration object for the woodpecker manager\n\nSee also: [woodpecker](https://docs.renovatebot.com/configuration-options/#woodpecker)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["/^\\.woodpecker(?:/[^/]+)?\\.ya?ml$/"]
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "workingDirTemplate": {
+      "description": "A template describing the working directory in which post-upgrade tasks should be executed.\nSee also: https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate",
+      "markdownDescription": "A template describing the working directory in which post-upgrade tasks should be executed.\n\nSee also: [workingDirTemplate](https://docs.renovatebot.com/configuration-options/#postupgradetasksworkingdirtemplate)",
+      "type": "string"
+    },
+    "xcodegen": {
+      "$ref": "#",
+      "description": "Configuration object for the xcodegen manager\nSee also: https://docs.renovatebot.com/configuration-options/#xcodegen",
+      "markdownDescription": "Configuration object for the xcodegen manager\n\nSee also: [xcodegen](https://docs.renovatebot.com/configuration-options/#xcodegen)",
+      "type": "object",
+      "default": {
+        "managerFilePatterns": ["**/project.yml"],
+        "pinDigests": false
+      },
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "A custom description for this configuration object"
+                    }
+                  },
+                  {
+                    "type": "string",
+                    "description": "A custom description for this configuration object"
+                  }
+                ]
+              },
+              "enabled": {
+                "$ref": "#/definitions/enabled"
+              },
+              "managerFilePatterns": {
+                "$ref": "#/definitions/managerFilePatterns"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "abandonmentThreshold": {
+      "$ref": "#/definitions/abandonmentThreshold"
+    },
+    "addLabels": {
+      "$ref": "#/definitions/addLabels"
+    },
+    "additionalBranchPrefix": {
+      "$ref": "#/definitions/additionalBranchPrefix"
+    },
+    "additionalReviewers": {
+      "$ref": "#/definitions/additionalReviewers"
+    },
+    "ansible": {
+      "$ref": "#/definitions/ansible"
+    },
+    "ansible-galaxy": {
+      "$ref": "#/definitions/ansible-galaxy"
+    },
+    "ant": {
+      "$ref": "#/definitions/ant"
+    },
+    "argocd": {
+      "$ref": "#/definitions/argocd"
+    },
+    "asdf": {
+      "$ref": "#/definitions/asdf"
+    },
+    "assignAutomerge": {
+      "$ref": "#/definitions/assignAutomerge"
+    },
+    "assignees": {
+      "$ref": "#/definitions/assignees"
+    },
+    "assigneesFromCodeOwners": {
+      "$ref": "#/definitions/assigneesFromCodeOwners"
+    },
+    "assigneesSampleSize": {
+      "$ref": "#/definitions/assigneesSampleSize"
+    },
+    "autoApprove": {
+      "$ref": "#/definitions/autoApprove"
+    },
+    "autoReplaceGlobalMatch": {
+      "$ref": "#/definitions/autoReplaceGlobalMatch"
+    },
+    "automerge": {
+      "$ref": "#/definitions/automerge"
+    },
+    "automergeComment": {
+      "$ref": "#/definitions/automergeComment"
+    },
+    "automergeSchedule": {
+      "$ref": "#/definitions/automergeSchedule"
+    },
+    "automergeStrategy": {
+      "$ref": "#/definitions/automergeStrategy"
+    },
+    "automergeType": {
+      "$ref": "#/definitions/automergeType"
+    },
+    "azure-pipelines": {
+      "$ref": "#/definitions/azure-pipelines"
+    },
+    "azureWorkItemId": {
+      "$ref": "#/definitions/azureWorkItemId"
+    },
+    "azureWorkItemType": {
+      "$ref": "#/definitions/azureWorkItemType"
+    },
+    "baseBranchPatterns": {
+      "$ref": "#/definitions/baseBranchPatterns"
+    },
+    "batect": {
+      "$ref": "#/definitions/batect"
+    },
+    "batect-wrapper": {
+      "$ref": "#/definitions/batect-wrapper"
+    },
+    "bazel": {
+      "$ref": "#/definitions/bazel"
+    },
+    "bazel-module": {
+      "$ref": "#/definitions/bazel-module"
+    },
+    "bazelisk": {
+      "$ref": "#/definitions/bazelisk"
+    },
+    "bbAutoResolvePrTasks": {
+      "$ref": "#/definitions/bbAutoResolvePrTasks"
+    },
+    "bbUseDefaultReviewers": {
+      "$ref": "#/definitions/bbUseDefaultReviewers"
+    },
+    "bbUseDevelopmentBranch": {
+      "$ref": "#/definitions/bbUseDevelopmentBranch"
+    },
+    "bicep": {
+      "$ref": "#/definitions/bicep"
+    },
+    "bitbucket-pipelines": {
+      "$ref": "#/definitions/bitbucket-pipelines"
+    },
+    "bitrise": {
+      "$ref": "#/definitions/bitrise"
+    },
+    "branchConcurrentLimit": {
+      "$ref": "#/definitions/branchConcurrentLimit"
+    },
+    "branchName": {
+      "$ref": "#/definitions/branchName"
+    },
+    "branchNameStrict": {
+      "$ref": "#/definitions/branchNameStrict"
+    },
+    "branchPrefix": {
+      "$ref": "#/definitions/branchPrefix"
+    },
+    "branchPrefixOld": {
+      "$ref": "#/definitions/branchPrefixOld"
+    },
+    "branchTopic": {
+      "$ref": "#/definitions/branchTopic"
+    },
+    "buildkite": {
+      "$ref": "#/definitions/buildkite"
+    },
+    "buildpacks": {
+      "$ref": "#/definitions/buildpacks"
+    },
+    "bumpVersion": {
+      "$ref": "#/definitions/bumpVersion"
+    },
+    "bumpVersions": {
+      "$ref": "#/definitions/bumpVersions"
+    },
+    "bun": {
+      "$ref": "#/definitions/bun"
+    },
+    "bun-version": {
+      "$ref": "#/definitions/bun-version"
+    },
+    "bundler": {
+      "$ref": "#/definitions/bundler"
+    },
+    "cake": {
+      "$ref": "#/definitions/cake"
+    },
+    "cargo": {
+      "$ref": "#/definitions/cargo"
+    },
+    "cdnurl": {
+      "$ref": "#/definitions/cdnurl"
+    },
+    "circleci": {
+      "$ref": "#/definitions/circleci"
+    },
+    "cloneSubmodules": {
+      "$ref": "#/definitions/cloneSubmodules"
+    },
+    "cloneSubmodulesFilter": {
+      "$ref": "#/definitions/cloneSubmodulesFilter"
+    },
+    "cloudbuild": {
+      "$ref": "#/definitions/cloudbuild"
+    },
+    "cocoapods": {
+      "$ref": "#/definitions/cocoapods"
+    },
+    "commitBody": {
+      "$ref": "#/definitions/commitBody"
+    },
+    "commitBodyTable": {
+      "$ref": "#/definitions/commitBodyTable"
+    },
+    "commitHourlyLimit": {
+      "$ref": "#/definitions/commitHourlyLimit"
+    },
+    "commitMessage": {
+      "$ref": "#/definitions/commitMessage"
+    },
+    "commitMessageAction": {
+      "$ref": "#/definitions/commitMessageAction"
+    },
+    "commitMessageExtra": {
+      "$ref": "#/definitions/commitMessageExtra"
+    },
+    "commitMessageLowerCase": {
+      "$ref": "#/definitions/commitMessageLowerCase"
+    },
+    "commitMessagePrefix": {
+      "$ref": "#/definitions/commitMessagePrefix"
+    },
+    "commitMessageSuffix": {
+      "$ref": "#/definitions/commitMessageSuffix"
+    },
+    "commitMessageTopic": {
+      "$ref": "#/definitions/commitMessageTopic"
+    },
+    "commitTrailers": {
+      "$ref": "#/definitions/commitTrailers"
+    },
+    "composer": {
+      "$ref": "#/definitions/composer"
+    },
+    "composerIgnorePlatformReqs": {
+      "$ref": "#/definitions/composerIgnorePlatformReqs"
+    },
+    "conan": {
+      "$ref": "#/definitions/conan"
+    },
+    "confidential": {
+      "$ref": "#/definitions/confidential"
+    },
+    "configFileNames": {
+      "$ref": "#/definitions/configFileNames"
+    },
+    "configMigration": {
+      "$ref": "#/definitions/configMigration"
+    },
+    "configWarningReuseIssue": {
+      "$ref": "#/definitions/configWarningReuseIssue"
+    },
+    "constraints": {
+      "$ref": "#/definitions/constraints"
+    },
+    "constraintsFiltering": {
+      "$ref": "#/definitions/constraintsFiltering"
+    },
+    "constraintsVersioning": {
+      "$ref": "#/definitions/constraintsVersioning"
+    },
+    "copier": {
+      "$ref": "#/definitions/copier"
+    },
+    "cpanfile": {
+      "$ref": "#/definitions/cpanfile"
+    },
+    "crossplane": {
+      "$ref": "#/definitions/crossplane"
+    },
+    "crow": {
+      "$ref": "#/definitions/crow"
+    },
+    "customDatasources": {
+      "$ref": "#/definitions/customDatasources"
+    },
+    "customManagers": {
+      "$ref": "#/definitions/customManagers"
+    },
+    "customizeDashboard": {
+      "$ref": "#/definitions/customizeDashboard"
+    },
+    "defaultRegistryUrls": {
+      "$ref": "#/definitions/defaultRegistryUrls"
+    },
+    "deno": {
+      "$ref": "#/definitions/deno"
+    },
+    "dependencyDashboard": {
+      "$ref": "#/definitions/dependencyDashboard"
+    },
+    "dependencyDashboardApproval": {
+      "$ref": "#/definitions/dependencyDashboardApproval"
+    },
+    "dependencyDashboardAutoclose": {
+      "$ref": "#/definitions/dependencyDashboardAutoclose"
+    },
+    "dependencyDashboardCategory": {
+      "$ref": "#/definitions/dependencyDashboardCategory"
+    },
+    "dependencyDashboardFooter": {
+      "$ref": "#/definitions/dependencyDashboardFooter"
+    },
+    "dependencyDashboardHeader": {
+      "$ref": "#/definitions/dependencyDashboardHeader"
+    },
+    "dependencyDashboardLabels": {
+      "$ref": "#/definitions/dependencyDashboardLabels"
+    },
+    "dependencyDashboardOSVVulnerabilitySummary": {
+      "$ref": "#/definitions/dependencyDashboardOSVVulnerabilitySummary"
+    },
+    "dependencyDashboardReportAbandonment": {
+      "$ref": "#/definitions/dependencyDashboardReportAbandonment"
+    },
+    "dependencyDashboardTitle": {
+      "$ref": "#/definitions/dependencyDashboardTitle"
+    },
+    "deps-edn": {
+      "$ref": "#/definitions/deps-edn"
+    },
+    "description": {
+      "$ref": "#/definitions/description"
+    },
+    "devbox": {
+      "$ref": "#/definitions/devbox"
+    },
+    "devcontainer": {
+      "$ref": "#/definitions/devcontainer"
+    },
+    "digest": {
+      "$ref": "#/definitions/digest"
+    },
+    "docker-compose": {
+      "$ref": "#/definitions/docker-compose"
+    },
+    "dockerfile": {
+      "$ref": "#/definitions/dockerfile"
+    },
+    "draftPR": {
+      "$ref": "#/definitions/draftPR"
+    },
+    "droneci": {
+      "$ref": "#/definitions/droneci"
+    },
+    "enabled": {
+      "$ref": "#/definitions/enabled"
+    },
+    "enabledManagers": {
+      "$ref": "#/definitions/enabledManagers"
+    },
+    "encrypted": {
+      "$ref": "#/definitions/encrypted"
+    },
+    "env": {
+      "$ref": "#/definitions/env"
+    },
+    "excludeCommitPaths": {
+      "$ref": "#/definitions/excludeCommitPaths"
+    },
+    "expandCodeOwnersGroups": {
+      "$ref": "#/definitions/expandCodeOwnersGroups"
+    },
+    "extends": {
+      "$ref": "#/definitions/extends"
+    },
+    "extractVersion": {
+      "$ref": "#/definitions/extractVersion"
+    },
+    "fetchChangeLogs": {
+      "$ref": "#/definitions/fetchChangeLogs"
+    },
+    "filterUnavailableUsers": {
+      "$ref": "#/definitions/filterUnavailableUsers"
+    },
+    "fleet": {
+      "$ref": "#/definitions/fleet"
+    },
+    "flux": {
+      "$ref": "#/definitions/flux"
+    },
+    "followTag": {
+      "$ref": "#/definitions/followTag"
+    },
+    "forkModeDisallowMaintainerEdits": {
+      "$ref": "#/definitions/forkModeDisallowMaintainerEdits"
+    },
+    "forkProcessing": {
+      "$ref": "#/definitions/forkProcessing"
+    },
+    "fvm": {
+      "$ref": "#/definitions/fvm"
+    },
+    "git-submodules": {
+      "$ref": "#/definitions/git-submodules"
+    },
+    "gitAuthor": {
+      "$ref": "#/definitions/gitAuthor"
+    },
+    "gitIgnoredAuthors": {
+      "$ref": "#/definitions/gitIgnoredAuthors"
+    },
+    "gitLabIgnoreApprovals": {
+      "$ref": "#/definitions/gitLabIgnoreApprovals"
+    },
+    "github-actions": {
+      "$ref": "#/definitions/github-actions"
+    },
+    "gitlabci": {
+      "$ref": "#/definitions/gitlabci"
+    },
+    "gitlabci-include": {
+      "$ref": "#/definitions/gitlabci-include"
+    },
+    "glasskube": {
+      "$ref": "#/definitions/glasskube"
+    },
+    "gleam": {
+      "$ref": "#/definitions/gleam"
+    },
+    "goGetDirs": {
+      "$ref": "#/definitions/goGetDirs"
+    },
+    "gomod": {
+      "$ref": "#/definitions/gomod"
+    },
+    "gradle": {
+      "$ref": "#/definitions/gradle"
+    },
+    "gradle-wrapper": {
+      "$ref": "#/definitions/gradle-wrapper"
+    },
+    "group": {
+      "$ref": "#/definitions/group"
+    },
+    "groupName": {
+      "$ref": "#/definitions/groupName"
+    },
+    "groupSingleUpdates": {
+      "$ref": "#/definitions/groupSingleUpdates"
+    },
+    "groupSlug": {
+      "$ref": "#/definitions/groupSlug"
+    },
+    "hashedBranchLength": {
+      "$ref": "#/definitions/hashedBranchLength"
+    },
+    "haskell-cabal": {
+      "$ref": "#/definitions/haskell-cabal"
+    },
+    "helm-requirements": {
+      "$ref": "#/definitions/helm-requirements"
+    },
+    "helm-values": {
+      "$ref": "#/definitions/helm-values"
+    },
+    "helmfile": {
+      "$ref": "#/definitions/helmfile"
+    },
+    "helmsman": {
+      "$ref": "#/definitions/helmsman"
+    },
+    "helmv3": {
+      "$ref": "#/definitions/helmv3"
+    },
+    "hermit": {
+      "$ref": "#/definitions/hermit"
+    },
+    "homeassistant-manifest": {
+      "$ref": "#/definitions/homeassistant-manifest"
+    },
+    "homebrew": {
+      "$ref": "#/definitions/homebrew"
+    },
+    "hostRules": {
+      "$ref": "#/definitions/hostRules"
+    },
+    "html": {
+      "$ref": "#/definitions/html"
+    },
+    "ignoreDeprecated": {
+      "$ref": "#/definitions/ignoreDeprecated"
+    },
+    "ignoreDeps": {
+      "$ref": "#/definitions/ignoreDeps"
+    },
+    "ignorePaths": {
+      "$ref": "#/definitions/ignorePaths"
+    },
+    "ignorePlugins": {
+      "$ref": "#/definitions/ignorePlugins"
+    },
+    "ignorePresets": {
+      "$ref": "#/definitions/ignorePresets"
+    },
+    "ignoreReviewers": {
+      "$ref": "#/definitions/ignoreReviewers"
+    },
+    "ignoreScripts": {
+      "$ref": "#/definitions/ignoreScripts"
+    },
+    "ignoreTests": {
+      "$ref": "#/definitions/ignoreTests"
+    },
+    "ignoreUnstable": {
+      "$ref": "#/definitions/ignoreUnstable"
+    },
+    "includePaths": {
+      "$ref": "#/definitions/includePaths"
+    },
+    "internalChecksAsSuccess": {
+      "$ref": "#/definitions/internalChecksAsSuccess"
+    },
+    "internalChecksFilter": {
+      "$ref": "#/definitions/internalChecksFilter"
+    },
+    "jenkins": {
+      "$ref": "#/definitions/jenkins"
+    },
+    "jsonata": {
+      "$ref": "#/definitions/jsonata"
+    },
+    "jsonnet-bundler": {
+      "$ref": "#/definitions/jsonnet-bundler"
+    },
+    "keepUpdatedLabel": {
+      "$ref": "#/definitions/keepUpdatedLabel"
+    },
+    "kotlin-script": {
+      "$ref": "#/definitions/kotlin-script"
+    },
+    "kubernetes": {
+      "$ref": "#/definitions/kubernetes"
+    },
+    "kustomize": {
+      "$ref": "#/definitions/kustomize"
+    },
+    "labels": {
+      "$ref": "#/definitions/labels"
+    },
+    "leiningen": {
+      "$ref": "#/definitions/leiningen"
+    },
+    "lockFileMaintenance": {
+      "$ref": "#/definitions/lockFileMaintenance"
+    },
+    "logLevelRemap": {
+      "$ref": "#/definitions/logLevelRemap"
+    },
+    "major": {
+      "$ref": "#/definitions/major"
+    },
+    "maven": {
+      "$ref": "#/definitions/maven"
+    },
+    "maven-wrapper": {
+      "$ref": "#/definitions/maven-wrapper"
+    },
+    "maxMajorIncrement": {
+      "$ref": "#/definitions/maxMajorIncrement"
+    },
+    "meteor": {
+      "$ref": "#/definitions/meteor"
+    },
+    "milestone": {
+      "$ref": "#/definitions/milestone"
+    },
+    "minimumGroupSize": {
+      "$ref": "#/definitions/minimumGroupSize"
+    },
+    "minimumReleaseAge": {
+      "$ref": "#/definitions/minimumReleaseAge"
+    },
+    "minimumReleaseAgeBehaviour": {
+      "$ref": "#/definitions/minimumReleaseAgeBehaviour"
+    },
+    "minor": {
+      "$ref": "#/definitions/minor"
+    },
+    "mint": {
+      "$ref": "#/definitions/mint"
+    },
+    "mise": {
+      "$ref": "#/definitions/mise"
+    },
+    "mix": {
+      "$ref": "#/definitions/mix"
+    },
+    "mode": {
+      "$ref": "#/definitions/mode"
+    },
+    "nix": {
+      "$ref": "#/definitions/nix"
+    },
+    "nodenv": {
+      "$ref": "#/definitions/nodenv"
+    },
+    "npm": {
+      "$ref": "#/definitions/npm"
+    },
+    "npmToken": {
+      "$ref": "#/definitions/npmToken"
+    },
+    "npmrc": {
+      "$ref": "#/definitions/npmrc"
+    },
+    "npmrcMerge": {
+      "$ref": "#/definitions/npmrcMerge"
+    },
+    "nuget": {
+      "$ref": "#/definitions/nuget"
+    },
+    "nvm": {
+      "$ref": "#/definitions/nvm"
+    },
+    "ocb": {
+      "$ref": "#/definitions/ocb"
+    },
+    "onboarding": {
+      "$ref": "#/definitions/onboarding"
+    },
+    "onboardingAutoCloseAge": {
+      "$ref": "#/definitions/onboardingAutoCloseAge"
+    },
+    "onboardingBranch": {
+      "$ref": "#/definitions/onboardingBranch"
+    },
+    "onboardingCommitMessage": {
+      "$ref": "#/definitions/onboardingCommitMessage"
+    },
+    "onboardingConfig": {
+      "$ref": "#/definitions/onboardingConfig"
+    },
+    "onboardingConfigFileName": {
+      "$ref": "#/definitions/onboardingConfigFileName"
+    },
+    "onboardingNoDeps": {
+      "$ref": "#/definitions/onboardingNoDeps"
+    },
+    "onboardingPrTitle": {
+      "$ref": "#/definitions/onboardingPrTitle"
+    },
+    "osgi": {
+      "$ref": "#/definitions/osgi"
+    },
+    "osvVulnerabilityAlerts": {
+      "$ref": "#/definitions/osvVulnerabilityAlerts"
+    },
+    "packageRules": {
+      "$ref": "#/definitions/packageRules"
+    },
+    "patch": {
+      "$ref": "#/definitions/patch"
+    },
+    "pep621": {
+      "$ref": "#/definitions/pep621"
+    },
+    "pep723": {
+      "$ref": "#/definitions/pep723"
+    },
+    "pin": {
+      "$ref": "#/definitions/pin"
+    },
+    "pinDigest": {
+      "$ref": "#/definitions/pinDigest"
+    },
+    "pinDigests": {
+      "$ref": "#/definitions/pinDigests"
+    },
+    "pip-compile": {
+      "$ref": "#/definitions/pip-compile"
+    },
+    "pip_requirements": {
+      "$ref": "#/definitions/pip_requirements"
+    },
+    "pip_setup": {
+      "$ref": "#/definitions/pip_setup"
+    },
+    "pipenv": {
+      "$ref": "#/definitions/pipenv"
+    },
+    "pixi": {
+      "$ref": "#/definitions/pixi"
+    },
+    "platformAutomerge": {
+      "$ref": "#/definitions/platformAutomerge"
+    },
+    "platformCommit": {
+      "$ref": "#/definitions/platformCommit"
+    },
+    "poetry": {
+      "$ref": "#/definitions/poetry"
+    },
+    "postUpdateOptions": {
+      "$ref": "#/definitions/postUpdateOptions"
+    },
+    "postUpgradeTasks": {
+      "$ref": "#/definitions/postUpgradeTasks"
+    },
+    "prBodyColumns": {
+      "$ref": "#/definitions/prBodyColumns"
+    },
+    "prBodyDefinitions": {
+      "$ref": "#/definitions/prBodyDefinitions"
+    },
+    "prBodyHeadingDefinitions": {
+      "$ref": "#/definitions/prBodyHeadingDefinitions"
+    },
+    "prBodyNotes": {
+      "$ref": "#/definitions/prBodyNotes"
+    },
+    "prBodyTemplate": {
+      "$ref": "#/definitions/prBodyTemplate"
+    },
+    "prConcurrentLimit": {
+      "$ref": "#/definitions/prConcurrentLimit"
+    },
+    "prCreation": {
+      "$ref": "#/definitions/prCreation"
+    },
+    "prFooter": {
+      "$ref": "#/definitions/prFooter"
+    },
+    "prHeader": {
+      "$ref": "#/definitions/prHeader"
+    },
+    "prHourlyLimit": {
+      "$ref": "#/definitions/prHourlyLimit"
+    },
+    "prNotPendingHours": {
+      "$ref": "#/definitions/prNotPendingHours"
+    },
+    "prTitle": {
+      "$ref": "#/definitions/prTitle"
+    },
+    "prTitleStrict": {
+      "$ref": "#/definitions/prTitleStrict"
+    },
+    "pre-commit": {
+      "$ref": "#/definitions/pre-commit"
+    },
+    "printConfig": {
+      "$ref": "#/definitions/printConfig"
+    },
+    "proto": {
+      "$ref": "#/definitions/proto"
+    },
+    "pruneBranchAfterAutomerge": {
+      "$ref": "#/definitions/pruneBranchAfterAutomerge"
+    },
+    "pruneStaleBranches": {
+      "$ref": "#/definitions/pruneStaleBranches"
+    },
+    "pub": {
+      "$ref": "#/definitions/pub"
+    },
+    "puppet": {
+      "$ref": "#/definitions/puppet"
+    },
+    "pyenv": {
+      "$ref": "#/definitions/pyenv"
+    },
+    "quadlet": {
+      "$ref": "#/definitions/quadlet"
+    },
+    "rangeStrategy": {
+      "$ref": "#/definitions/rangeStrategy"
+    },
+    "rebaseLabel": {
+      "$ref": "#/definitions/rebaseLabel"
+    },
+    "rebaseWhen": {
+      "$ref": "#/definitions/rebaseWhen"
+    },
+    "recreateWhen": {
+      "$ref": "#/definitions/recreateWhen"
+    },
+    "regex": {
+      "$ref": "#/definitions/regex"
+    },
+    "registryAliases": {
+      "$ref": "#/definitions/registryAliases"
+    },
+    "registryUrls": {
+      "$ref": "#/definitions/registryUrls"
+    },
+    "renovate-config": {
+      "$ref": "#/definitions/renovate-config"
+    },
+    "replacement": {
+      "$ref": "#/definitions/replacement"
+    },
+    "replacementApproach": {
+      "$ref": "#/definitions/replacementApproach"
+    },
+    "requireConfig": {
+      "$ref": "#/definitions/requireConfig"
+    },
+    "respectLatest": {
+      "$ref": "#/definitions/respectLatest"
+    },
+    "reviewers": {
+      "$ref": "#/definitions/reviewers"
+    },
+    "reviewersFromCodeOwners": {
+      "$ref": "#/definitions/reviewersFromCodeOwners"
+    },
+    "reviewersSampleSize": {
+      "$ref": "#/definitions/reviewersSampleSize"
+    },
+    "rollback": {
+      "$ref": "#/definitions/rollback"
+    },
+    "rollbackPrs": {
+      "$ref": "#/definitions/rollbackPrs"
+    },
+    "ruby-version": {
+      "$ref": "#/definitions/ruby-version"
+    },
+    "runtime-version": {
+      "$ref": "#/definitions/runtime-version"
+    },
+    "rust-toolchain": {
+      "$ref": "#/definitions/rust-toolchain"
+    },
+    "sbt": {
+      "$ref": "#/definitions/sbt"
+    },
+    "scalafmt": {
+      "$ref": "#/definitions/scalafmt"
+    },
+    "schedule": {
+      "$ref": "#/definitions/schedule"
+    },
+    "semanticCommitScope": {
+      "$ref": "#/definitions/semanticCommitScope"
+    },
+    "semanticCommitType": {
+      "$ref": "#/definitions/semanticCommitType"
+    },
+    "semanticCommits": {
+      "$ref": "#/definitions/semanticCommits"
+    },
+    "separateMajorMinor": {
+      "$ref": "#/definitions/separateMajorMinor"
+    },
+    "separateMinorPatch": {
+      "$ref": "#/definitions/separateMinorPatch"
+    },
+    "separateMultipleMajor": {
+      "$ref": "#/definitions/separateMultipleMajor"
+    },
+    "separateMultipleMinor": {
+      "$ref": "#/definitions/separateMultipleMinor"
+    },
+    "setup-cfg": {
+      "$ref": "#/definitions/setup-cfg"
+    },
+    "skipArtifactsUpdate": {
+      "$ref": "#/definitions/skipArtifactsUpdate"
+    },
+    "skipInstalls": {
+      "$ref": "#/definitions/skipInstalls"
+    },
+    "smithy": {
+      "$ref": "#/definitions/smithy"
+    },
+    "statusCheckNames": {
+      "$ref": "#/definitions/statusCheckNames"
+    },
+    "statusCheckWhen": {
+      "$ref": "#/definitions/statusCheckWhen"
+    },
+    "stopUpdatingLabel": {
+      "$ref": "#/definitions/stopUpdatingLabel"
+    },
+    "suppressNotifications": {
+      "$ref": "#/definitions/suppressNotifications"
+    },
+    "sveltos": {
+      "$ref": "#/definitions/sveltos"
+    },
+    "swift": {
+      "$ref": "#/definitions/swift"
+    },
+    "tekton": {
+      "$ref": "#/definitions/tekton"
+    },
+    "terraform": {
+      "$ref": "#/definitions/terraform"
+    },
+    "terraform-version": {
+      "$ref": "#/definitions/terraform-version"
+    },
+    "terragrunt": {
+      "$ref": "#/definitions/terragrunt"
+    },
+    "terragrunt-version": {
+      "$ref": "#/definitions/terragrunt-version"
+    },
+    "tflint-plugin": {
+      "$ref": "#/definitions/tflint-plugin"
+    },
+    "timezone": {
+      "$ref": "#/definitions/timezone"
+    },
+    "toolSettings": {
+      "$ref": "#/definitions/toolSettings"
+    },
+    "travis": {
+      "$ref": "#/definitions/travis"
+    },
+    "typst": {
+      "$ref": "#/definitions/typst"
+    },
+    "unity3d": {
+      "$ref": "#/definitions/unity3d"
+    },
+    "updateInternalDeps": {
+      "$ref": "#/definitions/updateInternalDeps"
+    },
+    "updateNotScheduled": {
+      "$ref": "#/definitions/updateNotScheduled"
+    },
+    "updatePinnedDependencies": {
+      "$ref": "#/definitions/updatePinnedDependencies"
+    },
+    "useBaseBranchConfig": {
+      "$ref": "#/definitions/useBaseBranchConfig"
+    },
+    "userStrings": {
+      "$ref": "#/definitions/userStrings"
+    },
+    "velaci": {
+      "$ref": "#/definitions/velaci"
+    },
+    "vendir": {
+      "$ref": "#/definitions/vendir"
+    },
+    "versionCompatibility": {
+      "$ref": "#/definitions/versionCompatibility"
+    },
+    "versioning": {
+      "$ref": "#/definitions/versioning"
+    },
+    "vulnerabilityAlerts": {
+      "$ref": "#/definitions/vulnerabilityAlerts"
+    },
+    "woodpecker": {
+      "$ref": "#/definitions/woodpecker"
+    },
+    "xcodegen": {
+      "$ref": "#/definitions/xcodegen"
+    }
+  },
+  "not": {
+    "anyOf": [
+      {
+        "required": ["allowedHeaders"]
+      },
+      {
+        "required": ["autodiscoverRepoOrder"]
+      },
+      {
+        "required": ["autodiscoverRepoSort"]
+      },
+      {
+        "required": ["allowedEnv"]
+      },
+      {
+        "required": ["detectGlobalManagerConfig"]
+      },
+      {
+        "required": ["detectHostRulesFromEnv"]
+      },
+      {
+        "required": ["mergeConfidenceEndpoint"]
+      },
+      {
+        "required": ["mergeConfidenceDatasources"]
+      },
+      {
+        "required": ["useCloudMetadataServices"]
+      },
+      {
+        "required": ["userAgent"]
+      },
+      {
+        "required": ["allowedCommands"]
+      },
+      {
+        "required": ["productLinks"]
+      },
+      {
+        "required": ["secrets"]
+      },
+      {
+        "required": ["variables"]
+      },
+      {
+        "required": ["migratePresets"]
+      },
+      {
+        "required": ["presetCachePersistence"]
+      },
+      {
+        "required": ["globalExtends"]
+      },
+      {
+        "required": ["repositoryCache"]
+      },
+      {
+        "required": ["repositoryCacheType"]
+      },
+      {
+        "required": ["repositoryCacheForceLocal"]
+      },
+      {
+        "required": ["reportType"]
+      },
+      {
+        "required": ["reportPath"]
+      },
+      {
+        "required": ["reportFormatting"]
+      },
+      {
+        "required": ["force"]
+      },
+      {
+        "required": ["forceCli"]
+      },
+      {
+        "required": ["dryRun"]
+      },
+      {
+        "required": ["binarySource"]
+      },
+      {
+        "required": ["redisUrl"]
+      },
+      {
+        "required": ["redisPrefix"]
+      },
+      {
+        "required": ["baseDir"]
+      },
+      {
+        "required": ["cacheDir"]
+      },
+      {
+        "required": ["containerbaseDir"]
+      },
+      {
+        "required": ["customEnvVariables"]
+      },
+      {
+        "required": ["dockerChildPrefix"]
+      },
+      {
+        "required": ["dockerCliOptions"]
+      },
+      {
+        "required": ["dockerSidecarImage"]
+      },
+      {
+        "required": ["dockerUser"]
+      },
+      {
+        "required": ["logContext"]
+      },
+      {
+        "required": ["onboardingRebaseCheckbox"]
+      },
+      {
+        "required": ["includeMirrors"]
+      },
+      {
+        "required": ["forkCreation"]
+      },
+      {
+        "required": ["forkToken"]
+      },
+      {
+        "required": ["forkOrg"]
+      },
+      {
+        "required": ["githubTokenWarn"]
+      },
+      {
+        "required": ["encryptedWarning"]
+      },
+      {
+        "required": ["inheritConfig"]
+      },
+      {
+        "required": ["inheritConfigRepoName"]
+      },
+      {
+        "required": ["inheritConfigFileName"]
+      },
+      {
+        "required": ["inheritConfigStrict"]
+      },
+      {
+        "required": ["optimizeForDisabled"]
+      },
+      {
+        "required": ["privateKey"]
+      },
+      {
+        "required": ["privateKeyOld"]
+      },
+      {
+        "required": ["privateKeyPath"]
+      },
+      {
+        "required": ["privateKeyPathOld"]
+      },
+      {
+        "required": ["persistRepoData"]
+      },
+      {
+        "required": ["exposeAllEnv"]
+      },
+      {
+        "required": ["allowPlugins"]
+      },
+      {
+        "required": ["allowScripts"]
+      },
+      {
+        "required": ["allowShellExecutorForPostUpgradeCommands"]
+      },
+      {
+        "required": ["allowCustomCrateRegistries"]
+      },
+      {
+        "required": ["platform"]
+      },
+      {
+        "required": ["endpoint"]
+      },
+      {
+        "required": ["token"]
+      },
+      {
+        "required": ["username"]
+      },
+      {
+        "required": ["password"]
+      },
+      {
+        "required": ["autodiscover"]
+      },
+      {
+        "required": ["autodiscoverFilter"]
+      },
+      {
+        "required": ["autodiscoverNamespaces"]
+      },
+      {
+        "required": ["autodiscoverProjects"]
+      },
+      {
+        "required": ["autodiscoverTopics"]
+      },
+      {
+        "required": ["prCommitsPerRunLimit"]
+      },
+      {
+        "required": ["repositories"]
+      },
+      {
+        "required": ["gitPrivateKey"]
+      },
+      {
+        "required": ["gitPrivateKeyPassphrase"]
+      },
+      {
+        "required": ["gitTimeout"]
+      },
+      {
+        "required": ["executionTimeout"]
+      },
+      {
+        "required": ["processEnv"]
+      },
+      {
+        "required": ["cacheHardTtlMinutes"]
+      },
+      {
+        "required": ["cacheTtlOverride"]
+      },
+      {
+        "required": ["unicodeEmoji"]
+      },
+      {
+        "required": ["ignorePrAuthor"]
+      },
+      {
+        "required": ["allowedUnsafeExecutions"]
+      },
+      {
+        "required": ["gitNoVerify"]
+      },
+      {
+        "required": ["gitUrl"]
+      },
+      {
+        "required": ["writeDiscoveredRepos"]
+      },
+      {
+        "required": ["checkedBranches"]
+      },
+      {
+        "required": ["rebaseAllOpenBranches"]
+      },
+      {
+        "required": ["httpCacheTtlDays"]
+      },
+      {
+        "required": ["prCacheSyncMaxPages"]
+      },
+      {
+        "required": ["dockerMaxPages"]
+      },
+      {
+        "required": ["deleteConfigFile"]
+      },
+      {
+        "required": ["deleteAdditionalConfigFile"]
+      },
+      {
+        "required": ["s3Endpoint"]
+      },
+      {
+        "required": ["s3PathStyle"]
+      },
+      {
+        "required": ["cachePrivatePackages"]
+      },
+      {
+        "required": ["configValidationError"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Now we've released Renovate 44, we'll store the 43.288.0 JSON schema as
an older version for folks to access.

(Note that Claude Opus 4.8 was used to automate the steps followed in similar PRs by the Renovate project, but still with a human-in-the-loop LMK if there are any issues!)

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
