### PR TITLE
fix(gematik): correct insurance catalog url and hcpis schema $id

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10121,7 +10121,7 @@
         "**/testdata/insurance/insurance.yml",
         "**/testdata/insurance/insurance.yaml"
       ],
-      "url": "https://www.schemastore.org/gematik-test-hcpis.json"
+      "url": "https://www.schemastore.org/gematik-test-insurances.json"
     },
     {
       "name": "gematik tiger test environment configuration",

--- a/src/schemas/json/gematik-test-hcpis.json
+++ b/src/schemas/json/gematik-test-hcpis.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://json.schemastore.org/gematik-test-hcp1s.json",
+  "$id": "https://json.schemastore.org/gematik-test-hcpis.json",
   "title": "HCPIsRepository",
   "description": "List of all hcpis",
   "definitions": {


### PR DESCRIPTION
Two small, mechanically-forced fixes in the gematik test-data schema family.

**1. Catalog entry points at the wrong schema** (`src/api/json/catalog.json`)

The "gematik health care insurance list" entry has `url: .../gematik-test-hcpis.json`, but every other field is insurance-specific (`description`: "A list of health care insurances…", `fileMatch`: `**/testdata/insurance/insurance.yml`). The url was copied from the "institution list" entry directly above it. The correct schema `gematik-test-insurances.json` exists (title `InsurancesRepository`, top-level `insurances`) but was referenced nowhere in the catalog, while the mis-pointed `gematik-test-hcpis.json` is a structurally different schema (title `HCPIsRepository`, top-level `hcpis`, `additionalProperties: false`) — so an insurance file would validate against the wrong schema. This points the entry at `gematik-test-insurances.json`.

**2. `$id` typo in the hcpis schema** (`src/schemas/json/gematik-test-hcpis.json`)

The file name and hosting URL are `gematik-test-hcpis.json`, but its `$id` read `gematik-test-hcp1s.json` (digit `1` instead of letter `i`). The four sibling gematik schemas (`hcps`, `patients`, `insurances`, `tiger`) all have an `$id` that matches their filename.

Both changes are +1/-1; no other entries or fields are touched.

---
AI disclosure: prepared with AI assistance (Claude Code); every change was verified against the repository before submitting.
