### PR TITLE
Update crucible-code schema for 0.25.2

### DIFF
--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -240,7 +240,7 @@
               "minimum": 0,
               "type": "integer"
             },
-            "description": "How many tokens a model accepts at once, keyed by the model name, where crucible cannot ask the provider or has it wrong",
+            "description": "The context-window size in tokens, keyed by model name; an explicit value may opt into a larger native window",
             "properties": {
               "$schema": {
                 "type": "string"
@@ -262,7 +262,7 @@
             "type": "object"
           },
           "defaultContextWindow": {
-            "description": "How many tokens to assume any model of this provider accepts, where it is not named above",
+            "description": "The context-window size in tokens for any model of this provider not named above",
             "minimum": 0,
             "type": "integer"
           },


### PR DESCRIPTION
Syncs `crucible-code-schema.json` with the schema generated by crucible 0.25.2, the current release.

Only two `description` strings changed — the context-window keys now say what the value is rather than when to reach for it:

- `providers.*.contextWindow` — "The context-window size in tokens, keyed by model name; an explicit value may opt into a larger native window"
- `providers.*.defaultContextWindow` — "The context-window size in tokens for any model of this provider not named above"

No keys, types or constraints move, so every existing configuration still validates.

`node ./cli.js check --schema-name=crucible-code-schema.json` passes, and `lint`, `check-strict` and `prettier` report exactly what they report on `master` today.

This supersedes #6210 and #6214, which were opened against 0.1.5 and 0.1.9 and whose content has since landed through #6220, #6227, #6230 and #6234. I am closing both.