### PR TITLE
Archival TOML configuration file schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -518,6 +518,30 @@
       "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
+      "name": "Archival editor configuration",
+      "description": "Per-object editor configuration for an archival site",
+      "fileMatch": ["archival_editor.toml"],
+      "url": "https://archival.dev/schemas/archival_editor.schema.json"
+    },
+    {
+      "name": "Archival object definitions",
+      "description": "Object definitions for an archival site",
+      "fileMatch": ["archival_objects.toml"],
+      "url": "https://archival.dev/schemas/objects.schema.json"
+    },
+    {
+      "name": "Archival site configuration",
+      "description": "Site configuration for an archival site",
+      "fileMatch": ["archival.toml"],
+      "url": "https://archival.dev/schemas/manifest.schema.json"
+    },
+    {
+      "name": "Archival template definition",
+      "description": "Metadata describing an archival site template",
+      "fileMatch": ["archival_template.toml"],
+      "url": "https://archival.dev/schemas/archival_template.schema.json"
+    },
+    {
       "name": "Argo CD",
       "description": "Argo CD base resources",
       "url": "https://raw.githubusercontent.com/argoproj/argo-schema-generator/main/schema/argo_cd_kustomize_schema.json"


### PR DESCRIPTION
Adds JSON schema definitions for [archival](https://github.com/jesseditson/archival) configuration files. Archival uses toml files to define schemas for websites and the [archival editor](https://archival.dev). Full documentation of archival, which includes coverage of these files, available at [archival.dev/docs](https://archival.dev/docs).

These schemas are validated in [CI in the archival repo](https://github.com/jesseditson/archival/actions/workflows/rust-ci.yml), so no local tests are provided. LMK if that's expected and I will add!

