### PR TITLE
Update crucible-code schema to 0.1.9

### DIFF
--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://www.schemastore.org/crucible-code-schema.json",
   "additionalProperties": false,
-  "description": "Settings for the crucible coding agent. Formats are unstable while the version is 0.0.x: any key here may be renamed or removed in any release, with no deprecation period.",
+  "description": "Settings for the crucible coding agent. Formats are unstable while the version is 0.x: any key here may be renamed or removed in any release, with no deprecation period.",
   "properties": {
     "$schema": {
       "type": "string"
@@ -12,7 +12,7 @@
     },
     "env": {
       "additionalProperties": false,
-      "description": "Environment variables for the commands crucible runs. A checked-in file may set only crucible's own CRUCIBLE_CODE_ names",
+      "description": "Environment variables for the commands crucible runs. A file under the working directory may set only crucible's own CRUCIBLE_CODE_ names",
       "patternProperties": {
         "^[^$]": {
           "type": "string"
@@ -48,6 +48,11 @@
           "enum": ["unicode", "ascii"],
           "type": "string"
         },
+        "mouse": {
+          "description": "off leaves the mouse to the terminal, so the wheel scrolls it; click lets you place the cursor in the prompt, and the wheel stops scrolling",
+          "enum": ["off", "click"],
+          "type": "string"
+        },
         "toolDetail": {
           "description": "How much of a tool call and its result one line shows",
           "enum": ["compact", "full"],
@@ -67,7 +72,7 @@
           "type": "string"
         },
         "allow": {
-          "description": "Rules for calls that run without being put to you",
+          "description": "Rules for calls that run without being put to you. Read only from the configuration file in your home directory",
           "items": {
             "examples": ["read(src/**)", "bash(cargo test)"],
             "type": "string"
@@ -94,7 +99,7 @@
           "uniqueItems": true
         },
         "extraDirectories": {
-          "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, so this belongs in .crucible/config.local.json",
+          "description": "Absolute paths to directories outside the working directory that tools may reach. Read only from the configuration file in your home directory",
           "items": {
             "examples": [
               "/home/you/src/shared-library",
@@ -106,12 +111,16 @@
           "uniqueItems": true
         },
         "mode": {
-          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything",
+          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything. Read only from the configuration file in your home directory",
           "enum": ["ask", "allowEdits", "fullAccess"],
           "type": "string"
         }
       },
       "type": "object"
+    },
+    "provider": {
+      "description": "Which provider to ask, by the name --model qualifies a model with. Read only from the configuration file in your home directory",
+      "type": "string"
     },
     "providers": {
       "additionalProperties": false,
@@ -130,6 +139,16 @@
               "description": "Name of the environment variable holding this provider's API key — the name, never the key",
               "type": "string"
             },
+            "baseUrl": {
+              "description": "Address to send this provider's requests to instead of the vendor's, for a gateway or a proxy",
+              "examples": ["https://gateway.example/v1/messages"],
+              "type": "string"
+            },
+            "effort": {
+              "description": "How hard to think before answering, when --effort does not say. Left off, the vendor's own default for whichever model is being asked",
+              "enum": ["low", "medium", "high", "xhigh", "max"],
+              "type": "string"
+            },
             "model": {
               "description": "The model to ask when --model does not name one",
               "type": "string"
@@ -143,6 +162,24 @@
           "type": "string"
         },
         "$comment": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "updates": {
+      "additionalProperties": false,
+      "description": "Whether crucible finds out that a newer release exists",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "check": {
+          "description": "Whether crucible asks GitHub which release is newest, and says so when this one is behind",
+          "enum": ["auto", "never"],
           "type": "string"
         }
       },


### PR DESCRIPTION
Updates the crucible-code schema to the copy shipped with the 0.1.9 release. Permission and provider key descriptions now match the released documentation (these settings are read only from the configuration file in the user's home directory). No key was added, removed or reshaped, so the existing positive and negative tests are untouched. Formatted with the repository prettier config; `node ./cli.js check --schema-name=crucible-code-schema.json` passes.