### PR TITLE
Update crucible-code schema for the input block

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-send.json
+++ b/src/negative_test/crucible-code-schema/not-a-send.json
@@ -1,0 +1,3 @@
+{
+  "input": { "send": "shiftEnter" }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -66,6 +66,24 @@
       },
       "type": "object"
     },
+    "input": {
+      "additionalProperties": false,
+      "description": "What the keyboard does",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "send": {
+          "description": "Which press sends a prompt: enter sends and Shift+Enter, Alt+Enter or Ctrl+J opens a line; altEnter swaps the two, for a terminal that keeps Enter for itself",
+          "enum": ["enter", "altEnter"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "output": {
       "additionalProperties": false,
       "description": "What the terminal shows",

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -12,6 +12,9 @@
     "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12",
     "RUST_LOG": "warn"
   },
+  "input": {
+    "send": "altEnter"
+  },
   "output": {
     "color": "auto",
     "glyphs": "unicode",


### PR DESCRIPTION
crucible 0.14.0 adds an `input` block with a `send` key, choosing which press sends a prompt. The schema is generated from the parser, so this is the file that release ships, run through `prettier` with your config.

The positive test gains the new block — it is meant to exercise every one — and a negative test covers a value `send` does not accept. `node ./cli.js check --schema-name=crucible-code-schema.json` passes.