### PR TITLE
feat(helmfile): sync schema with upstream helmfile config

### DIFF
--- a/src/schemas/json/helmfile.json
+++ b/src/schemas/json/helmfile.json
@@ -2,526 +2,262 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/helmfile.json",
   "definitions": {
-    "repository": {
-      "type": "object",
-      "required": ["name"],
+    "dependency": {
       "properties": {
-        "name": {
+        "alias": {
           "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "certFile": {
-          "type": "string"
-        },
-        "keyFile": {
-          "type": "string"
-        },
-        "caFile": {
-          "type": "string"
-        },
-        "username": {
-          "type": "string"
-        },
-        "password": {
-          "type": "string"
-        },
-        "oci": {
-          "type": "boolean"
-        },
-        "passCredentials": {
-          "type": "boolean"
-        }
-      }
-    },
-    "helmDefaults": {
-      "type": "object",
-      "description": "Default values to set for args along with dedicated keys that can be set by contributors, cli args take precedence over these.",
-      "properties": {
-        "kubeContext": {
-          "type": "string",
-          "description": "Dedicated default key for kube-context (--kube-context)."
-        },
-        "cleanupOnFail": {
-          "type": "boolean",
-          "description": "When true, cleans up any new resources created during a failed release.",
-          "default": false
-        },
-        "args": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "verify": {
-          "type": "boolean",
-          "description": "Verify the chart before upgrading (only works with packaged charts not directories).",
-          "default": false
-        },
-        "wait": {
-          "type": "boolean",
-          "description": "Wait for k8s resources via --wait.",
-          "default": false
-        },
-        "waitForJobs": {
-          "type": "boolean",
-          "description": "If true and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout",
-          "default": false
-        },
-        "timeout": {
-          "type": "number",
-          "description": "Time in seconds to wait for any individual Kubernetes operation (like Jobs for hooks, and waits on pod/pvc/svc/deployment readiness)",
-          "default": 300
-        },
-        "recreatePods": {
-          "type": "boolean",
-          "description": "Performs pods restart for the resource if applicable.",
-          "default": false
-        },
-        "force": {
-          "type": "boolean",
-          "description": "Forces resource update through delete/recreate if needed.",
-          "default": false
-        },
-        "historyMax": {
-          "type": "number",
-          "description": "Limit the maximum number of revisions saved per release. Use 0 for no limit.",
-          "default": 10
-        },
-        "createNamespace": {
-          "type": "boolean",
-          "description": "When using helm 3.2+, automatically create release namespaces if they do not exist.",
-          "default": true
-        },
-        "devel": {
-          "type": "boolean",
-          "description": "If used with charts museum allows to pull unstable charts for deployment, for example: if 1.2.3 and 1.2.4-dev versions exist and set to true, 1.2.4-dev will be pulled (default false)",
-          "default": false
-        },
-        "reuseValues": {
-          "type": "boolean",
-          "description": "If set to true, reuses the last release's values and merges them with ones provided in helmfile.",
-          "default": false
-        },
-        "skipDeps": {
-          "description": "When set to `true`, skips running `helm dep up` and `helm dep build` on this release's chart.",
-          "type": "boolean",
-          "default": false
-        },
-        "cascade": {
-          "type": "string",
-          "description": "Cascade `--cascade` to helmv3 delete, available values: background, foreground, or orphan.",
-          "default": "background",
-          "enum": ["background", "foreground", "orphan"]
-        },
-        "postRenderer": {
-          "type": "string",
-          "description": "Propagate `--post-renderer` to helmv3 template and helm install.",
-          "examples": ["path/to/postRenderer"]
-        },
-        "insecureSkipTLSVerify": {
-          "type": "boolean",
-          "description": "Is true if the TLS verification should be skipped when fetching remote chart.",
-          "default": false
-        }
-      }
-    },
-    "release": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the release."
-        },
-        "namespace": {
-          "type": "string",
-          "description": "The namespace to install the release into."
         },
         "chart": {
-          "description": "The chart name to be installed. The chart name can be either: 1) a chart reference: https://helm.sh/docs/topics/charts/#chart-references, 2) a path to a directory containing a chart, 3) a path to a packaged chart, or 4) a URL.",
           "type": "string"
         },
-        "atomic": {
-          "type": "boolean",
-          "description": "Restores previous state in case of failed release.",
-          "default": false
-        },
-        "cleanupOnFail": {
-          "type": "boolean",
-          "description": "When true, cleans up any new resources created during a failed release.",
-          "default": false
-        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["chart"],
+      "type": "object"
+    },
+    "environment": {
+      "properties": {
         "kubeContext": {
-          "type": "string",
-          "description": "--kube-context to be passed to helm commands.\nDefaults tp an empty string, which means the standard kubeconfig, either ~/kubeconfig or the file pointed by $KUBECONFIG environment variable)",
-          "default": ""
+          "type": "string"
         },
-        "condition": {
-          "type": "string",
-          "description": "Wen set, helmfile will only attempt to install the release if the condition is true"
-        },
-        "createNamespace": {
-          "type": "boolean",
-          "description": "When using helm 3.2+, automatically create release namespaces if they do not exist.",
-          "default": true
-        },
-        "devel": {
-          "type": "boolean",
-          "description": "If used with charts museum allows to pull unstable charts for deployment, for example: if 1.2.3 and 1.2.4-dev versions exist and set to true, 1.2.4-dev will be pulled.",
-          "default": false
-        },
-        "disableValidation": {
-          "description": "Disables validation of the rendered templates before releasing.",
-          "type": "boolean",
-          "default": false
-        },
-        "disableValidationOnInstall": {
-          "type": "boolean",
-          "description": "Passes --disable-validation to helm 3 diff plugin, this requires diff plugin >= 3.1.2",
-          "default": false
-        },
-        "disableOpenAPIValidation": {
-          "type": "boolean",
-          "description": "Passes --disable-openapi-validation to helm 3 diff plugin, this requires diff plugin >= 3.1.2",
-          "default": false
-        },
-        "historyMax": {
-          "type": "number",
-          "description": "Limit the maximum number of revisions saved per release. Use 0 for no limit.",
-          "default": 10
-        },
-        "skipDeps": {
-          "description": "When set to `true`, skips running `helm dep up` and `helm dep build` on this release's chart.",
-          "type": "boolean",
-          "default": false
-        },
-        "cascade": {
-          "type": "string",
-          "description": "Cascade `--cascade` to helmv3 delete, available values: background, foreground, or orphan",
-          "default": "background",
-          "enum": ["background", "foreground", "orphan"]
-        },
-        "postRenderer": {
-          "type": "string",
-          "description": "Propagate `--post-renderer` to helmv3 template and helm install.",
-          "examples": ["path/to/postRenderer"]
-        },
-        "insecureSkipTLSVerify": {
-          "type": "boolean",
-          "description": "Is true if the TLS verification should be skipped when fetching remote chart",
-          "default": false
-        },
-        "hooks": {
-          "description": "Hooks allow to trigger actions at certain points in helm's lifecycle.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/hook"
-          }
-        },
-        "installed": {
-          "description": "Set `false` to uninstall this release on sync.",
-          "default": true,
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ]
-        },
-        "labels": {
-          "$ref": "#/definitions/map"
+        "mergeStrategy": {
+          "description": "MergeStrategy controls precedence when multiple values files are listed under `values`.\n\n\"override\" (default): later files override earlier files (the historical helmfile behavior).\n\"fallback\":           earlier files take precedence; later files only fill gaps.\n\nUnder the \"fallback\" strategy, an explicit non-nil value in an earlier file (including\nthe zero values false, 0, \"\", and empty list) is preserved against any later file. Maps\nare deep-merged, so an earlier map does not block later files from adding nested keys.\nAn explicit null in an earlier file falls through to a later file's value (matching how\nhelmfile's MergeMaps treats nil from the override side elsewhere). Subsequent .gotmpl\nvalues files can also reference values from earlier files via .Values.",
+          "type": "string"
         },
         "missingFileHandler": {
-          "$ref": "#/definitions/missingFileHandler",
+          "description": "MissingFileHandler instructs helmfile to fail when unable to find a environment values file listed\nunder `environments.NAME.values`.\n\nPossible values are  \"Error\", \"Warn\", \"Info\", \"Debug\". The default is \"Error\".\n\nUse \"Warn\", \"Info\", or \"Debug\" if you want helmfile to not fail when a values file is missing, while just leaving\na message about the missing file at the log-level.",
+          "enum": ["Error", "Warn", "Info", "Debug"],
           "type": "string"
         },
+        "missingFileHandlerConfig": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/missingFileHandlerConfig"
+            }
+          ],
+          "description": "MissingFileHandlerConfig is composed of various settings for the MissingFileHandler"
+        },
         "secrets": {
-          "type": "array",
-          "description": "Will attempt to decrypt it using helm-secrets plugin",
           "items": {
             "type": "string"
-          }
-        },
-        "inherit": {
-          "type": "array",
-          "description": "Inherit from one or more release templates",
-          "items": {
-            "type": "object",
-            "properties": {
-              "template": {
-                "type": "string"
-              },
-              "except": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["template"]
-          }
-        },
-        "set": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "file": {
-                    "type": "string"
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "values": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        }
-                      ]
-                    }
-                  }
-                }
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "timeout": {
-          "type": "number",
-          "description": "Time in seconds to wait for any individual Kubernetes operation (like Jobs for hooks, and waits on pod/pvc/svc/deployment readiness)",
-          "default": 300
-        },
-        "recreatePods": {
-          "type": "boolean",
-          "description": "Performs pods restart for the resource if applicable",
-          "default": false
-        },
-        "force": {
-          "type": "boolean",
-          "description": "Forces resource update through delete/recreate if needed.",
-          "default": false
+          },
+          "type": "array"
         },
         "values": {
-          "type": "array",
           "items": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
-                "$ref": "#/definitions/map"
+                "type": "object"
               }
             ]
