### PR TITLE
Add ArchSmith diagram schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10970,6 +10970,15 @@
       "description": "Configuration for preview servers in Claude Code Desktop",
       "fileMatch": ["**/.claude/launch.json"],
       "url": "https://www.schemastore.org/claude-code-launch.json"
+    },
+    {
+      "name": "ArchSmith diagram IR",
+      "description": "Intermediate representation consumed by ArchSmith to validate and render architecture diagrams",
+      "fileMatch": ["*.archsmith.json"],
+      "url": "https://ayeshlk.github.io/archsmith/schema/latest/diagram-schema.json",
+      "versions": {
+        "0.3.0": "https://ayeshlk.github.io/archsmith/schema/0.3.0/diagram-schema.json"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- register the externally hosted ArchSmith diagram IR schema
- associate it with the canonical `*.archsmith.json` filename pattern
- expose the immutable `0.3.0` schema alongside the floating latest URL

ArchSmith validates a JSON intermediate representation and deterministically renders it as an architecture diagram. The schema is hosted on GitHub Pages and the versioned URL is immutable.

Tracking issue: https://github.com/ayeshLK/archsmith/issues/13

## Validation

- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/api/json/catalog.json`
- `npm run typecheck`
- `node ./cli.js check-remote`
- `node ./cli.js check`