### PR TITLE
Add gojo.yaml project manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4026,6 +4026,15 @@
       "url": "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/.schema/flag-schema.json"
     },
     {
+      "name": "gojo.yaml",
+      "description": "gojo project manifest (profiles, agents, schedules)",
+      "fileMatch": [
+        "gojo.yaml",
+        "**/.gojo/project.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/detroitpro/gojo/main/packages/contracts/schemas/gojo.project.schema.json"
+    },
+    {
       "name": "Goreleaser",
       "description": "Goreleaser configuration file",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4028,10 +4028,7 @@
     {
       "name": "gojo.yaml",
       "description": "gojo project manifest (profiles, agents, schedules)",
-      "fileMatch": [
-        "gojo.yaml",
-        "**/.gojo/project.yaml"
-      ],
+      "fileMatch": ["gojo.yaml", "**/.gojo/project.yaml"],
       "url": "https://raw.githubusercontent.com/detroitpro/gojo/main/packages/contracts/schemas/gojo.project.schema.json"
     },
     {


### PR DESCRIPTION
## Summary

Adds a Schema Store catalog entry for [gojo](https://github.com/detroitpro/gojo) project manifests (`gojo.yaml`).

- **Schema (external):** https://raw.githubusercontent.com/detroitpro/gojo/main/packages/contracts/schemas/gojo.project.schema.json
- **fileMatch:** `gojo.yaml`, `**/.gojo/project.yaml`
- Schema is generated from the project's Zod `ProjectManifestSchema` and kept in sync in the gojo repo (see [detroitpro/gojo#65](https://github.com/detroitpro/gojo/pull/65)).

## Checklist

- [x] Catalog entry only (self-hosted schema)
- [x] Non-generic fileMatch (`gojo.yaml`)
- [x] Schema URL returns JSON Schema draft-07


Made with [Cursor](https://cursor.com)