### PR TITLE
Redesign SchemaStore.org homepage to lead with value and sponsorship

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -980,35 +980,75 @@ async function taskBuildWebsite() {
   )
 
   const pageTitle = 'JSON Schema Store'
-  const pageDescription = 'JSON Schemas for common JSON file formats'
-  const body = `<article id="schemalist">
-  <h3 id="count">JSON Schemas are available for the following {0} files:</h3>
+  const pageDescription =
+    'JSON, YAML, and TOML schemas used by Visual Studio, VS Code, JetBrains, and other editors'
+  const body = `<article id="intro">
+  <h2>SchemaStore.org powers JSON, YAML, and TOML in the major IDEs</h2>
+  <p class="lede">
+    Visual Studio, Visual Studio Code, JetBrains, Neovim, Emacs, and Sublime Text
+    all use this catalog. Open a GitHub workflow, <code>docker-compose.yaml</code>,
+    <code>tsconfig.json</code>, or <code>Cargo.toml</code>, and completion, validation,
+    and tooltips are already there. One public catalog, used worldwide.
+  </p>
+  <p class="lede">
+    About 1400 schemas. Over a terabyte of schema files served every day.
+  </p>
+  <div class="shots">
+    <figure>
+      <img src="/img/autocomplete.png" width="354" height="171" alt="JSON schema auto completion" />
+      <figcaption>Auto completion</figcaption>
+    </figure>
+    <figure>
+      <img src="/img/tooltip.png" width="411" height="98" alt="JSON schema tooltip" />
+      <figcaption>Tooltips</figcaption>
+    </figure>
+  </div>
+</article>
 
+<article id="sponsor">
+  <h3>Sponsorships <span class="heart">♡</span></h3>
+  <p>
+    That traffic is carried by volunteers. If your editor, product, or company
+    depends on SchemaStore.org, please consider sponsoring so it stays online.
+  </p>
+  <ul class="tiers">
+    <li><strong>$10 / month</strong>: Individual, with thanks</li>
+    <li><strong>$500 / month</strong>: company name on this site</li>
+    <li><strong>$2000 / month</strong>: logo on this site</li>
+  </ul>
+  <p><a href="https://github.com/sponsors/SchemaStore">GitHub Sponsors</a></p>
+</article>
+
+<article id="schemalist">
+  <h3 id="count">Find a schema ({0} files)</h3>
   <input type="search" placeholder="Search schemas" id="search" />
   <ul id="schemas" class="columns" role="directory" data-api="/api/json/catalog.json"></ul>
 </article>
 
 <article>
-  <h3 id="auto-completion">Auto completion</h3>
+  <h3 id="editors">Supporting editors</h3>
   <p>
-    <img src="/img/autocomplete.png" width="354" height="171" alt="JSON schema auto completion" class="left" />
-    In supported JSON editors like Visual Studio and Visual Studio Code,
-    schema files can offer auto-completion and validation to make sure your JSON document is correct.
+    These editors load SchemaStore automatically for JSON, YAML, and TOML. A schema merged here shows up in the next sync.
   </p>
 
