### PR TITLE
feat(catalog): add GitLab Duo Workflow schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3855,6 +3855,14 @@
       "url": "https://gitlab.com/gitlab-org/gitlab-foss/-/raw/master/app/assets/javascripts/editor/schema/ci.json"
     },
     {
+      "name": "GitLab Duo Workflow",
+      "description": "YAML configuration for GitLab Duo Workflows",
+      "fileMatch": [
+        ".gitlab/duo/flows/*.yaml"
+      ],
+      "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
+    },
+    {
       "name": "Gitpod Automations",
       "description": "Configuration for Gitpod Automations",
       "fileMatch": [

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3857,9 +3857,7 @@
     {
       "name": "GitLab Duo Workflow",
       "description": "YAML configuration for GitLab Duo Workflows",
-      "fileMatch": [
-        ".gitlab/duo/flows/*.yaml"
-      ],
+      "fileMatch": [".gitlab/duo/flows/*.yaml"],
       "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
     },
     {


### PR DESCRIPTION
This pull request adds support for validating GitLab Duo Workflow YAML configuration files using a JSON schema. The main change is the inclusion of a new catalog entry for these workflow files.

Schema catalog update:

* Added a new entry for "GitLab Duo Workflow" to the `src/api/json/catalog.json` file, enabling schema validation for files matching `.gitlab/duo/flows/*.yaml` using the specified schema URL.