### PR TITLE
Add agentctl schemas (config, permissions, mcp)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -10828,6 +10828,24 @@
       }
     },
     {
+      "name": "AgentCtl config",
+      "description": "agentctl config file (.ai/config.yaml): runtimes, project name, and sync settings for AI coding-agent configuration",
+      "fileMatch": ["**/.ai/config.yaml", "**/.ai/config.yml"],
+      "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/config.schema.json"
+    },
+    {
+      "name": "AgentCtl MCP",
+      "description": "agentctl MCP server declarations (.ai/mcp.yaml): Model Context Protocol servers rendered into each runtime's format",
+      "fileMatch": ["**/.ai/mcp.yaml", "**/.ai/mcp.yml"],
+      "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/mcp.schema.json"
+    },
+    {
+      "name": "AgentCtl permissions",
+      "description": "agentctl runtime-neutral permissions (.ai/permissions.yaml): filesystem and shell rules using deny-over-allow precedence",
+      "fileMatch": ["**/.ai/permissions.yaml", "**/.ai/permissions.yml"],
+      "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/permissions.schema.json"
+    },
+    {
       "name": "AgentLoopKit",
       "description": "Configuration file for AgentLoopKit, a repo-level engineering loop for coding agents",
       "fileMatch": ["agentloop.config.json"],


### PR DESCRIPTION
Adds three self-hosted catalog entries for [agentctl](https://github.com/itslab42/agentctl) — a single source of truth for AI coding-agent configuration that generates settings for Claude Code, Codex CLI, OpenCode, Cursor, and Kiro from a runtime-neutral `.ai/` directory.

## Entries

| name | fileMatch | schema |
| --- | --- | --- |
| AgentCtl config | `**/.ai/config.yaml`, `**/.ai/config.yml` | config.schema.json |
| AgentCtl MCP | `**/.ai/mcp.yaml`, `**/.ai/mcp.yml` | mcp.schema.json |
| AgentCtl permissions | `**/.ai/permissions.yaml`, `**/.ai/permissions.yml` | permissions.schema.json |

The schemas are self-hosted at `raw.githubusercontent.com/itslab42/agentctl/main/schemas/`.

## Notes

- Schemas are `draft-07`.
- `fileMatch` patterns are directory-prefixed (`**/.ai/...`) to avoid generic-pattern false positives, per the contributing guide.
- `additionalProperties` is permissive (not `false`), so unknown fields introduced by future agentctl versions won't error, per the "Avoiding Overconstraint" guidance.
- Entries added in alphabetical order alongside the existing `Agent*` cluster.

## Validation

`node ./cli.js check` passes locally:
- catalog.json validates against its schema
- no fields that break guidelines
- no duplicate `fileMatch` values
- no invalid schema URLs
