### PR TITLE
feat: update Ona config schema paths

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3861,17 +3861,6 @@
       "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
     },
     {
-      "name": "Gitpod Automations",
-      "description": "Configuration for Gitpod Automations",
-      "fileMatch": [
-        "**/.gitpod/automations.json",
-        "**/.gitpod/automations.yaml",
-        "**/.gitpod/automations.yml",
-        "**/.gitpod/automation.yaml"
-      ],
-      "url": "https://app.gitpod.io/jsonschema/v1/automations_file.jsonschema.json"
-    },
-    {
       "name": "Gitpod Configuration",
       "description": "configuring Gitpod.io",
       "fileMatch": [".gitpod.yml"],
@@ -5574,15 +5563,17 @@
       "url": "https://www.schemastore.org/omnisharp.json"
     },
     {
-      "name": "Ona Automations",
-      "description": "Configuration for Ona Automations",
+      "name": "Ona Tasks and Services",
+      "description": "Tasks and services configuration for Ona environments",
       "fileMatch": [
-        "**/.ona/automations.json",
+        "**/.ona/config.yaml",
+        "**/.ona/config.yml",
         "**/.ona/automations.yaml",
         "**/.ona/automations.yml",
-        "**/.ona/automation.yaml"
+        "**/.gitpod/automations.yaml",
+        "**/.gitpod/automations.yml"
       ],
-      "url": "https://app.ona.com/jsonschema/v1/automations_file.jsonschema.json"
+      "url": "https://app.gitpod.io/jsonschema/v1/ona_config.jsonschema.json"
     },
     {
       "name": "openapi.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3857,7 +3857,7 @@
     {
       "name": "GitLab Duo Workflow",
       "description": "YAML configuration for GitLab Duo Workflows",
-      "fileMatch": [".gitlab/duo/flows/*.yaml"],
+      "fileMatch": ["**/.gitlab/duo/flows/*.yaml"],
       "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
     },
     {


### PR DESCRIPTION
SchemaStore currently recognizes only the legacy Ona and Gitpod automations filenames. As Ona adopts `.ona/config.yaml`, YAML language-server users would not receive schema validation or completion for the new canonical path, while the catalog would retain two entries for one configuration format.

This consolidates those entries under **Ona Tasks and Services**, maps the two new paths and all four supported legacy paths to Ona's canonical schema endpoint, and removes unsupported JSON and singular filename patterns. The legacy YAML paths remain matched, and Ona continues serving the legacy schema URL for direct consumers.

This PR is intentionally a draft. Ona's reader support has landed, but the supported runner and prebuild rollout gate must clear before this catalog change is marked ready. After this catalog update is deployed, [gitpod-io/gitpod-next#28807](https://github.com/gitpod-io/gitpod-next/pull/28807) will switch new writers to `.ona/config.yaml`.

Related: [LAB-975](https://linear.app/ona-team/issue/LAB-975/resolve-automations-ambiguity)

## Review focus

- The catalog contains one entry for this configuration format.
- The six filename patterns exactly match Ona's supported discovery paths.
- The external URL uses the live canonical schema route; the legacy route currently serves byte-equivalent content.

## How to test

The catalog passes formatting, type checking, linting, URL validation, and duplicate `fileMatch` validation:

```bash
npm clean-install
npm run prettier
npm run typecheck
npm run eslint
node ./cli.js check
git diff --check
```
