### PR TITLE
feat(youtrack-app): add borderless flag for MARKDOWN widgets

### DIFF
--- a/src/schemas/json/youtrack-app.json
+++ b/src/schemas/json/youtrack-app.json
@@ -298,6 +298,10 @@
             },
             "then": {
               "properties": {
+                "borderless": {
+                  "type": "boolean",
+                  "description": "When set to true, the widget is rendered without a border (no dashboard-like wrapping island around the widget)."
+                },
                 "defaultDimensions": {
                   "$ref": "#/definitions/defaultDimensions",
                   "properties": {

--- a/src/test/youtrack-app/borderless-markdown-widget.json
+++ b/src/test/youtrack-app/borderless-markdown-widget.json
@@ -1,0 +1,12 @@
+{
+  "name": "borderless-app",
+  "widgets": [
+    {
+      "key": "borderless-widget",
+      "name": "Borderless Widget",
+      "indexPath": "index.html",
+      "extensionPoint": "MARKDOWN",
+      "borderless": true
+    }
+  ]
+}

--- a/src/test/youtrack-app/borderless-markdown-widget.json
+++ b/src/test/youtrack-app/borderless-markdown-widget.json
@@ -2,11 +2,11 @@
   "name": "borderless-app",
   "widgets": [
     {
-      "key": "borderless-widget",
-      "name": "Borderless Widget",
-      "indexPath": "index.html",
+      "borderless": true,
       "extensionPoint": "MARKDOWN",
-      "borderless": true
+      "indexPath": "index.html",
+      "key": "borderless-widget",
+      "name": "Borderless Widget"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add optional `borderless` boolean property to YouTrack app manifest widgets, available only when `extensionPoint` is `MARKDOWN`
- When set to `true`, the widget renders without a dashboard-like wrapping border

Implements [JT-94655](https://youtrack.jetbrains.com/issue/JT-94655)

## Test plan
- Added positive test: MARKDOWN widget with `borderless: true`