### PR TITLE
Add skill-map schema catalog entries

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7019,6 +7019,34 @@
       "url": "https://www.schemastore.org/size-limit.json"
     },
     {
+      "name": "skill-map plugin extension manifest",
+      "description": "Declarative manifest of a skill-map plugin extension (version, description, stability, defaultEnabled), read before any code is imported",
+      "fileMatch": [
+        "**/.skill-map/plugins/*/providers/*/extension.json",
+        "**/.skill-map/plugins/*/extractors/*/extension.json",
+        "**/.skill-map/plugins/*/analyzers/*/extension.json",
+        "**/.skill-map/plugins/*/actions/*/extension.json",
+        "**/.skill-map/plugins/*/formatters/*/extension.json",
+        "**/.skill-map/plugins/*/hooks/*/extension.json"
+      ],
+      "url": "https://skill-map.ai/spec/v1/extensions/extension-manifest.schema.json"
+    },
+    {
+      "name": "skill-map project settings",
+      "description": "Per-project skill-map configuration (.skill-map/settings.json and its .local partner)",
+      "fileMatch": [
+        "**/.skill-map/settings.json",
+        "**/.skill-map/settings.local.json"
+      ],
+      "url": "https://skill-map.ai/spec/v1/project-config.schema.json"
+    },
+    {
+      "name": "skill-map provider kind",
+      "description": "Node-kind descriptor a skill-map Provider plugin declares",
+      "fileMatch": ["**/.skill-map/plugins/*/kinds/*/kind.json"],
+      "url": "https://skill-map.ai/spec/v1/extensions/provider-kind.schema.json"
+    },
+    {
       "name": "Slack app manifest",
       "description": "A manifest file containing the settings for a Slack app",
       "url": "https://www.schemastore.org/slack-app-manifest.json"


### PR DESCRIPTION
Registers three externally hosted schemas for [skill-map](https://skill-map.ai), following the self-hosted/remote/external flow in CONTRIBUTING.md (catalog entries only, the schemas are served from skill-map.ai):

- **skill-map plugin extension manifest**: the declarative manifest read before any plugin code is imported, one `extension.json` per extension under `.skill-map/plugins/*/{providers,extractors,analyzers,actions,formatters,hooks}/*`
- **skill-map project settings**: per-project configuration at `.skill-map/settings.json` and its `.local` partner
- **skill-map provider kind**: the node-kind descriptor a Provider plugin declares under `kinds/*/kind.json`

All three `fileMatch` patterns are anchored under a `.skill-map/` directory, so they cannot collide with similarly-named files from other ecosystems.

Validated locally against this repo's own tooling: `node ./cli.js check` passes (the full catalog assertion suite: schema validation, jsonlint, duplicate names, `fileMatch` conflicts) and `prettier --check src/api/json/catalog.json` is clean with the repo config.

One note in the interest of transparency: the `/spec/v1/` URLs above go live with skill-map's 1.0.0 release, which is imminent (the domain currently serves the pre-stable `/spec/v0/` path, and `/spec/v0/` will redirect to `/spec/v1/` once it ships). The version-stable path is what belongs in the catalog, so the entries point there rather than at a path that is about to become a redirect. Happy to hold this PR until the deploy lands if you prefer to verify the URLs first.
