### PR TITLE
Update crucible-code-schema.json for crucible 0.1.5

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-rung.json
+++ b/src/negative_test/crucible-code-schema/not-a-rung.json
@@ -1,0 +1,3 @@
+{
+  "providers": { "anthropic": { "effort": "hardest" } }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://www.schemastore.org/crucible-code-schema.json",
   "additionalProperties": false,
-  "description": "Settings for the crucible coding agent. Formats are unstable while the version is 0.0.x: any key here may be renamed or removed in any release, with no deprecation period.",
+  "description": "Settings for the crucible coding agent. Formats are unstable while the version is 0.x: any key here may be renamed or removed in any release, with no deprecation period.",
   "properties": {
     "$schema": {
       "type": "string"
@@ -12,7 +12,7 @@
     },
     "env": {
       "additionalProperties": false,
-      "description": "Environment variables for the commands crucible runs. A checked-in file may set only crucible's own CRUCIBLE_CODE_ names",
+      "description": "Environment variables for the commands crucible runs. A file under the working directory may set only crucible's own CRUCIBLE_CODE_ names",
       "patternProperties": {
         "^[^$]": {
           "type": "string"
@@ -48,6 +48,11 @@
           "enum": ["unicode", "ascii"],
           "type": "string"
         },
+        "mouse": {
+          "description": "off leaves the mouse to the terminal, so the wheel scrolls it; click lets you place the cursor in the prompt, and the wheel stops scrolling",
+          "enum": ["off", "click"],
+          "type": "string"
+        },
         "toolDetail": {
           "description": "How much of a tool call and its result one line shows",
           "enum": ["compact", "full"],
@@ -67,7 +72,7 @@
           "type": "string"
         },
         "allow": {
-          "description": "Rules for calls that run without being put to you",
+          "description": "Rules for calls that run without being put to you. Not read from .crucible/config.json, which everyone who clones gets",
           "items": {
             "examples": ["read(src/**)", "bash(cargo test)"],
             "type": "string"
@@ -94,7 +99,7 @@
           "uniqueItems": true
         },
         "extraDirectories": {
-          "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, so this belongs in .crucible/config.local.json",
+          "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, and this is not read from .crucible/config.json, so it belongs in .crucible/config.local.json",
           "items": {
             "examples": [
               "/home/you/src/shared-library",
@@ -106,12 +111,16 @@
           "uniqueItems": true
         },
         "mode": {
-          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything",
+          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything. Not read from .crucible/config.json, which everyone who clones gets",
           "enum": ["ask", "allowEdits", "fullAccess"],
           "type": "string"
         }
       },
       "type": "object"
+    },
+    "provider": {
+      "description": "Which provider to ask, by the name --model qualifies a model with. Not read from .crucible/config.json, which everyone who clones gets",
+      "type": "string"
     },
     "providers": {
       "additionalProperties": false,
@@ -130,6 +139,16 @@
               "description": "Name of the environment variable holding this provider's API key — the name, never the key",
               "type": "string"
             },
+            "baseUrl": {
+              "description": "Address to send this provider's requests to instead of the vendor's, for a gateway or a proxy",
+              "examples": ["https://gateway.example/v1/messages"],
+              "type": "string"
+            },
+            "effort": {
+              "description": "How hard to think before answering, when --effort does not say. Left off, the vendor's own default for whichever model is being asked",
+              "enum": ["low", "medium", "high", "xhigh", "max"],
+              "type": "string"
+            },
             "model": {
               "description": "The model to ask when --model does not name one",
               "type": "string"
@@ -143,6 +162,24 @@
           "type": "string"
         },
         "$comment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "updates": {
+      "additionalProperties": false,
+      "description": "Whether crucible finds out that a newer release exists",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "check": {
+          "description": "Whether crucible asks GitHub which release is newest, and says so when this one is behind",
+          "enum": ["auto", "never"],
           "type": "string"
         }
       },

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -2,7 +2,12 @@
   "$comment": "every block, so the positive test exercises all of them",
   "$schema": "https://www.schemastore.org/crucible-code-schema.json",
   "env": { "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12", "RUST_LOG": "warn" },
-  "output": { "color": "auto", "glyphs": "unicode", "toolDetail": "compact" },
+  "output": {
+    "color": "auto",
+    "glyphs": "unicode",
+    "mouse": "click",
+    "toolDetail": "compact"
+  },
   "permissions": {
     "allow": ["read(src/**)", "bash(cargo test)"],
     "ask": ["bash(git push)"],
@@ -10,11 +15,17 @@
     "extraDirectories": ["/home/you/src/shared-library"],
     "mode": "allowEdits"
   },
+  "provider": "anthropic",
   "providers": {
     "anthropic": {
       "apiKeyEnv": "WORK_ANTHROPIC_KEY",
+      "effort": "high",
       "model": "claude-opus-5"
     },
-    "openai": { "model": "gpt-5.2" }
-  }
+    "openai": {
+      "baseUrl": "https://gateway.example/v1/chat/completions",
+      "model": "gpt-5.2"
+    }
+  },
+  "updates": { "check": "never" }
 }


### PR DESCRIPTION
The served copy was last updated for crucible 0.1.2. This catches it up with
0.1.3 through 0.1.5, generated from the parser as always:

- `output.mouse` — whether the wheel scrolls the terminal or the click places
  the cursor in the prompt.
- `updates.check` — whether crucible asks GitHub which release is newest.
- `providers.<name>.baseUrl` and `providers.<name>.effort`.
- `provider` — which vendor to ask, by the name `--model` qualifies a model
  with.
- Two descriptions corrected: the format is unstable for the whole 0.x line,
  and the keys a checked-in file is not read for now say so.

`src/test/crucible-code-schema/config.json` exercises the new blocks, and
`src/negative_test/crucible-code-schema/not-a-rung.json` covers the `effort`
enum. Prettier and `node ./cli.js check --schema-name=crucible-code-schema.json`
both run clean here.