### PR TITLE
Restore limited version of opentelemetry fileMatch

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5666,7 +5666,12 @@
     {
       "name": "OpenTelemetry Declarative Configuration",
       "description": "OpenTelemetry declarative configuration for SDKs and instrumentation",
-      "fileMatch": ["opentelemetry*.yaml", "opentelemetry*.yml", "otel-sdk*.yaml", "otel-sdk*.yml"],
+      "fileMatch": [
+        "opentelemetry*.yaml",
+        "opentelemetry*.yml",
+        "otel-sdk*.yaml",
+        "otel-sdk*.yml"
+      ],
       "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
       "versions": {
         "1.1.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5666,7 +5666,7 @@
     {
       "name": "OpenTelemetry Declarative Configuration",
       "description": "OpenTelemetry declarative configuration for SDKs and instrumentation",
-      "fileMatch": ["opentelemetry*.yaml", "opentelemetry*.yml"],
+      "fileMatch": ["opentelemetry*.yaml", "opentelemetry*.yml", "otel-sdk*.yaml", "otel-sdk*.yml"],
       "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
       "versions": {
         "1.1.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",


### PR DESCRIPTION
Followup to #6145. See https://github.com/SchemaStore/schemastore/pull/6145#issuecomment-5181520040. 