### PR TITLE
appveyor: add image Ubuntu2404

### DIFF
--- a/src/schemas/json/appveyor.json
+++ b/src/schemas/json/appveyor.json
@@ -136,6 +136,7 @@
         "Ubuntu1804",
         "Ubuntu2004",
         "Ubuntu2204",
+        "Ubuntu2404",
         "Previous Ubuntu",
         "Previous Ubuntu1604",
         "Previous Ubuntu1804",


### PR DESCRIPTION
Added `Ubuntu2404` to the list of AppVeyor images (available as of [May 13, 2026](https://www.appveyor.com/updates/2026/05/13/)).