### PR TITLE
Update crucible-code schema

### DIFF
--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "mouse": {
-          "description": "off leaves the mouse to the terminal, so the wheel scrolls it; click lets you place the cursor in the prompt, and the wheel stops scrolling",
+          "description": "off leaves the mouse to the terminal, so the wheel scrolls it; click lets you place the cursor in the prompt and open a result that was cut short, and the wheel stops scrolling",
           "enum": ["off", "click"],
           "type": "string"
         },
@@ -72,7 +72,7 @@
           "type": "string"
         },
         "allow": {
-          "description": "Rules for calls that run without being put to you. Not read from .crucible/config.json, which everyone who clones gets",
+          "description": "Rules for calls that run without being put to you. Read only from the configuration file in your home directory",
           "items": {
             "examples": ["read(src/**)", "bash(cargo test)"],
             "type": "string"
@@ -99,7 +99,7 @@
           "uniqueItems": true
         },
         "extraDirectories": {
-          "description": "Absolute paths to directories outside the working directory that tools may reach. An absolute path names one machine, and this is not read from .crucible/config.json, so it belongs in .crucible/config.local.json",
+          "description": "Absolute paths to directories outside the working directory that tools may reach. Read only from the configuration file in your home directory",
           "items": {
             "examples": [
               "/home/you/src/shared-library",
@@ -111,12 +111,16 @@
           "uniqueItems": true
         },
         "mode": {
-          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything. Not read from .crucible/config.json, which everyone who clones gets",
+          "description": "What happens to a call no rule mentions: ask about every change and command, allow changes to files, or allow everything. Read only from the configuration file in your home directory",
           "enum": ["ask", "allowEdits", "fullAccess"],
           "type": "string"
         }
       },
       "type": "object"
+    },
+    "provider": {
+      "description": "Which provider to ask, by the name --model qualifies a model with. Read only from the configuration file in your home directory",
+      "type": "string"
     },
     "providers": {
       "additionalProperties": false,

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -15,6 +15,7 @@
     "extraDirectories": ["/home/you/src/shared-library"],
     "mode": "allowEdits"
   },
+  "provider": "anthropic",
   "providers": {
     "anthropic": {
       "apiKeyEnv": "WORK_ANTHROPIC_KEY",


### PR DESCRIPTION
The served copy of `crucible-code-schema.json` predates crucible's `provider`
key. `additionalProperties` is `false`, so a configuration file that names a
provider is currently marked invalid by every editor pointed at this schema.

Four descriptions moved with it: `permissions.allow`, `permissions.mode` and
`permissions.extraDirectories` are now read only from the file in the user's
home directory, and `output.mouse` in `click` opens a result that was cut short
as well as placing the cursor in the prompt.

The file is generated from the configuration parser in
[crucible](https://github.com/augments-labs/crucible-code) and matches the copy
that ships with `v0.5.0`, run through `prettier --config .prettierrc.cjs`. The
positive test gains `provider`, which its own `$comment` says it should
exercise.

`node ./cli.js check --schema-name=crucible-code-schema.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)