-  <p>
-    See <a href="https://json-schema.org/tools">a list</a>
-    of editors, validators and other software supporting JSON schemas.
-  </p>
-</article>
-
-<article>
-  <h3 id="tooltips">Tooltips</h3>
-  <p>
-    <img src="/img/tooltip.png" width="411" height="98" alt="JSON schema tooltip" class="right" />
-    When a JSON editor supports schemas, tooltips can help inform the user
-    about the various properties and values.
-  </p>
+  <ul id="editorlist" class="columns">
+    <li>Android Studio</li>
+    <li>CLion</li>
+    <li>Emacs via <a href="https://github.com/joaotavora/eglot" target="_blank">eglot</a></li>
+    <li>IntelliJ IDEA</li>
+    <li>JSONBuddy</li>
+    <li>Neovim via <a href="https://github.com/b0o/SchemaStore.nvim" target="_blank">SchemaStore.nvim</a></li>
+    <li>PhpStorm</li>
+    <li>PyCharm</li>
+    <li>ReSharper</li>
+    <li>Rider</li>
+    <li>RubyMine</li>
+    <li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a>,<a href="https://packagecontrol.io/packages/LSP-yaml" target="_blank">LSP-yaml</a></li>
+    <li>Visual Studio</li>
+    <li>Visual Studio Code (<a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml" target="_blank">TOML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a>)</li>
+    <li>Visual Studio for Mac</li>
+    <li>WebStorm</li>
+  </ul>
 </article>
 
 <article>
@@ -1041,81 +1081,29 @@ async function taskBuildWebsite() {
 </article>
 
 <article>
-    <h3 id="editors">Supporting editors</h3>
-    <p>
-        Various editors and IDEs have direct support for schemas hosted on SchemaStore.org.
-    </p>
-
-    <ul id="editorlist" class="columns">
-        <li>Android Studio</li>
-    <li>CLion</li>
-    <li>Emacs via <a href="https://github.com/joaotavora/eglot" target="_blank">eglot</a></li>
-    <li>IntelliJ IDEA</li>
-        <li>JSONBuddy</li>
-        <li>Neovim via <a href="https://github.com/b0o/SchemaStore.nvim" target="_blank">SchemaStore.nvim</a></li>
-        <li>PhpStorm</li>
-        <li>PyCharm</li>
-    <li>ReSharper</li>
-        <li>Rider</li>
-        <li>RubyMine</li>
-    <li>SublimeText via <a href="https://packagecontrol.io/packages/LSP-json" target="_blank">LSP-json</a>,<a href="https://packagecontrol.io/packages/LSP-yaml" target="_blank">LSP-yaml</a></li>
-        <li>Visual Studio</li>
-        <li>Visual Studio Code (<a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml" target="_blank">YAML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml" target="_blank">TOML</a>,<a href="https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore" target="_blank">JSON</a>)</li>
-        <li>Visual Studio for Mac</li>
-        <li>WebStorm</li>
-    </ul>
-
-    <p>Any schema on SchemaStore.org will automatically be synchronized to the supporting editors.</p>
-</article>
-
-<article>
-    <h3 id="sponsor">Sponsorships <span style="color:mediumvioletred">♡</span></h3>
-    <p>
-        <img src="/img/sponsor.png" width="160" height="192" alt="Sponsor SchemaStore.org now" class="right" />
-    Over 1 TB of JSON Schema files are served each day from SchemaStore.org. It's a big effort to maintain
-    and keep running, and it's all done by JSON Schema loving volunteers.
-
-        If your business gets value from SchemaStore.org, please consider sponsoring to keep the project alive and healthy.
-    </p>
-
-    <p>Premium sponsors:</p>
-
-  <ul>
-    <li>Your business?</li>
-  </ul>
-
-    <p>
-    Do you build IDEs or editors that integrate with SchemaStore.org, or host a schema for your paying customers, consider a sponsorship.
+  <h3 id="ci">Supporting Continuous Integration tools</h3>
+  <p>
+    CI/CD applications can detect all JSON and YAML files and validate them if a matching schema is found on SchemaStore.org
   </p>
 
-  <p><a href="https://github.com/sponsors/SchemaStore">SchemaStore.org sponsorships <span style="color:mediumvioletred">♡</span></a></p>
+  <ul>
+    <li><a href="https://megalinter.github.io" target="_blank">MegaLinter</a></li>
+  </ul>
 </article>
 
 <article>
-    <h3 id="ci">Supporting Continuous Integration tools</h3>
-    <p>
-        CI/CD applications can detect all JSON and YAML files and validate them if a matching schema is found on SchemaStore.org
-    </p>
+  <h3 id="contribute">Contribute</h3>
+  <p>
+    <img src="/img/octocat.svg" width="250" height="208" alt="Hosted on GitHub" class="left octocat" />
+    The goal of this API is to include schemas for JSON, YAML, and TOML files people actually use.
+    To do that we encourage contributions in terms of new schemas, modifications and test files.
+  </p>
 
-    <ul>
-        <li><a href="https://megalinter.github.io" target="_blank">MegaLinter</a></li>
-    </ul>
-</article>
-
-<article>
-    <h3 id="contribute">Contribute</h3>
-    <p>
-        <img src="/img/octocat.svg" width="250" height="208" alt="Hosted on GitHub" class="left octocat" />
-        The goal of this API is to include schemas for all commonly
-        known JSON file formats. To do that we encourage contributions in terms of new schemas,
-        modifications and test files.
-    </p>
-
-    <p>
-        SchemaStore.org is owned by the community, and we have a history of accepting most pull requests.
-        Even if you're new to JSON Schemas, please submit new schemas anyway. We have many contributors that
-        will help turn the schemas into perfection.
-    </p>
+  <p>
+    SchemaStore.org is owned by the community, and we have a history of accepting most pull requests.
+    Even if you're new to JSON Schemas, please submit new schemas anyway. We have many contributors that
+    will help turn the schemas into perfection.
+  </p>
 </article>`
 
   await fs.writeFile(
@@ -1167,7 +1155,15 @@ async function taskBuildWebsite() {
 
 	<header role="banner">
 		<div class="container">
-			<h1><a href="/" itemprop="name">${pageTitle}</a></h1>
+			<div class="header-inner">
+				<h1><a href="/" itemprop="name">${pageTitle}</a></h1>
+				<nav>
+					<a href="#schemalist">Catalog</a>
+					<a href="#api">API</a>
+					<a href="#contribute">Contribute</a>
+					<a class="sponsor" href="#sponsor">Sponsor ♡</a>
+				</nav>
+			</div>
 		</div>
 	</header>
 

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -79,8 +79,37 @@ ol {
 header {
   background: var(--bg-header);
   color: var(--fg-header);
-  height: 60px;
-  line-height: 60px;
+  height: auto;
+  line-height: 1.2;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  min-height: 60px;
+}
+
+header nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.25em 1.1em;
+}
+
+header nav a {
+  color: var(--fg-header);
+  text-decoration: none;
+  font-size: 0.9em;
+}
+
+header nav a:hover {
+  text-decoration: underline;
+}
+
+header nav a.sponsor {
+  color: #f3b3c6;
 }
 
 header h1 a {
@@ -125,6 +154,75 @@ header h1 a {
 #main article img.right {
   float: right;
   margin-left: 2em;
+}
+
+#intro h2 {
+  font-size: 1.65em;
+  font-weight: normal;
+  margin: 0 0 0.4em;
+}
+
+#intro .lede {
+  margin: 0 0 1em;
+  max-width: 40em;
+}
+
+.shots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25em 2em;
+  margin: 1.25em 0 0;
+  align-items: flex-start;
+}
+
+.shots figure {
+  margin: 0;
+}
+
+.shots img {
+  display: block;
+  background: var(--bg-1);
+  border: 1px solid var(--bg-2);
+  padding: 6px;
+}
+
+#main article .shots img {
+  margin-bottom: 0;
+}
+
+.shots figcaption {
+  font-size: 0.8em;
+  margin-top: 0.35em;
+}
+
+#search {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  padding: 0.45em 0.65em;
+  margin: 0.75em 0 1em;
+  border: 1px solid var(--bg-2);
+  background: var(--bg-0);
+  color: var(--fg-0);
+}
+
+#sponsor .heart {
+  color: mediumvioletred;
+}
+
+.tiers {
+  margin: 0.75em 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tiers li {
+  margin: 0.15em 0;
+}
+
+.tiers li:before {
+  content: none;
 }
 
 #schemalist,
@@ -181,6 +279,25 @@ footer p {
 
 footer a {
   color: inherit;
+}
+
+@media (max-width: 640px) {
+  .header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    padding-top: 0.75em;
+    padding-bottom: 0.75em;
+  }
+
+  header nav {
+    justify-content: flex-start;
+  }
+
+  #main article img.left,
+  #main article img.right {
+    float: none;
+    margin: 0 0 1em;
+  }
 }
 
 @media print {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the generated SchemaStore.org homepage (`node ./cli.js build-website` in `cli.js`, plus `src/css/site.css`) to match the preview Mads approved.

- Lead with value: SchemaStore.org powers JSON, YAML, and TOML in the major IDEs. Catalog search is no longer the first thing on the page.
- Sponsorship is visible in the header and in a section under the intro (tiers + GitHub Sponsors link). No salesy landing-page treatment, and no GitHub Sponsors octocat (`sponsor.png`) in that section.
- Keep the existing Segoe UI / gray header / diamond list look. No Inter, gradients, or feature cards.
- Header nav: Catalog, API, Contribute, Sponsor ♡.
- Contribute still uses `/img/octocat.svg` with class `octocat`. Public API still uses `/img/json-schema-logo-blue.svg`.
- Footer is unchanged (`Open source on GitHub`). It does not say "local preview".
- Copy avoids em-dashes and en-dashes.

`site.js` still works: `#schemalist` contains `ul#schemas` with `data-api="/api/json/catalog.json"`, `#count` with the `{0}` placeholder, and `#search`. Extra CSS is folded into `src/css/site.css` so the Pages build does not miss a second stylesheet.

`website/` is gitignored and is not committed. `src/json.cshtml` is unused by the live site and is left alone.

## Test plan

- [x] `node ./cli.js build-website` generates `website/index.html` with the new header, intro, sponsorships (no `sponsor.png`), catalog markup, editors, API, CI, and Contribute
- [x] Generated page keeps `#schemalist`, `#count` with `{0}`, `#search`, and `ul#schemas[data-api="/api/json/catalog.json"]`
- [x] No em-dashes / en-dashes in generated copy; footer does not say "local preview"
- [x] Local preview of the generated site: header nav, intro + shots, sponsorships, catalog search (`tsconfig` filters to `tsconfig.json`), remaining sections, mobile header wrap
- [ ] After merge, GitHub Pages deploy shows the new homepage

Desktop top of page (header, value-prop intro, shots, sponsorships, catalog search):

[Desktop top of redesigned homepage](https://cursor.com/agents/bc-0f095e66-59e0-4528-a28f-c69042a6672e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_top_intro_and_sponsors.png)

Catalog search filtering to `tsconfig.json`, plus supporting editors and Public API:

[Catalog search for tsconfig](https://cursor.com/agents/bc-0f095e66-59e0-4528-a28f-c69042a6672e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_catalog_search_tsconfig.png)

Contribute keeps `/img/octocat.svg`. Footer is "Open source on GitHub":

[Contribute section and footer](https://cursor.com/agents/bc-0f095e66-59e0-4528-a28f-c69042a6672e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_contribute_and_footer.png)

Mobile header stacks; intro shots wrap:

[Mobile header and intro](https://cursor.com/agents/bc-0f095e66-59e0-4528-a28f-c69042a6672e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_mobile_header.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f095e66-59e0-4528-a28f-c69042a6672e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f095e66-59e0-4528-a28f-c69042a6672e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

