### PR TITLE
feat: add crucible schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2531,6 +2531,15 @@
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/scenario_schema.yaml"
     },
     {
+      "name": "crucible",
+      "description": "Settings for the crucible coding agent",
+      "fileMatch": [
+        "**/.crucible/config.json",
+        "**/.crucible/config.local.json"
+      ],
+      "url": "https://www.schemastore.org/crucible-code-schema.json"
+    },
+    {
       "name": "cypress.json",
       "description": "Cypress.io test runner configuration file",
       "fileMatch": ["cypress.json"],

--- a/src/negative_test/crucible-code-schema/not-a-choice.json
+++ b/src/negative_test/crucible-code-schema/not-a-choice.json
@@ -1,0 +1,3 @@
+{
+  "output": { "color": "beige" }
+}

--- a/src/negative_test/crucible-code-schema/not-a-mode.json
+++ b/src/negative_test/crucible-code-schema/not-a-mode.json
@@ -1,0 +1,3 @@
+{
+  "permissions": { "mode": "everything" }
+}

--- a/src/negative_test/crucible-code-schema/unknown-key.json
+++ b/src/negative_test/crucible-code-schema/unknown-key.json
@@ -1,0 +1,3 @@
+{
+  "output": { "colour": "never" }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/crucible-code-schema.json",
+  "additionalProperties": false,
+  "description": "Settings for the crucible coding agent. Formats are unstable while the version is 0.0.x: any key here may be renamed or removed in any release, with no deprecation period.",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "$comment": {
+      "type": "string"
+    },
+    "env": {
+      "additionalProperties": false,
+      "description": "Environment variables for the commands crucible runs. A checked-in file may set only crucible's own CRUCIBLE_CODE_ names",
+      "patternProperties": {
+        "^[^$]": {
+          "type": "string"
+        }
+      },
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "output": {
+      "additionalProperties": false,
+      "description": "What the terminal shows",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "color": {
+          "description": "Whether to dim the prompt: auto follows the terminal and NO_COLOR, always and never override it",
+          "enum": ["auto", "always", "never"],
+          "type": "string"
+        },
+        "toolDetail": {
+          "description": "How much of a tool call and its result one line shows",
+          "enum": ["compact", "full"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "providers": {
+      "additionalProperties": false,
+      "description": "Per-provider defaults, keyed by provider name",
+      "patternProperties": {
+        "^[^$]": {
+          "additionalProperties": false,
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "apiKeyEnv": {
+              "description": "Name of the environment variable holding this provider's API key — the name, never the key",
+              "type": "string"
+            },
+            "model": {
+              "description": "The model to ask when --model does not name one",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "title": "crucible configuration",
+  "type": "object"
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -51,6 +51,60 @@
       },
       "type": "object"
     },
+    "permissions": {
+      "additionalProperties": false,
+      "description": "What runs without being put to you, what is refused outright, and where tools may reach",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "allow": {
+          "description": "Rules for calls that run without being put to you",
+          "items": {
+            "examples": ["read(src/**)", "bash(cargo test)"],
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "ask": {
+          "description": "Rules for calls that are always put to you, whatever the mode says",
+          "items": {
+            "examples": ["edit(Cargo.lock)", "bash(git push)"],
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "deny": {
+          "description": "Rules for calls that are refused in every mode, beating any allow written beside them",
+          "items": {
+            "examples": ["read(.env)", "edit(.git/**)"],
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "extraDirectories": {
+          "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, so this belongs in .crucible/config.local.json",
+          "items": {
+            "examples": ["/home/you/src/shared-library"],
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "mode": {
+          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything",
+          "enum": ["ask", "allowEdits", "fullAccess"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "providers": {
       "additionalProperties": false,
       "description": "Per-provider defaults, keyed by provider name",

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -1,0 +1,13 @@
+{
+  "$comment": "every block, so the positive test exercises all of them",
+  "$schema": "https://www.schemastore.org/crucible-code-schema.json",
+  "env": { "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12", "RUST_LOG": "warn" },
+  "output": { "color": "auto", "toolDetail": "compact" },
+  "providers": {
+    "anthropic": {
+      "apiKeyEnv": "WORK_ANTHROPIC_KEY",
+      "model": "claude-opus-5"
+    },
+    "openai": { "model": "gpt-5.2" }
+  }
+}

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -3,6 +3,13 @@
   "$schema": "https://www.schemastore.org/crucible-code-schema.json",
   "env": { "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12", "RUST_LOG": "warn" },
   "output": { "color": "auto", "toolDetail": "compact" },
+  "permissions": {
+    "allow": ["read(src/**)", "bash(cargo test)"],
+    "ask": ["bash(git push)"],
+    "deny": ["read(.env)", "edit(.git/**)"],
+    "extraDirectories": ["/home/you/src/shared-library"],
+    "mode": "allowEdits"
+  },
   "providers": {
     "anthropic": {
       "apiKeyEnv": "WORK_ANTHROPIC_KEY",


### PR DESCRIPTION
Adds a schema for [crucible](https://github.com/augments-labs/crucible-code), a terminal coding agent. It reads `.crucible/config.json` (checked in) and `.crucible/config.local.json` (git-ignored) from a project, plus one in the user's home directory.

The schema is not hand-written. crucible's parser declares the document once, and both the parser and this file are derived from that declaration, with a test in that repository that regenerates the schema and fails if the checked-in copy has drifted. So a key an editor completes is a key the program accepts, by construction rather than by review.

Included:

- `src/schemas/json/crucible-code-schema.json`
- `src/test/crucible-code-schema/config.json` — exercises every block
- `src/negative_test/crucible-code-schema/unknown-key.json` — a misspelled key
- `src/negative_test/crucible-code-schema/not-a-choice.json` — a value outside an `enum`

`node ./cli.js check --schema-name=crucible-code-schema.json` passes, and the files are formatted with the repository's prettier config. draft-07, and the `$id` is `https://www.schemastore.org/crucible-code-schema.json`, per CONTRIBUTING.md.

The `fileMatch` patterns are `**/.crucible/config.json` and `**/.crucible/config.local.json` — both scoped to crucible's own directory, so neither can match another project's file.

One thing worth flagging: crucible is at `0.0.x` and says in its own documentation that config keys may be renamed or removed in any release with no deprecation period. The schema's `description` says so too, so an editor shows it. I will open a follow-up PR whenever the shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
