### PR TITLE
update: Tombi schema

### DIFF
--- a/src/schemas/json/tombi.json
+++ b/src/schemas/json/tombi.json
@@ -204,6 +204,19 @@
           ],
           "default": 1
         },
+        "comment-style": {
+          "title": "The style used to format comments",
+          "description": "- `normalize`: Normalize comment text according to Tombi's formatting rules.\n- `preserve`: Preserve the original comment text while formatting its placement normally.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CommentStyle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "normalize"
+        },
         "date-time-delimiter": {
           "title": "The delimiter between date and time",
           "description": "In accordance with [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339), you can use `T` or space character between date and time.\n\n- `T`: Use `T` between date and time like `2001-01-01T00:00:00`\n- `space`: Use space between date and time like `2001-01-01 00:00:00`\n- `preserve`: Preserve the original delimiter.",
@@ -360,7 +373,7 @@
         },
         "line-width": {
           "title": "The maximum line width",
-          "description": "The formatter will try to keep lines within this width.",
+          "description": "The formatter will try to keep lines within this width when specified.\nIf omitted, there is no line-width limit.",
           "anyOf": [
             {
               "$ref": "#/definitions/LineWidth"
@@ -368,8 +381,7 @@
             {
               "type": "null"
             }
-          ],
-          "default": 80
+          ]
         },
         "table-blank-lines": {
           "title": "The number of blank lines between tables.",
@@ -412,6 +424,21 @@
       "format": "uint8",
       "minimum": 0,
       "maximum": 255
+    },
+    "CommentStyle": {
+      "description": "The style used to format comments.",
+      "oneOf": [
+        {
+          "description": "Normalize comment text according to Tombi's formatting rules.",
+          "type": "string",
+          "const": "normalize"
+        },
+        {
+          "description": "Preserve the original comment text while formatting its placement normally.",
+          "type": "string",
+          "const": "preserve"
+        }
+      ]
     },
     "DateTimeDelimiter": {
       "description": "DateTime delimiter",
@@ -1005,6 +1032,18 @@
             "$ref": "#/definitions/GlobPattern"
           }
         },
+        "strict": {
+          "title": "Enable strict schema validation",
+          "description": "If `additionalProperties` is not specified in the JSON Schema,\nthe strict mode treats it as `additionalProperties: false`,\nwhich is different from the JSON Schema specification.\nIf omitted, the global `schema.strict` setting is used.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "format": {
           "title": "Schema-specific format options",
           "anyOf": [
@@ -1357,6 +1396,18 @@
           "items": {
             "$ref": "#/definitions/GlobPattern"
           }
+        },
+        "strict": {
+          "title": "Enable strict schema validation",
+          "description": "If `additionalProperties` is not specified in the JSON Schema,\nthe strict mode treats it as `additionalProperties: false`,\nwhich is different from the JSON Schema specification.\nThis setting takes precedence over the matching root schema setting.\nIf omitted, the matching root schema or global `schema.strict` setting is used.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoolDefaultTrue"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "format": {
           "title": "Schema-specific format options",


### PR DESCRIPTION
## Summary

- update the Tombi configuration schema from the official v1.3.3 generated schema
- add `comment-style` and per-schema/per-override `strict` options
- reflect the new optional `line-width` behavior
- preserve SchemaStore's public schema `$id`

## Impact

Editors and validators using SchemaStore can recognize the latest Tombi configuration options and defaults.

## Validation

- `node ./cli.js check --schema-name=tombi.json`
- `prettier --check src/schemas/json/tombi.json`
- `git diff --check`
- semantic comparison with `tombi-toml/tombi` v1.3.3, allowing only SchemaStore's normalized `$id`
