### PR TITLE
Update crucible-code-schema.json for crucible 0.0.8

### DIFF
--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -39,8 +39,13 @@
           "type": "string"
         },
         "color": {
-          "description": "Whether to dim the prompt: auto follows the terminal and NO_COLOR, always and never override it",
+          "description": "Whether to write colour: auto follows the terminal and NO_COLOR, always and never override it",
           "enum": ["auto", "always", "never"],
+          "type": "string"
+        },
+        "glyphs": {
+          "description": "Which characters crucible draws with: unicode for box drawing, ascii for a font that lacks it",
+          "enum": ["unicode", "ascii"],
           "type": "string"
         },
         "toolDetail": {
@@ -91,7 +96,10 @@
         "extraDirectories": {
           "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, so this belongs in .crucible/config.local.json",
           "items": {
-            "examples": ["/home/you/src/shared-library"],
+            "examples": [
+              "/home/you/src/shared-library",
+              "C:\\Users\\you\\src\\shared-library"
+            ],
             "type": "string"
           },
           "type": "array",

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -2,7 +2,7 @@
   "$comment": "every block, so the positive test exercises all of them",
   "$schema": "https://www.schemastore.org/crucible-code-schema.json",
   "env": { "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12", "RUST_LOG": "warn" },
-  "output": { "color": "auto", "toolDetail": "compact" },
+  "output": { "color": "auto", "glyphs": "unicode", "toolDetail": "compact" },
   "permissions": {
     "allow": ["read(src/**)", "bash(cargo test)"],
     "ask": ["bash(git push)"],


### PR DESCRIPTION
[crucible 0.0.8](https://github.com/augments-labs/crucible-code/releases/tag/v0.0.8) is out, and the served copy of its schema is now a release behind. Three changes:

- **`output.glyphs`** is new — `unicode` (the default) or `ascii`, for a terminal whose font has no box drawing.
- **`output.color`**'s description said "whether to dim the prompt"; it governs everything crucible draws, not just the prompt.
- **`permissions.extraDirectories`** gains a Windows example beside the POSIX one, since the key takes an absolute path and crucible ships for Windows.

The schema is generated from the configuration parser in the crucible tree and a gate keeps the checked-in copy honest, so this is a copy rather than a hand edit. `prettier` with your config and `node ./cli.js check --schema-name=crucible-code-schema.json` both ran clean over it.

`src/test/crucible-code-schema/config.json` gains `glyphs` — its `$comment` promises it exercises every block, and a new key in an existing block would otherwise go untested. The negative tests are unchanged: nothing they assert about changed shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)