### PR TITLE
feat: add Draugr Saga fragment

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2662,6 +2662,17 @@
       "url": "https://draugr.dev/schema/draugr.saga.schema.json"
     },
     {
+      "name": "Draugr Saga fragment",
+      "description": "A partial Draugr Saga - components and exclusions, merged into the descriptor that names it",
+      "fileMatch": [
+        "*.saga-fragment.yaml",
+        "*.saga-fragment.yml",
+        ".saga-fragment.yaml",
+        ".saga-fragment.yml"
+      ],
+      "url": "https://draugr.dev/schema/draugr.saga-fragment.schema.json"
+    },
+    {
       "name": "Deno Config (deno.json)",
       "description": "A JSON representation of a Deno configuration file",
       "fileMatch": ["deno.json", "deno.jsonc"],


### PR DESCRIPTION
Adds a catalog entry for **Draugr Saga fragments**, alongside the existing `Draugr Saga` entry.

## What it is

A [Draugr](https://draugr.dev) Saga describes an application's security surface. Descriptors can now be split across files: a *fragment* carries components and exclusions and is merged into the descriptor that names it.

A fragment therefore has **no `release:`** — and the Saga schema has `"required": ["release"]`. If fragments shared the `*.saga.yaml` file type, the existing entry would match them and every valid fragment would be reported as missing a required property, in every editor that consults this catalog. So they are a distinct file type with a schema of their own.

## Checks

- **Externally hosted**, at `https://draugr.dev/schema/draugr.saga-fragment.schema.json` — the same arrangement as the existing `Draugr Saga` entry. Live and serving `application/json`.
- **Valid JSON Schema** (Draft 2020-12), verified with a validator: all `$defs` resolve, a real fragment validates, and one carrying `release:` is rejected.
- **`fileMatch` is specific, not generic.** `*.saga-fragment.yaml` / `.yml` is namespaced by `saga`, a word already registered to this project. I checked both directions against the current catalog: these patterns match no other entry's files, and no other entry's patterns match a `*.saga-fragment.yaml` — including the existing `Draugr Saga` entry, since `*.saga.yaml` requires the name to end in `.saga.yaml`.
- `node ./cli.js lint` and `prettier --check` both pass.

Placed directly after `Draugr Saga` so the two related entries read together.