### PR TITLE
Add Dagger module config (dagger.json) to the catalog

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2631,6 +2631,12 @@
       "url": "https://www.schemastore.org/csslintrc.json"
     },
     {
+      "name": "Dagger module",
+      "description": "Module metadata for the Dagger CI/CD engine: SDK, dependencies, and engine version",
+      "fileMatch": ["dagger.json"],
+      "url": "https://docs.dagger.io/reference/dagger.schema.json"
+    },
+    {
       "name": "Dart Build Config (dart-build.json)",
       "description": "Configuration for Dart's build system",
       "url": "https://www.schemastore.org/dart-build.json"


### PR DESCRIPTION
Adds a catalog entry for `dagger.json`, the module configuration file of [Dagger](https://dagger.io). The schema is externally hosted, so this is a catalog entry only and no schema file is added to this repository.

- **Schema URL:** https://docs.dagger.io/reference/dagger.schema.json — JSON Schema 2020-12, internal `$ref`s only. Dagger's docs link it as the schema for `dagger.json`, and it's generated from the engine's config types on every docs build, so it won't go stale.
- **`fileMatch` is just `dagger.json`** — a fixed filename written by `dagger init`, never user-chosen. A repo can hold several, one per module at any depth; the slash-free pattern matches those.

Inserted alphabetically between `CSS Lint (.csslintrc)` and `Dart Build Config (dart-build.json)`. `node ./cli.js check` and `pre-commit` pass locally.