### PR TITLE
feat(github-workflow): add missing issues activity types

### DIFF
--- a/src/schemas/json/github-workflow.json
+++ b/src/schemas/json/github-workflow.json
@@ -1400,7 +1400,11 @@
                       "locked",
                       "unlocked",
                       "milestoned",
-                      "demilestoned"
+                      "demilestoned",
+                      "typed",
+                      "untyped",
+                      "field_added",
+                      "field_removed"
                     ]
                   },
                   "default": [
@@ -1419,7 +1423,11 @@
                     "locked",
                     "unlocked",
                     "milestoned",
-                    "demilestoned"
+                    "demilestoned",
+                    "typed",
+                    "untyped",
+                    "field_added",
+                    "field_removed"
                   ]
                 }
               }

--- a/src/test/github-workflow/issues-activity-types.yaml
+++ b/src/test/github-workflow/issues-activity-types.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../schemas/json/github-workflow.json
+name: Issues activity types
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - transferred
+      - pinned
+      - unpinned
+      - closed
+      - reopened
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - locked
+      - unlocked
+      - milestoned
+      - demilestoned
+      - typed
+      - untyped
+      - field_added
+      - field_removed
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the issue type
+        run: echo "${{ github.event.issue.type.name }}"


### PR DESCRIPTION
Closes #6211

## What

Adds the four `issues` activity types that GitHub supports but the schema does not accept:

`typed`, `untyped`, `field_added`, `field_removed`

ref: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issues

`typed` and `untyped` came with Issue Types. They are the only way to start a workflow when a user sets or removes the type of an issue, so a triage workflow that acts on one type cannot see an issue that gets its type after creation.

The value list appears twice in the `issues` block, so this changes both the `enum` and the identical `default`.

## Test

Adds `src/test/github-workflow/issues-activity-types.yaml`, which lists every documented activity type for the event.

I checked that the test fails without the schema change (5 Ajv errors) and passes with it:

```console
$ node ./cli.js check --schema-name=github-workflow.json
✔️ Completed "pre-checks"
✔️ Completed "Ajv validation"
```

Prettier reports no changes for either file.
