### PR TITLE
fix: correct proxy key names and add missing fetch settings in pnpm-workspace schema

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -486,8 +486,12 @@
       "description": "A proxy to use for outgoing HTTPS requests. If the HTTPS_PROXY, https_proxy, HTTP_PROXY or http_proxy environment variables are set, their values will be used instead.",
       "type": "string"
     },
+    "httpProxy": {
+      "description": "A proxy to use for outgoing HTTP requests. If the HTTP_PROXY or http_proxy environment variables are set, proxy settings will be honored by the underlying request library.",
+      "type": "string"
+    },
     "proxy": {
-      "description": "A proxy to use for outgoing http requests. If the HTTP_PROXY or http_proxy environment variables are set, proxy settings will be honored by the underlying request library.",
+      "description": "npm's legacy proxy setting, used as the fallback for both httpsProxy and httpProxy. If the HTTP_PROXY or http_proxy environment variables are set, proxy settings will be honored by the underlying request library.",
       "type": "string"
     },
     "localAddress": {
@@ -498,7 +502,7 @@
       "description": "The maximum number of connections to use per origin (protocol/host/port combination).",
       "type": "number"
     },
-    "noproxy": {
+    "noProxy": {
       "description": "A comma-separated string of domain extensions that a proxy should not be used for.",
       "type": "string"
     },
@@ -528,6 +532,14 @@
     },
     "fetchTimeout": {
       "description": "The maximum amount of time to wait for HTTP requests to complete.",
+      "type": "number"
+    },
+    "fetchWarnTimeoutMs": {
+      "description": "A warning message is displayed if a metadata request to the registry takes longer than the specified threshold (in milliseconds). Added in pnpm v10.18.0.",
+      "type": "number"
+    },
+    "fetchMinSpeedKiBps": {
+      "description": "A warning message is displayed if the download speed of a tarball from the registry falls below the specified threshold (in KiB/s). Added in pnpm v10.18.0.",
       "type": "number"
     },
     "autoInstallPeers": {


### PR DESCRIPTION
- Rename noproxy to noProxy to match pnpm's camelCase setting name
- Add httpProxy setting (proxy is kept as npm's legacy fallback)
- Add fetchWarnTimeoutMs and fetchMinSpeedKiBps (pnpm v10.18.0)

Fixes SchemaStore/schemastore#6164
https://pnpm.io/settings/network
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
