### PR TITLE
Remove border from homepage screenshot images

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -181,9 +181,6 @@ header h1 a {
 
 .shots img {
   display: block;
-  background: var(--bg-1);
-  border: 1px solid var(--bg-2);
-  padding: 6px;
 }
 
 #main article .shots img {


### PR DESCRIPTION
Drops the CSS border (and the padding/background that framed them) from the intro autocomplete and tooltip images. Same design as #6257 otherwise.