### PR TITLE
Add yaml-workflow schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11006,6 +11006,12 @@
       "versions": {
         "0.3.0": "https://ayeshlk.github.io/archsmith/schema/0.3.0/diagram-schema.json"
       }
+    },
+    {
+      "name": "yaml-workflow",
+      "description": "Workflow definition for the yaml-workflow engine — params, tasks, steps, imports, and flows",
+      "fileMatch": ["**/*.yaml-workflow.yaml", "**/*.yaml-workflow.yml"],
+      "url": "https://raw.githubusercontent.com/orieg/yaml-workflow/main/schema/workflow-schema.json"
     }
   ]
 }


### PR DESCRIPTION
Adds a catalog entry for [**yaml-workflow**](https://github.com/orieg/yaml-workflow), a lightweight Python workflow engine that defines tasks in YAML (params, steps, imports, flows) — [PyPI](https://pypi.org/project/yaml-workflow/), [docs](https://orieg.github.io/yaml-workflow/).

- **Self-hosted/remote schema** — `url` points at the project's raw `schema/workflow-schema.json` (draft-07), so there's no copy to maintain in this repo (same pattern as the ory/hydra and ArchSmith entries).
- **Specific `fileMatch`** — uses a distinctive `**/*.yaml-workflow.yaml` / `.yml` suffix rather than a generic `workflows/*.yaml` pattern, to avoid the false positives the contributing guidelines warn about.
- Ran `node ./cli.js check` locally; all catalog pre-checks pass (schema-catalog conformance, no duplicate names, no fileMatch conflicts, valid schema URL, no bad fields).
