### PR TITLE
claude-code-settings: add missing documented tools to permissionRule pattern

### DIFF
--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -5,7 +5,7 @@
     "permissionRule": {
       "type": "string",
       "description": "Tool permission rule.\nSee https://code.claude.com/docs/en/settings#permission-rule-syntax\nSee https://code.claude.com/docs/en/tools-reference for full list of tools available to Claude.",
-      "pattern": "^((Agent|Artifact|Bash|Cd|Edit|EnterWorktree|ExitPlanMode|Glob|Grep|KillShell|LSP|Monitor|MultiEdit|NotebookEdit|PowerShell|Read|ShareOnboardingGuide|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WebFetch|WebSearch|Workflow|Write)(\\([^)]+\\))?|mcp__.*)$",
+      "pattern": "^((Agent|Artifact|AskUserQuestion|Bash|Cd|CronCreate|CronDelete|CronList|Edit|EndConversation|EnterPlanMode|EnterWorktree|ExitPlanMode|ExitWorktree|Glob|Grep|KillShell|ListAgents|ListMcpResourcesTool|LSP|Monitor|MultiEdit|NotebookEdit|PowerShell|PushNotification|Read|ReadMcpResourceTool|RemoteTrigger|ReportFindings|ScheduleWakeup|SendMessage|SendUserFile|ShareOnboardingGuide|Skill|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WaitForMcpServers|WebFetch|WebSearch|Workflow|Write)(\\([^)]+\\))?|mcp__.*)$",
       "examples": [
         "Bash",
         "Bash(npm run build)",

--- a/src/test/claude-code-settings/permissions-advanced.json
+++ b/src/test/claude-code-settings/permissions-advanced.json
@@ -25,7 +25,32 @@
     ],
     "ask": ["Write(~/projects/**)", "Bash(make:*)", "ShareOnboardingGuide"],
     "defaultMode": "acceptEdits",
-    "deny": ["Bash(rm:*)", "Write(/etc/**)", "WebFetch(domain:malicious.com)"],
+    "deny": [
+      "Bash(rm:*)",
+      "Write(/etc/**)",
+      "WebFetch(domain:malicious.com)",
+      "WebSearch",
+      "EndConversation",
+      "EnterPlanMode",
+      "ExitPlanMode",
+      "EnterWorktree",
+      "ExitWorktree",
+      "NotebookEdit",
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+      "AskUserQuestion",
+      "ListAgents",
+      "ListMcpResourcesTool",
+      "ReadMcpResourceTool",
+      "PushNotification",
+      "RemoteTrigger",
+      "ReportFindings",
+      "ScheduleWakeup",
+      "SendMessage",
+      "SendUserFile",
+      "WaitForMcpServers"
+    ],
     "disableBypassPermissionsMode": "disable"
   }
 }


### PR DESCRIPTION
## What

Adds 17 tool names to the `permissionRule` pattern in `claude-code-settings.json` that are documented in the official [Claude Code tools reference](https://code.claude.com/docs/en/tools-reference) but were missing from the pattern:

`AskUserQuestion`, `CronCreate`, `CronDelete`, `CronList`, `EndConversation`, `EnterPlanMode`, `ExitWorktree`, `ListAgents`, `ListMcpResourcesTool`, `PushNotification`, `ReadMcpResourceTool`, `RemoteTrigger`, `ReportFindings`, `ScheduleWakeup`, `SendMessage`, `SendUserFile`, `WaitForMcpServers`

## Why

Valid permission rules naming these tools (e.g. `"deny": ["EnterPlanMode", "CronCreate"]`) are flagged in editors with:

> String does not match the pattern of "^((Agent|Artifact|Bash|…"

even though Claude Code accepts and enforces them. The asymmetry was confusing in practice: `ExitPlanMode` passed while its sibling `EnterPlanMode` was flagged, `EnterWorktree` passed while `ExitWorktree` was flagged.

## Changes

- Merged the missing names into the pattern, keeping alphabetical order. Existing undocumented-but-real names (`Cd`, `KillShell`, `MultiEdit`) are kept.
- Extended `src/test/claude-code-settings/permissions-advanced.json` deny list to cover the added names.

## Validation

- `node cli.js check` passes
- `prettier --check` passes on both files
- Spot-checked with schemasafe: the extended test file validates, and a bogus tool name (`TotallyFakeTool`) is still rejected