### PR TITLE
fix(oxc): add jsonc config variants to oxc family

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10601,13 +10601,13 @@
     {
       "name": "oxfmt",
       "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem",
-      "fileMatch": ["**/.oxfmtrc.json"],
+      "fileMatch": ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json"
     },
     {
       "name": "oxlint",
       "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack",
-      "fileMatch": ["**/.oxlintrc.json"],
+      "fileMatch": ["**/.oxlintrc.json", "**/.oxlintrc.jsonc"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxlint/configuration_schema.json"
     },
     {


### PR DESCRIPTION
Add JSONC format file matches for oxlint and oxfmt

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
