### PR TITLE
Enable strict validation for GitHub workflow templates

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -140,7 +140,6 @@
     "gaspar-3.0.json",
     "github-action.json",
     "github-funding.json",
-    "github-workflow-template-properties.json",
     "github-workflow.json",
     "helmfile.json",
     "hemtt-0.6.2.json",

--- a/src/schemas/json/github-workflow-template-properties.json
+++ b/src/schemas/json/github-workflow-template-properties.json
@@ -2,27 +2,33 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/github-workflow-template-properties.json",
   "$comment": "https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization",
+  "title": "GitHub starter workflow config file schema",
+  "description": "Metadata for a GitHub Actions starter workflow.\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization",
   "additionalProperties": false,
   "properties": {
     "name": {
+      "title": "Name",
       "description": "A workflow template name\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample name"]
     },
     "description": {
+      "title": "Description",
       "description": "A workflow template description\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample description"]
     },
     "iconName": {
+      "title": "Icon name",
       "description": "A workflow template icon\nMust be the name of an SVG file, without the file name extension, stored in the workflow-templates directory\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "string",
       "minLength": 1,
       "examples": ["Sample icon"]
     },
     "categories": {
+      "title": "Categories",
       "description": "A workflow category\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "array",
       "uniqueItems": true,
@@ -899,6 +905,7 @@
       }
     },
     "filePatterns": {
+      "title": "File patterns",
       "description": "A file name pattern to match against repository to enable this workflow when match is succeed\nhttps://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow",
       "type": "array",
       "minItems": 1,
@@ -911,6 +918,5 @@
     }
   },
   "required": ["name", "description"],
-  "title": "GitHub starter workflow config file schema",
   "type": "object"
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Summary

- add strict-schema titles and a source-backed root description to `github-workflow-template-properties.json`
- remove the schema from the `ajvNotStrictMode` exceptions

Part of #6038

## Validation

- `CI=1 node cli.js check-strict --schema-name=github-workflow-template-properties.json`
- `CI=1 node cli.js check --schema-name=github-workflow-template-properties.json`
- `npx prettier --config .prettierrc.cjs --ignore-path .gitignore --check src/schemas/json/github-workflow-template-properties.json src/schema-validation.jsonc`
- `npm run typecheck`
- `npm run eslint`
