### PR TITLE
Added servercn configuration schema for backend component registry

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11119,7 +11119,7 @@
     },
     {
       "name": "servercn",
-      "description": "Servercn is the backend component registry for node.js inspired by shadcn/ui.",
+      "description": "Servercn is the backend component registry for node.js inspired by shadcn/ui",
       "fileMatch": ["servercn.config.json", "servercn.json"],
       "url": "https://www.akkaldhami.com.np/schema/servercn.config.json"
     }

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11116,6 +11116,12 @@
       "description": "Workflow definition for the yaml-workflow engine — params, tasks, steps, imports, and flows",
       "fileMatch": ["**/*.yaml-workflow.yaml", "**/*.yaml-workflow.yml"],
       "url": "https://raw.githubusercontent.com/orieg/yaml-workflow/main/schema/workflow-schema.json"
+    },
+    {
+      "name": "servercn",
+      "description": "Servercn is the backend component registry for node.js inspired by shadcn/ui.",
+      "fileMatch": ["servercn.config.json", "servercn.json"],
+      "url": "https://www.akkaldhami.com.np/schema/servercn.config.json"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Description

Adds support for `servercn.config.json` or `servercn.json`.

Servercn is a backend component registry for Node.js inspired by shadcn/ui.
Website: https://servercn.vercel.app or https://www.akkaldhami.com.np

Schema URL:
https://www.akkaldhami.com.np/schema/servercn.config.json

Configuration files:
- servercn.config.json
- servercn.json
