### PR TITLE
Fix generated homepage sponsor copy

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1081,8 +1081,6 @@ async function taskBuildWebsite() {
     <p>Premium sponsors:</p>
 
   <ul>
-    <li><strong>Microsoft</strong></li>
-        <li><strong>JetBrains</strong></li>
     <li>Your business?</li>
   </ul>
 
@@ -1090,7 +1088,7 @@ async function taskBuildWebsite() {
     Do you build IDEs or editors that integrate with SchemaStore.org, or host a schema for your paying customers, consider a sponsorship.
   </p>
 
-  <p><a href="https://github.com/sponsors/madskristensen">SchemaStore.org sponsorships <span style="color:mediumvioletred">♡</span></a></p>
+  <p><a href="https://github.com/sponsors/SchemaStore">SchemaStore.org sponsorships <span style="color:mediumvioletred">♡</span></a></p>
 </article>
 
 <article>


### PR DESCRIPTION
## Summary
- The GitHub Pages homepage is generated from a hardcoded HTML string in `cli.js` (`node ./cli.js build-website` → `website/index.html`), not from `src/json.cshtml`.
- #6252 updated `json.cshtml`, which Pages never serves. This updates the actual source so premium unpaid logos drop and the Sponsor Me link goes to https://github.com/sponsors/SchemaStore.

## Test plan
- [ ] `node ./cli.js build-website` writes the new sponsor block into `website/index.html`
- [ ] After Pages deploy, https://www.schemastore.org/ links to the org Sponsors page and does not list Microsoft/JetBrains as premium