-          }
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "helmDefaults": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "atomic": {
+          "description": "Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt",
+          "type": "boolean"
+        },
+        "cascade": {
+          "description": "Cascade '--cascade' to helmv3 delete, available values: background, foreground, or orphan, default: background",
+          "enum": ["background", "foreground", "orphan"],
+          "type": "string"
+        },
+        "cleanupOnFail": {
+          "description": "CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command",
+          "type": "boolean"
+        },
+        "createNamespace": {
+          "description": "CreateNamespace, when set to true (default), --create-namespace is passed to helm on install/upgrade",
+          "type": "boolean"
+        },
+        "deleteTimeout": {
+          "description": "Timeout is the time in seconds to wait for helmfile delete command (default 300)",
+          "type": "integer"
+        },
+        "deleteWait": {
+          "description": "Wait, if set to true, will wait until all resources are deleted before mark delete command as successful",
+          "type": "boolean"
+        },
+        "devel": {
+          "description": "Devel, when set to true, use development versions, too. Equivalent to version '\u003e0.0.0-0'",
+          "type": "boolean"
+        },
+        "diffArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "disableAutoDetectedKubeVersionForDiff": {
+          "description": "DisableAutoDetectedKubeVersionForDiff controls whether auto-detected kubeVersion should be passed\nto helm diff. When false (default), auto-detected kubeVersion is passed to fix issue #2275.\nSet to true to only pass explicit kubeVersion from helmfile.yaml, preventing helm-diff from\nnormalizing server-side defaults which could hide real changes (e.g., ipFamilyPolicy, ipFamilies).",
+          "type": "boolean"
+        },
+        "disableOpenAPIValidation": {
+          "type": "boolean"
+        },
+        "disableValidation": {
+          "type": "boolean"
+        },
+        "enableDNS": {
+          "description": "EnableDNS, when set to true, enable DNS lookups when rendering templates",
+          "type": "boolean"
+        },
+        "force": {
+          "description": "Force, when set to true, forces resource update through delete/recreate if needed",
+          "type": "boolean"
+        },
+        "forceConflicts": {
+          "description": "ForceConflicts, when set to true, force server-side apply changes against conflicts (Helm 4 only)",
+          "type": "boolean"
+        },
+        "helmStuckGrace": {
+          "description": "HelmStuckGrace, when \u003e 0, enables the helmfile-side safety-valve\nhelm-killer for releases using --track-mode kubedog. See\nReleaseSpec.HelmStuckGrace for semantics.",
+          "type": "integer"
+        },
+        "historyMax": {
+          "description": "HistoryMax, limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)",
+          "type": "integer"
+        },
+        "insecureSkipTLSVerify": {
+          "description": "InsecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart",
+          "type": "boolean"
+        },
+        "keyring": {
+          "type": "string"
+        },
+        "kubeContext": {
+          "type": "string"
+        },
+        "plainHttp": {
+          "description": "PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS",
+          "type": "boolean"
+        },
+        "postRenderer": {
+          "description": "Propagate '--post-renderer' to helmv3 template and helm install",
+          "type": "string"
+        },
+        "postRendererArgs": {
+          "description": "Propagate '--post-renderer-args' to helmv3 template and helm install",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "recreatePods": {
+          "description": "RecreatePods, when set to true, instruct helmfile to perform pods restart for the resource if applicable",
+          "type": "boolean"
+        },
+        "reuseValues": {
+          "description": "on helm upgrade/diff, reuse values currently set in the release and merge them with the ones defined within helmfile",
+          "type": "boolean"
+        },
+        "rollbackOnFailure": {
+          "description": "RollbackOnFailure, when set to true, restores previous state on a failed install/upgrade via the\nHelm 4 --rollback-on-failure flag (the successor to the deprecated --atomic flag). Requires Helm 4 or greater.",
+          "type": "boolean"
+        },
+        "serverSide": {
+          "description": "ServerSide controls the helm 4 --server-side flag for upgrade. Must be \"true\", \"false\", or \"auto\".",
+          "type": "string"
+        },
+        "skipCRDs": {
+          "description": "SkipCRDs passes the --skip-crds flag to helm upgrade --install to ensure any CRDs contained in the crds/\nsubdirectory of a helm chart are not automatically applied with every helmfile sync or apply",
+          "type": "boolean"
+        },
+        "skipDeps": {
+          "description": "SkipDeps disables running `helm dependency up` and `helm dependency build` on this release's chart.\nThis is relevant only when your release uses a local chart or a directory containing K8s manifests or a Kustomization\nas a Helm chart.",
+          "type": "boolean"
+        },
+        "skipRefresh": {
+          "description": "SkipRefresh disables running `helm dependency up`",
+          "type": "boolean"
+        },
+        "skipSchemaValidation": {
+          "description": "Propagate '--skip-schema-validation' to helmv3 template and helm install",
+          "type": "boolean"
+        },
+        "suppressOutputLineRegex": {
+          "description": "SuppressOutputLineRegex is a list of regexes to suppress output lines",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "syncArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "syncReleaseLabels": {
+          "description": "SyncReleaseLabels is true if the release labels should be synced with the helmfile labels",
+          "type": "boolean"
+        },
+        "takeOwnership": {
+          "description": "TakeOwnership is true if the helmfile should take ownership of the release",
+          "type": "boolean"
+        },
+        "templateArgs": {
+          "description": "TemplateArgs are extra args appended to the helm template / helm diff rendering\n(e.g. \"--dry-run=server\" to enable the helm lookup function). Overridden by the\n--template-args CLI flag on a per-invocation basis.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timeout": {
+          "description": "Timeout is the time in seconds to wait for any individual Kubernetes operation (like Jobs for hooks, and waits on pod/pvc/svc/deployment readiness) (default 300)",
+          "type": "integer"
+        },
+        "trackMode": {
+          "description": "TrackMode specifies whether to use 'helm' or 'kubedog' for tracking resources",
+          "type": "string"
         },
         "verify": {
           "type": "boolean"
         },
-        "version": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "number"
-            },
-            {
-              "type": "integer"
-            }
-          ]
-        },
         "wait": {
-          "type": "boolean",
-          "description": "Wait for k8s resources via --wait.",
-          "default": false
+          "description": "Wait, if set to true, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful",
+          "type": "boolean"
         },
         "waitForJobs": {
-          "type": "boolean",
-          "description": "If set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout.",
-          "default": false
+          "description": "WaitForJobs, if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout",
+          "type": "boolean"
         },
