### PR TITLE
Add Dark Factory darkfactory.yaml schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1868,10 +1868,7 @@
     {
       "name": "Dark Factory consumer config",
       "description": "Unified darkfactory.yaml for the Cerebe / Dark Factory CLI (doctrine, deny, hooks, MCP, critics, policy)",
-      "fileMatch": [
-        "darkfactory.yaml",
-        "darkfactory.yml"
-      ],
+      "fileMatch": ["darkfactory.yaml", "darkfactory.yml"],
       "url": "https://raw.githubusercontent.com/momentiq-ai/cerebe/main/schemas/darkfactory/v1.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1866,6 +1866,15 @@
       }
     },
     {
+      "name": "Dark Factory consumer config",
+      "description": "Unified darkfactory.yaml for the Cerebe / Dark Factory CLI (doctrine, deny, hooks, MCP, critics, policy)",
+      "fileMatch": [
+        "darkfactory.yaml",
+        "darkfactory.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/momentiq-ai/cerebe/main/schemas/darkfactory/v1.json"
+    },
+    {
       "name": "DataYoga Connections",
       "description": "Collection of defined source and target connections used within DataYoga jobs",
       "fileMatch": ["connections.dy.yaml"],


### PR DESCRIPTION
Remote catalog entry for the Cerebe / Dark Factory unified consumer config.

- **fileMatch:** `darkfactory.yaml`, `darkfactory.yml` only (no generic `*.yaml`)
- **url:** https://raw.githubusercontent.com/momentiq-ai/cerebe/main/schemas/darkfactory/v1.json
- **\$id:** `https://schemas.dark-factory.dev/darkfactory/v1.json`

The live URL is published and read back by the `momentiq-ai/dark-factory` CLI release. Editors that already honor the in-file `# yaml-language-server: $schema=` line do not need this; SchemaStore makes the same schema auto-apply with no per-user setup.