### PR TITLE
Add .devprune.json (dev-prune per-repository configuration)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2222,6 +2222,12 @@
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
     },
     {
+      "name": ".devprune.json",
+      "description": "Per-repository configuration for dev-prune, the lockfile-verified workspace cleaner",
+      "fileMatch": [".devprune.json"],
+      "url": "https://devprune.vkrishna04.me/schemas/v1/devprune.schema.json"
+    },
+    {
       "name": "Codecov configuration files",
       "description": "codecov.yml files",
       "fileMatch": [


### PR DESCRIPTION
Registers the externally hosted schema for `.devprune.json`, the per-repository configuration file of [dev-prune](https://github.com/Life-Experimentalist/dev-prune) — a cross-platform CLI that reclaims disk space from idle Git repositories by deleting dependency directories (`node_modules`, `.venv`, `target`, `vendor`) only after the project's package manager verifies a lockfile can rebuild them.

- Schema URL: https://devprune.vkrishna04.me/schemas/v1/devprune.schema.json (draft-07, `description` on every key, `additionalProperties: false`)
- The URL is versioned (`/v1/`) and stable; the site build copies it from the canonical file in the CLI's repository on every deploy, so it cannot drift from what the CLI parses.
- `fileMatch` is only `.devprune.json`. The companion file `ignore.devprune.json` is deliberately not matched: its *presence alone* opts a repository out, its contents are ignored by design, and it is usually empty — a schema would flag that as an error.

Following the "[How to add a JSON Schema that's self-hosted/remote/external](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal)" instructions: catalog entry only, no files added to this repository.