-        "needs": {
-          "type": "array",
-          "description": "Define dependencies between releases. This release will only be installed after all releases in the needs list are installed.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "dependencies": {
-          "type": "array",
-          "description": "Add chart dependencies without forking. Can be local paths or OCI charts.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "chart": {
-                "type": "string"
-              },
-              "version": {
-                "type": "string"
-              },
-              "alias": {
-                "type": "string"
-              }
-            },
-            "required": ["chart"]
-          }
-        },
-        "strategicMergePatches": {
-          "type": "array",
-          "description": "Apply strategic merge patches to Kubernetes resources using Kustomize.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "transformers": {
-          "type": "array",
-          "description": "Apply Kustomize transformers to add labels, annotations, etc.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "jsonPatches": {
-          "type": "array",
-          "description": "Apply JSON patches to Kubernetes resources.",
-          "items": {
-            "type": "object"
-          }
-        },
-        "adopt": {
-          "type": "array",
-          "description": "Adopt existing resources into Helm management.",
-          "items": {
-            "type": "string"
-          }
+        "waitRetries": {
+          "description": "WaitRetries, if set and --wait enabled, will retry any failed check on resource state, except if HTTP status code \u003c 500 is received, subject to the specified number of retries\nDEPRECATED: This field is ignored as the --wait-retries flag was removed from Helm. Preserved for backward compatibility.",
+          "type": "integer"
         }
       },
