### PR TITLE
Add glslint config schema (glslint.toml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,6 +3,12 @@
   "version": 1,
   "schemas": [
     {
+      "name": "glslint config",
+      "description": "glslint project config and shader-dialect preset (glslint.toml): ecosystem detection, #pragma expansion, shared-library and injected-define declarations",
+      "fileMatch": ["glslint.toml"],
+      "url": "https://raw.githubusercontent.com/johncarmack1984/glslint/main/schema/glslint.schema.json"
+    },
+    {
       "name": "Mermaid config",
       "description": "Configuration for Mermaid diagrams and charts",
       "fileMatch": ["mermaid.config.json", ".mermaidrc.json", "mermaidrc.json"],


### PR DESCRIPTION
Adds a catalog entry for [`glslint`](https://github.com/johncarmack1984/glslint)'s project config file, `glslint.toml`.

glslint is a GLSL checker and language server for WebGL shader toolkits (luma.gl/deck.gl, maplibre, ShaderToy), published on [crates.io](https://crates.io/crates/glslint), [npm (`@glslint/cli`)](https://www.npmjs.com/package/@glslint/cli), and the VS Code marketplace. `glslint.toml` defines a project's shader-dialect preset — ecosystem detection, `#pragma` expansion rules, shared-library files, and injected-`#define` declarations. The same schema is used by glslint's bundled presets.

- **Schema**: `draft-07`, `additionalProperties: false`, hosted in the glslint repo (used by the tool itself, so it stays in sync).
- **fileMatch**: `glslint.toml` (specific, non-generic).
- **url**: https://raw.githubusercontent.com/johncarmack1984/glslint/main/schema/glslint.schema.json (HTTP 200).

Schema source: https://github.com/johncarmack1984/glslint/blob/main/schema/glslint.schema.json