### PR TITLE
Add LiquiLens Evidence Carrier schemas to catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4919,6 +4919,24 @@
       "url": "https://w3id.org/linkml/meta.schema.json"
     },
     {
+      "name": "LiquiLens Evidence Carrier v1",
+      "description": "Transport-neutral, content-addressed financial evidence carrier",
+      "fileMatch": [
+        "liquilens-evidence-carrier.json",
+        "*.liquilens-evidence-carrier.json"
+      ],
+      "url": "https://liquilens.in/protocol/liquilens-evidence-carrier-v1.schema.json"
+    },
+    {
+      "name": "LiquiLens Evidence Carrier Reference v1",
+      "description": "Policy-redacted reference to a verified LiquiLens Evidence Carrier",
+      "fileMatch": [
+        "liquilens-evidence-carrier-reference.json",
+        "*.liquilens-evidence-carrier-reference.json"
+      ],
+      "url": "https://liquilens.in/protocol/liquilens-evidence-carrier-reference-v1.schema.json"
+    },
+    {
       "name": "Lively Properties",
       "description": "Lively Wallpaper configuration file. Documentation: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#lively-properties",
       "fileMatch": ["LivelyProperties.json"],


### PR DESCRIPTION
## Summary

- Register the canonical LiquiLens Evidence Carrier v1 schema.
- Register its policy-redacted reference schema separately.
- Use product-specific filename patterns to avoid collisions with generic JSON files.

These are self-hosted remote schemas, so this follows the catalog-only contribution path documented in CONTRIBUTING.md; no SchemaStore-hosted copy or fixture is needed. The source artifacts are Apache-2.0 and released at https://github.com/beepboop2025/liquilens-evidence-carrier/releases/tag/v0.13.5.

Canonical schema SHA-256 values at submission:

- Full carrier: 7f8494d8470853dc88665ea32c1dccb40cc58c55b07e9267aa28c81f83c1ccd3
- Redacted reference: d54043bf11359749597bff7495b0fffe6ff8453a35144cee4a2bd69711fec7e8

## Validation

- npm clean-install
- npm run prettier
- npm run typecheck
- npm run eslint
- node ./cli.js check
- node ./cli.js coverage
- pre-commit run --all-files
- Both remote draft 2020-12 schemas compile under Ajv strict mode.