### PR TITLE
Add service alias shortcut to Drupal services schema.

### DIFF
--- a/src/negative_test/drupal-services/drupal-services-alias.yml
+++ b/src/negative_test/drupal-services/drupal-services-alias.yml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=../../schemas/json/drupal-services.json
 services:
-
   # Defines an alias shortcut that fails because of missing @.
   Drupal\Example\WithModuleHandler: 'example.with_module_handler'

--- a/src/negative_test/drupal-services/drupal-services-alias.yml
+++ b/src/negative_test/drupal-services/drupal-services-alias.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/drupal-services.json
+services:
+
+  # Defines an alias shortcut that fails because of missing @.
+  Drupal\Example\WithModuleHandler: 'example.with_module_handler'

--- a/src/schemas/json/drupal-services.json
+++ b/src/schemas/json/drupal-services.json
@@ -10,128 +10,140 @@
     "services": {
       "type": "object",
       "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "title": "Service class",
-            "type": "string"
+        "oneOf": [
+          {
+            "title": "Drupal Service Alias (shorthand)",
+            "description": "Shorthand for an alias to another service, e.g. '@some.service.id'.",
+            "type": "string",
+            "pattern": "^@"
           },
-          "parent": {
-            "title": "Parent service to extend",
-            "type": "string"
-          },
-          "factory": {
-            "title": "A factory to create the object",
-            "oneOf": [
-              {
+          {
+            "title": "Drupal Services",
+            "type": "object",
+            "properties": {
+              "class": {
+                "title": "Service class",
                 "type": "string"
               },
-              {
-                "type": "array"
-              }
-            ]
-          },
-          "decorates": {
-            "title": "Service name to decorate",
-            "type": "string"
-          },
-          "deprecated": {
-            "title": "A flag indicating that the service is deprecated",
-            "type": "string"
-          },
-          "lazy": {
-            "title": "Lazy service instantiation",
-            "type": "boolean"
-          },
-          "shared": {
-            "title": "Shared service",
-            "type": "boolean"
-          },
-          "abstract": {
-            "title": "Abstract service",
-            "type": "boolean"
-          },
-          "public": {
-            "title": "A flag indication that the service cannot be accessed directly from the container object",
-            "type": "boolean"
-          },
-          "alias": {
-            "title": "A shortcut to access some services",
-            "type": "string"
-          },
-          "arguments": {
-            "title": "Service arguments",
-            "type": "array",
-            "uniqueItems": true
-          },
-          "configurator": {
-            "title": "A callable to configure a service after its instantiation",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "tags": {
-            "title": "List of tags tell Drupal that your service can be processed in some special way",
-            "examples": [
-              "event_subscriber",
-              "service_collector",
-              "theme_negotiator",
-              "twig.extension",
-              "access_check"
-            ],
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "call": {
-                  "type": "string"
-                },
-                "alias": {
-                  "type": "string"
-                },
-                "required": {
-                  "type": "boolean"
-                },
-                "tag": {
-                  "type": "string"
-                },
-                "priority": {
-                  "type": "integer"
-                },
-                "default_backend": {
-                  "type": "string"
-                },
-                "responder": {
-                  "type": "boolean"
-                },
-                "format": {
-                  "type": "string"
-                },
-                "applies_to": {
-                  "type": "string"
-                },
-                "provider_id": {
-                  "type": "string"
-                },
-                "needs_incoming_request": {
-                  "type": "boolean"
-                },
-                "scheme": {
+              "parent": {
+                "title": "Parent service to extend",
+                "type": "string"
+              },
+              "factory": {
+                "title": "A factory to create the object",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array"
+                  }
+                ]
+              },
+              "decorates": {
+                "title": "Service name to decorate",
+                "type": "string"
+              },
+              "deprecated": {
+                "title": "A flag indicating that the service is deprecated",
+                "type": "string"
+              },
+              "lazy": {
+                "title": "Lazy service instantiation",
+                "type": "boolean"
+              },
+              "shared": {
+                "title": "Shared service",
+                "type": "boolean"
+              },
+              "abstract": {
+                "title": "Abstract service",
+                "type": "boolean"
+              },
+              "public": {
+                "title": "A flag indication that the service cannot be accessed directly from the container object",
+                "type": "boolean"
+              },
+              "alias": {
+                "title": "A shortcut to access some services",
+                "type": "string"
+              },
+              "arguments": {
+                "title": "Service arguments",
+                "type": "array",
+                "uniqueItems": true
+              },
+              "configurator": {
+                "title": "A callable to configure a service after its instantiation",
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
+              },
+              "tags": {
+                "title": "List of tags tell Drupal that your service can be processed in some special way",
+                "examples": [
+                  "event_subscriber",
+                  "service_collector",
+                  "theme_negotiator",
+                  "twig.extension",
+                  "access_check"
+                ],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "call": {
+                      "type": "string"
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "required": {
+                      "type": "boolean"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "default_backend": {
+                      "type": "string"
+                    },
+                    "responder": {
+                      "type": "boolean"
+                    },
+                    "format": {
+                      "type": "string"
+                    },
+                    "applies_to": {
+                      "type": "string"
+                    },
+                    "provider_id": {
+                      "type": "string"
+                    },
+                    "needs_incoming_request": {
+                      "type": "boolean"
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "calls": {
+                "title": "Methods to set optional dependencies",
+                "type": "array",
+                "uniqueItems": true
               }
-            }
-          },
-          "calls": {
-            "title": "Methods to set optional dependencies",
-            "type": "array",
-            "uniqueItems": true
+            },
+            "additionalProperties": false
           }
-        }
+        ]
       }
     }
   },

--- a/src/test/drupal-services/drupal-services.yml
+++ b/src/test/drupal-services/drupal-services.yml
@@ -9,5 +9,8 @@ services:
     class: Drupal\Example\WithModuleHandler
     arguments: ['@module_handler', '%example.parameter%']
 
+  # Defines an alias shortcut.
+  Drupal\Example\WithModuleHandler: '@example.with_module_handler'
+
 parameters:
   example.parameter: TRUE


### PR DESCRIPTION
Resolves #6228.


Adds shorthand service alias definition to Drupal services.

This allows aliases to be defined as follows:

```
services:
  Drupal\Example\WithModuleHandler: '@example.with_module_handler'
```

Examples of this are already widespread in Drupal core, so this is updating the schema to match what's already in use.

Adds positive and negative test.