### PR TITLE
feat: add BOSH Ops File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*
 *~
+\#*
+.#*
 *.dbmdl
 *.[Pp]ublish.xml
 *.pfx

--- a/cli.js
+++ b/cli.js
@@ -194,7 +194,12 @@ async function readJsonFile(/** @type {string} */ filename) {
 }
 
 function isIgnoredFile(/** @type {string} */ file) {
-  return file === '.DS_Store'
+  return (
+    file === '.DS_Store' ||
+    file.startsWith('#') ||
+    file.startsWith('.#') ||
+    file.endsWith('~')
+  )
 }
 
 async function forEachCatalogUrl(

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1361,6 +1361,11 @@
       "url": "https://www.schemastore.org/bosh-package-spec.json"
     },
     {
+      "name": "BOSH Ops File",
+      "description": "Ops File for BOSH CLI",
+      "url": "https://www.schemastore.org/bosh-ops-file.json"
+    },
+    {
       "name": "Boyka Framework",
       "description": "Boyka Framework config file",
       "fileMatch": ["boyka-config.json"],

--- a/src/negative_test/bosh-ops-file/missing-type.yaml
+++ b/src/negative_test/bosh-ops-file/missing-type.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-ops-file.json
+- path: /name
+  value: other-cf

--- a/src/negative_test/bosh-ops-file/remove-missing-path.yaml
+++ b/src/negative_test/bosh-ops-file/remove-missing-path.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-ops-file.json
+- type: remove

--- a/src/negative_test/bosh-ops-file/replace-missing-path.yaml
+++ b/src/negative_test/bosh-ops-file/replace-missing-path.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-ops-file.json
+- type: replace
+  value: other-cf

--- a/src/negative_test/bosh-ops-file/replace-missing-value.yaml
+++ b/src/negative_test/bosh-ops-file/replace-missing-value.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-ops-file.json
+- type: replace
+  path: /name

--- a/src/schemas/json/bosh-ops-file.json
+++ b/src/schemas/json/bosh-ops-file.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/bosh-ops-file.json",
+  "$comment": "Schema built from https://bosh.io/docs/cli-ops-files/.",
+  "$ref": "#/definitions/Operations",
+  "title": "BOSH Ops File",
+  "description": "A collection of operations for interpolating a YAML file.\n\nDocs: https://bosh.io/docs/cli-ops-files/",
+  "definitions": {
+    "Operations": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/definitions/Replace" },
+          { "$ref": "#/definitions/Remove" }
+        ]
+      }
+    },
+    "Replace": {
+      "type": "object",
+      "required": ["type", "path", "value"],
+      "properties": {
+        "type": { "const": "replace" },
+        "path": { "type": "string" },
+        "value": {}
+      }
+    },
+    "Remove": {
+      "type": "object",
+      "required": ["type", "path"],
+      "properties": {
+        "type": { "const": "remove" },
+        "path": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/test/bosh-ops-file/acceptance.yaml
+++ b/src/test/bosh-ops-file/acceptance.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../schemas/json/bosh-ops-file.json
+- type: replace
+  path: /name
+  value: other-cf
+
+- type: remove
+  path: /key


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

BOSH Ops Files consists of a series of replace and/or remove operations which can be interpolated into a YAML file. Typically used against BOSH Deployment manifests. The closest analogues are [Kustomize and YTT's overlay feature](https://carvel.dev/ytt/docs/v0.41.0/ytt-vs-x/#ytt-vs-kustomize-and-cf-bosh-ops-files).

Additional ignore patterns were added to `cli.js` and `.gitignore` for the Emacs environment.