### PR TITLE
feat: add Vogi schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7889,6 +7889,15 @@
       "url": "https://www.schemastore.org/vim-addon-info.json"
     },
     {
+      "name": "Vogi",
+      "description": "Repository configuration for Vogi agents",
+      "fileMatch": [".vogi.yaml"],
+      "url": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json",
+      "versions": {
+        "1": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json"
+      }
+    },
+    {
       "name": "vsls.json",
       "description": "Visual Studio Live Share configuration file",
       "fileMatch": [".vsls.json"],


### PR DESCRIPTION
Adds SchemaStore discovery for Vogi repository configuration files.

- Matches `.vogi.yaml`
- Uses Vogi's versioned, publicly hosted JSON Schema
- Keeps the schema source and release lifecycle with Vogi

Schema URL: https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json

Validation:

- `npm run prettier`
- `npm run typecheck`
- `npm run eslint`
- `node ./cli.js check`
