### PR TITLE
Add Symfony configuration schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7477,13 +7477,13 @@
       "name": "Symfony Routing Configuration",
       "description": "Symfony routing configuration file (config/routes)",
       "fileMatch": ["**/config/routes.yaml", "**/config/routes/**/*.yaml"],
-      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Routing/Loader/schema/routing.schema.json"
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Routing/Loader/schema/routing.schema.json"
     },
     {
       "name": "Symfony Serializer Mapping",
       "description": "Symfony serializer mapping configuration file",
       "fileMatch": ["**/config/serializer/**/*.yaml"],
-      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json"
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json"
     },
     {
       "name": "Symfony Services Configuration",
@@ -7493,13 +7493,13 @@
         "**/config/services_*.yaml",
         "**/config/packages/**/*.yaml"
       ],
-      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
     },
     {
       "name": "Symfony Validation Mapping",
       "description": "Symfony validation mapping configuration file",
       "fileMatch": ["**/config/validator/**/*.yaml"],
-      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Validator/Mapping/Loader/schema/validation.schema.json"
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Validator/Mapping/Loader/schema/validation.schema.json"
     },
     {
       "name": "Synadia Connect Component",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7487,12 +7487,8 @@
     },
     {
       "name": "Symfony Services Configuration",
-      "description": "Symfony parameters and services configuration file (config/services and config/packages)",
-      "fileMatch": [
-        "**/config/services.yaml",
-        "**/config/services_*.yaml",
-        "**/config/packages/**/*.yaml"
-      ],
+      "description": "Symfony parameters and services configuration file (config/services)",
+      "fileMatch": ["**/config/services.yaml", "**/config/services_*.yaml"],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7474,6 +7474,34 @@
       "url": "https://spec.openapis.org/oas/2.0/schema/2017-08-27"
     },
     {
+      "name": "Symfony Routing Configuration",
+      "description": "Symfony routing configuration file (config/routes)",
+      "fileMatch": ["**/config/routes.yaml", "**/config/routes/**/*.yaml"],
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Routing/Loader/schema/routing.schema.json"
+    },
+    {
+      "name": "Symfony Serializer Mapping",
+      "description": "Symfony serializer mapping configuration file",
+      "fileMatch": ["**/config/serializer/**/*.yaml"],
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json"
+    },
+    {
+      "name": "Symfony Services Configuration",
+      "description": "Symfony parameters and services configuration file (config/services and config/packages)",
+      "fileMatch": [
+        "**/config/services.yaml",
+        "**/config/services_*.yaml",
+        "**/config/packages/**/*.yaml"
+      ],
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
+    },
+    {
+      "name": "Symfony Validation Mapping",
+      "description": "Symfony validation mapping configuration file",
+      "fileMatch": ["**/config/validator/**/*.yaml"],
+      "url": "https://raw.githubusercontent.com/symfony/symfony/8.2/src/Symfony/Component/Validator/Mapping/Loader/schema/validation.schema.json"
+    },
+    {
       "name": "Synadia Connect Component",
       "description": "Synadia Connect component definition",
       "fileMatch": [


### PR DESCRIPTION
Symfony ships official JSON schemas for its YAML configuration files. This registers them in the catalog so compatible editors (VS Code, JetBrains, yaml-language-server) get autocompletion and validation.

The schemas are hosted in the Symfony repository, so the catalog entries reference them externally on the 8.2 branch (the repository default branch), similar to how composer.json points to getcomposer.org. No copy is stored in this repository.

Added entries:
- Symfony Services Configuration (config/services, config/packages)
- Symfony Routing Configuration (config/routes)
- Symfony Validation Mapping (config/validator)
- Symfony Serializer Mapping (config/serializer)

The fileMatch patterns target the Symfony config/ paths to avoid overly generic matches.