### PR TITLE
chore: enable strict validation for github funding schema

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -139,7 +139,6 @@
     "gaspar-1.0.json",
     "gaspar-3.0.json",
     "github-action.json",
-    "github-funding.json",
     "github-workflow.json",
     "helmfile.json",
     "hemtt-0.6.2.json",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Summary

Remove `github-funding.json` from the `ajvNotStrictMode` exception list. The schema already passes Ajv strict validation without any schema changes.

Part of #6038.

## Validation

- `node cli.js check --schema-name=github-funding.json`
- `node cli.js check`
- `npm run prettier`
- `npm run typecheck`
- `npm run eslint`
- `git diff --check`
- tracked-diff secret scan against `upstream/master`: `blocking_new_hits=[]`
