### PR TITLE
add v0.14.7 schema version for bottom

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -812,6 +812,7 @@
       "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.10/bottom.json",
       "versions": {
         "nightly": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json",
+        "0.14.7: "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.14.7/bottom.json",
         "0.14.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.14.0/bottom.json",
         "0.13.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.13.0/bottom.json",
         "0.12.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.12.0/bottom.json",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -812,7 +812,7 @@
       "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.10/bottom.json",
       "versions": {
         "nightly": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json",
-        "0.14.7: "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.14.7/bottom.json",
+        "0.14.7": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.14.7/bottom.json",
         "0.14.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.14.0/bottom.json",
         "0.13.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.13.0/bottom.json",
         "0.12.0": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.12.0/bottom.json",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This adds the new schema for 0.14.7 of [bottom](github.com/ClementTsang/bottom).