### PR TITLE
fix: remove overeager OTel Declarative Configuration otel* fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5631,12 +5631,7 @@
     {
       "name": "OpenTelemetry Declarative Configuration",
       "description": "OpenTelemetry declarative configuration for SDKs and instrumentation",
-      "fileMatch": [
-        "opentelemetry*.yaml",
-        "opentelemetry*.yml",
-        "otel*.yaml",
-        "otel*.yml"
-      ],
+      "fileMatch": ["opentelemetry*.yaml", "opentelemetry*.yml"],
       "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
       "versions": {
         "1.1.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",


### PR DESCRIPTION
`otel*.yaml` / `otel*.yml` match `otel-collector.yaml` — the conventional name for an OpenTelemetry **Collector** config. That is a different format from the SDK declarative configuration this schema describes, with no root `file_format` key, so those files get a spurious error-severity `Missing property "file_format"`. By code search that one filename is ~2,000 files. `#6143` has the reproduction.

## Why removal rather than a narrower glob

`otel*` was not tracking a convention. From open-telemetry/opentelemetry-configuration#468, where this entry was proposed:

> I set file match to: `opentelemetry*.yaml`, `opentelemetry*.yml`, `otel*.yaml`, `otel*.yml` … This means we should adjust our examples to follow this format.

open-telemetry/opentelemetry-configuration#488 then renamed the examples to fit, so they are downstream of the pattern rather than evidence for it. The format has no filename convention otherwise — the spec fixes only the extension.

The candidate replacement `otel-sdk*` is ~11 files across public GitHub against ~2,000, and two of those are the renamed examples. Happy to add `otel-sdk*.yaml` / `otel-sdk*.yml` if you would rather keep them matched — it carries no Collector-collision risk — but it looked like codifying a name almost nobody uses, so I would rather you called it. Losing the inference follows `#5557`; users opt back in with a `$schema` modeline or by selecting the schema manually.

## What this does not fix, and an open question

The surviving `opentelemetry*` patterns are no better than the two this removes. By code search they match roughly 1,260 files — ~566 `opentelemetry.yaml`, ~116 `.yml`, ~450 `opentelemetry-collector.yaml`, ~74 `opentelemetry-values.yaml`, ~40 `opentelemetry-config.yaml` — of which **one** contains `file_format`, the key this schema requires at its root. At least 29 are Kubernetes `kind: OpenTelemetryCollector` operator manifests; ~89 are Helm values files.

In the entry's defence, declarative configuration was only recently marked stable, so that near-zero count reflects nascent adoption rather than a wrong idea — the glob looks premature rather than misconceived.

I have kept this diff to what `#6143` proposed rather than widening it unilaterally. We could also make it `"fileMatch": []` instead — the remedy `CONTRIBUTING.md` names and `#5556` used, leaving the schema registered and manually selectable — if you would rather fix both halves at once. A specific pattern can be added later once a filename convention exists.

There is also a cheaper durable fix upstream, too: renaming the examples to `opentelemetry-*.yaml` keeps them matched by the surviving patterns, and #488 is the precedent for exactly that move.

cc @jack-berg, who added this entry in `#5436`.

Closes #6143.