-      "required": ["name"],
-      "anyOf": [
-        {
-          "required": ["chart"]
-        },
-        {
-          "required": ["inherit"]
-        }
-      ]
-    },
-    "helmfile": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "required": ["path"],
-          "properties": {
-            "path": {
-              "type": "string"
-            },
-            "selectors": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "values": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "key1": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        }
-      ]
-    },
-    "missingFileHandler": {
-      "type": "string",
-      "enum": ["Error", "Warn", "Info", "Debug"]
-    },
-    "environment": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/definitions/map"
-              }
-            ]
-          }
-        },
-        "secrets": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "missingFileHandler": {
-          "$ref": "#/definitions/missingFileHandler"
-        },
-        "kubeContext": {
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "hook": {
-      "type": "object",
       "properties": {
-        "events": {
-          "type": "array",
+        "args": {
           "items": {
-            "type": "string",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "command": {
+          "type": "string"
+        },
+        "events": {
+          "items": {
             "enum": [
               "prepare",
               "preapply",
@@ -530,137 +266,787 @@
               "postuninstall",
               "postsync",
               "cleanup"
-            ]
-          }
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kubectlApply": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
         },
         "showlogs": {
           "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "missingFileHandlerConfig": {
+      "properties": {
+        "ignoreMissingGitBranch": {
+          "description": "IgnoreMissingGitBranch is set to true in order to let the missing file handler\ntreat missing git branch errors like `pathspec 'develop' did not match any file(s) known to git` safe\nand ignored when the handler is set to Warn or Info.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "release": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/releaseSpec"
+        }
+      ],
+      "required": ["name"]
+    },
+    "releaseSpec": {
+      "properties": {
+        "adopt": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
-        "command": {
+        "apiVersions": {
+          "description": "Capabilities.APIVersions",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "atomic": {
+          "description": "Atomic, when set to true, restore previous state in case of a failed install/upgrade attempt",
+          "type": "boolean"
+        },
+        "cascade": {
+          "description": "Cascade '--cascade' to helmv3 delete, available values: background, foreground, or orphan, default: background",
+          "enum": ["background", "foreground", "orphan"],
           "type": "string"
         },
-        "args": {
-          "type": "array",
+        "chart": {
+          "description": "Chart is the name of the chart being installed to create this release",
+          "type": "string"
+        },
+        "chartPath": {
+          "description": "ChartPath is the downloaded and modified version of the remote Chart specified by the Chart field.\nThis field is empty when the release is going to use the remote chart as-is, without any modifications(e.g. chartify).",
+          "type": "string"
+        },
+        "cleanupOnFail": {
+          "description": "CleanupOnFail, when set to true, the --cleanup-on-fail helm flag is passed to the upgrade command",
+          "type": "boolean"
+        },
+        "condition": {
+          "description": "Condition, when set, evaluate the mapping specified in this string to a boolean which decides whether or not to process the release",
+          "type": "string"
+        },
+        "conditionTemplate": {
+          "type": "string"
+        },
+        "createNamespace": {
+          "description": "CreateNamespace, when set to true (default), --create-namespace is passed to helm on install",
+          "type": "boolean"
+        },
+        "deleteTimeout": {
+          "description": "Timeout is the time in seconds to wait for helmfile delete command (default 300)",
+          "type": "integer"
+        },
+        "deleteWait": {
+          "description": "--wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful",
+          "type": "boolean"
+        },
+        "dependencies": {
+          "description": "These settings requires helm-x integration to work",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Description is the description for this release that will be passed to helm upgrade with --description flag",
+          "type": "string"
+        },
+        "devel": {
+          "description": "Devel, when set to true, use development versions, too. Equivalent to version '\u003e0.0.0-0'",
+          "type": "boolean"
+        },
+        "directory": {
+          "description": "Directory is an alias to Chart which may be of more fit when you want to use a local/remote directory containing\nK8s manifests or Kustomization as a chart",
+          "type": "string"
+        },
+        "disableAutoDetectedKubeVersionForDiff": {
+          "description": "DisableAutoDetectedKubeVersionForDiff controls whether auto-detected kubeVersion should be passed\nto helm diff for this release. See HelmSpec.DisableAutoDetectedKubeVersionForDiff for details.",
+          "type": "boolean"
+        },
+        "disableOpenAPIValidation": {
+          "description": "DisableOpenAPIValidation is rarely used to bypass OpenAPI validations only that is used for e.g.\nwork-around against broken CRs\nSee also:\n- https://github.com/helm/helm/pull/6819\n- https://github.com/roboll/helmfile/issues/1167",
+          "type": "boolean"
+        },
+        "disableValidation": {
+          "description": "DisableValidation is rarely used to bypass the whole validation of manifests against the Kubernetes cluster\nso that `helm diff` can be run containing a chart that installs both CRD and CRs on first install.\nFYI, such diff without `--disable-validation` fails on first install because the K8s cluster doesn't have CRDs registered yet.",
+          "type": "boolean"
+        },
+        "disableValidationOnInstall": {
+          "description": "DisableValidationOnInstall disables the K8s API validation while running helm-diff on the release being newly installed on helmfile-apply.\nIt is useful when any release contains custom resources for CRDs that is not yet installed onto the cluster.",
+          "type": "boolean"
+        },
+        "enableDNS": {
+          "description": "EnableDNS, when set to true, enable DNS lookups when rendering templates",
+          "type": "boolean"
+        },
+        "env": {
+          "description": "The 'env' section is not really necessary any longer, as 'set' would now provide the same functionality",
+          "items": {
+            "$ref": "#/definitions/setValue"
+          },
+          "type": "array"
+        },
+        "force": {
+          "description": "Force, when set to true, forces resource update through delete/recreate if needed",
+          "type": "boolean"
+        },
+        "forceConflicts": {
+          "description": "ForceConflicts, when set to true, force server-side apply changes against conflicts (Helm 4 only)",
+          "type": "boolean"
+        },
+        "forceGoGetter": {
+          "description": "ForceGoGetter forces the use of go-getter for fetching remote directory as maniefsts/chart/kustomization\nby parsing the url from `chart` field of the release.\nThis is handy when getting the go-getter url parsing error when it doesn't work as expected.\nWithout this, any error in url parsing result in silently falling-back to normal process of treating `chart:` as the regular\nhelm chart name.",
+          "type": "boolean"
+        },
+        "forceNamespace": {
+          "description": "ForceNamespace is an experimental feature to set metadata.namespace in every K8s resource rendered by the chart,\nregardless of the template, even when it doesn't have `namespace: {{ .Namespace | quote }}`.\nThis is only needed when you can't FIX your chart to have `namespace: {{ .Namespace }}` AND you're using `helmfile template`.\nIn standard use-cases, `Namespace` should be sufficient.\nUse this only when you know what you want to do!",
+          "type": "string"
+        },
+        "helmStuckGrace": {
+          "description": "HelmStuckGrace, when \u003e 0, enables the safety-valve helm-killer for\nkubedog tracking: if the cluster confirms every tracked resource has\nconverged but the helm subprocess is still running, helmfile waits\nthis many seconds before sending SIGINT to helm. Targets the helm v4\nhook waiter wedge that --track-timeout would otherwise resolve only\nafter hours. Zero (or absent) disables the killer.",
+          "type": "integer"
+        },
+        "historyMax": {
+          "description": "HistoryMax, limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)",
+          "type": "integer"
+        },
+        "hooks": {
+          "description": "Hooks is a list of extension points paired with operations, that are executed in specific points of the lifecycle of releases defined in helmfile",
+          "items": {
+            "$ref": "#/definitions/hook"
+          },
+          "type": "array"
+        },
+        "inherit": {
+          "anyOf": [
+            {
+              "items": {
+                "properties": {
+                  "except": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "template": {
+                    "type": "string"
+                  }
+                },
+                "required": ["template"],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "description": "DEPRECATED. Wrap the single template into an array. The bare-object form is removed in helmfile v0.152.0.",
+              "properties": {
+                "except": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "template": {
+                  "type": "string"
+                }
+              },
+              "required": ["template"],
+              "type": "object"
+            }
+          ],
+          "description": "Inherit is used to inherit a release template from a release or another release template"
+        },
+        "insecureSkipTLSVerify": {
+          "description": "InsecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart.",
+          "type": "boolean"
+        },
+        "installed": {
+          "description": "Installed, when set to true, `delete --purge` the release",
+          "type": ["boolean", "string"]
+        },
+        "installedTemplate": {
+          "type": "string"
+        },
+        "jsonPatches": {
+          "items": {},
+          "type": "array"
+        },
+        "keyring": {
+          "type": "string"
+        },
+        "kubeContext": {
+          "type": "string"
+        },
+        "kubeVersion": {
+          "description": "Capabilities.KubeVersion",
+          "type": "string"
+        },
+        "kubedogBurst": {
+          "description": "KubedogBurst specifies the burst for kubedog kubernetes client",
+          "type": "integer"
+        },
+        "kubedogQPS": {
+          "description": "KubedogQPS specifies the QPS (queries per second) for kubedog kubernetes client",
+          "type": "number"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "missingFileHandler": {
+          "description": "MissingFileHandler is set to either \"Error\" or \"Warn\". \"Error\" instructs helmfile to fail when unable to find a values or secrets file. When \"Warn\", it prints the file and continues.\nThe default value for MissingFileHandler is \"Error\".",
+          "enum": ["Error", "Warn", "Info", "Debug"],
+          "type": "string"
+        },
+        "missingFileHandlerConfig": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/missingFileHandlerConfig"
+            }
+          ],
+          "description": "MissingFileHandlerConfig is composed of various settings for the MissingFileHandler"
+        },
+        "name": {
+          "description": "Name is the name of this release",
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "needs": {
+          "description": "Needs is the [KUBECONTEXT/][NS/]NAME representations of releases that this release depends on.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "plainHttp": {
+          "description": "PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS",
+          "type": "boolean"
+        },
+        "postRenderer": {
+          "description": "Propagate '--post-renderer' to helmv3 template and helm install",
+          "type": "string"
+        },
+        "postRendererArgs": {
+          "description": "Propagate '--post-renderer-args' to helmv3 template and helm install",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "recreatePods": {
+          "description": "RecreatePods, when set to true, instruct helmfile to perform pods restart for the resource if applicable",
+          "type": "boolean"
+        },
+        "reuseValues": {
+          "description": "ReuseValues, on helm upgrade/diff, reuse values currently set in the release and merge them with the ones defined within helmfile",
+          "type": "boolean"
+        },
+        "rollbackOnFailure": {
+          "description": "RollbackOnFailure, when set to true, restores previous state on a failed install/upgrade via the\nHelm 4 --rollback-on-failure flag (the successor to the deprecated --atomic flag). Requires Helm 4 or greater.",
+          "type": "boolean"
+        },
+        "secrets": {
+          "items": {},
+          "type": "array"
+        },
+        "serverSide": {
+          "description": "ServerSide controls the helm 4 --server-side flag for this release. Must be \"true\", \"false\", or \"auto\".",
+          "type": "string"
+        },
+        "set": {
+          "items": {
+            "$ref": "#/definitions/setValue"
+          },
+          "type": "array"
+        },
+        "setString": {
+          "items": {
+            "$ref": "#/definitions/setValue"
+          },
+          "type": "array"
+        },
+        "setTemplate": {
+          "items": {
+            "$ref": "#/definitions/setValue"
+          },
+          "type": "array"
+        },
+        "skipDeps": {
+          "description": "SkipDeps disables running `helm dependency up` and `helm dependency build` on this release's chart.\nThis is relevant only when your release uses a local chart or a directory containing K8s manifests or a Kustomization\nas a Helm chart.",
+          "type": "boolean"
+        },
+        "skipKinds": {
+          "description": "SkipKinds is a blacklist of resource kinds to skip tracking",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "skipRefresh": {
+          "description": "SkipRefresh disables running `helm dependency up`",
+          "type": "boolean"
+        },
+        "skipSchemaValidation": {
+          "description": "Propagate '--skip-schema-validation' to helmv3 template and helm install",
+          "type": "boolean"
+        },
+        "strategicMergePatches": {
+          "items": {},
+          "type": "array"
+        },
+        "suppressDiff": {
+          "description": "SuppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff.",
+          "type": "boolean"
+        },
+        "suppressOutputLineRegex": {
+          "description": "SuppressOutputLineRegex is a list of regexes to suppress output lines",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "syncReleaseLabels": {
+          "description": "SyncReleaseLabels is true if the release labels should be synced with the helmfile labels",
+          "type": "boolean"
+        },
+        "takeOwnership": {
+          "description": "TakeOwnership is true if release should take ownership of resources",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Timeout is the time in seconds to wait for any individual Kubernetes operation (like Jobs for hooks, and waits on pod/pvc/svc/deployment readiness) (default 300)",
+          "type": "integer"
+        },
+        "trackFailOnError": {
+          "description": "TrackFailOnError controls whether kubedog tracking failures cause a non-zero exit code",
+          "type": "boolean"
+        },
+        "trackFailedLogs": {
+          "description": "TrackFailedLogs streams logs only for pods that enter a failed state\n(CrashLoopBackOff, Error, etc.). Pods that succeed produce no output.\nHas no effect when TrackLogs is true (full streaming wins).",
+          "type": "boolean"
+        },
+        "trackKinds": {
+          "description": "TrackKinds is a whitelist of resource kinds to track",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "trackLogs": {
+          "description": "TrackLogs enables log streaming with kubedog",
+          "type": "boolean"
+        },
+        "trackMode": {
+          "description": "TrackMode specifies whether to use 'helm' or 'kubedog' for tracking resources",
+          "type": "string"
+        },
+        "trackResources": {
+          "description": "TrackResources is a whitelist of specific resources to track",
+          "items": {
+            "$ref": "#/definitions/trackResource"
+          },
+          "type": "array"
+        },
+        "trackTimeout": {
+          "description": "TrackTimeout specifies timeout for kubedog tracking (in seconds)",
+          "type": "integer"
+        },
+        "transformers": {
+          "description": "Transformers is the list of Kustomize transformers\n\nEach item can be a path to a YAML or go template file, or an embedded transformer declaration as a YAML hash.\nIt's often used to add common labels and annotations to your resources.\nSee https://github.com/kubernetes-sigs/kustomize/blob/master/examples/configureBuiltinPlugin.md#configuring-the-builtin-plugins-instead for more information.",
+          "items": {},
+          "type": "array"
+        },
+        "unitTests": {
+          "description": "UnitTests is a list of test file or directory paths for helm-unittest integration.\nWhen specified, `helmfile unittest` will run `helm unittest` with the merged values and these test paths.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "updateStrategy": {
+          "description": "UpdateStrategy, when set, indicate the strategy to use to update the release",
+          "type": "string"
+        },
+        "values": {
           "items": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
-                "type": "string"
+                "type": "object"
               }
             ]
-          }
+          },
+          "type": "array"
+        },
+        "valuesPathPrefix": {
+          "type": "string"
+        },
+        "valuesTemplate": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "verify": {
+          "description": "Verify enables signature verification on fetched chart.\nBeware some (or many?) chart repositories and charts don't seem to support it.",
+          "type": "boolean"
+        },
+        "verifyTemplate": {
+          "description": "These values are used in templating",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the semver version or version constraint for the chart",
+          "type": "string"
+        },
+        "wait": {
+          "description": "Wait, if set to true, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready state before marking the release as successful",
+          "type": "boolean"
+        },
+        "waitForJobs": {
+          "description": "WaitForJobs, if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout",
+          "type": "boolean"
+        },
+        "waitRetries": {
+          "description": "WaitRetries, if set and --wait enabled, will retry any failed check on resource state, except if HTTP status code \u003c 500 is received, subject to the specified number of retries\nDEPRECATED: This field is ignored as the --wait-retries flag was removed from Helm. Preserved for backward compatibility.",
+          "type": "integer"
+        },
+        "waitTemplate": {
+          "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "map": {
-      "type": "object",
-      "patternProperties": {
-        "[a-zA-Z\\d_-]+": {
-          "anyOf": [
-            {
-              "type": "object"
-            },
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "array"
-            },
-            {
-              "type": "null"
-            },
-            {
-              "type": "integer"
-            }
-          ]
+    "repository": {
+      "properties": {
+        "caFile": {
+          "type": "string"
+        },
+        "certFile": {
+          "type": "string"
+        },
+        "keyFile": {
+          "type": "string"
+        },
+        "keyring": {
+          "type": "string"
+        },
+        "managed": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "oci": {
+          "type": "boolean"
+        },
+        "passCredentials": {
+          "type": "boolean"
+        },
+        "password": {
+          "type": "string"
+        },
+        "plainHttp": {
+          "type": "boolean"
+        },
+        "registryConfig": {
+          "type": "string"
+        },
+        "skipTLSVerify": {
+          "type": "boolean"
+        },
+        "url": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "verify": {
+          "type": "boolean"
         }
-      }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "setValue": {
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "values": {
+          "items": {},
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "subHelmfile": {
+      "properties": {
+        "environment": {
+          "$ref": "#/definitions/subHelmfileEnvironment"
+        },
+        "inherits": {
+          "description": "Inherits is the list of parent-helmfile config categories this\nsub-helmfile inherits. Allowed values are listed in AllowedInherits\n(repositories, helmDefaults, commonLabels, apiVersions, kubeVersion,\ntemplates, environments). Child values win; parent fills gaps. See\nMergeInherited. Empty (the default) preserves the historical behavior\nwhere sub-helmfiles are independent.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "path or glob pattern for the sub helmfiles",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "chosen selectors for the sub helmfiles",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "selectorsInherited": {
+          "description": "do the sub helmfiles inherits from parent selectors",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "subHelmfileEnvironment": {
+      "properties": {
+        "values": {
+          "items": {},
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "trackResource": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "properties": {
     "apiVersions": {
-      "type": "array",
-      "description": "Configure a fixed list of API versions to pass to 'helm template' via the `--api-versions` flag.",
+      "description": "Capabilities.APIVersions",
       "items": {
-        "type": "string",
-        "examples": ["example/v1"]
-      }
+        "type": "string"
+      },
+      "type": "array"
     },
     "bases": {
-      "type": "array",
+      "description": "List of base helmfile YAML files layered under this one before rendering.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "chart": {
+      "description": "Override the chart used by all releases in this helmfile.",
+      "type": "string"
+    },
+    "commonLabels": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Labels applied to all releases in this helmfile. Useful when templating a helmfile per environment or customer to avoid copying the same label onto each release.",
+      "type": "object"
+    },
+    "defaultInherit": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Default release templates that every release inherits from, unless overridden per release with `inherit`."
+    },
+    "environments": {
+      "additionalProperties": {
+        "$ref": "#/definitions/environment"
+      },
+      "description": "The environments managed by this helmfile, keyed by environment name.",
+      "type": "object"
+    },
+    "helmBinary": {
+      "description": "Path to an alternative helm binary (--helm-binary).",
+      "type": "string"
+    },
+    "helmDefaults": {
+      "$ref": "#/definitions/helmDefaults",
+      "description": "Default settings applied to every release, unless overridden on the release itself."
+    },
+    "helmfiles": {
+      "description": "Sub-helmfiles to run, each given as a path/glob string or a sub-helmfile object.",
       "items": {
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "$ref": "#/definitions/subHelmfile"
           }
         ]
-      }
-    },
-    "environments": {
-      "type": "object",
-      "description": "The list of environments managed by helmfile.",
-      "default": {
-        "default": {}
       },
-      "examples": [
-        {
-          "default": {
-            "values": []
-          }
-        }
-      ],
-      "patternProperties": {
-        "[a-zA-Z\\d_-]+": {
-          "$ref": "#/definitions/environment"
-        }
-      }
-    },
-    "commonLabels": {
-      "$ref": "#/definitions/map",
-      "type": "object",
-      "description": "these labels will be applied to all releases in a Helmfile. Useful in templating if you have a helmfile per environment or customer and don't want to copy the same label to each release"
-    },
-    "helmBinary": {
-      "type": "string",
-      "description": "Path to alternative helm binary (--helm-binary)",
-      "examples": ["path/to/helm3"]
-    },
-    "helmDefaults": {
-      "$ref": "#/definitions/helmDefaults"
-    },
-    "helmfiles": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/helmfile"
-      }
+      "type": "array"
     },
     "hooks": {
-      "type": "array",
+      "description": "Hooks is a list of extension points paired with operations, that are executed in specific points of the lifecycle of releases defined in helmfile",
       "items": {
         "$ref": "#/definitions/hook"
-      }
+      },
+      "type": "array"
+    },
+    "kubeContext": {
+      "description": "Override the kube-context used by all releases (--kube-context).",
+      "type": "string"
+    },
+    "kubeVersion": {
+      "description": "Capabilities.KubeVersion",
+      "type": "string"
+    },
+    "kustomizeBinary": {
+      "description": "Path to an alternative kustomize binary.",
+      "type": "string"
+    },
+    "llm": {
+      "$comment": "UNDOCUMENTED. OpenAI-compatible config for AI-assisted subcommands such as `helmfile doctor`.",
+      "description": "LLM is the optional OpenAI-compatible configuration used by AI-assisted\nsubcommands such as `helmfile doctor`. When absent (the default),\nthose commands degrade to their non-AI equivalents (e.g. plain `diff`).\nThis field is read at app layer; the state layer treats it as inert.",
+      "properties": {
+        "apiKey": {
+          "description": "APIKey authenticates against BaseURL. May be templated in helmfile.yaml\nvia {{ env \"KEY\" }}.",
+          "type": "string"
+        },
+        "baseURL": {
+          "description": "BaseURL is the OpenAI-compatible endpoint base URL, e.g.\n\"https://one-api.internal/v1\" or \"https://api.deepseek.com/v1\".\nWhen empty, defaults to \"https://api.openai.com/v1\".",
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "MaxTokens caps the completion length. Defaults to 4096 when zero.",
+          "type": "integer"
+        },
+        "model": {
+          "description": "Model is the chat completion model identifier, e.g. \"gpt-4o\",\n\"claude-3-5-sonnet\" (via gateway), \"deepseek-chat\".",
+          "type": "string"
+        },
+        "temperature": {
+          "description": "Temperature controls generation randomness. Defaults to 0.2 when zero\n(deterministic-ish for risk analysis).",
+          "type": "number"
+        },
+        "timeout": {
+          "description": "Timeout is the per-request timeout. Defaults to 60s when zero.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "lockFilePath": {
+      "description": "Path to the dependency lock file (defaults to helmfile.lock next to the helmfile).",
+      "type": "string"
     },
     "missingFileHandler": {
-      "$ref": "#/definitions/missingFileHandler"
+      "description": "If set to \"Error\", return an error when a subhelmfile points to a\nnon-existent path. The default behavior is to print a warning. Note the\ndiffering default compared to other MissingFileHandlers.",
+      "enum": ["Error", "Warn", "Info", "Debug"],
+      "type": "string"
+    },
+    "missingFileHandlerConfig": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/missingFileHandlerConfig"
+        }
+      ],
+      "description": "MissingFileHandlerConfig is composed of various settings for the MissingFileHandler"
+    },
+    "namespace": {
+      "description": "Override the namespace used by all releases (--namespace).",
+      "type": "string"
     },
     "releases": {
-      "type": "array",
-      "description": "Helmfile runs various helm commands to converge the current state in the live cluster to the desired state defined here.",
+      "description": "Releases that helmfile converges to the desired state via helm commands.",
       "items": {
         "$ref": "#/definitions/release"
-      }
+      },
+      "type": "array"
     },
     "repositories": {
-      "type": "array",
+      "description": "Helm chart repositories available to the releases in this helmfile.",
       "items": {
         "$ref": "#/definitions/repository"
-      }
+      },
+      "type": "array"
+    },
+    "templates": {
+      "additionalProperties": {
+        "$ref": "#/definitions/releaseSpec"
+      },
+      "description": "Reusable release templates, referenced by name via `inherit` or `defaultInherit`.",
+      "type": "object"
+    },
+    "values": {
+      "description": "DefaultValues is the default values to be overrode by environment values and command-line overrides",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
     }
   },
-  "title": "Helmfile config schema"
+  "title": "Helmfile config schema",
+  "type": "object"
 }

--- a/src/test/helmfile/helmfile-default-inherit.json
+++ b/src/test/helmfile/helmfile-default-inherit.json
@@ -1,0 +1,25 @@
+{
+  "defaultInherit": "default",
+  "releases": [
+    {
+      "name": "database"
+    },
+    {
+      "inherit": [
+        {
+          "except": ["values"],
+          "template": "other"
+        }
+      ],
+      "name": "cache"
+    },
+    {
+      "chart": "stable/nginx",
+      "name": "web"
+    },
+    {
+      "directory": "./charts/local-app",
+      "name": "local"
+    }
+  ]
+}

--- a/src/test/helmfile/helmfile-full.json
+++ b/src/test/helmfile/helmfile-full.json
@@ -1,0 +1,92 @@
+{
+  "commonLabels": {
+    "team": "platform"
+  },
+  "defaultInherit": ["base", "labels"],
+  "environments": {
+    "default": {
+      "mergeStrategy": "override",
+      "missingFileHandler": "Warn",
+      "values": ["env/default.yaml", { "replicaCount": 2 }]
+    }
+  },
+  "helmBinary": "helm",
+  "helmDefaults": {
+    "cascade": "foreground",
+    "forceConflicts": true,
+    "skipCRDs": false,
+    "syncArgs": ["--take-ownership"],
+    "timeout": 600,
+    "wait": true,
+    "waitForJobs": true
+  },
+  "helmfiles": [
+    "apps/*/helmfile.yaml",
+    {
+      "environment": {
+        "values": ["shared/values.yaml"]
+      },
+      "inherits": ["repositories", "helmDefaults"],
+      "path": "infra/helmfile.yaml",
+      "selectors": ["tier=infra"],
+      "selectorsInherited": true
+    }
+  ],
+  "hooks": [
+    {
+      "args": ["global hook"],
+      "command": "echo",
+      "events": ["prepare", "cleanup"],
+      "showlogs": true
+    }
+  ],
+  "kubeContext": "prod",
+  "kubeVersion": "1.29",
+  "kustomizeBinary": "kustomize",
+  "lockFilePath": "helmfile.lock",
+  "namespace": "default",
+  "releases": [
+    {
+      "cascade": "background",
+      "forceConflicts": true,
+      "hooks": [
+        {
+          "events": ["presync"],
+          "kubectlApply": { "manifest": "extra.yaml" }
+        }
+      ],
+      "inherit": [{ "except": ["values"], "template": "base" }],
+      "installed": true,
+      "name": "web",
+      "needs": ["cache"],
+      "set": [{ "name": "replicas", "value": "3" }],
+      "skipSchemaValidation": false,
+      "trackMode": "kubedog",
+      "values": ["web/values.yaml", { "image": { "tag": "latest" } }],
+      "version": "1.2.3",
+      "waitRetries": 3
+    },
+    {
+      "name": "cache"
+    }
+  ],
+  "repositories": [
+    {
+      "name": "bitnami",
+      "oci": true,
+      "plainHttp": false,
+      "skipTLSVerify": false,
+      "url": "registry-1.docker.io/bitnamicharts"
+    }
+  ],
+  "templates": {
+    "base": {
+      "chart": "bitnami/nginx",
+      "missingFileHandler": "Info",
+      "trackResources": [{ "kind": "Deployment", "name": "nginx" }]
+    },
+    "labels": {
+      "labels": { "managed-by": "helmfile" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Regenerates `helmfile.json` from helmfile's own Go config structs (`pkg/state.ReleaseSetSpec`) at `helmfile` `main`, so the schema matches what the tool actually parses today. Field descriptions are taken from the upstream Go doc comments.

Motivation: the schema was missing the new top-level `defaultInherit` key ([helmfile/helmfile#2600](https://github.com/helmfile/helmfile/pull/2600)) and had drifted well behind upstream (only ~10 top-level and ~30 release fields vs. 22 and 86 today).

## Changes

- **`defaultInherit`** (helmfile/helmfile#2600) - accepts a single template name or a list.
- **New top-level fields**: `kustomizeBinary`, `kubeContext`, `namespace`, `chart`, `kubeVersion`, `templates`, `missingFileHandlerConfig`, `lockFilePath`, `values`, `llm`.
- **Full field coverage** for `release`, `helmDefaults`, `repository`, `environment`, `hook`, and sub-helmfile entries.
- **Correct polymorphism** for the custom `UnmarshalYAML` types: `defaultInherit` (string or list), `inherit` (array, plus the single-object form marked `DEPRECATED`), `helmfiles` (path string or object).
- `release` (requires `name`) split from `releaseSpec` (used by `templates`, which are partial and keyed by name).
- A release requires only `name`: a chart can come from `chart`, `directory`, `inherit`, `defaultInherit`, the top-level `chart` override, or a `bases:` layer, so a chart/inherit constraint would produce false positives.

## Conventions

- draft-07; undocumented `llm` flagged `UNDOCUMENTED.`; deprecated `inherit` form flagged `DEPRECATED.`; no `additionalProperties: false` (matches helmfile's permissive parsing).
- Two new positive test files exercising the added surface.

## Validation

- `node cli.js check` passes.
- `prettier --check` passes.