### PR TITLE
feat: support `utoo` as a package manager in `package.json` schema

### DIFF
--- a/src/schemas/json/package.json
+++ b/src/schemas/json/package.json
@@ -825,7 +825,7 @@
       "type": "string",
       "oneOf": [
         {
-          "pattern": "(npm|pnpm|yarn|bun|aube|nub)@\\d+\\.\\d+\\.\\d+(-.+)?"
+          "pattern": "(npm|pnpm|yarn|bun|aube|nub|utoo)@\\d+\\.\\d+\\.\\d+(-.+)?"
         },
         {
           "const": "bun"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR updates the `package.json` schema to support [utoo](https://utoo.land/) as a valid package manager.

Reference: https://utoo.land/en/docs/utoo
