### PR TITLE
Update crucible-code-schema for 0.13.0

### DIFF
--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -10,6 +10,44 @@
     "$comment": {
       "type": "string"
     },
+    "compaction": {
+      "additionalProperties": false,
+      "description": "What happens when the model's window fills up",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "askOnResume": {
+          "description": "How large a session has to be, in tokens, before picking it up asks whether to carry it whole. Zero never asks",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "keep": {
+          "description": "How many tokens of recent turns are kept word for word after the rest becomes a recap",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "reserve": {
+          "description": "Tokens to keep free for the next answer and the tools it calls, instead of the room crucible works out from the model",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "spendCeiling": {
+          "description": "The most tokens one turn may produce before crucible stops it, where a runaway turn is worth bounding",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "when": {
+          "description": "Whether a full window is answered by compacting the session, or by letting the turn fail",
+          "enum": ["full", "never"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "env": {
       "additionalProperties": false,
       "description": "Environment variables for the commands crucible runs. A file under the working directory may set only crucible's own CRUCIBLE_CODE_ names",
@@ -51,6 +89,23 @@
         "mouse": {
           "description": "off leaves the mouse to the terminal, so the wheel scrolls it; click lets you place the cursor in the prompt and open a result that was cut short, and the wheel stops scrolling",
           "enum": ["off", "click"],
+          "type": "string"
+        },
+        "syntaxTheme": {
+          "description": "Which theme fenced code is drawn in — a name from /theme, such as Monokai Extended, GitHub, Dracula or Nord",
+          "examples": ["Monokai Extended", "GitHub"],
+          "type": "string"
+        },
+        "theme": {
+          "description": "Which colours crucible draws with: auto follows the terminal's own background, ansi spends only the sixteen it already has",
+          "enum": [
+            "auto",
+            "dark",
+            "light",
+            "colourblind-dark",
+            "colourblind-light",
+            "ansi"
+          ],
           "type": "string"
         },
         "toolDetail": {
@@ -143,6 +198,30 @@
               "description": "Address to send this provider's requests to instead of the vendor's, for a gateway or a proxy",
               "examples": ["https://gateway.example/v1/messages"],
               "type": "string"
+            },
+            "contextWindow": {
+              "additionalProperties": false,
+              "description": "How many tokens a model accepts at once, keyed by the model name, where crucible cannot ask the provider or has it wrong",
+              "patternProperties": {
+                "^[^$]": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "properties": {
+                "$schema": {
+                  "type": "string"
+                },
+                "$comment": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "defaultContextWindow": {
+              "description": "How many tokens to assume any model of this provider accepts, where it is not named above",
+              "minimum": 0,
+              "type": "integer"
             },
             "effort": {
               "description": "How hard to think before answering, when --effort does not say. Left off, the vendor's own default for whichever model is being asked",

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -1,11 +1,22 @@
 {
   "$comment": "every block, so the positive test exercises all of them",
   "$schema": "https://www.schemastore.org/crucible-code-schema.json",
-  "env": { "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12", "RUST_LOG": "warn" },
+  "compaction": {
+    "askOnResume": 0,
+    "keep": 20000,
+    "reserve": 16000,
+    "spendCeiling": 0,
+    "when": "full"
+  },
+  "env": {
+    "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12",
+    "RUST_LOG": "warn"
+  },
   "output": {
     "color": "auto",
     "glyphs": "unicode",
     "mouse": "click",
+    "syntaxTheme": "GitHub",
     "toolDetail": "compact"
   },
   "permissions": {
@@ -23,7 +34,15 @@
       "effort": "high",
       "model": "claude-opus-5"
     },
-    "openai": { "model": "gpt-5.2" }
+    "openai": {
+      "contextWindow": {
+        "gpt-5.2-pro": 400000
+      },
+      "defaultContextWindow": 272000,
+      "model": "gpt-5.2"
+    }
   },
-  "updates": { "check": "never" }
+  "updates": {
+    "check": "never"
+  }
 }


### PR DESCRIPTION
The served copy predates the `compaction` section added in crucible 0.12.0 (and the `syntaxTheme` / provider `contextWindow` keys alongside it), so editors pointed at the published URL have been marking valid keys red and missing completions.

This replaces it with the schema the [v0.13.0](https://github.com/augments-labs/crucible-code/releases/tag/v0.13.0) tag ships, formatted with the repo's prettier config, and extends the positive test to exercise the new blocks. `cli.js check` passes locally.