### PR TITLE
Rename repo-settings-as-code catalog entry to github-settings-as-code

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -6590,10 +6590,10 @@
       "url": "https://www.schemastore.org/replit.json"
     },
     {
-      "name": "repo-settings-as-code",
-      "description": "Declarative GitHub repository settings applied by the repo-settings-as-code action; accepts Probot Settings app files as-is. Documentation: https://github.com/Vivswan/repo-settings-as-code",
+      "name": "github-settings-as-code",
+      "description": "Declarative GitHub repository settings applied by the github-settings-as-code action; accepts Probot Settings app files as-is. Documentation: https://github.com/Vivswan/github-settings-as-code",
       "fileMatch": ["**/.github/settings.yml"],
-      "url": "https://raw.githubusercontent.com/Vivswan/repo-settings-as-code/main/lib/settings.schema.json"
+      "url": "https://raw.githubusercontent.com/Vivswan/github-settings-as-code/main/lib/settings.schema.json"
     },
     {
       "name": "reposets Configuration",


### PR DESCRIPTION
Follow-up to #6077: the action repository was renamed from `Vivswan/repo-settings-as-code` to `Vivswan/github-settings-as-code` (the project's scope outgrew per-repository settings), so the catalog entry's name, schema URL, and documentation link move with it.

- The new raw URL serves the same schema and is verified live: https://raw.githubusercontent.com/Vivswan/github-settings-as-code/main/lib/settings.schema.json
- The old URL keeps redirecting for existing users, so this is a canonical-reference update, not a breakage fix.
- `fileMatch` is unchanged (`**/.github/settings.yml`).