### PR TITLE
Add Open Pentest Format to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5700,6 +5700,12 @@
       }
     },
     {
+      "name": "Open Pentest Format",
+      "description": "OPF finding library or engagement export (*.opf.json): portable penetration test findings",
+      "fileMatch": ["*.opf.json"],
+      "url": "https://cairnsecurity.com/opf/schema/opf-1.1.schema.json"
+    },
+    {
       "name": "OpenSRM",
       "description": "Open Service Reliability Manifest - Define service reliability requirements as code",
       "fileMatch": [


### PR DESCRIPTION
Adds a catalog entry for the [Open Pentest Format](https://github.com/cairnsec/opf) (OPF), a small JSON format for penetration test findings and finding libraries.

The schema is externally hosted, so this is a catalog entry only and no schema file is added to this repository.

```json
{
  "name": "Open Pentest Format",
  "description": "OPF finding library or engagement export (*.opf.json): portable penetration test findings",
  "fileMatch": ["*.opf.json"],
  "url": "https://cairnsecurity.com/opf/schema/opf-1.1.schema.json"
}
```

## About the format

OPF carries findings between pentest tools without flattening them into prose. Only `title` and `severity` are required, so both scanner exports and hand-authored library templates validate. The specification, schema and worked examples are at [cairnsec/opf](https://github.com/cairnsec/opf), released under CC0 1.0, and every example there is validated against this schema in CI.

Reference converters to and from SARIF, DefectDojo, GitLab, Markdown, HTML and CSV are published as [`@cairnsec/opf-tools`](https://www.npmjs.com/package/@cairnsec/opf-tools).

## Notes on the entry

- **`fileMatch`** is `*.opf.json`. The doubled extension is specific to the format, so false positives against unrelated JSON should not be a concern.
- **The schema is JSON Schema 2020-12**, not draft-07. I saw the contributing guide's recommendation. Happy to publish a draft-07 variant and point the entry at that instead if you would prefer, since the schema uses nothing that does not translate.
- **`additionalProperties` is permitted at every level** by design, not by omission. The format requires readers to preserve keys they do not recognise so that a document survives a round trip through a tool that predates a field.

Insertion point is alphabetical, between `Open Data Product Standard (ODPS)` and `OpenSRM`.