### PR TITLE
Point GitHub Sponsors at the SchemaStore org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 # These are supported funding model platforms
-github: ['madskristensen', 'hyperupcall']
+github: [SchemaStore]

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ And here’s the thing: for-profit organizations are among the biggest beneficia
 
 Your support would help cover hosting, maintenance, and development costs, ensuring this resource remains free and open for the entire community. It’s a small way to give back to something that likely saves you (and your team) time and effort every day.
 
-You can find [sponsorship details on the site](https://github.com/sponsors/madskristensen), or feel free to reach out to me directly.
+You can find [sponsorship details on the site](https://github.com/sponsors/SchemaStore), or feel free to reach out to me directly.

--- a/src/json.cshtml
+++ b/src/json.cshtml
@@ -104,8 +104,6 @@
     <p>Premium sponsors:</p>
 
 	<ul>
-		<li><strong>Microsoft</strong></li>
-        <li><strong>JetBrains</strong></li>
 		<li>Your business?</li>
 	</ul>
 
@@ -113,7 +111,7 @@
 		Do you build IDEs or editors that integrate with SchemaStore.org, or host a schema for your paying customers, consider a sponsorship.
 	</p>
 
-	<p><a href="https://github.com/sponsors/madskristensen">SchemaStore.org sponsorships <span style="color:mediumvioletred">♡</span></a></p>
+	<p><a href="https://github.com/sponsors/SchemaStore">SchemaStore.org sponsorships <span style="color:mediumvioletred">♡</span></a></p>
 </article>
 
 <article>


### PR DESCRIPTION
## Summary
- Point `.github/FUNDING.yml`, the site Sponsor Me link, and the README at [github.com/sponsors/SchemaStore](https://github.com/sponsors/SchemaStore) now that org Sponsors is enabled.
- Remove Microsoft and JetBrains from the live premium list (they are not currently paying).

Personal GitHub Sponsors for madskristensen remains for Visual Studio extensions, not SchemaStore.

## Test plan
- [ ] Confirm the repo Sponsor button goes to https://github.com/sponsors/SchemaStore
- [ ] Confirm schemastore.org sponsorships section links there after deploy
- [ ] Confirm Microsoft and JetBrains are no longer listed as premium sponsors