### PR TITLE
Add openREA economic-activity document schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11005,7 +11005,7 @@
     },
     {
       "name": "openREA",
-      "description": "openREA economic-activity document (agent-native, evidence-linked accounting schema)",
+      "description": "openREA economic-activity document (agent-native, evidence-linked accounting records)",
       "fileMatch": ["*.openrea.json"],
       "url": "https://raw.githubusercontent.com/openrea/openrea/main/schema/openrea.schema.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11002,6 +11002,12 @@
       "versions": {
         "0.3.0": "https://ayeshlk.github.io/archsmith/schema/0.3.0/diagram-schema.json"
       }
+    },
+    {
+      "name": "openREA",
+      "description": "openREA economic-activity document (agent-native, evidence-linked accounting schema)",
+      "fileMatch": ["*.openrea.json"],
+      "url": "https://raw.githubusercontent.com/openrea/openrea/main/schema/openrea.schema.json"
     }
   ]
 }


### PR DESCRIPTION
Adds a catalog entry for **openREA** — an open (Apache-2.0) schema for representing economic activity: events, commitments, agreements, evidence, assertions, and policies as JSON records, with accounting views derived from the record. REA lineage (McCarthy 1982; Geerts & McCarthy 2000–2006).

- **Schema (externally hosted, stable):** https://raw.githubusercontent.com/openrea/openrea/main/schema/openrea.schema.json
- **Spec + conformance suite:** https://github.com/openrea/openrea — JSON Schema draft 2020-12; the repo's conformance suite exercises the schema against valid and must-fail fixtures on every change
- **fileMatch:** `*.openrea.json` — the suffix convention is normative in the spec (SPEC §3.1)
- Entry appended at the end of the catalog per recent-addition practice

Maintained by the openREA project; happy to adjust the entry to house conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)