### PR TITLE
Add Context Passport

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4,53 +4,38 @@
   "schemas": [
     {
       "name": "Context Passport",
-      "description": "Tamper-evident record of an AI agent event: what an agent was asked, what it decided, and a SHA-256 chain linking it to the record before it",
-      "fileMatch": [
-        "*.passport.json"
-      ],
+      "description": "Tamper-evident record of an AI agent event: what the agent was asked, what it decided, and a SHA-256 chain linking it to the record before it",
+      "fileMatch": ["*.passport.json"],
       "url": "https://contextpassport.com/schema/v2.json"
     },
     {
       "name": "glslint config",
       "description": "glslint project config and shader-dialect preset (glslint.toml): ecosystem detection, #pragma expansion, shared-library and injected-define declarations",
-      "fileMatch": [
-        "glslint.toml"
-      ],
+      "fileMatch": ["glslint.toml"],
       "url": "https://raw.githubusercontent.com/johncarmack1984/glslint/main/schema/glslint.schema.json"
     },
     {
       "name": "Mermaid config",
       "description": "Configuration for Mermaid diagrams and charts",
-      "fileMatch": [
-        "mermaid.config.json",
-        ".mermaidrc.json",
-        "mermaidrc.json"
-      ],
+      "fileMatch": ["mermaid.config.json", ".mermaidrc.json", "mermaidrc.json"],
       "url": "https://mermaid.js.org/schemas/config.schema.json"
     },
     {
       "name": "Specpin spec file",
       "description": "Specpin business-spec file (.specs/*.spec.json): rules, descriptions, and acceptance criteria pinned to UI elements",
-      "fileMatch": [
-        "**/.specs/*.spec.json"
-      ],
+      "fileMatch": ["**/.specs/*.spec.json"],
       "url": "https://specpin.ohnice.app/schema/v1.json"
     },
     {
       "name": "Burnless SRE config",
       "description": "Burnless sre.yaml — SLOs, error budgets, runbooks, on-call, and dashboards as code",
-      "fileMatch": [
-        "sre.yaml",
-        "sre.yml"
-      ],
+      "fileMatch": ["sre.yaml", "sre.yml"],
       "url": "https://raw.githubusercontent.com/Custos-com/Burnless/main/schema/sre.schema.json"
     },
     {
       "name": "SigmaCV CV",
       "description": "SigmaCV canonical academic-CV object — open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information",
-      "fileMatch": [
-        "**/*.sigmacv.json"
-      ],
+      "fileMatch": ["**/*.sigmacv.json"],
       "url": "https://www.schemastore.org/sigmacv.json"
     },
     {
@@ -88,35 +73,25 @@
     {
       "name": "ReleaseKit",
       "description": "Configuration for ReleaseKit release automation",
-      "fileMatch": [
-        "releasekit.config.json"
-      ],
+      "fileMatch": ["releasekit.config.json"],
       "url": "https://goosewobbler.github.io/releasekit/schema.json"
     },
     {
       "name": "Releasaurus Config",
       "description": "Configuration file for Releasaurus",
-      "fileMatch": [
-        "releasaurus.toml"
-      ],
+      "fileMatch": ["releasaurus.toml"],
       "url": "https://raw.githubusercontent.com/robgonnella/releasaurus/refs/heads/main/schema/schema.json"
     },
     {
       "name": "Bacon config",
       "description": "Bacon configuration file",
-      "fileMatch": [
-        "bacon.toml",
-        "**/bacon/prefs.toml"
-      ],
+      "fileMatch": ["bacon.toml", "**/bacon/prefs.toml"],
       "url": "https://dystroy.org/bacon/.bacon.schema.json"
     },
     {
       "name": "Upsun config",
       "description": "Upsun configuration file",
-      "fileMatch": [
-        "**/.upsun/config.yml",
-        "**/.upsun/config.yaml"
-      ],
+      "fileMatch": ["**/.upsun/config.yml", "**/.upsun/config.yaml"],
       "url": "https://meta.upsun.com/schema/upsun"
     },
     {
@@ -134,27 +109,19 @@
     {
       "name": "Platform.sh routes",
       "description": "Platform.sh routes configuration file",
-      "fileMatch": [
-        "**/.platform/routes.yml",
-        "**/.platform/routes.yaml"
-      ],
+      "fileMatch": ["**/.platform/routes.yml", "**/.platform/routes.yaml"],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/platformsh.routes.json"
     },
     {
       "name": "Platform.sh services",
       "description": "Platform.sh services configuration file",
-      "fileMatch": [
-        "**/.platform/services.yml",
-        "**/.platform/services.yaml"
-      ],
+      "fileMatch": ["**/.platform/services.yml", "**/.platform/services.yaml"],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/platformsh.services.json"
     },
     {
       "name": "1Password SSH Agent Config",
       "description": "Configuration file for the 1Password SSH agent",
-      "fileMatch": [
-        "**/1password/ssh/agent.toml"
-      ],
+      "fileMatch": ["**/1password/ssh/agent.toml"],
       "url": "https://developer.1password.com/schema/ssh-agent-config.json"
     },
     {
@@ -170,9 +137,7 @@
     {
       "name": "Application Accelerator",
       "description": "Application Accelerator for VMware Tanzu",
-      "fileMatch": [
-        "accelerator.yaml"
-      ],
+      "fileMatch": ["accelerator.yaml"],
       "url": "https://www.schemastore.org/accelerator.json"
     },
     {
@@ -188,18 +153,13 @@
     {
       "name": "amplify.yml",
       "description": "AWS Amplify Console build settings file",
-      "fileMatch": [
-        "amplify.yml",
-        "amplify.yaml"
-      ],
+      "fileMatch": ["amplify.yml", "amplify.yaml"],
       "url": "https://www.schemastore.org/amplify.json"
     },
     {
       "name": "Applicant Profile Protocol",
       "description": "Structured JSON format for professional profiles, resumes, and CVs with skills, experience, education, and certifications",
-      "fileMatch": [
-        "*.app-profile.json"
-      ],
+      "fileMatch": ["*.app-profile.json"],
       "url": "https://app-protocol.org/schema/app-1.0.json"
     },
     {
@@ -221,9 +181,7 @@
     {
       "name": ".NET Aspire 8.0 Manifest",
       "description": "Manifest generated by .NET Aspire AppHosts to support deployment automation",
-      "fileMatch": [
-        "aspire-manifest.json"
-      ],
+      "fileMatch": ["aspire-manifest.json"],
       "url": "https://www.schemastore.org/aspire-8.0.json",
       "versions": {
         "8.0": "https://www.schemastore.org/aspire-8.0.json"
@@ -232,13 +190,7 @@
     {
       "name": "AnyWork Automation Configuration",
       "description": "AnyWork Automation Configuration used to configure automation scripts on AnyWork",
-      "fileMatch": [
-        ".awc.yaml",
-        ".awc.yml",
-        ".awc.json",
-        ".awc.jsonc",
-        ".awc"
-      ],
+      "fileMatch": [".awc.yaml", ".awc.yml", ".awc.json", ".awc.jsonc", ".awc"],
       "url": "https://www.schemastore.org/anywork-ac-1.1.json",
       "versions": {
         "1.1": "https://www.schemastore.org/anywork-ac-1.1.json",
@@ -248,50 +200,37 @@
     {
       "name": "@factorial/drupal-breakpoints-css",
       "description": "@factorial/drupal-breakpoints-css config file",
-      "fileMatch": [
-        "breakpoints.config.yml"
-      ],
+      "fileMatch": ["breakpoints.config.yml"],
       "url": "https://www.schemastore.org/factorial-drupal-breakpoints-css-0.2.0.json"
     },
     {
       "name": ".adonisrc.json",
       "description": "AdonisJS configuration file",
-      "fileMatch": [
-        ".adonisrc.json"
-      ],
+      "fileMatch": [".adonisrc.json"],
       "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
     },
     {
       "name": "aerleon.yml",
       "description": "Aerleon configuration file",
-      "fileMatch": [
-        "aerleon.yml"
-      ],
+      "fileMatch": ["aerleon.yml"],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-config.schema.json"
     },
     {
       "name": "Aerleon Network & Service Definitions",
       "description": "Aerleon network & service definition file",
-      "fileMatch": [
-        "**/def/**/*.yaml"
-      ],
+      "fileMatch": ["**/def/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-definitions.schema.json"
     },
     {
       "name": "Aerleon Policy",
       "description": "Aerleon policy file",
-      "fileMatch": [
-        "**/policies/**/*.yaml"
-      ],
+      "fileMatch": ["**/policies/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-policies.schema.json"
     },
     {
       "name": ".agripparc.json",
       "description": "the Agrippa config file",
-      "fileMatch": [
-        ".agripparc.json",
-        "agripparc.json"
-      ],
+      "fileMatch": [".agripparc.json", "agripparc.json"],
       "url": "https://www.schemastore.org/agripparc-1.4.json",
       "versions": {
         "1.2": "https://www.schemastore.org/agripparc-1.2.json",
@@ -302,18 +241,13 @@
     {
       "name": "Air",
       "description": "R formatter and language server",
-      "fileMatch": [
-        "air.toml",
-        ".air.toml"
-      ],
+      "fileMatch": ["air.toml", ".air.toml"],
       "url": "https://github.com/posit-dev/air/releases/latest/download/air.schema.json"
     },
     {
       "name": ".aiproj.json",
       "description": "Settings for project analysis by the Application Inspector",
-      "fileMatch": [
-        ".aiproj.json"
-      ],
+      "fileMatch": [".aiproj.json"],
       "url": "https://www.schemastore.org/aiproj-1.11.json",
       "versions": {
         "1.0": "https://www.schemastore.org/aiproj-1.0.json",
@@ -333,17 +267,13 @@
     {
       "name": "abtop",
       "description": "abtop configuration file",
-      "fileMatch": [
-        "**/abtop/config.toml"
-      ],
+      "fileMatch": ["**/abtop/config.toml"],
       "url": "https://www.schemastore.org/abtop.json"
     },
     {
       "name": "ABCInventoryModuleData",
       "description": "ABCInventoryModuleData defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module",
-      "fileMatch": [
-        "abc-inventory-module-data-*.json"
-      ],
+      "fileMatch": ["abc-inventory-module-data-*.json"],
       "url": "https://www.schemastore.org/abc-inventory-module-data-5.4.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-inventory-module-data-1.0.0.json",
@@ -359,9 +289,7 @@
     {
       "name": "ABCClinicalDemandForecast",
       "description": "ABCClinicalDemandForecast defining the structure of clinical trial demand forecasting data in ABC-Plan",
-      "fileMatch": [
-        "abc-clinical-demand-forecast-*.json"
-      ],
+      "fileMatch": ["abc-clinical-demand-forecast-*.json"],
       "url": "https://www.schemastore.org/abc-clinical-demand-forecast-5.1.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-clinical-demand-forecast-1.0.0.json",
@@ -375,9 +303,7 @@
     {
       "name": "ABCSupplyPlan",
       "description": "ABCSupplyPlan representing all the state for performing inventory optimization and expiry analysis in ABC-Plan MasterPlanner",
-      "fileMatch": [
-        "abc-supply-plan-*.json"
-      ],
+      "fileMatch": ["abc-supply-plan-*.json"],
       "url": "https://www.schemastore.org/abc-supply-plan-14.1.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-supply-plan-1.0.0.json",
@@ -405,78 +331,55 @@
     {
       "name": "ACP Attempts",
       "description": "AI Context Protocol debug session tracking file",
-      "fileMatch": [
-        "**/.acp/acp.attempts.json",
-        "acp.attempts.json"
-      ],
+      "fileMatch": ["**/.acp/acp.attempts.json", "acp.attempts.json"],
       "url": "https://acp-protocol.dev/schemas/v1/attempts.schema.json"
     },
     {
       "name": "ACP Cache File",
       "description": "AI Context Protocol cache file format for storing indexed codebase metadata",
-      "fileMatch": [
-        ".acp.cache.json"
-      ],
+      "fileMatch": [".acp.cache.json"],
       "url": "https://acp-protocol.dev/schemas/v1/cache.schema.json"
     },
     {
       "name": "ACP Configuration File",
       "description": "AI Context Protocol configuration file for project-level settings",
-      "fileMatch": [
-        ".acp.config.json"
-      ],
+      "fileMatch": [".acp.config.json"],
       "url": "https://acp-protocol.dev/schemas/v1/config.schema.json"
     },
     {
       "name": "ACP Primer",
       "description": "AI Context Protocol primer definition for AI context bootstrapping",
-      "fileMatch": [
-        "primer.json",
-        "*.primer.json",
-        "primer.defaults.json"
-      ],
+      "fileMatch": ["primer.json", "*.primer.json", "primer.defaults.json"],
       "url": "https://acp-protocol.dev/schemas/v1/primer.schema.json"
     },
     {
       "name": "ACP Sync",
       "description": "AI Context Protocol tool synchronization configuration",
-      "fileMatch": [
-        "**/.acp/acp.sync.json",
-        "acp.sync.json"
-      ],
+      "fileMatch": ["**/.acp/acp.sync.json", "acp.sync.json"],
       "url": "https://acp-protocol.dev/schemas/v1/sync.schema.json"
     },
     {
       "name": "ACP Variables File",
       "description": "AI Context Protocol variables file for reusable context variables",
-      "fileMatch": [
-        ".acp.vars.json"
-      ],
+      "fileMatch": [".acp.vars.json"],
       "url": "https://acp-protocol.dev/schemas/v1/vars.schema.json"
     },
     {
       "name": "actionlint",
       "description": "Configuration file for actionlint",
-      "fileMatch": [
-        "actionlint.yaml",
-        "actionlint.yml"
-      ],
+      "fileMatch": ["actionlint.yaml", "actionlint.yml"],
       "url": "https://www.schemastore.org/actionlint.json"
     },
     {
       "name": "AI Harness config",
       "description": "Repository bootstrap-intent marker for ai-harness, including context directory, resolved AI coding targets, and posture",
-      "fileMatch": [
-        ".aih-config.json"
-      ],
+      "fileMatch": [".aih-config.json"],
       "url": "https://www.schemastore.org/aih-config.json"
     },
     {
       "name": "AI Harness org policy",
       "description": "Repository governance policy for ai-harness command guardrails, MCP policy, and trust gates",
-      "fileMatch": [
-        "aih-org-policy.json"
-      ],
+      "fileMatch": ["aih-org-policy.json"],
       "url": "https://www.schemastore.org/aih-org-policy.json"
     },
     {
@@ -513,26 +416,19 @@
     {
       "name": "angular.json",
       "description": "Angular configuration file",
-      "fileMatch": [
-        "angular.json"
-      ],
+      "fileMatch": ["angular.json"],
       "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json"
     },
     {
       "name": ".angular-cli.json",
       "description": "Angular CLI configuration file",
-      "fileMatch": [
-        ".angular-cli.json",
-        "angular-cli.json"
-      ],
+      "fileMatch": [".angular-cli.json", "angular-cli.json"],
       "url": "https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json"
     },
     {
       "name": "apple-app-site-association",
       "description": "Apple Universal Link, App Site Association",
-      "fileMatch": [
-        "apple-app-site-association"
-      ],
+      "fileMatch": ["apple-app-site-association"],
       "url": "https://www.schemastore.org/apple-app-site-association.json"
     },
     {
@@ -551,78 +447,55 @@
     {
       "name": "app-definition.yaml",
       "description": "Appsemble app definition",
-      "fileMatch": [
-        "app-definition.yaml"
-      ],
+      "fileMatch": ["app-definition.yaml"],
       "url": "https://appsemble.app/api.json#/components/schemas/AppDefinition"
     },
     {
       "name": ".appsemblerc.yaml",
       "description": "Appsemble RC file",
-      "fileMatch": [
-        ".appsemblerc.yaml"
-      ],
+      "fileMatch": [".appsemblerc.yaml"],
       "url": "https://gitlab.com/appsemble/appsemble/-/raw/HEAD/packages/cli/assets/appsemblerc.schema.json"
     },
     {
       "name": "appsscript.json",
       "description": "Google Apps Script manifest file",
-      "fileMatch": [
-        "appsscript.json"
-      ],
+      "fileMatch": ["appsscript.json"],
       "url": "https://www.schemastore.org/appsscript.json"
     },
     {
       "name": "appsettings.json",
       "description": "ASP.NET Core's configuration file",
-      "fileMatch": [
-        "appsettings.json",
-        "appsettings.*.json"
-      ],
+      "fileMatch": ["appsettings.json", "appsettings.*.json"],
       "url": "https://www.schemastore.org/appsettings.json"
     },
     {
       "name": "appveyor.yml",
       "description": "AppVeyor CI configuration file",
-      "fileMatch": [
-        "appveyor.yml"
-      ],
+      "fileMatch": ["appveyor.yml"],
       "url": "https://www.schemastore.org/appveyor.json"
     },
     {
       "name": "appsettings.StormPetrel.json",
       "description": "Scand.StormPetrel.Generator NuGet package appsettings.StormPetrel.json file",
-      "fileMatch": [
-        "appsettings.StormPetrel.json"
-      ],
+      "fileMatch": ["appsettings.StormPetrel.json"],
       "url": "https://raw.githubusercontent.com/Scandltd/storm-petrel/main/generator/assets/appsettings.StormPetrel.Schema.json"
     },
     {
       "name": "aqua.yaml",
       "description": "aqua configuration file",
-      "fileMatch": [
-        ".aqua.yaml",
-        ".aqua.yml",
-        "aqua.yaml",
-        "aqua.yml"
-      ],
+      "fileMatch": [".aqua.yaml", ".aqua.yml", "aqua.yaml", "aqua.yml"],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json"
     },
     {
       "name": "aqua-generate-registry.yaml",
       "description": "aqua generate registry configuration file",
-      "fileMatch": [
-        "aqua-generate-registry.yaml"
-      ],
+      "fileMatch": ["aqua-generate-registry.yaml"],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json"
     },
     {
       "name": "aqua-policy.yaml",
       "description": "aqua policy configuration file",
-      "fileMatch": [
-        ".aqua-policy.yaml",
-        "aqua-policy.yaml"
-      ],
+      "fileMatch": [".aqua-policy.yaml", "aqua-policy.yaml"],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/policy.json"
     },
     {
@@ -634,19 +507,13 @@
     {
       "name": "arazzo.json",
       "description": "An OpenAPI Arazzo document",
-      "fileMatch": [
-        "arazzo.json",
-        "arazzo.yml",
-        "arazzo.yaml"
-      ],
+      "fileMatch": ["arazzo.json", "arazzo.yml", "arazzo.yaml"],
       "url": "https://www.schemastore.org/openapi-arazzo-1.X.json"
     },
     {
       "name": "arb.json",
       "description": "Application Resource Bundle",
-      "fileMatch": [
-        "arb.json"
-      ],
+      "fileMatch": ["arb.json"],
       "url": "https://raw.githubusercontent.com/google/app-resource-bundle/main/schema/arb.json"
     },
     {
@@ -663,43 +530,31 @@
     {
       "name": "arc.json",
       "description": "A OpenJS Architect",
-      "fileMatch": [
-        "arc.json",
-        "arc.yml",
-        "arc.yaml"
-      ],
+      "fileMatch": ["arc.json", "arc.yml", "arc.yaml"],
       "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
       "name": "Archival editor configuration",
       "description": "Per-object editor configuration for an archival site",
-      "fileMatch": [
-        "archival_editor.toml"
-      ],
+      "fileMatch": ["archival_editor.toml"],
       "url": "https://archival.dev/schemas/archival_editor.schema.json"
     },
     {
       "name": "Archival object definitions",
       "description": "Object definitions for an archival site",
-      "fileMatch": [
-        "archival_objects.toml"
-      ],
+      "fileMatch": ["archival_objects.toml"],
       "url": "https://archival.dev/schemas/objects.schema.json"
     },
     {
       "name": "Archival site configuration",
       "description": "Site configuration for an archival site",
-      "fileMatch": [
-        "archival.toml"
-      ],
+      "fileMatch": ["archival.toml"],
       "url": "https://archival.dev/schemas/manifest.schema.json"
     },
     {
       "name": "Archival template definition",
       "description": "Metadata describing an archival site template",
-      "fileMatch": [
-        "archival_template.toml"
-      ],
+      "fileMatch": ["archival_template.toml"],
       "url": "https://archival.dev/schemas/archival_template.schema.json"
     },
     {
@@ -720,43 +575,31 @@
     {
       "name": "artifacthub-repo.yml",
       "description": "Artifact Hub repository metadata file",
-      "fileMatch": [
-        "artifacthub-repo.yml"
-      ],
+      "fileMatch": ["artifacthub-repo.yml"],
       "url": "https://www.schemastore.org/artifacthub-repo.json"
     },
     {
       "name": "Are The Types Wrong?",
       "description": "Configuration for the Are The Types Wrong? CLI",
-      "fileMatch": [
-        ".attw.json"
-      ],
+      "fileMatch": [".attw.json"],
       "url": "https://www.schemastore.org/attw.json"
     },
     {
       "name": "asm-lsp",
       "description": "Configuration file for asm-lsp",
-      "fileMatch": [
-        ".asm-lsp.toml",
-        "asm-lsp.toml"
-      ],
+      "fileMatch": [".asm-lsp.toml", "asm-lsp.toml"],
       "url": "https://raw.githubusercontent.com/bergercookie/asm-lsp/master/asm-lsp_config_schema.json"
     },
     {
       "name": "AssemblyScript",
       "description": "AssemblyScript is TypeScript-like language that is compiled to WebAssembly (wasm)",
-      "fileMatch": [
-        "asconfig.json"
-      ],
+      "fileMatch": ["asconfig.json"],
       "url": "https://www.schemastore.org/asconfig-schema.json"
     },
     {
       "name": "ast-grep sgconfig.yml",
       "description": "ast-grep project config",
-      "fileMatch": [
-        "sgconfig.yml",
-        "sgconfig.yaml"
-      ],
+      "fileMatch": ["sgconfig.yml", "sgconfig.yaml"],
       "url": "https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/project.json"
     },
     {
@@ -777,19 +620,13 @@
     {
       "name": "AsyncAPI",
       "description": "AsyncAPI documentation files",
-      "fileMatch": [
-        "*asyncapi*.json",
-        "*asyncapi*.yml",
-        "*asyncapi*.yaml"
-      ],
+      "fileMatch": ["*asyncapi*.json", "*asyncapi*.yml", "*asyncapi*.yaml"],
       "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"
     },
     {
       "name": "AsyncAPI Tool File",
       "description": "A validating AsyncAPI tool files",
-      "fileMatch": [
-        ".asyncapi-tool"
-      ],
+      "fileMatch": [".asyncapi-tool"],
       "url": "https://raw.githubusercontent.com/asyncapi/website/master/scripts/tools/tools-schema.json"
     },
     {
@@ -801,10 +638,7 @@
     {
       "name": "Aurora Agile Meta-Framework",
       "description": "Yaml for Aurora Agile Meta-Framework",
-      "fileMatch": [
-        "*.aurora.yaml",
-        "*.aurora.yml"
-      ],
+      "fileMatch": ["*.aurora.yaml", "*.aurora.yml"],
       "url": "https://www.schemastore.org/aurora-2.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/aurora-1.0.json",
@@ -817,9 +651,7 @@
     {
       "name": "Avro Avsc",
       "description": "Avro Avsc file",
-      "fileMatch": [
-        "*.avsc"
-      ],
+      "fileMatch": ["*.avsc"],
       "url": "https://www.schemastore.org/avro-avsc.json"
     },
     {
@@ -835,18 +667,13 @@
     {
       "name": "AWS AppConfig Feature Flags-v1",
       "description": "AWS CDK AppConfig Feature Flags",
-      "fileMatch": [
-        "*.appConfig.featureFlags.json"
-      ],
+      "fileMatch": ["*.appConfig.featureFlags.json"],
       "url": "https://www.schemastore.org/aws-cdk-appconfig-featureflags-1.0.0.json"
     },
     {
       "name": "azure.yaml",
       "description": "Azure Developer CLI (azd) configuration file",
-      "fileMatch": [
-        "azure.yaml",
-        "azure.yml"
-      ],
+      "fileMatch": ["azure.yaml", "azure.yml"],
       "url": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json",
       "versions": {
         "alpha": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json",
@@ -856,17 +683,13 @@
     {
       "name": "Azure Container App template for defining an immutable revision",
       "description": "Azure Container App template for defining an immutable revision",
-      "fileMatch": [
-        "*.containerapp-template.json"
-      ],
+      "fileMatch": ["*.containerapp-template.json"],
       "url": "https://www.schemastore.org/azure-containerapp-template.json"
     },
     {
       "name": "Azure Device Update for IoT Hub import manifest",
       "description": "Azure Device Update for IoT Hub import manifest",
-      "fileMatch": [
-        "*.importmanifest.json"
-      ],
+      "fileMatch": ["*.importmanifest.json"],
       "url": "https://www.schemastore.org/azure-deviceupdate-import-manifest-5.0.json",
       "versions": {
         "4.0": "https://www.schemastore.org/azure-deviceupdate-import-manifest-4.0.json",
@@ -876,9 +699,7 @@
     {
       "name": "Azure Device Update for IoT Hub update manifest",
       "description": "Azure Device Update for IoT Hub update manifest",
-      "fileMatch": [
-        "*.updatemanifest.json"
-      ],
+      "fileMatch": ["*.updatemanifest.json"],
       "url": "https://www.schemastore.org/azure-deviceupdate-update-manifest-5.json",
       "versions": {
         "4": "https://www.schemastore.org/azure-deviceupdate-update-manifest-4.json",
@@ -939,9 +760,7 @@
     {
       "name": "Azure Landing Zones Library metadata",
       "description": "Azure Landing Zones Library metadata",
-      "fileMatch": [
-        "alz_library_metadata.json"
-      ],
+      "fileMatch": ["alz_library_metadata.json"],
       "url": "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/main/schemas/library_metadata.json"
     },
     {
@@ -987,26 +806,19 @@
     {
       "name": "Barba-CV",
       "description": "Deterministic CV / resume data format",
-      "fileMatch": [
-        "barba-cv.json"
-      ],
+      "fileMatch": ["barba-cv.json"],
       "url": "https://raw.githubusercontent.com/Eurobotics-Association/barba-cv/main/schema/barba-cv.schema.json"
     },
     {
       "name": "Biome Formatter Config",
       "description": "Configuration file for the Biome formatter",
-      "fileMatch": [
-        "biome.json",
-        "biome.jsonc"
-      ],
+      "fileMatch": ["biome.json", "biome.jsonc"],
       "url": "https://biomejs.dev/schemas/latest/schema.json"
     },
     {
       "name": "bottom configuration",
       "description": "Configuration file for bottom",
-      "fileMatch": [
-        "bottom.toml"
-      ],
+      "fileMatch": ["bottom.toml"],
       "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.10/bottom.json",
       "versions": {
         "nightly": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json",
@@ -1036,57 +848,43 @@
     {
       "name": "buf.yaml",
       "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration",
-      "fileMatch": [
-        "buf.yaml"
-      ],
+      "fileMatch": ["buf.yaml"],
       "url": "https://www.schemastore.org/buf.json"
     },
     {
       "name": "buf.gen.yaml",
       "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice",
-      "fileMatch": [
-        "buf.gen.yaml"
-      ],
+      "fileMatch": ["buf.gen.yaml"],
       "url": "https://www.schemastore.org/buf.gen.json"
     },
     {
       "name": "buf.lock",
       "description": "buf.lock is a dependency lock file generated by buf via 'buf dep update'. It represents a single, reproducible build of the workspace's external dependencies and should never be hand-edited",
-      "fileMatch": [
-        "buf.lock"
-      ],
+      "fileMatch": ["buf.lock"],
       "url": "https://www.schemastore.org/buf.lock.json"
     },
     {
       "name": "buf.plugin.yaml",
       "description": "A `buf.plugin.yaml` file captures metadata about the plugin. It includes mandatory and optional fields that are displayed on the individual plugin page and the BSR plugin. Documentation: https://buf.build/plugins",
-      "fileMatch": [
-        "buf.plugin.yaml"
-      ],
+      "fileMatch": ["buf.plugin.yaml"],
       "url": "https://www.schemastore.org/buf.plugin.json"
     },
     {
       "name": "buf.policy.yaml",
       "description": "buf.policy.yaml defines a policy containing lint, breaking change detection, and plugin configuration that can be shared across BSR modules",
-      "fileMatch": [
-        "buf.policy.yaml"
-      ],
+      "fileMatch": ["buf.policy.yaml"],
       "url": "https://www.schemastore.org/buf.policy.json"
     },
     {
       "name": "buf.work.yaml",
       "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint)",
-      "fileMatch": [
-        "buf.work.yaml"
-      ],
+      "fileMatch": ["buf.work.yaml"],
       "url": "https://www.schemastore.org/buf.work.json"
     },
     {
       "name": "cargo-mutants-config.yaml",
       "description": "cargo-mutants configuration file",
-      "fileMatch": [
-        "**/.cargo/mutants.toml"
-      ],
+      "fileMatch": ["**/.cargo/mutants.toml"],
       "url": "https://www.schemastore.org/cargo-mutants-config.json"
     },
     {
@@ -1098,29 +896,19 @@
     {
       "name": "Cloud.gov Workshop Configuration",
       "description": "Configuration for IaC managed resources in Cloud.gov Workshop",
-      "fileMatch": [
-        "cg-workshop.yml",
-        "**/cg-workshop/*.yml"
-      ],
+      "fileMatch": ["cg-workshop.yml", "**/cg-workshop/*.yml"],
       "url": "https://workshop.cloud.gov/workshop/workshop-schemas/-/raw/main/cg-workshop.schema.json"
     },
     {
       "name": "cmdx.yaml",
       "description": "cmdx configuration file",
-      "fileMatch": [
-        ".cmdx.yaml",
-        ".cmdx.yml",
-        "cmdx.yaml",
-        "cmdx.yml"
-      ],
+      "fileMatch": [".cmdx.yaml", ".cmdx.yml", "cmdx.yaml", "cmdx.yml"],
       "url": "https://raw.githubusercontent.com/suzuki-shunsuke/cmdx/refs/heads/main/json-schema/cmdx.json"
     },
     {
       "name": "CodeRabbit",
       "description": "Supercharge your entire team with AI-driven contextual feedback & smart chat",
-      "fileMatch": [
-        ".coderabbit.yaml"
-      ],
+      "fileMatch": [".coderabbit.yaml"],
       "url": "https://coderabbit.ai/integrations/schema.v2.json"
     },
     {
@@ -1289,93 +1077,67 @@
     {
       "name": "Lando (landofile)",
       "description": "The configuration file for a Lando app. Documentation: https://github.com/lando-community/lando-spec",
-      "fileMatch": [
-        ".lando.yml",
-        ".lando.*.yml"
-      ],
+      "fileMatch": [".lando.yml", ".lando.*.yml"],
       "url": "https://lando-community.github.io/lando-spec/landofile-spec.json"
     },
     {
       "name": "latexindent configuration",
       "description": "Configuration file for latexindent",
-      "fileMatch": [
-        "latexindent.yaml",
-        ".latexindent.yaml"
-      ],
+      "fileMatch": ["latexindent.yaml", ".latexindent.yaml"],
       "url": "https://github.com/cmhughes/latexindent.pl/raw/main/documentation/latexindent-yaml-schema.json"
     },
     {
       "name": "Lobe AI Agent",
       "description": "Lobe Agents is an AI agent for LobeChat",
-      "fileMatch": [
-        "lobe-agent.json"
-      ],
+      "fileMatch": ["lobe-agent.json"],
       "url": "https://chat-agents.lobehub.com/schema/lobeAgentSchema_v1.json"
     },
     {
       "name": "Loki",
       "description": "Like Prometheus, but for logs",
-      "fileMatch": [
-        "loki.yml",
-        "loki.yaml"
-      ],
+      "fileMatch": ["loki.yml", "loki.yaml"],
       "url": "https://www.schemastore.org/loki.json"
     },
     {
       "name": "lsd config",
       "description": "Configuration for lsd, the next-generation ls command",
-      "fileMatch": [
-        "**/.config/lsd/config.yaml"
-      ],
+      "fileMatch": ["**/.config/lsd/config.yaml"],
       "url": "https://www.schemastore.org/lsd-config.json"
     },
     {
       "name": "lsd colors",
       "description": "Color theme configuration for lsd",
-      "fileMatch": [
-        "**/.config/lsd/colors.yaml"
-      ],
+      "fileMatch": ["**/.config/lsd/colors.yaml"],
       "url": "https://www.schemastore.org/lsd-colors.json"
     },
     {
       "name": "lsd icons",
       "description": "Icon theme configuration for lsd",
-      "fileMatch": [
-        "**/.config/lsd/icons.yaml"
-      ],
+      "fileMatch": ["**/.config/lsd/icons.yaml"],
       "url": "https://www.schemastore.org/lsd-icons.json"
     },
     {
       "name": "Azure Pipelines",
       "description": "Azure Pipelines YAML pipelines definition",
-      "fileMatch": [
-        "azure-pipelines.yml",
-        "azure-pipelines.yaml"
-      ],
+      "fileMatch": ["azure-pipelines.yml", "azure-pipelines.yaml"],
       "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
     },
     {
       "name": "FasterCI Configuration",
       "description": "FasterCI repository configuration file",
-      "fileMatch": [
-        "**/.fasterci/config.yaml"
-      ],
+      "fileMatch": ["**/.fasterci/config.yaml"],
       "url": "https://fasterci.com/config.schema.json"
     },
     {
       "name": "Fence configuration",
       "description": "Configuration file for fence, a lightweight, container-free sandbox for running commands with network and filesystem restrictions",
-      "fileMatch": [
-        "fence.json"
-      ],
+      "fileMatch": ["fence.json"],
       "url": "https://raw.githubusercontent.com/Use-Tusk/fence/refs/heads/main/docs/schema/fence.schema.json"
     },
     {
       "name": "Foxx Manifest",
       "description": "ArangoDB Foxx service manifest file",
-      "fileMatch": [
-        "manifest.json"
-      ],
+      "fileMatch": ["manifest.json"],
       "url": "https://www.schemastore.org/foxx-manifest.json"
     },
     {
@@ -1398,17 +1160,13 @@
     {
       "name": "fly.io Configuration",
       "description": "fly.io, a cloud provider, configuration",
-      "fileMatch": [
-        "fly.toml"
-      ],
+      "fileMatch": ["fly.toml"],
       "url": "https://www.schemastore.org/fly.json"
     },
     {
       "name": "Freifunk.de Community API",
       "description": "Freifunk.de Community API. Documentation: https://github.com/freifunk/directory.api.freifunk.net",
-      "fileMatch": [
-        "*.freifunk-api.json"
-      ],
+      "fileMatch": ["*.freifunk-api.json"],
       "url": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/0.5.2.json",
       "versions": {
         "development": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/development.json",
@@ -1430,61 +1188,43 @@
     {
       "name": "Frogbot Config",
       "description": "The Frogbot configuration required to scan Git repositories",
-      "fileMatch": [
-        "frogbot-config.yml"
-      ],
+      "fileMatch": ["frogbot-config.yml"],
       "url": "https://raw.githubusercontent.com/jfrog/frogbot/master/schema/frogbot-schema.json"
     },
     {
       "name": ".asmdef",
       "description": "Unity 3D assembly definition file",
-      "fileMatch": [
-        "*.asmdef"
-      ],
+      "fileMatch": ["*.asmdef"],
       "url": "https://www.schemastore.org/asmdef.json"
     },
     {
       "name": "babelrc.json",
       "description": "Babel configuration file",
-      "fileMatch": [
-        ".babelrc",
-        ".babelrc.json",
-        "babel.config.json"
-      ],
+      "fileMatch": [".babelrc", ".babelrc.json", "babel.config.json"],
       "url": "https://www.schemastore.org/babelrc.json"
     },
     {
       "name": ".backportrc.json",
       "description": "Backport configuration file",
-      "fileMatch": [
-        ".backportrc.json"
-      ],
+      "fileMatch": [".backportrc.json"],
       "url": "https://www.schemastore.org/backportrc.json"
     },
     {
       "name": "basedpyright",
       "description": "Basedpyright configuration file",
-      "fileMatch": [
-        "basedpyrightconfig.json"
-      ],
+      "fileMatch": ["basedpyrightconfig.json"],
       "url": "https://raw.githubusercontent.com/DetachHead/basedpyright/refs/heads/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"
     },
     {
       "name": "batect.yml",
       "description": "Batect configuration file",
-      "fileMatch": [
-        "batect.yml",
-        "batect-bundle.yml"
-      ],
+      "fileMatch": ["batect.yml", "batect-bundle.yml"],
       "url": "https://ide-integration.batect.dev/v1/configSchema.json"
     },
     {
       "name": "bamboo-spec",
       "description": "The Bamboo Specs allows you to define Bamboo configuration as code, and have corresponding plans/deployments created or updated automatically in Bamboo",
-      "fileMatch": [
-        "**/bamboo-specs/*.yaml",
-        "**/bamboo-specs/*.yml"
-      ],
+      "fileMatch": ["**/bamboo-specs/*.yaml", "**/bamboo-specs/*.yml"],
       "url": "https://www.schemastore.org/bamboo-spec.json"
     },
     {
@@ -1554,77 +1294,55 @@
     {
       "name": "bigquery-table",
       "description": "BigQuery table",
-      "fileMatch": [
-        "*.bigquery.json"
-      ],
+      "fileMatch": ["*.bigquery.json"],
       "url": "https://www.schemastore.org/bigquery-table.json"
     },
     {
       "name": "Bigconfig",
       "description": "Bigconfig is a yaml-based declarative monitoring as code solution. Data engineers can deploy Bigeye metrics from the command-line for convenient and scalable data quality monitoring",
-      "fileMatch": [
-        "bigconfig.yml",
-        "bigconfig.yaml"
-      ],
+      "fileMatch": ["bigconfig.yml", "bigconfig.yaml"],
       "url": "https://www.schemastore.org/bigconfig.json"
     },
     {
       "name": "bitbucket-pipelines",
       "description": "Bitbucket Pipelines CI/CD manifest",
-      "fileMatch": [
-        "bitbucket-pipelines.yml"
-      ],
+      "fileMatch": ["bitbucket-pipelines.yml"],
       "url": "https://api.bitbucket.org/schemas/pipelines-configuration"
     },
     {
       "name": "bitrise",
       "description": "The configuration format of the Bitrise CLI. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps",
-      "fileMatch": [
-        "bitrise.yml",
-        "bitrise.yaml",
-        "bitrise.json"
-      ],
+      "fileMatch": ["bitrise.yml", "bitrise.yaml", "bitrise.json"],
       "url": "https://www.schemastore.org/bitrise.json"
     },
     {
       "name": "bitrise-step",
       "description": "Steps and Workflows are the heart of how Bitrise works. A Bitrise build is simply a series of Steps. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps",
-      "fileMatch": [
-        "step.yml"
-      ],
+      "fileMatch": ["step.yml"],
       "url": "https://www.schemastore.org/bitrise-step.json"
     },
     {
       "name": ".bootstraprc",
       "description": "Webpack bootstrap-loader configuration file",
-      "fileMatch": [
-        ".bootstraprc"
-      ],
+      "fileMatch": [".bootstraprc"],
       "url": "https://www.schemastore.org/bootstraprc.json"
     },
     {
       "name": "bower.json",
       "description": "Bower package description file",
-      "fileMatch": [
-        "bower.json",
-        ".bower.json"
-      ],
+      "fileMatch": ["bower.json", ".bower.json"],
       "url": "https://www.schemastore.org/bower.json"
     },
     {
       "name": ".bowerrc",
       "description": "Bower configuration file",
-      "fileMatch": [
-        ".bowerrc"
-      ],
+      "fileMatch": [".bowerrc"],
       "url": "https://www.schemastore.org/bowerrc.json"
     },
     {
       "name": "BOSH BPM Config",
       "description": "Config for Jobs in BOSH Releases to utilize BPM",
-      "fileMatch": [
-        "**/jobs/*/config/bpm.yml"
-      ],
+      "fileMatch": ["**/jobs/*/config/bpm.yml"],
       "url": "https://www.schemastore.org/bosh-bpm-config.json"
     },
     {
@@ -1640,17 +1358,13 @@
     {
       "name": "BOSH Job Spec",
       "description": "Job Spec for BOSH Releases",
-      "fileMatch": [
-        "**/jobs/*/spec"
-      ],
+      "fileMatch": ["**/jobs/*/spec"],
       "url": "https://www.schemastore.org/bosh-job-spec.json"
     },
     {
       "name": "BOSH Package Spec",
       "description": "Package Spec for BOSH Releases",
-      "fileMatch": [
-        "**/packages/*/spec"
-      ],
+      "fileMatch": ["**/packages/*/spec"],
       "url": "https://www.schemastore.org/bosh-package-spec.json"
     },
     {
@@ -1661,18 +1375,13 @@
     {
       "name": "Boyka Framework",
       "description": "Boyka Framework config file",
-      "fileMatch": [
-        "boyka-config.json"
-      ],
+      "fileMatch": ["boyka-config.json"],
       "url": "https://www.schemastore.org/boyka-config.json"
     },
     {
       "name": "behat.yml",
       "description": "Behat configuration file",
-      "fileMatch": [
-        "behat.yml",
-        "*.behat.yml"
-      ],
+      "fileMatch": ["behat.yml", "*.behat.yml"],
       "url": "https://www.schemastore.org/behat.json"
     },
     {
@@ -1696,34 +1405,25 @@
     {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
-      "fileMatch": [
-        ".suite.json",
-        ".xsuite.json"
-      ],
+      "fileMatch": [".suite.json", ".xsuite.json"],
       "url": "https://www.schemastore.org/bozr.json"
     },
     {
       "name": "browser.i18n.json",
       "description": "browser.i18n messages.json translation file",
-      "fileMatch": [
-        "messages.json"
-      ],
+      "fileMatch": ["messages.json"],
       "url": "https://www.schemastore.org/browser.i18n.json"
     },
     {
       "name": "browsh configuration",
       "description": "Configuration file for browsh",
-      "fileMatch": [
-        "**/browsh/config.toml"
-      ],
+      "fileMatch": ["**/browsh/config.toml"],
       "url": "https://raw.githubusercontent.com/browsh-org/browsh/master/webext/assets/browsh-schema.json"
     },
     {
       "name": "bucklescript",
       "description": "BuckleScript configuration file",
-      "fileMatch": [
-        "bsconfig.json"
-      ],
+      "fileMatch": ["bsconfig.json"],
       "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"
     },
     {
@@ -1739,19 +1439,13 @@
     {
       "name": "Build Info",
       "description": "Build Info is the metadata of a build. It includes all the details about the build broken down into segments that include version history, artifacts, project modules, dependencies, and everything that was required to create the build",
-      "fileMatch": [
-        "*buildinfo*.json",
-        "*build-info*.json",
-        "*.buildinfo"
-      ],
+      "fileMatch": ["*buildinfo*.json", "*build-info*.json", "*.buildinfo"],
       "url": "https://raw.githubusercontent.com/jfrog/build-info-go/main/buildinfo-schema.json"
     },
     {
       "name": "Bukkit plugin.yml",
       "description": "Minecraft Bukkit plugin description files",
-      "fileMatch": [
-        "plugin.yml"
-      ],
+      "fileMatch": ["plugin.yml"],
       "url": "https://www.schemastore.org/bukkit-plugin.json"
     },
     {
@@ -1776,9 +1470,7 @@
     {
       "name": ".build.yml",
       "description": "Sourcehut Build Manifest",
-      "fileMatch": [
-        ".build.yml"
-      ],
+      "fileMatch": [".build.yml"],
       "url": "https://www.schemastore.org/sourcehut-build-0.65.0.json",
       "versions": {
         "0.41.2": "https://www.schemastore.org/sourcehut-build-0.41.2.json",
@@ -1788,42 +1480,31 @@
     {
       "name": "bun.lock",
       "description": "bun.lock file",
-      "fileMatch": [
-        "bun.lock"
-      ],
+      "fileMatch": ["bun.lock"],
       "url": "https://www.schemastore.org/bun-lock.json"
     },
     {
       "name": "bundleconfig.json",
       "description": "bundleconfig.json files",
-      "fileMatch": [
-        "bundleconfig.json"
-      ],
+      "fileMatch": ["bundleconfig.json"],
       "url": "https://www.schemastore.org/bundleconfig.json"
     },
     {
       "name": "bunfig.toml",
       "description": "bunfig.toml file",
-      "fileMatch": [
-        "bunfig.toml"
-      ],
+      "fileMatch": ["bunfig.toml"],
       "url": "https://www.schemastore.org/bunfig.json"
     },
     {
       "name": "BungeeCord plugin.yml",
       "description": "BungeeCord plugin description files",
-      "fileMatch": [
-        "plugin.yml",
-        "bungee.yml"
-      ],
+      "fileMatch": ["plugin.yml", "bungee.yml"],
       "url": "https://www.schemastore.org/bungee-plugin.json"
     },
     {
       "name": "block.json",
       "description": "WordPress block.json files",
-      "fileMatch": [
-        "block.json"
-      ],
+      "fileMatch": ["block.json"],
       "url": "https://schemas.wp.org/trunk/block.json",
       "versions": {
         "trunk": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
@@ -1832,18 +1513,13 @@
     {
       "name": "Block Protocol Metadata",
       "description": "Block Metadata in Block Protocol",
-      "fileMatch": [
-        "block-metadata.json"
-      ],
+      "fileMatch": ["block-metadata.json"],
       "url": "https://blockprotocol.org/schemas/block-metadata.json"
     },
     {
       "name": "BX CI",
       "description": "CI configuration for Amdocs Bill Experience projects",
-      "fileMatch": [
-        "**/bxci.yaml",
-        "**/bxci.yml"
-      ],
+      "fileMatch": ["**/bxci.yaml", "**/bxci.yml"],
       "url": "https://www.schemastore.org/bxci.schema-3.x.json",
       "versions": {
         "1.0": "https://www.schemastore.org/bxci.schema-1.0.json",
@@ -1867,19 +1543,13 @@
     {
       "name": "Bleep",
       "description": "A bleeping fast Scala build tool",
-      "fileMatch": [
-        "bleep.yaml",
-        "bleep.yml"
-      ],
+      "fileMatch": ["bleep.yaml", "bleep.yml"],
       "url": "https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json"
     },
     {
       "name": "CMake Presets",
       "description": "CMake Presets",
-      "fileMatch": [
-        "CMakePresets.json",
-        "CMakeUserPresets.json"
-      ],
+      "fileMatch": ["CMakePresets.json", "CMakeUserPresets.json"],
       "url": "https://raw.githubusercontent.com/Kitware/CMake/master/Help/manual/presets/schema.json"
     },
     {
@@ -1895,10 +1565,7 @@
     {
       "name": "Calqulus pipeline",
       "description": "Qualisys Calqulus pipeline",
-      "fileMatch": [
-        "*.calqulus.yaml",
-        "*.calqulus.yml"
-      ],
+      "fileMatch": ["*.calqulus.yaml", "*.calqulus.yml"],
       "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/calqulus-pipeline.schema.json"
     },
     {
@@ -1941,43 +1608,31 @@
     {
       "name": "Cargo Manifest",
       "description": "Manifest for Cargo, the Rust package manager and build tool",
-      "fileMatch": [
-        "Cargo.toml"
-      ],
+      "fileMatch": ["Cargo.toml"],
       "url": "https://www.schemastore.org/cargo.json"
     },
     {
       "name": "Cargo Make",
       "description": "cargo-make, a Rust task runner and build tool",
-      "fileMatch": [
-        "Makefile.toml"
-      ],
+      "fileMatch": ["Makefile.toml"],
       "url": "https://www.schemastore.org/cargo-make.json"
     },
     {
       "name": "Catalog Info Backstage",
       "description": "Backstage Catalog Info",
-      "fileMatch": [
-        "catalog-info.yaml",
-        "*.catalog-info.yaml"
-      ],
+      "fileMatch": ["catalog-info.yaml", "*.catalog-info.yaml"],
       "url": "https://www.schemastore.org/catalog-info.json"
     },
     {
       "name": "Changie",
       "description": "Changie configuration file",
-      "fileMatch": [
-        ".changie.yaml",
-        ".changie.yml"
-      ],
+      "fileMatch": [".changie.yaml", ".changie.yml"],
       "url": "https://changie.dev/schema.json"
     },
     {
       "name": "Charmcraft",
       "description": "Charmcraft project. Documentation: https://documentation.ubuntu.com/charmcraft/stable/",
-      "fileMatch": [
-        "charmcraft.yaml"
-      ],
+      "fileMatch": ["charmcraft.yaml"],
       "url": "https://raw.githubusercontent.com/canonical/charmcraft/main/schema/charmcraft.json"
     },
     {
@@ -2008,35 +1663,25 @@
     {
       "name": "Chromia Model",
       "description": "Chromia Model Config File",
-      "fileMatch": [
-        "chromia.yml",
-        "chromia.yaml"
-      ],
+      "fileMatch": ["chromia.yml", "chromia.yaml"],
       "url": "https://gitlab.com/chromaway/core-tools/chromia-cli-tools/-/raw/dev/chromia-build-tools/src/main/resources/chromia-model-schema.json"
     },
     {
       "name": "Chromia Seeder Root Config",
       "description": "Chromia Seeder Root Config File",
-      "fileMatch": [
-        "**/.chromia/seeder/**/seeder.yml"
-      ],
+      "fileMatch": ["**/.chromia/seeder/**/seeder.yml"],
       "url": "https://gitlab.com/chromaway/core-tools/rell-toolbox/-/raw/dev/seeder/src/main/resources/chromia-seeder-config-schema.json"
     },
     {
       "name": "Chromia Seeder Module Config",
       "description": "Chromia Seeder Module Config File",
-      "fileMatch": [
-        "**/.chromia/seeder/**/modules/**/*.yml"
-      ],
+      "fileMatch": ["**/.chromia/seeder/**/modules/**/*.yml"],
       "url": "https://gitlab.com/chromaway/core-tools/rell-toolbox/-/raw/dev/seeder/src/main/resources/chromia-seeder-module-schema.json"
     },
     {
       "name": "cibuildwheel",
       "description": "cibuildwheel, a Python redistributable wheel builder",
-      "fileMatch": [
-        "cibuildwheel.toml",
-        ".cibuildwheel.toml"
-      ],
+      "fileMatch": ["cibuildwheel.toml", ".cibuildwheel.toml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/cibuildwheel.json"
     },
     {
@@ -2065,33 +1710,25 @@
     {
       "name": "conda-forge",
       "description": "Conda-forge configuration file",
-      "fileMatch": [
-        "conda-forge.yml"
-      ],
+      "fileMatch": ["conda-forge.yml"],
       "url": "https://raw.githubusercontent.com/conda-forge/conda-smithy/main/conda_smithy/data/conda-forge.json"
     },
     {
       "name": "Convex",
       "description": "Configuration for Convex project settings",
-      "fileMatch": [
-        "convex.json"
-      ],
+      "fileMatch": ["convex.json"],
       "url": "https://raw.githubusercontent.com/get-convex/convex-backend/refs/heads/main/npm-packages/convex/schemas/convex.schema.json"
     },
     {
       "name": "Conjure",
       "description": "Conjure Human-Readable Format",
-      "fileMatch": [
-        "**/conjure/**.yml"
-      ],
+      "fileMatch": ["**/conjure/**.yml"],
       "url": "https://raw.githubusercontent.com/palantir/conjure/master/conjure.schema.json"
     },
     {
       "name": "CNC Codes",
       "description": "G/M codes for Machine Tools or 3D Printers",
-      "fileMatch": [
-        "*.cncc.json"
-      ],
+      "fileMatch": ["*.cncc.json"],
       "url": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
       "versions": {
         "latest": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
@@ -2102,10 +1739,7 @@
     {
       "name": "Cog config file",
       "description": "cog.yaml files",
-      "fileMatch": [
-        "cog.yaml",
-        "cog.yml"
-      ],
+      "fileMatch": ["cog.yaml", "cog.yml"],
       "url": "https://raw.githubusercontent.com/replicate/cog/main/pkg/config/data/config_schema_v1.0.json",
       "versions": {
         "1.0": "https://raw.githubusercontent.com/replicate/cog/main/pkg/config/data/config_schema_v1.0.json"
@@ -2124,175 +1758,127 @@
     {
       "name": "Common Package Specification",
       "description": "A cross-tool mechanism for locating software dependencies",
-      "fileMatch": [
-        "*.cps"
-      ],
+      "fileMatch": ["*.cps"],
       "url": "https://cps-org.github.io/cps/cps.schema.json"
     },
     {
       "name": "CumulusCI Config",
       "description": "cumulusci.yml file for configuring CumulusCI, a Salesforce automation framework",
-      "fileMatch": [
-        "cumulusci.yml"
-      ],
+      "fileMatch": ["cumulusci.yml"],
       "url": "https://raw.githubusercontent.com/SFDO-Tooling/CumulusCI/main/cumulusci/schema/cumulusci.jsonschema.json"
     },
     {
       "name": "Clawject config",
       "description": "Clawject configuration file",
-      "fileMatch": [
-        ".clawjectrc",
-        ".clawjectrc.json"
-      ],
+      "fileMatch": [".clawjectrc", ".clawjectrc.json"],
       "url": "https://raw.githubusercontent.com/clawject/clawject/main/packages/core/src/config/schema.json"
     },
     {
       "name": "Claude Code Keybindings",
       "description": "Keyboard shortcut configuration for Claude Code",
-      "fileMatch": [
-        "**/.claude/keybindings.json"
-      ],
+      "fileMatch": ["**/.claude/keybindings.json"],
       "url": "https://www.schemastore.org/claude-code-keybindings.json"
     },
     {
       "name": "Claude Code Plugin Manifest",
       "description": "Manifest (.claude-plugin/plugin.json) for a Claude Code plugin",
-      "fileMatch": [
-        "**/.claude-plugin/plugin.json"
-      ],
+      "fileMatch": ["**/.claude-plugin/plugin.json"],
       "url": "https://www.schemastore.org/claude-code-plugin-manifest.json"
     },
     {
       "name": "Claude Code Plugin Marketplace",
       "description": "Marketplace manifest (.claude-plugin/marketplace.json) listing Claude Code plugins",
-      "fileMatch": [
-        "**/.claude-plugin/marketplace.json"
-      ],
+      "fileMatch": ["**/.claude-plugin/marketplace.json"],
       "url": "https://www.schemastore.org/claude-code-marketplace.json"
     },
     {
       "name": "Claude Code Settings",
       "description": "Configuration file for Claude Code",
-      "fileMatch": [
-        "**/.claude/settings.json"
-      ],
+      "fileMatch": ["**/.claude/settings.json"],
       "url": "https://www.schemastore.org/claude-code-settings.json"
     },
     {
       "name": "cmakefmt",
       "description": "Configuration file for cmakefmt, a fast native CMake formatter",
-      "fileMatch": [
-        ".cmakefmt.yaml",
-        ".cmakefmt.yml",
-        ".cmakefmt.toml"
-      ],
+      "fileMatch": [".cmakefmt.yaml", ".cmakefmt.yml", ".cmakefmt.toml"],
       "url": "https://cmakefmt.dev/schemas/latest/schema.json"
     },
     {
       "name": "CVE Record Format",
       "description": "CVE record format to describe security vulnerabilities",
-      "fileMatch": [
-        "CVE-*.json"
-      ],
+      "fileMatch": ["CVE-*.json"],
       "url": "https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/docs/CVE_Record_Format_bundled.json"
     },
     {
       "name": "CVX personal.yaml",
       "description": "Identity and contact details for a CVX CV (name, title, contact rows)",
-      "fileMatch": [
-        "**/cv-content/personal.yaml"
-      ],
+      "fileMatch": ["**/cv-content/personal.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/personal.schema.json"
     },
     {
       "name": "CVX summary.yaml",
       "description": "Professional-summary bullets for a CVX CV",
-      "fileMatch": [
-        "**/cv-content/summary.yaml"
-      ],
+      "fileMatch": ["**/cv-content/summary.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/summary.schema.json"
     },
     {
       "name": "CVX experience.yaml",
       "description": "Work history entries for a CVX CV (roles, progression, impact bullets)",
-      "fileMatch": [
-        "**/cv-content/experience.yaml"
-      ],
+      "fileMatch": ["**/cv-content/experience.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/experience.schema.json"
     },
     {
       "name": "CVX education.yaml",
       "description": "Education entries for a CVX CV",
-      "fileMatch": [
-        "**/cv-content/education.yaml"
-      ],
+      "fileMatch": ["**/cv-content/education.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/education.schema.json"
     },
     {
       "name": "CVX competencies.yaml",
       "description": "Skill tags for a CVX CV",
-      "fileMatch": [
-        "**/cv-content/competencies.yaml"
-      ],
+      "fileMatch": ["**/cv-content/competencies.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/competencies.schema.json"
     },
     {
       "name": "CVX achievements.yaml",
       "description": "Awards and recognitions for a CVX CV",
-      "fileMatch": [
-        "**/cv-content/achievements.yaml"
-      ],
+      "fileMatch": ["**/cv-content/achievements.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/achievements.schema.json"
     },
     {
       "name": "CVX referees.yaml",
       "description": "References for a CVX CV",
-      "fileMatch": [
-        "**/cv-content/referees.yaml"
-      ],
+      "fileMatch": ["**/cv-content/referees.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/referees.schema.json"
     },
     {
       "name": "CVX keywords.yaml",
       "description": "ATS keywords embedded in CVX PDF metadata",
-      "fileMatch": [
-        "**/cv-content/keywords.yaml"
-      ],
+      "fileMatch": ["**/cv-content/keywords.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/keywords.schema.json"
     },
     {
       "name": "CVX config.yaml",
       "description": "CVX build configuration (theme, layout, pagination, ATS keywords)",
-      "fileMatch": [
-        "**/cv-content/config.yaml"
-      ],
+      "fileMatch": ["**/cv-content/config.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/config.schema.json"
     },
     {
       "name": "CVX layout",
       "description": "Custom page layout for a CVX CV (section placement per page)",
-      "fileMatch": [
-        "**/cv-content/layouts/*.yaml"
-      ],
+      "fileMatch": ["**/cv-content/layouts/*.yaml"],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/layout.schema.json"
     },
     {
       "name": "Cycle Stack File",
       "description": "A Cycle.io stack file for environments as code",
-      "fileMatch": [
-        "cycle.json",
-        "cycle.yml",
-        "cycle.yaml"
-      ],
+      "fileMatch": ["cycle.json", "cycle.yml", "cycle.yaml"],
       "url": "https://raw.githubusercontent.com/cycleplatform/api-spec/main/stackspec/stackspec.json"
     },
     {
       "name": "CycloneDX",
       "description": "CycloneDX Bill of Materials (BOM) file",
-      "fileMatch": [
-        "bom.json",
-        "*.cdx.json"
-      ],
+      "fileMatch": ["bom.json", "*.cdx.json"],
       "url": "https://raw.githubusercontent.com/CycloneDX/specification/refs/heads/master/schema/bom-1.6.schema.json",
       "versions": {
         "1.2": "https://raw.githubusercontent.com/CycloneDX/specification/refs/heads/master/schema/bom-1.2.schema.json",
@@ -2307,71 +1893,49 @@
     {
       "name": "Dark Factory consumer config",
       "description": "Unified darkfactory.yaml for the Cerebe / Dark Factory CLI (doctrine, deny, hooks, MCP, critics, policy)",
-      "fileMatch": [
-        "darkfactory.yaml",
-        "darkfactory.yml"
-      ],
+      "fileMatch": ["darkfactory.yaml", "darkfactory.yml"],
       "url": "https://raw.githubusercontent.com/momentiq-ai/cerebe/main/schemas/darkfactory/v1.json"
     },
     {
       "name": "DataYoga Connections",
       "description": "Collection of defined source and target connections used within DataYoga jobs",
-      "fileMatch": [
-        "connections.dy.yaml"
-      ],
+      "fileMatch": ["connections.dy.yaml"],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/connections.schema.json"
     },
     {
       "name": "DataYoga Job",
       "description": "Declarative definition of sequential pipeline steps within a DataYoga job",
-      "fileMatch": [
-        "**/jobs/**/*.dy.yaml"
-      ],
+      "fileMatch": ["**/jobs/**/*.dy.yaml"],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/job.schema.json"
     },
     {
       "name": "dbt-bouncer",
       "description": "dbt-bouncer configuration file for enforcing conventions in dbt projects",
-      "fileMatch": [
-        "dbt-bouncer.yml",
-        "dbt-bouncer.yaml"
-      ],
+      "fileMatch": ["dbt-bouncer.yml", "dbt-bouncer.yaml"],
       "url": "https://raw.githubusercontent.com/godatadriven/dbt-bouncer/main/schema.json"
     },
     {
       "name": "dbt Dependencies",
       "description": "dbt's dependencies.yml file for external packages and cross-project refs",
-      "fileMatch": [
-        "**/*dbt*/dependencies.yaml",
-        "**/*dbt*/dependencies.yml"
-      ],
+      "fileMatch": ["**/*dbt*/dependencies.yaml", "**/*dbt*/dependencies.yml"],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dependencies-latest-fusion.json"
     },
     {
       "name": "dbt Project",
       "description": "dbt's project configuration file",
-      "fileMatch": [
-        "dbt_project.yaml",
-        "dbt_project.yml"
-      ],
+      "fileMatch": ["dbt_project.yaml", "dbt_project.yml"],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dbt_project-latest-fusion.json"
     },
     {
       "name": "dbt Packages",
       "description": "dbt's packages.yml file for external packages",
-      "fileMatch": [
-        "**/*dbt*/packages.yaml",
-        "**/*dbt*/packages.yml"
-      ],
+      "fileMatch": ["**/*dbt*/packages.yaml", "**/*dbt*/packages.yml"],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/packages-latest-fusion.json"
     },
     {
       "name": "dbt Selectors",
       "description": "dbt's selectors.yml file for configuring YAML selectors",
-      "fileMatch": [
-        "**/*dbt*/selectors.yaml",
-        "**/*dbt*/selectors.yml"
-      ],
+      "fileMatch": ["**/*dbt*/selectors.yaml", "**/*dbt*/selectors.yml"],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/selectors-latest-fusion.json"
     },
     {
@@ -2392,18 +1956,13 @@
     {
       "name": "Debian Upstream Metadata file",
       "description": "Debian packaging file for describing metadata about the upstream project",
-      "fileMatch": [
-        "**/debian/upstream/metadata"
-      ],
+      "fileMatch": ["**/debian/upstream/metadata"],
       "url": "https://salsa.debian.org/debian/debian-json-schemas/-/raw/main/schemas/debian-upstream-metadata/debian-upstream-metadata-latest.json"
     },
     {
       "name": "DebtLens",
       "description": "Configuration file for the DebtLens maintainability scanner",
-      "fileMatch": [
-        "debtlens.config.json",
-        ".debtlensrc.json"
-      ],
+      "fileMatch": ["debtlens.config.json", ".debtlensrc.json"],
       "url": "https://raw.githubusercontent.com/ColumbusLabs/DebtLens/main/schema/debtlens.config.schema.json"
     },
     {
@@ -2431,17 +1990,13 @@
     {
       "name": "Dein Config",
       "description": "Dein.vim, a Vim/Neovim plugin manager",
-      "fileMatch": [
-        "dein.toml"
-      ],
+      "fileMatch": ["dein.toml"],
       "url": "https://www.schemastore.org/dein.json"
     },
     {
       "name": "Dependency cruiser",
       "description": "Configuration file for Dependency cruiser",
-      "fileMatch": [
-        "dependency-cruiser.config.json"
-      ],
+      "fileMatch": ["dependency-cruiser.config.json"],
       "url": "https://raw.githubusercontent.com/sverweij/dependency-cruiser/main/src/schema/configuration.schema.json"
     },
     {
@@ -2466,212 +2021,157 @@
     {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",
-      "fileMatch": [
-        "Spacefile"
-      ],
+      "fileMatch": ["Spacefile"],
       "url": "https://deta.space/assets/spacefile.schema.json"
     },
     {
       "name": "Devbox Config",
       "description": "Configuration for a Devbox shell environment",
-      "fileMatch": [
-        "devbox.json"
-      ],
+      "fileMatch": ["devbox.json"],
       "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json"
     },
     {
       "name": "Devbox Plugin",
       "description": "Configuration for a Devbox plugin specification",
-      "fileMatch": [
-        "devbox-plugin.json"
-      ],
+      "fileMatch": ["devbox-plugin.json"],
       "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json"
     },
     {
       "name": "devconcurrent",
       "description": "Easily manage multiple, isolated development environments",
-      "fileMatch": [
-        "**/devconcurrent/config.toml"
-      ],
+      "fileMatch": ["**/devconcurrent/config.toml"],
       "url": "https://devconcurrent.paholg.com/devconcurrent.schema.json"
     },
     {
       "name": "Drupal Breakpoints",
       "description": "Drupal configuration for breakpoints",
-      "fileMatch": [
-        "*.breakpoints.yml"
-      ],
+      "fileMatch": ["*.breakpoints.yml"],
       "url": "https://www.schemastore.org/drupal-breakpoints.json"
     },
     {
       "name": "Drupal Info",
       "description": "Drupal configuration for info",
-      "fileMatch": [
-        "*.info.yml"
-      ],
+      "fileMatch": ["*.info.yml"],
       "url": "https://www.schemastore.org/drupal-info.json"
     },
     {
       "name": "Drupal Layouts",
       "description": "Drupal configuration for layouts",
-      "fileMatch": [
-        "*.layouts.yml"
-      ],
+      "fileMatch": ["*.layouts.yml"],
       "url": "https://www.schemastore.org/drupal-layouts.json"
     },
     {
       "name": "Drupal Libraries",
       "description": "Drupal configuration for libraries",
-      "fileMatch": [
-        "*.libraries.yml"
-      ],
+      "fileMatch": ["*.libraries.yml"],
       "url": "https://www.schemastore.org/drupal-libraries.json"
     },
     {
       "name": "Drupal Links Action",
       "description": "Drupal configuration for action links",
-      "fileMatch": [
-        "*.links.action.yml"
-      ],
+      "fileMatch": ["*.links.action.yml"],
       "url": "https://www.schemastore.org/drupal-links-action.json"
     },
     {
       "name": "Drupal Links Contextual",
       "description": "Drupal configuration for contextual links",
-      "fileMatch": [
-        "*.links.contextual.yml"
-      ],
+      "fileMatch": ["*.links.contextual.yml"],
       "url": "https://www.schemastore.org/drupal-links-contextual.json"
     },
     {
       "name": "Drupal Links Menu",
       "description": "Drupal configuration for menu links",
-      "fileMatch": [
-        "*.links.menu.yml"
-      ],
+      "fileMatch": ["*.links.menu.yml"],
       "url": "https://www.schemastore.org/drupal-links-menu.json"
     },
     {
       "name": "Drupal Links Task",
       "description": "Drupal configuration for task links",
-      "fileMatch": [
-        "*.links.task.yml"
-      ],
+      "fileMatch": ["*.links.task.yml"],
       "url": "https://www.schemastore.org/drupal-links-task.json"
     },
     {
       "name": "Drupal Migration",
       "description": "Drupal configuration for migration",
-      "fileMatch": [
-        "*.migration.*.yml",
-        "**/migrations/*.yml"
-      ],
+      "fileMatch": ["*.migration.*.yml", "**/migrations/*.yml"],
       "url": "https://www.schemastore.org/drupal-migration.json"
     },
     {
       "name": "Drupal Permissions",
       "description": "Drupal configuration for permissions",
-      "fileMatch": [
-        "*.permissions.yml"
-      ],
+      "fileMatch": ["*.permissions.yml"],
       "url": "https://www.schemastore.org/drupal-permissions.json"
     },
     {
       "name": "Drupal Recipe",
       "description": "Drupal configuration for recipe",
-      "fileMatch": [
-        "drupal-recipe.yml",
-        "drupal-recipe.yaml"
-      ],
+      "fileMatch": ["drupal-recipe.yml", "drupal-recipe.yaml"],
       "url": "https://www.schemastore.org/drupal-recipe.json"
     },
     {
       "name": "Drupal Routing",
       "description": "Drupal configuration for routing",
-      "fileMatch": [
-        "*.routing.yml"
-      ],
+      "fileMatch": ["*.routing.yml"],
       "url": "https://www.schemastore.org/drupal-routing.json"
     },
     {
       "name": "Drupal Config",
       "description": "Drupal configuration for config",
-      "fileMatch": [
-        "**/config/schema/*.schema.yml"
-      ],
+      "fileMatch": ["**/config/schema/*.schema.yml"],
       "url": "https://www.schemastore.org/drupal-config.json"
     },
     {
       "name": "Drupal Services",
       "description": "Drupal configuration for services",
-      "fileMatch": [
-        "*.services.yml"
-      ],
+      "fileMatch": ["*.services.yml"],
       "url": "https://www.schemastore.org/drupal-services.json"
     },
     {
       "name": "Helm Chart.yaml",
       "description": "The Chart.yaml file is required for a chart",
-      "fileMatch": [
-        "Chart.yaml"
-      ],
+      "fileMatch": ["Chart.yaml"],
       "url": "https://www.schemastore.org/chart.json"
     },
     {
       "name": "Helm Chart.lock",
       "description": "The Chart.lock file locks dependencies from Chart.yaml",
-      "fileMatch": [
-        "Chart.lock"
-      ],
+      "fileMatch": ["Chart.lock"],
       "url": "https://www.schemastore.org/chart-lock.json"
     },
     {
       "name": "Helm Unittest Test Suite",
       "description": "A Helm Unittest Test Suite file",
-      "fileMatch": [
-        "**/charts/*/tests/*.yaml"
-      ],
+      "fileMatch": ["**/charts/*/tests/*.yaml"],
       "url": "https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json"
     },
     {
       "name": "Hex file",
       "description": "Hex notebook file format - create and maintain data notebooks on Hex.tech",
-      "fileMatch": [
-        "*.hex.yaml"
-      ],
+      "fileMatch": ["*.hex.yaml"],
       "url": "https://static.hex.site/hex-file-schema.json"
     },
     {
       "name": "CircleCI config.yml",
       "description": "CircleCI config files",
-      "fileMatch": [
-        "**/.circleci/config.yml"
-      ],
+      "fileMatch": ["**/.circleci/config.yml"],
       "url": "https://www.schemastore.org/circleciconfig.json"
     },
     {
       "name": "Code Climate",
       "description": "Configuration file as an alternative for configuring your repository in the settings page",
-      "fileMatch": [
-        ".codeclimate.yml",
-        ".codeclimate.json"
-      ],
+      "fileMatch": [".codeclimate.yml", ".codeclimate.json"],
       "url": "https://www.schemastore.org/codeclimate.json"
     },
     {
       "name": ".cirrus.yml",
       "description": "Cirrus CI configuration files",
-      "fileMatch": [
-        ".cirrus.yml"
-      ],
+      "fileMatch": [".cirrus.yml"],
       "url": "https://raw.githubusercontent.com/cirruslabs/cirrus-cli/main/pkg/parser/testdata/cirrus.json"
     },
     {
       "name": ".clasp.json",
       "description": "Google Apps Script CLI project file",
-      "fileMatch": [
-        ".clasp.json"
-      ],
+      "fileMatch": [".clasp.json"],
       "url": "https://www.schemastore.org/clasp.json"
     },
     {
@@ -2688,27 +2188,19 @@
     {
       "name": "clang-tidy",
       "description": "clang-tidy linter from LLVM",
-      "fileMatch": [
-        ".clang-tidy",
-        "clang-tidy.yml",
-        "clang-tidy.yaml"
-      ],
+      "fileMatch": [".clang-tidy", "clang-tidy.yml", "clang-tidy.yaml"],
       "url": "https://www.schemastore.org/clang-tidy.json"
     },
     {
       "name": "clib",
       "description": "C package manager-ish",
-      "fileMatch": [
-        "clib.json"
-      ],
+      "fileMatch": ["clib.json"],
       "url": "https://www.schemastore.org/clib.json"
     },
     {
       "name": "cloudify",
       "description": "Cloudify Blueprint",
-      "fileMatch": [
-        "*.cfy.yaml"
-      ],
+      "fileMatch": ["*.cfy.yaml"],
       "url": "https://www.schemastore.org/cloudify.json"
     },
     {
@@ -2725,75 +2217,55 @@
     {
       "name": "Codex",
       "description": "OpenAI Codex configuration file",
-      "fileMatch": [
-        "**/.codex/config.toml"
-      ],
+      "fileMatch": ["**/.codex/config.toml"],
       "url": "https://developers.openai.com/codex/config-schema.json"
     },
     {
       "name": "Codex Hooks",
       "description": "OpenAI Codex hooks configuration file",
-      "fileMatch": [
-        "**/.codex/hooks.json"
-      ],
+      "fileMatch": ["**/.codex/hooks.json"],
       "url": "https://www.schemastore.org/codex-hooks.json"
     },
     {
       "name": "Codex Plugin Manifest",
       "description": "OpenAI Codex plugin manifest file",
-      "fileMatch": [
-        "**/.codex-plugin/plugin.json"
-      ],
+      "fileMatch": ["**/.codex-plugin/plugin.json"],
       "url": "https://www.schemastore.org/codex-plugin-manifest.json"
     },
     {
       "name": "Codex Skill Metadata",
       "description": "OpenAI Codex skill metadata file",
-      "fileMatch": [
-        "**/agents/openai.yaml"
-      ],
+      "fileMatch": ["**/agents/openai.yaml"],
       "url": "https://www.schemastore.org/codex-skill-metadata.json"
     },
     {
       "name": "codemagic",
       "description": "Codemagic CI/CD file configuration",
-      "fileMatch": [
-        "codemagic.yaml",
-        "codemagic.yml"
-      ],
+      "fileMatch": ["codemagic.yaml", "codemagic.yml"],
       "url": "https://codemagic.io/codemagic-schema.json"
     },
     {
       "name": "Codux",
       "description": "Codux configuration file",
-      "fileMatch": [
-        "codux.config.json"
-      ],
+      "fileMatch": ["codux.config.json"],
       "url": "https://wixplosives.github.io/codux-config-schema/codux.config.schema.json"
     },
     {
       "name": "devcontainer.json",
       "description": "dev container configuration files",
-      "fileMatch": [
-        "devcontainer.json",
-        ".devcontainer.json"
-      ],
+      "fileMatch": ["devcontainer.json", ".devcontainer.json"],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json"
     },
     {
       "name": "devcontainer-feature.json",
       "description": "Dev Container Feature metadata files",
-      "fileMatch": [
-        "devcontainer-feature.json"
-      ],
+      "fileMatch": ["devcontainer-feature.json"],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
     },
     {
       "name": ".devprune.json",
       "description": "Per-repository configuration for dev-prune, the lockfile-verified workspace cleaner",
-      "fileMatch": [
-        ".devprune.json"
-      ],
+      "fileMatch": [".devprune.json"],
       "url": "https://devprune.vkrishna04.me/schemas/v1/devprune.schema.json"
     },
     {
@@ -2812,73 +2284,55 @@
     {
       "name": "CodeShip Pro services configuration files",
       "description": "codeship-services.yml files",
-      "fileMatch": [
-        "codeship-services.yml"
-      ],
+      "fileMatch": ["codeship-services.yml"],
       "url": "https://www.schemastore.org/codeship-services.json"
     },
     {
       "name": "CodeShip Pro steps configuration files",
       "description": "codeship-steps.yml files",
-      "fileMatch": [
-        "codeship-steps.yml"
-      ],
+      "fileMatch": ["codeship-steps.yml"],
       "url": "https://www.schemastore.org/codeship-steps.json"
     },
     {
       "name": "vcpkg manifest file",
       "description": "vcpkg manifest file",
-      "fileMatch": [
-        "vcpkg.json"
-      ],
+      "fileMatch": ["vcpkg.json"],
       "url": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json"
     },
     {
       "name": "vcpkg configuration file",
       "description": "vcpkg configuration file",
-      "fileMatch": [
-        "vcpkg-configuration.json"
-      ],
+      "fileMatch": ["vcpkg-configuration.json"],
       "url": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json"
     },
     {
       "name": "Vercel",
       "description": "Vercel configuration file",
-      "fileMatch": [
-        "vercel.json"
-      ],
+      "fileMatch": ["vercel.json"],
       "url": "https://openapi.vercel.sh/vercel.json"
     },
     {
       "name": "VSCode Code Snippets",
       "description": "code snippet files in visual studio code extensions",
-      "fileMatch": [
-        "*.code-snippets"
-      ],
+      "fileMatch": ["*.code-snippets"],
       "url": "https://raw.githubusercontent.com/Yash-Singh1/vscode-snippets-json-schema/main/schema.json"
     },
     {
       "name": "compilerconfig.json",
       "description": "compilerconfig.json files",
-      "fileMatch": [
-        "compilerconfig.json"
-      ],
+      "fileMatch": ["compilerconfig.json"],
       "url": "https://www.schemastore.org/compilerconfig.json"
     },
     {
       "name": "compile_commands.json",
       "description": "LLVM compilation database",
-      "fileMatch": [
-        "compile_commands.json"
-      ],
+      "fileMatch": ["compile_commands.json"],
       "url": "https://www.schemastore.org/compile-commands.json"
     },
     {
       "name": "commands.json",
       "description": "Config file for Command Task Runner",
-      "fileMatch": [
-        "commands.json"
-      ],
+      "fileMatch": ["commands.json"],
       "url": "https://www.schemastore.org/commands.json"
     },
     {
@@ -2895,9 +2349,7 @@
     {
       "name": "cosmos.config.json",
       "description": "React Cosmos configuration file",
-      "fileMatch": [
-        "cosmos.config.json"
-      ],
+      "fileMatch": ["cosmos.config.json"],
       "url": "https://www.schemastore.org/cosmos-config.json"
     },
     {
@@ -2908,33 +2360,25 @@
     {
       "name": "chrome-extension-locales-messages.json",
       "description": "Google Chrome extension localization file",
-      "fileMatch": [
-        "**/_locales/*/messages.json"
-      ],
+      "fileMatch": ["**/_locales/*/messages.json"],
       "url": "https://www.schemastore.org/chrome-extension-locales-messages.json"
     },
     {
       "name": "chutzpah.json",
       "description": "Chutzpah configuration file",
-      "fileMatch": [
-        "chutzpah.json"
-      ],
+      "fileMatch": ["chutzpah.json"],
       "url": "https://www.schemastore.org/chutzpah.json"
     },
     {
       "name": "contentmanifest.json",
       "description": "Visual Studio manifest injection file",
-      "fileMatch": [
-        "contentmanifest.json"
-      ],
+      "fileMatch": ["contentmanifest.json"],
       "url": "https://www.schemastore.org/vsix-manifestinjection.json"
     },
     {
       "name": "cloud-sdk-pipeline-configuration",
       "description": "SAP Cloud SDK Pipeline configuration",
-      "fileMatch": [
-        "pipeline_config.yml"
-      ],
+      "fileMatch": ["pipeline_config.yml"],
       "url": "https://www.schemastore.org/cloud-sdk-pipeline-config-schema.json"
     },
     {
@@ -2966,9 +2410,7 @@
     {
       "name": "AWS CDK cdk.json",
       "description": "AWS CDK context files",
-      "fileMatch": [
-        "cdk.json"
-      ],
+      "fileMatch": ["cdk.json"],
       "url": "https://www.schemastore.org/cdk.json"
     },
     {
@@ -3002,99 +2444,73 @@
     {
       "name": "AWS SAM CLI Samconfig",
       "description": "AWS SAM CLI samconfig configuration file",
-      "fileMatch": [
-        "samconfig.toml",
-        "samconfig.yaml",
-        "samconfig.yml"
-      ],
+      "fileMatch": ["samconfig.toml", "samconfig.yaml", "samconfig.yml"],
       "url": "https://raw.githubusercontent.com/aws/aws-sam-cli/master/schema/samcli.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Accounts Config",
       "description": "Used to manage all of the AWS accounts within the AWS Organization",
-      "fileMatch": [
-        "accounts-config.yaml"
-      ],
+      "fileMatch": ["accounts-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Customizations Config",
       "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks",
-      "fileMatch": [
-        "customizations-config.yaml"
-      ],
+      "fileMatch": ["customizations-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Global Config",
       "description": "Used to manage all of the global properties that can be inherited across the AWS Organization",
-      "fileMatch": [
-        "global-config.yaml"
-      ],
+      "fileMatch": ["global-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/global-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - IAM Config",
       "description": "Used to manage all of the IAM resources across the AWS Organization",
-      "fileMatch": [
-        "iam-config.yaml"
-      ],
+      "fileMatch": ["iam-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Network Config",
       "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS",
-      "fileMatch": [
-        "network-config.yaml"
-      ],
+      "fileMatch": ["network-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/network-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Organization Config",
       "description": "Used to manage all of the organization units in the AWS Organization",
-      "fileMatch": [
-        "organization-config.yaml"
-      ],
+      "fileMatch": ["organization-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Replacements Config",
       "description": "Used to manage all of the replacement values across the configuration files",
-      "fileMatch": [
-        "replacements-config.yaml"
-      ],
+      "fileMatch": ["replacements-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Security Config",
       "description": "Used to manage configuration of AWS security services",
-      "fileMatch": [
-        "security-config.yaml"
-      ],
+      "fileMatch": ["security-config.yaml"],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/security-config.json"
     },
     {
       "name": "Changesets",
       "description": "A way to manage your versioning and changelogs with a focus on monorepos",
-      "fileMatch": [
-        "**/.changeset/config.json"
-      ],
+      "fileMatch": ["**/.changeset/config.json"],
       "url": "https://unpkg.com/@changesets/config/schema.json"
     },
     {
       "name": "chisel-slices.json",
       "description": "Canonical Chisel slices definition file",
-      "fileMatch": [
-        "**/slices/*.yaml"
-      ],
+      "fileMatch": ["**/slices/*.yaml"],
       "url": "https://www.schemastore.org/chisel-slices.json"
     },
     {
       "name": "Citation File Format",
       "description": "A YAML file with citation metadata for software or datasets",
-      "fileMatch": [
-        "CITATION.cff"
-      ],
+      "fileMatch": ["CITATION.cff"],
       "url": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/1.2.0/schema.json",
       "versions": {
         "1.2.0": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/1.2.0/schema.json"
@@ -3103,9 +2519,7 @@
     {
       "name": "coffeelint.json",
       "description": "CoffeeLint configuration file",
-      "fileMatch": [
-        "coffeelint.json"
-      ],
+      "fileMatch": ["coffeelint.json"],
       "url": "https://www.schemastore.org/coffeelint.json"
     },
     {
@@ -3122,58 +2536,43 @@
     {
       "name": "committed.toml",
       "description": "committed configuration file",
-      "fileMatch": [
-        "committed.toml"
-      ],
+      "fileMatch": ["committed.toml"],
       "url": "https://raw.githubusercontent.com/crate-ci/committed/master/config.schema.json"
     },
     {
       "name": "composer.json",
       "description": "PHP Composer configuration file",
-      "fileMatch": [
-        "composer.json"
-      ],
+      "fileMatch": ["composer.json"],
       "url": "https://getcomposer.org/schema.json"
     },
     {
       "name": "component.json",
       "description": "Web component file",
-      "fileMatch": [
-        "component.json"
-      ],
+      "fileMatch": ["component.json"],
       "url": "https://www.schemastore.org/component.json"
     },
     {
       "name": "component-detection-manifest.json",
       "description": "Component Detection manifest",
-      "fileMatch": [
-        "cdmanifest.json",
-        "cgmanifest.json"
-      ],
+      "fileMatch": ["cdmanifest.json", "cgmanifest.json"],
       "url": "https://www.schemastore.org/component-detection-manifest.json"
     },
     {
       "name": "contribute.json",
       "description": "A open-source project contribution data by Mozilla",
-      "fileMatch": [
-        "contribute.json"
-      ],
+      "fileMatch": ["contribute.json"],
       "url": "https://raw.githubusercontent.com/mozilla/contribute.json/master/schema.json"
     },
     {
       "name": "crowdin.yml",
       "description": "Crowdin, a crowd-translation platform. Documentation: https://support.crowdin.com/configuration-file/",
-      "fileMatch": [
-        "**/crowdin.yml"
-      ],
+      "fileMatch": ["**/crowdin.yml"],
       "url": "https://www.schemastore.org/crowdin.json"
     },
     {
       "name": "Crowdsec collection config",
       "description": "A YAML Crowdsec collection configuration files",
-      "fileMatch": [
-        "**/collections/*/*.yaml"
-      ],
+      "fileMatch": ["**/collections/*/*.yaml"],
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/collection_schema.yaml"
     },
     {
@@ -3191,9 +2590,7 @@
     {
       "name": "Crowdsec scenario config",
       "description": "A YAML Crowdsec scenario configuration files",
-      "fileMatch": [
-        "**/scenarios/*/*.yaml"
-      ],
+      "fileMatch": ["**/scenarios/*/*.yaml"],
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/scenario_schema.yaml"
     },
     {
@@ -3208,17 +2605,13 @@
     {
       "name": "cypress.json",
       "description": "Cypress.io test runner configuration file",
-      "fileMatch": [
-        "cypress.json"
-      ],
+      "fileMatch": ["cypress.json"],
       "url": "https://on.cypress.io/cypress.schema.json"
     },
     {
       "name": ".creatomic",
       "description": "A config for Atomic Design 4 React generator",
-      "fileMatch": [
-        ".creatomic"
-      ],
+      "fileMatch": [".creatomic"],
       "url": "https://www.schemastore.org/creatomic.json"
     },
     {
@@ -3240,25 +2633,19 @@
     {
       "name": "CSS Comb (.csscomb.json)",
       "description": "CSS Comb's configuration file",
-      "fileMatch": [
-        ".csscomb.json"
-      ],
+      "fileMatch": [".csscomb.json"],
       "url": "https://www.schemastore.org/csscomb.json"
     },
     {
       "name": "CSS Lint (.csslintrc)",
       "description": "CSS Lint's configuration file",
-      "fileMatch": [
-        ".csslintrc"
-      ],
+      "fileMatch": [".csslintrc"],
       "url": "https://www.schemastore.org/csslintrc.json"
     },
     {
       "name": "Dagger module",
       "description": "Module metadata for the Dagger CI/CD engine: SDK, dependencies, and engine version",
-      "fileMatch": [
-        "dagger.json"
-      ],
+      "fileMatch": ["dagger.json"],
       "url": "https://docs.dagger.io/reference/dagger.schema.json"
     },
     {
@@ -3269,18 +2656,13 @@
     {
       "name": "Dart Test Config (dart-test.json)",
       "description": "Configuration for Dart's test package",
-      "fileMatch": [
-        "dart_test.yaml"
-      ],
+      "fileMatch": ["dart_test.yaml"],
       "url": "https://www.schemastore.org/dart-test.json"
     },
     {
       "name": "DashLord Configuration",
       "description": "Configuration for DashLord",
-      "fileMatch": [
-        "dashlord.yaml",
-        "dashlord.yml"
-      ],
+      "fileMatch": ["dashlord.yaml", "dashlord.yml"],
       "url": "https://raw.githubusercontent.com/socialgouv/dashlord/main/schema.json"
     },
     {
@@ -3324,52 +2706,37 @@
     {
       "name": "datalogic-scan2deploy-android",
       "description": "Datalogic Scan2Deploy Android file",
-      "fileMatch": [
-        ".dla.json"
-      ],
+      "fileMatch": [".dla.json"],
       "url": "https://www.schemastore.org/datalogic-scan2deploy-android.json"
     },
     {
       "name": "datalogic-scan2deploy-ce",
       "description": "Datalogic Scan2Deploy CE file",
-      "fileMatch": [
-        ".dlc.json"
-      ],
+      "fileMatch": [".dlc.json"],
       "url": "https://www.schemastore.org/datalogic-scan2deploy-ce.json"
     },
     {
       "name": "ddev-global",
       "description": "DDEV global configuration file",
-      "fileMatch": [
-        "**/.ddev/global_config.yaml"
-      ],
+      "fileMatch": ["**/.ddev/global_config.yaml"],
       "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/globalconfig/schema.json"
     },
     {
       "name": "ddev-project",
       "description": "DDEV project configuration file",
-      "fileMatch": [
-        "**/.ddev/config*.yaml"
-      ],
+      "fileMatch": ["**/.ddev/config*.yaml"],
       "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/ddevapp/schema.json"
     },
     {
       "name": "debugsettings.json",
       "description": "A the ASP.NET DebugSettings.json files",
-      "fileMatch": [
-        "debugsettings.json"
-      ],
+      "fileMatch": ["debugsettings.json"],
       "url": "https://www.schemastore.org/debugsettings.json"
     },
     {
       "name": "Draugr Saga",
       "description": "Draugr Saga - a declarative account of an application's security surface and the controls that must pass",
-      "fileMatch": [
-        "*.saga.yaml",
-        "*.saga.yml",
-        ".saga.yaml",
-        ".saga.yml"
-      ],
+      "fileMatch": ["*.saga.yaml", "*.saga.yml", ".saga.yaml", ".saga.yml"],
       "url": "https://draugr.dev/schema/draugr.saga.schema.json"
     },
     {
@@ -3386,18 +2753,13 @@
     {
       "name": "Deno Config (deno.json)",
       "description": "A JSON representation of a Deno configuration file",
-      "fileMatch": [
-        "deno.json",
-        "deno.jsonc"
-      ],
+      "fileMatch": ["deno.json", "deno.jsonc"],
       "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"
     },
     {
       "name": "dependabot.json",
       "description": "Dependabot config.yml files",
-      "fileMatch": [
-        "**/.dependabot/config.yml"
-      ],
+      "fileMatch": ["**/.dependabot/config.yml"],
       "url": "https://www.schemastore.org/dependabot.json"
     },
     {
@@ -3420,10 +2782,7 @@
     {
       "name": "Detekt Config (detekt.yml)",
       "description": "Detekt Configuration File",
-      "fileMatch": [
-        "detekt.yml",
-        "detekt.yaml"
-      ],
+      "fileMatch": ["detekt.yml", "detekt.yaml"],
       "url": "https://www.schemastore.org/detekt-1.22.0.json",
       "versions": {
         "1.14.1": "https://www.schemastore.org/detekt-1.14.1.json",
@@ -3438,10 +2797,7 @@
     {
       "name": "dockerd.json",
       "description": "Docker daemon configuration",
-      "fileMatch": [
-        "dockerd.json",
-        "docker.json"
-      ],
+      "fileMatch": ["dockerd.json", "docker.json"],
       "url": "https://www.schemastore.org/dockerd.json"
     },
     {
@@ -3453,10 +2809,7 @@
     {
       "name": "docker bake",
       "description": "Docker Bake configuration file. Documentation: https://docs.docker.com/build/bake/reference",
-      "fileMatch": [
-        "docker-bake.json",
-        "docker-bake.override.json"
-      ],
+      "fileMatch": ["docker-bake.json", "docker-bake.override.json"],
       "url": "https://www.schemastore.org/docker-bake.json"
     },
     {
@@ -3475,17 +2828,13 @@
     {
       "name": "DocFx Config (docfx.json)",
       "description": "A DocFx configuration files",
-      "fileMatch": [
-        "docfx.json"
-      ],
+      "fileMatch": ["docfx.json"],
       "url": "https://www.schemastore.org/docfx.json"
     },
     {
       "name": "Docs MCP Manifest",
       "description": "Configuration file for Docs MCP",
-      "fileMatch": [
-        ".docs-mcp.json"
-      ],
+      "fileMatch": [".docs-mcp.json"],
       "url": "https://raw.githubusercontent.com/speakeasy-api/docs-mcp/refs/heads/main/schemas/docs-mcp.schema.json"
     },
     {
@@ -3504,89 +2853,67 @@
     {
       "name": "Dolittle Artifacts",
       "description": "A Dolittle bounded context's artifacts",
-      "fileMatch": [
-        "**/.dolittle/artifacts.json"
-      ],
+      "fileMatch": ["**/.dolittle/artifacts.json"],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Artifacts.Configuration/artifacts.json"
     },
     {
       "name": "Dolittle Bounded Context Configuration",
       "description": "A Dolittle application's bounded context configuration",
-      "fileMatch": [
-        "bounded-context.json"
-      ],
+      "fileMatch": ["bounded-context.json"],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
     },
     {
       "name": "Dolittle Event Horizons Configuration",
       "description": "A Dolittle bounded context's event horizon configurations",
-      "fileMatch": [
-        "**/.dolittle/event-horizons.json"
-      ],
+      "fileMatch": ["**/.dolittle/event-horizons.json"],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
     },
     {
       "name": "Dolittle Resources Configuration",
       "description": "A Dolittle bounded context's resource configurations",
-      "fileMatch": [
-        "**/.dolittle/resources.json"
-      ],
+      "fileMatch": ["**/.dolittle/resources.json"],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/v5.1.0/Schemas/ResourceTypes.Configuration/resources.json"
     },
     {
       "name": "Dolittle Server Configuration",
       "description": "A Dolittle bounded context's event horizon's interaction server configuration",
-      "fileMatch": [
-        "**/.dolittle/server.json"
-      ],
+      "fileMatch": ["**/.dolittle/server.json"],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
     },
     {
       "name": "Dolittle Tenants Configuration",
       "description": "A Dolittle bounded context's tenant configuration",
-      "fileMatch": [
-        "**/.dolittle/tenants.json"
-      ],
+      "fileMatch": ["**/.dolittle/tenants.json"],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
     },
     {
       "name": "Dolittle Tenant Map Configuration",
       "description": "A Dolittle bounded context's tenant mapping configurations",
-      "fileMatch": [
-        "**/.dolittle/tenant-map.json"
-      ],
+      "fileMatch": ["**/.dolittle/tenant-map.json"],
       "url": "https://raw.githubusercontent.com/dolittle-obsolete/DotNET.Fundamentals/v4.10.0/Schemas/Tenancy.Configuration/tenant-map.json"
     },
     {
       "name": "Dolittle Topology",
       "description": "A Dolittle bounded context's topology",
-      "fileMatch": [
-        "**/.dolittle/topology.json"
-      ],
+      "fileMatch": ["**/.dolittle/topology.json"],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Applications.Configuration/topology.json"
     },
     {
       "name": "dotnet Release Index manifest",
       "description": ".NET product collection manifests",
-      "fileMatch": [
-        "dotnet-release-index.json"
-      ],
+      "fileMatch": ["dotnet-release-index.json"],
       "url": "https://www.schemastore.org/dotnet-releases-index.json"
     },
     {
       "name": "dotnet-tools.json",
       "description": ".NET tools manifest file",
-      "fileMatch": [
-        "dotnet-tools.json"
-      ],
+      "fileMatch": ["dotnet-tools.json"],
       "url": "https://www.schemastore.org/dotnet-tools.json"
     },
     {
       "name": "dotnetcli.host.json",
       "description": ".NET CLI template host files",
-      "fileMatch": [
-        "dotnetcli.host.json"
-      ],
+      "fileMatch": ["dotnetcli.host.json"],
       "url": "https://www.schemastore.org/dotnetcli.host.json"
     },
     {
@@ -3603,17 +2930,13 @@
     {
       "name": "drone.json",
       "description": "Drone CI configuration file",
-      "fileMatch": [
-        ".drone.yml"
-      ],
+      "fileMatch": [".drone.yml"],
       "url": "https://www.schemastore.org/drone.json"
     },
     {
       "name": "Drush site aliases",
       "description": "Drush 9 site aliases file",
-      "fileMatch": [
-        "**/sites/*.site.yml"
-      ],
+      "fileMatch": ["**/sites/*.site.yml"],
       "url": "https://www.schemastore.org/drush.site.yml.json"
     },
     {
@@ -3624,36 +2947,25 @@
     {
       "name": "dstack configuration",
       "description": "YAML dstack configurations",
-      "fileMatch": [
-        "*.dstack.yml",
-        "*.dstack.yaml"
-      ],
+      "fileMatch": ["*.dstack.yml", "*.dstack.yaml"],
       "url": "https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/latest/schemas/configuration.json"
     },
     {
       "name": "Dust configuration",
       "description": "TOML configuration for Dust",
-      "fileMatch": [
-        ".dust.toml",
-        "**/.config/dust/config.toml"
-      ],
+      "fileMatch": [".dust.toml", "**/.config/dust/config.toml"],
       "url": "https://www.schemastore.org/dust.json"
     },
     {
       "name": "dvc.yaml",
       "description": "dvc.yaml file",
-      "fileMatch": [
-        "dvc.yaml"
-      ],
+      "fileMatch": ["dvc.yaml"],
       "url": "https://raw.githubusercontent.com/iterative/dvcyaml-schema/master/schema.json"
     },
     {
       "name": "Devfile",
       "description": "Devfiles",
-      "fileMatch": [
-        "devfile.yaml",
-        ".devfile.yaml"
-      ],
+      "fileMatch": ["devfile.yaml", ".devfile.yaml"],
       "url": "https://raw.githubusercontent.com/devfile/api/v2.2.0/schemas/latest/devfile.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/eclipse-che/che-server/7.80.0/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
@@ -3707,18 +3019,13 @@
     {
       "name": "ECA - Editor Code Assistant",
       "description": "ECA AI coding agent configuration file",
-      "fileMatch": [
-        "**/eca/config.json",
-        "**/.eca/config.json"
-      ],
+      "fileMatch": ["**/eca/config.json", "**/.eca/config.json"],
       "url": "https://eca.dev/config.json"
     },
     {
       "name": "editorconfig-checker",
       "description": "editorconfig-checker configuration file",
-      "fileMatch": [
-        ".editorconfig-checker.json"
-      ],
+      "fileMatch": [".editorconfig-checker.json"],
       "url": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/main/.editorconfig-checker.schema.json",
       "versions": {
         "3.8.0": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/v3.8.0/.editorconfig-checker.schema.json"
@@ -3746,10 +3053,7 @@
     {
       "name": "Envilder Map File",
       "description": "Envilder secret mapping file that maps environment variable names to cloud secret paths",
-      "fileMatch": [
-        "envilder.json",
-        "envilder.*.json"
-      ],
+      "fileMatch": ["envilder.json", "envilder.*.json"],
       "url": "https://envilder.com/schema/map-file.v1.json"
     },
     {
@@ -4025,10 +3329,7 @@
     {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
-      "fileMatch": [
-        ".esmrc",
-        ".esmrc.json"
-      ],
+      "fileMatch": [".esmrc", ".esmrc.json"],
       "url": "https://www.schemastore.org/esmrc.json"
     },
     {
@@ -4039,43 +3340,31 @@
     {
       "name": "estampo.toml",
       "description": "Configuration for estampo, the build system for reproducible 3D prints",
-      "fileMatch": [
-        "estampo.toml",
-        "estampo.*.toml"
-      ],
+      "fileMatch": ["estampo.toml", "estampo.*.toml"],
       "url": "https://raw.githubusercontent.com/estampo/estampo/main/docs/estampo.schema.json"
     },
     {
       "name": "epr-manifest.json",
       "description": "Entry Point Regulation manifest file",
-      "fileMatch": [
-        "epr-manifest.json"
-      ],
+      "fileMatch": ["epr-manifest.json"],
       "url": "https://www.schemastore.org/epr-manifest.json"
     },
     {
       "name": "electron-builder configuration file",
       "description": "electron-build configuration file",
-      "fileMatch": [
-        "electron-builder.json"
-      ],
+      "fileMatch": ["electron-builder.json"],
       "url": "https://www.schemastore.org/electron-builder.json"
     },
     {
       "name": "evcc.yaml",
       "description": "evcc configuration file",
-      "fileMatch": [
-        "evcc*.yaml"
-      ],
+      "fileMatch": ["evcc*.yaml"],
       "url": "https://raw.githubusercontent.com/andig/evcc/master/schema.json"
     },
     {
       "name": "EveryVoice TTS Toolkit Aligner Configuration",
       "description": "EveryVoice Text-to-Speech Toolkit Aligner Configuration",
-      "fileMatch": [
-        "everyvoice-aligner.yaml",
-        "everyvoice-aligner.json"
-      ],
+      "fileMatch": ["everyvoice-aligner.yaml", "everyvoice-aligner.json"],
       "url": "https://raw.githubusercontent.com/EveryVoiceTTS/everyvoice/main/everyvoice/.schema/everyvoice-aligner-0.3.json",
       "versions": {
         "0.1": "https://raw.githubusercontent.com/EveryVoiceTTS/everyvoice/main/everyvoice/.schema/everyvoice-aligner-0.1.json",
@@ -4174,36 +3463,25 @@
     {
       "name": "EAS config",
       "description": "The EAS config (eas.json) validation and documentation",
-      "fileMatch": [
-        "eas.json"
-      ],
+      "fileMatch": ["eas.json"],
       "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
     },
     {
       "name": "Expoot app config",
       "description": "The config for creating a React Native Desktop app with best-effort Expo support, used by the expoot CLI",
-      "fileMatch": [
-        "expoot-app.json"
-      ],
+      "fileMatch": ["expoot-app.json"],
       "url": "https://raw.githubusercontent.com/shirakaba/expoot/main/packages/expoot/schemas/expoot-app.schema.json"
     },
     {
       "name": "EasyVCR .NET",
       "description": "EasyVCR .NET recording file",
-      "fileMatch": [
-        "*.easyvcr",
-        "**/cassettes/*.json"
-      ],
+      "fileMatch": ["*.easyvcr", "**/cassettes/*.json"],
       "url": "https://www.schemastore.org/easyvcr-net.json"
     },
     {
       "name": "ezd task runner",
       "description": "ezd task runner. Documentation: https://gitlab.com/sbenv/veroxis/ezd-rs",
-      "fileMatch": [
-        "ezd.yaml",
-        "ezd.json",
-        "ezd.yml"
-      ],
+      "fileMatch": ["ezd.yaml", "ezd.json", "ezd.yml"],
       "url": "https://gitlab.com/sbenv/veroxis/ezd-rs/-/raw/HEAD/ezd.schema.json"
     },
     {
@@ -4220,49 +3498,37 @@
     {
       "name": "ESLint Suppressions",
       "description": "ESLint bulk suppressions file",
-      "fileMatch": [
-        "eslint-suppressions.json"
-      ],
+      "fileMatch": ["eslint-suppressions.json"],
       "url": "https://www.schemastore.org/eslint-suppressions.json"
     },
     {
       "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
-      "fileMatch": [
-        "fabric.mod.json"
-      ],
+      "fileMatch": ["fabric.mod.json"],
       "url": "https://www.schemastore.org/fabric.mod.json"
     },
     {
       "name": "F-Droid Data metadata",
       "description": "F-Droid Data app metadata files",
-      "fileMatch": [
-        "**/metadata/*.yml"
-      ],
+      "fileMatch": ["**/metadata/*.yml"],
       "url": "https://gitlab.com/fdroid/fdroiddata/-/raw/master/schemas/metadata.json"
     },
     {
       "name": ".ffizer.yaml",
       "description": "ffizer template configuration files",
-      "fileMatch": [
-        ".ffizer.yaml"
-      ],
+      "fileMatch": [".ffizer.yaml"],
       "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
     },
     {
       "name": "Firebase",
       "description": "firebase",
-      "fileMatch": [
-        "firebase.json"
-      ],
+      "fileMatch": ["firebase.json"],
       "url": "https://raw.githubusercontent.com/firebase/firebase-tools/master/schema/firebase-config.json"
     },
     {
       "name": "Google Chrome Related Website Sets",
       "description": "Google Chrome Related Website Sets (formerly First Party Sets)",
-      "fileMatch": [
-        "**/.well-known/first-party-set.json"
-      ],
+      "fileMatch": ["**/.well-known/first-party-set.json"],
       "url": "https://raw.githubusercontent.com/GoogleChrome/related-website-sets/main/SCHEMA.json"
     },
     {
@@ -4293,18 +3559,13 @@
     {
       "name": "FlexGet Config",
       "description": "FlexGet config file",
-      "fileMatch": [
-        "**/.flexget/config.yml",
-        "**/flexget/config.yml"
-      ],
+      "fileMatch": ["**/.flexget/config.yml", "**/flexget/config.yml"],
       "url": "https://github.com/Flexget/Flexget/releases/latest/download/flexget-config.schema.json"
     },
     {
       "name": "first-timers-bot",
       "description": "A bot that helps onboarding new open-source contributors",
-      "fileMatch": [
-        "**/.github/first-timers.yml"
-      ],
+      "fileMatch": ["**/.github/first-timers.yml"],
       "url": "https://www.schemastore.org/first-timers.json"
     },
     {
@@ -4316,67 +3577,49 @@
     {
       "name": "Foundry VTT - Module Manifest",
       "description": "Foundry VTT module.json files",
-      "fileMatch": [
-        "**/modules/*/module.json"
-      ],
+      "fileMatch": ["**/modules/*/module.json"],
       "url": "https://www.schemastore.org/foundryvtt-module-manifest.json"
     },
     {
       "name": "Foundry VTT - System Manifest",
       "description": "Foundry VTT system.json files",
-      "fileMatch": [
-        "**/systems/*/system.json"
-      ],
+      "fileMatch": ["**/systems/*/system.json"],
       "url": "https://www.schemastore.org/foundryvtt-system-manifest.json"
     },
     {
       "name": "Foundry VTT - World Manifest",
       "description": "Foundry VTT world.json files",
-      "fileMatch": [
-        "**/worlds/*/world.json"
-      ],
+      "fileMatch": ["**/worlds/*/world.json"],
       "url": "https://www.schemastore.org/foundryvtt-world-manifest.json"
     },
     {
       "name": "Foundry VTT - System Data Template",
       "description": "Foundry VTT template.json files",
-      "fileMatch": [
-        "**/systems/*/template.json"
-      ],
+      "fileMatch": ["**/systems/*/template.json"],
       "url": "https://www.schemastore.org/foundryvtt-template.json"
     },
     {
       "name": "Fossa configuration file",
       "description": "FOSSA CLI's .fossa.yml configuration file",
-      "fileMatch": [
-        ".fossa.yml"
-      ],
+      "fileMatch": [".fossa.yml"],
       "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json"
     },
     {
       "name": "Fossa's fossa-deps file",
       "description": "FOSSA CLI's fossa-deps file",
-      "fileMatch": [
-        "fossa-deps.yml",
-        "fossa-deps.yaml",
-        "fossa-deps.json"
-      ],
+      "fileMatch": ["fossa-deps.yml", "fossa-deps.yaml", "fossa-deps.json"],
       "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-deps.schema.json"
     },
     {
       "name": "Karakum configuration file",
       "description": "configuring Karakum, a converter of TypeScript declaration files to Kotlin declarations",
-      "fileMatch": [
-        "karakum.config.json"
-      ],
+      "fileMatch": ["karakum.config.json"],
       "url": "https://raw.githubusercontent.com/karakum-team/karakum/master/karakum-schema/karakum-schema.json"
     },
     {
       "name": "Knative Functions - func.yaml",
       "description": "Knative Functions func.yaml files",
-      "fileMatch": [
-        "func.yaml"
-      ],
+      "fileMatch": ["func.yaml"],
       "url": "https://raw.githubusercontent.com/knative/func/latest-release/schema/func_yaml-schema.json",
       "versions": {
         "1.7": "https://raw.githubusercontent.com/knative/func/release-1.7/schema/func_yaml-schema.json",
@@ -4386,19 +3629,13 @@
     {
       "name": "Knip",
       "description": "Knip JSON configuration files",
-      "fileMatch": [
-        "knip.json",
-        ".knip.json"
-      ],
+      "fileMatch": ["knip.json", ".knip.json"],
       "url": "https://unpkg.com/knip@6/schema.json"
     },
     {
       "name": "Knip JSONC",
       "description": "Knip JSONC configuration files",
-      "fileMatch": [
-        "knip.jsonc",
-        ".knip.jsonc"
-      ],
+      "fileMatch": ["knip.jsonc", ".knip.jsonc"],
       "url": "https://unpkg.com/knip@6/schema-jsonc.json"
     },
     {
@@ -4425,18 +3662,13 @@
     {
       "name": "function.json",
       "description": "Azure Functions function.json files",
-      "fileMatch": [
-        "function.json"
-      ],
+      "fileMatch": ["function.json"],
       "url": "https://www.schemastore.org/function.json"
     },
     {
       "name": "G2P Mapping Configuration",
       "description": "defining mappings for Python-based grapheme-to-phoneme engine 'g2p'",
-      "fileMatch": [
-        "config-g2p.yaml",
-        "config-g2p.json"
-      ],
+      "fileMatch": ["config-g2p.yaml", "config-g2p.json"],
       "url": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.3.json",
       "versions": {
         "2.0": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.0.json",
@@ -4448,18 +3680,13 @@
     {
       "name": "GAMA",
       "description": "GAMA configuration file",
-      "fileMatch": [
-        "**/gama/config.yaml",
-        ".gama.yaml"
-      ],
+      "fileMatch": ["**/gama/config.yaml", ".gama.yaml"],
       "url": "https://www.schemastore.org/gama.json"
     },
     {
       "name": "Gaspar",
       "description": "Configuration for Gaspar",
-      "fileMatch": [
-        "gaspar.config.json"
-      ],
+      "fileMatch": ["gaspar.config.json"],
       "url": "https://www.schemastore.org/gaspar-3.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/gaspar-1.0.json",
@@ -4520,9 +3747,7 @@
     {
       "name": "Global Privacy Control",
       "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control",
-      "fileMatch": [
-        "**/.well-known/gpc.json"
-      ],
+      "fileMatch": ["**/.well-known/gpc.json"],
       "url": "https://www.schemastore.org/gpc.json"
     },
     {
@@ -4551,10 +3776,7 @@
     {
       "name": "Gitleaks",
       "description": "Gitleaks configuration file",
-      "fileMatch": [
-        "gitleaks.toml",
-        ".gitleaks.toml"
-      ],
+      "fileMatch": ["gitleaks.toml", ".gitleaks.toml"],
       "url": "https://www.schemastore.org/gitleaks.json"
     },
     {
@@ -4598,11 +3820,7 @@
     {
       "name": "gh-dash",
       "description": "Configuration for the gh-dash GitHub CLI dashboard",
-      "fileMatch": [
-        ".gh-dash.yml",
-        ".gh-dash.yaml",
-        "**/gh-dash/config.yml"
-      ],
+      "fileMatch": [".gh-dash.yml", ".gh-dash.yaml", "**/gh-dash/config.yml"],
       "url": "https://gh-dash.dev/schema.json"
     },
     {
@@ -4619,28 +3837,19 @@
     {
       "name": "GitHub Action",
       "description": "YAML GitHub Actions",
-      "fileMatch": [
-        "action.yml",
-        "action.yaml"
-      ],
+      "fileMatch": ["action.yml", "action.yaml"],
       "url": "https://www.schemastore.org/github-action.json"
     },
     {
       "name": "GitHub CLI configuration",
       "description": "Global configuration for the GitHub CLI",
-      "fileMatch": [
-        "**/gh/config.yml",
-        "**/GitHub CLI/config.yml"
-      ],
+      "fileMatch": ["**/gh/config.yml", "**/GitHub CLI/config.yml"],
       "url": "https://www.schemastore.org/github-cli-config.json"
     },
     {
       "name": "GitHub CLI hosts",
       "description": "Authentication and per-host configuration for the GitHub CLI",
-      "fileMatch": [
-        "**/gh/hosts.yml",
-        "**/GitHub CLI/hosts.yml"
-      ],
+      "fileMatch": ["**/gh/hosts.yml", "**/GitHub CLI/hosts.yml"],
       "url": "https://www.schemastore.org/github-cli-hosts.json"
     },
     {
@@ -4655,10 +3864,7 @@
     {
       "name": "GitHub Prompt",
       "description": "YAML prompt files for GitHub Models (.prompt.yml / .prompt.yaml)",
-      "fileMatch": [
-        "**/*.prompt.yml",
-        "**/*.prompt.yaml"
-      ],
+      "fileMatch": ["**/*.prompt.yml", "**/*.prompt.yaml"],
       "url": "https://www.schemastore.org/github-prompt.json"
     },
     {
@@ -4698,9 +3904,7 @@
     {
       "name": "GitHub Secret Scanning",
       "description": "YAML configuration for GitHub secret scanning exclusions",
-      "fileMatch": [
-        "**/.github/secret_scanning.yml"
-      ],
+      "fileMatch": ["**/.github/secret_scanning.yml"],
       "url": "https://www.schemastore.org/github-secret-scanning.json"
     },
     {
@@ -4719,17 +3923,13 @@
     {
       "name": "GitHub Workflow Template Properties",
       "description": "properties json file for a GitHub Workflow template",
-      "fileMatch": [
-        "**/.github/workflow-templates/**.properties.json"
-      ],
+      "fileMatch": ["**/.github/workflow-templates/**.properties.json"],
       "url": "https://www.schemastore.org/github-workflow-template-properties.json"
     },
     {
       "name": "GitHub automatically generated release notes configuration",
       "description": "YAML GitHub automatically generated release notes config",
-      "fileMatch": [
-        "**/.github/release.yml"
-      ],
+      "fileMatch": ["**/.github/release.yml"],
       "url": "https://www.schemastore.org/github-release-config.json"
     },
     {
@@ -4746,17 +3946,13 @@
     {
       "name": "GitLab Duo Workflow",
       "description": "YAML configuration for GitLab Duo Workflows",
-      "fileMatch": [
-        "**/.gitlab/duo/flows/*.yaml"
-      ],
+      "fileMatch": ["**/.gitlab/duo/flows/*.yaml"],
       "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
     },
     {
       "name": "Gitpod Configuration",
       "description": "configuring Gitpod.io",
-      "fileMatch": [
-        ".gitpod.yml"
-      ],
+      "fileMatch": [".gitpod.yml"],
       "url": "https://gitpod.io/schemas/gitpod-schema.json"
     },
     {
@@ -4773,41 +3969,31 @@
     {
       "name": "Ansible Execution Environment",
       "description": "Ansible execution-environment.yml file",
-      "fileMatch": [
-        "**/execution-environment.yml"
-      ],
+      "fileMatch": ["**/execution-environment.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json"
     },
     {
       "name": "Ansible Meta",
       "description": "Ansible meta/main.yml file",
-      "fileMatch": [
-        "**/meta/main.yml"
-      ],
+      "fileMatch": ["**/meta/main.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
     },
     {
       "name": "Ansible Meta Runtime",
       "description": "Ansible meta/runtime.yml file",
-      "fileMatch": [
-        "**/meta/runtime.yml"
-      ],
+      "fileMatch": ["**/meta/runtime.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json"
     },
     {
       "name": "Ansible Argument Specs",
       "description": "Ansible meta/argument_specs.yml file",
-      "fileMatch": [
-        "**/meta/argument_specs.yml"
-      ],
+      "fileMatch": ["**/meta/argument_specs.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json"
     },
     {
       "name": "Ansible Requirements",
       "description": "Ansible requirements file",
-      "fileMatch": [
-        "requirements.yml"
-      ],
+      "fileMatch": ["requirements.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
     },
     {
@@ -4850,36 +4036,25 @@
     {
       "name": "Ansible Rulebook",
       "description": "Ansible rulebook files",
-      "fileMatch": [
-        "**/rulebooks/*.yml",
-        "**/rulebooks/*.yaml"
-      ],
+      "fileMatch": ["**/rulebooks/*.yml", "**/rulebooks/*.yaml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
     },
     {
       "name": "Ansible Inventory",
       "description": "Ansible inventory files",
-      "fileMatch": [
-        "inventory.yml",
-        "inventory.yaml"
-      ],
+      "fileMatch": ["inventory.yml", "inventory.yaml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
     },
     {
       "name": "Ansible Collection Galaxy",
       "description": "Ansible Collection Galaxy metadata",
-      "fileMatch": [
-        "galaxy.yml"
-      ],
+      "fileMatch": ["galaxy.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json"
     },
     {
       "name": "Ansible-lint Configuration",
       "description": "Ansible-lint Configuration",
-      "fileMatch": [
-        ".ansible-lint",
-        "**/.config/ansible-lint.yml"
-      ],
+      "fileMatch": [".ansible-lint", "**/.config/ansible-lint.yml"],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
     },
     {
@@ -4898,9 +4073,7 @@
     {
       "name": "global.json",
       "description": "ASP.NET global configuration file",
-      "fileMatch": [
-        "global.json"
-      ],
+      "fileMatch": ["global.json"],
       "url": "https://www.schemastore.org/global.json"
     },
     {
@@ -4921,38 +4094,25 @@
     {
       "name": "Golangci-lint Custom Plugins Configuration",
       "description": "golangci-lint custom plugins configuration file",
-      "fileMatch": [
-        ".custom-gcl.yml",
-        ".custom-gcl.yaml"
-      ],
+      "fileMatch": [".custom-gcl.yml", ".custom-gcl.yaml"],
       "url": "https://golangci-lint.run/jsonschema/custom-gcl.jsonschema.json"
     },
     {
       "name": "gollama",
       "description": "gollama configuration file",
-      "fileMatch": [
-        "**/gollama/config.json"
-      ],
+      "fileMatch": ["**/gollama/config.json"],
       "url": "https://www.schemastore.org/gollama.json"
     },
     {
       "name": "go-feature-flag Flag Configuration",
       "description": "go-feature-flag flag configuration file",
-      "fileMatch": [
-        "*.goff.yml",
-        "*.goff.yaml",
-        "*.goff.json",
-        "*.goff.toml"
-      ],
+      "fileMatch": ["*.goff.yml", "*.goff.yaml", "*.goff.json", "*.goff.toml"],
       "url": "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/.schema/flag-schema.json"
     },
     {
       "name": "gojo.yaml",
       "description": "gojo project manifest (profiles, agents, schedules)",
-      "fileMatch": [
-        "gojo.yaml",
-        "**/.gojo/project.yaml"
-      ],
+      "fileMatch": ["gojo.yaml", "**/.gojo/project.yaml"],
       "url": "https://raw.githubusercontent.com/detroitpro/gojo/main/packages/contracts/schemas/gojo.project.schema.json"
     },
     {
@@ -4974,20 +4134,13 @@
     {
       "name": "Anodizer",
       "description": "Anodizer Rust release-automation configuration file",
-      "fileMatch": [
-        ".anodizer.yaml",
-        ".anodizer.yml"
-      ],
+      "fileMatch": [".anodizer.yaml", ".anodizer.yml"],
       "url": "https://tj-smith47.github.io/anodizer/schema.json"
     },
     {
       "name": "Goss",
       "description": "Goss - Quick and Easy server validation",
-      "fileMatch": [
-        "goss.yaml",
-        "goss.yml",
-        "goss.json"
-      ],
+      "fileMatch": ["goss.yaml", "goss.yml", "goss.json"],
       "url": "https://github.com/goss-org/goss/raw/master/docs/schema.yaml"
     },
     {
@@ -4998,17 +4151,13 @@
     {
       "name": "tree-sitter grammar.json",
       "description": "tree-sitter grammar.json",
-      "fileMatch": [
-        "grammar.json"
-      ],
+      "fileMatch": ["grammar.json"],
       "url": "https://raw.githubusercontent.com/tree-sitter/tree-sitter/master/docs/src/assets/schemas/config.schema.json"
     },
     {
       "name": "Treefmt",
       "description": "Treefmt configuration file",
-      "fileMatch": [
-        "treefmt.toml"
-      ],
+      "fileMatch": ["treefmt.toml"],
       "url": "https://www.schemastore.org/treefmt.json"
     },
     {
@@ -5066,85 +4215,61 @@
     {
       "name": "Grunt copy task",
       "description": "Grunt copy task configuration file",
-      "fileMatch": [
-        "copy.json"
-      ],
+      "fileMatch": ["copy.json"],
       "url": "https://www.schemastore.org/grunt-copy-task.json"
     },
     {
       "name": "Grunt clean task",
       "description": "Grunt clean task configuration file",
-      "fileMatch": [
-        "clean.json"
-      ],
+      "fileMatch": ["clean.json"],
       "url": "https://www.schemastore.org/grunt-clean-task.json"
     },
     {
       "name": "Grunt cssmin task",
       "description": "Grunt cssmin task configuration file",
-      "fileMatch": [
-        "cssmin.json"
-      ],
+      "fileMatch": ["cssmin.json"],
       "url": "https://www.schemastore.org/grunt-cssmin-task.json"
     },
     {
       "name": "Grunt JSHint task",
       "description": "Grunt JSHint task configuration file",
-      "fileMatch": [
-        "jshint.json"
-      ],
+      "fileMatch": ["jshint.json"],
       "url": "https://www.schemastore.org/grunt-jshint-task.json"
     },
     {
       "name": "Grunt Watch task",
       "description": "Grunt Watch task configuration file",
-      "fileMatch": [
-        "watch.json"
-      ],
+      "fileMatch": ["watch.json"],
       "url": "https://www.schemastore.org/grunt-watch-task.json"
     },
     {
       "name": "Grunt base task",
       "description": "standard Grunt tasks",
-      "fileMatch": [
-        "**/grunt/*.json",
-        "*-tasks.json"
-      ],
+      "fileMatch": ["**/grunt/*.json", "*-tasks.json"],
       "url": "https://www.schemastore.org/grunt-task.json"
     },
     {
       "name": "HashiCorp Vault",
       "description": "HashiCorp's Vault configuration file",
-      "fileMatch": [
-        "vault.json",
-        "vault.config.json"
-      ],
+      "fileMatch": ["vault.json", "vault.config.json"],
       "url": "https://www.schemastore.org/vault.json"
     },
     {
       "name": "haxelib.json",
       "description": "Haxelib manifest",
-      "fileMatch": [
-        "haxelib.json"
-      ],
+      "fileMatch": ["haxelib.json"],
       "url": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json"
     },
     {
       "name": "Hayson",
       "description": "Project Haystack data",
-      "fileMatch": [
-        "*.hayson.json",
-        "*.hayson.yaml",
-        "*.hayson.yml"
-      ],
+      "fileMatch": ["*.hayson.json", "*.hayson.yaml", "*.hayson.yml"],
       "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
     },
     {
       "name": "Haystack Pipeline",
       "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. Documentation: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
-      "fileMatch": [
-        "*.haystack-pipeline.yml"
-      ],
+      "fileMatch": ["*.haystack-pipeline.yml"],
       "url": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline.schema.json"
     },
     {
@@ -5161,9 +4286,7 @@
     {
       "name": "hassette.toml",
       "description": "Configuration file for Hassette, an async Python framework for Home Assistant automations",
-      "fileMatch": [
-        "hassette.toml"
-      ],
+      "fileMatch": ["hassette.toml"],
       "url": "https://raw.githubusercontent.com/NodeJSmith/hassette/main/hassette.schema.json"
     },
     {
@@ -5184,33 +4307,25 @@
     {
       "name": "host.json",
       "description": "Azure Functions host.json files",
-      "fileMatch": [
-        "host.json"
-      ],
+      "fileMatch": ["host.json"],
       "url": "https://www.schemastore.org/host.json"
     },
     {
       "name": "host-meta.json",
       "description": "host-meta JDR files",
-      "fileMatch": [
-        "host-meta.json"
-      ],
+      "fileMatch": ["host-meta.json"],
       "url": "https://www.schemastore.org/host-meta.json"
     },
     {
       "name": ".htmlhintrc",
       "description": "HTML Hint configuration file",
-      "fileMatch": [
-        ".htmlhintrc"
-      ],
+      "fileMatch": [".htmlhintrc"],
       "url": "https://www.schemastore.org/htmlhint.json"
     },
     {
       "name": ".htmlvalidate",
       "description": "HTML-validate is an offline HTML5 validator",
-      "fileMatch": [
-        ".htmlvalidate.json"
-      ],
+      "fileMatch": [".htmlvalidate.json"],
       "url": "https://html-validate.org/schemas/config.json"
     },
     {
@@ -5222,40 +4337,25 @@
     {
       "name": "Ory Hydra configuration",
       "description": "Ory Hydra configuration file",
-      "fileMatch": [
-        "hydra.json",
-        "hydra.yml",
-        "hydra.yaml",
-        "hydra.toml"
-      ],
+      "fileMatch": ["hydra.json", "hydra.yml", "hydra.yaml", "hydra.toml"],
       "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
     },
     {
       "name": "Hyperfoil benchmark configuration",
       "description": "Benchmark definition format for the Hyperfoil HTTP benchmark framework",
-      "fileMatch": [
-        "*.hf.yaml"
-      ],
+      "fileMatch": ["*.hf.yaml"],
       "url": "https://hyperfoil.io/schema.json"
     },
     {
       "name": "Hulak Configuration",
       "description": "Hulak API client configuration file",
-      "fileMatch": [
-        "**/*.hk.yaml",
-        "**/*.hk.yml",
-        "**/*.hk.json"
-      ],
+      "fileMatch": ["**/*.hk.yaml", "**/*.hk.yml", "**/*.hk.json"],
       "url": "https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json"
     },
     {
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
-      "fileMatch": [
-        "zapp.yaml",
-        "zapp.yml",
-        "zapp.json"
-      ],
+      "fileMatch": ["zapp.yaml", "zapp.yml", "zapp.json"],
       "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.11.0.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json",
@@ -5277,27 +4377,19 @@
     {
       "name": "IBM zCodeFormatSettings",
       "description": "IBM Enterprise languages code formatter settings file for IBM zDevOps development tools such as Z Open Editor",
-      "fileMatch": [
-        "zcodeformat.yaml",
-        "zcodeformat.json"
-      ],
+      "fileMatch": ["zcodeformat.yaml", "zcodeformat.json"],
       "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zcodeformat/zcodeformat-schema-0.0.1.json"
     },
     {
       "name": "ide.host.json",
       "description": "IDE template host file",
-      "fileMatch": [
-        "ide.host.json"
-      ],
+      "fileMatch": ["ide.host.json"],
       "url": "https://www.schemastore.org/ide.host.json"
     },
     {
       "name": "ifstate.yaml",
       "description": "IfState configuration file",
-      "fileMatch": [
-        "ifstate.yaml",
-        "**/ifstate/config.yml"
-      ],
+      "fileMatch": ["ifstate.yaml", "**/ifstate/config.yml"],
       "url": "https://ifstate.net/schema/2/ifstate.conf.schema.json",
       "versions": {
         "0.6": "https://ifstate.net/schema/0.6/ifstate.conf.schema.json",
@@ -5327,25 +4419,19 @@
     {
       "name": "imageoptimizer.json",
       "description": "imageoptimizer.json files",
-      "fileMatch": [
-        "imageoptimizer.json"
-      ],
+      "fileMatch": ["imageoptimizer.json"],
       "url": "https://www.schemastore.org/imageoptimizer.json"
     },
     {
       "name": ".imgbotconfig",
       "description": "Imgbot Configuration Files",
-      "fileMatch": [
-        ".imgbotconfig"
-      ],
+      "fileMatch": [".imgbotconfig"],
       "url": "https://www.schemastore.org/imgbotconfig.json"
     },
     {
       "name": "IMG Catapult PSP",
       "description": "Imagination Technologies Catapult platform support pack contents",
-      "fileMatch": [
-        "contents.yaml"
-      ],
+      "fileMatch": ["contents.yaml"],
       "url": "https://www.schemastore.org/img-catapult-psp-1.0.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/img-catapult-psp-1.0.0.json"
@@ -5354,21 +4440,13 @@
     {
       "name": "importmap.json",
       "description": "Import Maps files",
-      "fileMatch": [
-        "importmap.json",
-        "import_map.json",
-        "import-map.json"
-      ],
+      "fileMatch": ["importmap.json", "import_map.json", "import-map.json"],
       "url": "https://www.schemastore.org/importmap.json"
     },
     {
       "name": "Infinispan Configuration",
       "description": "Infinispan distributed cache configuration",
-      "fileMatch": [
-        "infinispan.json",
-        "infinispan.yaml",
-        "infinispan.yml"
-      ],
+      "fileMatch": ["infinispan.json", "infinispan.yaml", "infinispan.yml"],
       "url": "https://infinispan.org/schemas/infinispan-config.json"
     },
     {
@@ -5384,26 +4462,19 @@
     {
       "name": "Infrahub",
       "description": "Repository config definition for Infrahub by OpsMill",
-      "fileMatch": [
-        ".infrahub.yml",
-        ".infrahub.yaml"
-      ],
+      "fileMatch": [".infrahub.yml", ".infrahub.yaml"],
       "url": "https://schema.infrahub.app/python-sdk/repository-config/latest.json"
     },
     {
       "name": "instant_python_config",
       "description": "Instant Python Configuration",
-      "fileMatch": [
-        "ipy.yml"
-      ],
+      "fileMatch": ["ipy.yml"],
       "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/ipy-schemas.json"
     },
     {
       "name": "instant_python_custom_project",
       "description": "Instant Python Custom Project Structure",
-      "fileMatch": [
-        "main_structure.yml"
-      ],
+      "fileMatch": ["main_structure.yml"],
       "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/main-structure-schema.json"
     },
     {
@@ -5420,36 +4491,25 @@
     {
       "name": "ioBroker Configuration",
       "description": "The configuration file of an ioBroker installation",
-      "fileMatch": [
-        "iobroker.json",
-        "iobroker-dist.json"
-      ],
+      "fileMatch": ["iobroker.json", "iobroker-dist.json"],
       "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/iobroker.json"
     },
     {
       "name": "ioBroker JSON UI",
       "description": "ioBroker JSON-based admin user interfaces - config, custom and tabs",
-      "fileMatch": [
-        "jsonConfig.json",
-        "jsonCustom.json",
-        "jsonTab.json"
-      ],
+      "fileMatch": ["jsonConfig.json", "jsonCustom.json", "jsonTab.json"],
       "url": "https://raw.githubusercontent.com/ioBroker/json-config/main/schemas/jsonConfig.json"
     },
     {
       "name": "ioBroker Package manifest",
       "description": "ioBroker adapters io-package file",
-      "fileMatch": [
-        "io-package.json"
-      ],
+      "fileMatch": ["io-package.json"],
       "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
     },
     {
       "name": "ixpect.conf.yaml",
       "description": "IXpect configuration file",
-      "fileMatch": [
-        "ixpect.conf.yaml"
-      ],
+      "fileMatch": ["ixpect.conf.yaml"],
       "url": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json",
       "versions": {
         "0.1": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json"
@@ -5458,88 +4518,61 @@
     {
       "name": "Jasmine",
       "description": "jasmine JSON config file",
-      "fileMatch": [
-        "jasmine.json"
-      ],
+      "fileMatch": ["jasmine.json"],
       "url": "https://www.schemastore.org/jasmine.json"
     },
     {
       "name": "Jekyll",
       "description": "Jekyll static site generator config file",
-      "fileMatch": [
-        "_config.yml"
-      ],
+      "fileMatch": ["_config.yml"],
       "url": "https://www.schemastore.org/jekyll.json"
     },
     {
       "name": "Jenkins X Pipelines",
       "description": "Jenkins X Pipeline YAML configuration files",
-      "fileMatch": [
-        "jenkins-x*.yml"
-      ],
+      "fileMatch": ["jenkins-x*.yml"],
       "url": "https://jenkins-x.io/schemas/jx-schema.json"
     },
     {
       "name": "Jenkins X Requirements",
       "description": "Jenkins X Requirements YAML configuration file",
-      "fileMatch": [
-        "jx-requirements.yml"
-      ],
+      "fileMatch": ["jx-requirements.yml"],
       "url": "https://jenkins-x.io/schemas/jx-requirements.json"
     },
     {
       "name": "Jest",
       "description": "A JavaScript Testing Framework",
-      "fileMatch": [
-        "jest.config.json"
-      ],
+      "fileMatch": ["jest.config.json"],
       "url": "https://www.schemastore.org/jest.json"
     },
     {
       "name": "JDownloader2 crawler single-rules",
       "description": "A validating a single jdownloader2 rule",
-      "fileMatch": [
-        "*.jd2cr",
-        "*.jd2cr.json"
-      ],
+      "fileMatch": ["*.jd2cr", "*.jd2cr.json"],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2cr.schema.json"
     },
     {
       "name": "JDownloader2 crawler multi-rules",
       "description": "A validating an array of jdownloader2 rules",
-      "fileMatch": [
-        "*.jd2mcr",
-        "*.jd2mcr.json",
-        "*.linkcrawlerrules.json"
-      ],
+      "fileMatch": ["*.jd2mcr", "*.jd2mcr.json", "*.linkcrawlerrules.json"],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
     },
     {
       "name": "JFrog Applications Config",
       "description": "Refines JFrog Advanced Security scans behavior",
-      "fileMatch": [
-        "jfrog-apps-config.yml"
-      ],
+      "fileMatch": ["jfrog-apps-config.yml"],
       "url": "https://raw.githubusercontent.com/jfrog/jfrog-apps-config/main/schema.json"
     },
     {
       "name": "JFrog File Spec",
       "description": "JFrog File Spec",
-      "fileMatch": [
-        "**/filespecs/*.json",
-        "*filespec*.json",
-        "*.filespec"
-      ],
+      "fileMatch": ["**/filespecs/*.json", "*filespec*.json", "*.filespec"],
       "url": "https://raw.githubusercontent.com/jfrog/jfrog-cli/v2/schema/filespec-schema.json"
     },
     {
       "name": "JMeter DSL cli config",
       "description": "jmdsl JMeter DSL command line configuration file",
-      "fileMatch": [
-        "*.jmdsl.yml",
-        "*.jmdsl.yaml",
-        "*.jmdsl.json"
-      ],
+      "fileMatch": ["*.jmdsl.yml", "*.jmdsl.yaml", "*.jmdsl.json"],
       "url": "https://github.com/abstracta/jmeter-java-dsl/releases/latest/download/jmdsl-config-schema.json"
     },
     {
@@ -5561,10 +4594,7 @@
     {
       "name": "JReleaser",
       "description": "JReleaser config file",
-      "fileMatch": [
-        "jreleaser.yml",
-        "jreleaser.json"
-      ],
+      "fileMatch": ["jreleaser.yml", "jreleaser.json"],
       "url": "https://www.schemastore.org/jreleaser-1.25.0.json",
       "versions": {
         "1.25.0": "https://www.schemastore.org/jreleaser-1.25.0.json",
@@ -5593,51 +4623,37 @@
     {
       "name": "JSR Package Config (jsr.json)",
       "description": "JSR package configuration file",
-      "fileMatch": [
-        "jsr.json",
-        "jsr.jsonc"
-      ],
+      "fileMatch": ["jsr.json", "jsr.jsonc"],
       "url": "https://jsr.io/schema/config-file.v1.json"
     },
     {
       "name": ".jsbeautifyrc",
       "description": "js-beautify configuration file",
-      "fileMatch": [
-        ".jsbeautifyrc"
-      ],
+      "fileMatch": [".jsbeautifyrc"],
       "url": "https://www.schemastore.org/jsbeautifyrc.json"
     },
     {
       "name": ".jsbeautifyrc-nested",
       "description": "js-beautify configuration file allowing nested `js`, `css`, and `html` attributes",
-      "fileMatch": [
-        ".jsbeautifyrc"
-      ],
+      "fileMatch": [".jsbeautifyrc"],
       "url": "https://www.schemastore.org/jsbeautifyrc-nested.json"
     },
     {
       "name": ".jscsrc",
       "description": "JSCS configuration file",
-      "fileMatch": [
-        ".jscsrc",
-        "jscsrc.json"
-      ],
+      "fileMatch": [".jscsrc", "jscsrc.json"],
       "url": "https://www.schemastore.org/jscsrc.json"
     },
     {
       "name": ".jshintrc",
       "description": "JSHint configuration file",
-      "fileMatch": [
-        ".jshintrc"
-      ],
+      "fileMatch": [".jshintrc"],
       "url": "https://www.schemastore.org/jshintrc.json"
     },
     {
       "name": ".jsinspectrc",
       "description": "JSInspect configuration file",
-      "fileMatch": [
-        ".jsinspectrc"
-      ],
+      "fileMatch": [".jsinspectrc"],
       "url": "https://www.schemastore.org/jsinspectrc.json"
     },
     {
@@ -5653,9 +4669,7 @@
     {
       "name": "JSON Feed",
       "description": "the JSON Feed format",
-      "fileMatch": [
-        "feed.json"
-      ],
+      "fileMatch": ["feed.json"],
       "url": "https://www.schemastore.org/feed.json",
       "versions": {
         "1": "https://www.schemastore.org/feed-1.json",
@@ -5665,20 +4679,13 @@
     {
       "name": "*.jsonld",
       "description": "JSON Linked Data files",
-      "fileMatch": [
-        "*.jsonld"
-      ],
+      "fileMatch": ["*.jsonld"],
       "url": "https://www.schemastore.org/jsonld.json"
     },
     {
       "name": "JSONPatch",
       "description": "JSONPatch files",
-      "fileMatch": [
-        "*.patch",
-        "*.patch.json",
-        "*.patch.yml",
-        "*.patch.yaml"
-      ],
+      "fileMatch": ["*.patch", "*.patch.json", "*.patch.yml", "*.patch.yaml"],
       "url": "https://www.schemastore.org/json-patch.json"
     },
     {
@@ -5692,9 +4699,7 @@
     {
       "name": "jsconfig.json",
       "description": "JavaScript project configuration file",
-      "fileMatch": [
-        "jsconfig.json"
-      ],
+      "fileMatch": ["jsconfig.json"],
       "url": "https://www.schemastore.org/jsconfig.json"
     },
     {
@@ -5718,74 +4723,55 @@
     {
       "name": "k9s aliases.yaml",
       "description": "k9s CLI aliases.yaml file. Documentation: https://k9scli.io/topics/aliases",
-      "fileMatch": [
-        "**/k9s/aliases.yaml"
-      ],
+      "fileMatch": ["**/k9s/aliases.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/aliases.json"
     },
     {
       "name": "k9s config.yaml",
       "description": "k9s CLI config.yaml file. Documentation: https://k9scli.io/topics/config",
-      "fileMatch": [
-        "**/k9s/config.yaml"
-      ],
+      "fileMatch": ["**/k9s/config.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/k9s.json"
     },
     {
       "name": "k9s cluster-config.yaml",
       "description": "k9s CLI cluster-config.yaml file. Documentation: https://k9scli.io/topics/config",
-      "fileMatch": [
-        "**/k9s/clusters/*/*/config.yaml"
-      ],
+      "fileMatch": ["**/k9s/clusters/*/*/config.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/context.json"
     },
     {
       "name": "k9s hotkeys.yaml",
       "description": "k9s CLI hotkeys.yaml file. Documentation: https://k9scli.io/topics/hotkeys",
-      "fileMatch": [
-        "**/k9s/hotkeys.yaml"
-      ],
+      "fileMatch": ["**/k9s/hotkeys.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/hotkeys.json"
     },
     {
       "name": "k9s plugins.yaml",
       "description": "k9s CLI plugins.yaml file. Documentation: https://k9scli.io/topics/plugins",
-      "fileMatch": [
-        "**/k9s/plugins.yaml"
-      ],
+      "fileMatch": ["**/k9s/plugins.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/plugins.json"
     },
     {
       "name": "k9s skin.yaml",
       "description": "k9s CLI skin.yaml file. Documentation: https://k9scli.io/topics/skins",
-      "fileMatch": [
-        "**/k9s/skins/*.yaml"
-      ],
+      "fileMatch": ["**/k9s/skins/*.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/skin.json"
     },
     {
       "name": "k9s views.yaml",
       "description": "k9s CLI views.yaml file. Documentation: https://k9scli.io/topics/columns",
-      "fileMatch": [
-        "**/k9s/views.yaml"
-      ],
+      "fileMatch": ["**/k9s/views.yaml"],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/views.json"
     },
     {
       "name": "KIMMDY config file",
       "description": "KIMMDY config file, see: graeter-group.github.io/kimmdy",
-      "fileMatch": [
-        "kimmdy.yml",
-        "kimmdy.yaml"
-      ],
+      "fileMatch": ["kimmdy.yml", "kimmdy.yaml"],
       "url": "https://raw.githubusercontent.com/graeter-group/kimmdy/main/src/kimmdy/kimmdy-yaml-schema.json"
     },
     {
       "name": "Kestra flow file",
       "description": "Kestra Flow definition file, see: kestra.io/docs/workflow-components/flow#flow-sample",
-      "fileMatch": [
-        "**/flows/*.yml"
-      ],
+      "fileMatch": ["**/flows/*.yml"],
       "url": "https://www.schemastore.org/kestra-0.19.0.json",
       "versions": {
         "0.18.0": "https://www.schemastore.org/kestra-0.18.0.json",
@@ -5821,9 +4807,7 @@
     {
       "name": "Datadog Continuous Testing",
       "description": "Datadog Continuous Testing Configuration file",
-      "fileMatch": [
-        "*.synthetics.json"
-      ],
+      "fileMatch": ["*.synthetics.json"],
       "url": "https://raw.githubusercontent.com/DataDog/schema/main/datadog-ci/synthetics/test-config.schema.json"
     },
     {
@@ -5849,22 +4833,13 @@
     {
       "name": "Ory Keto configuration",
       "description": "Ory Keto configuration file",
-      "fileMatch": [
-        "keto.json",
-        "keto.yml",
-        "keto.yaml",
-        "keto.toml"
-      ],
+      "fileMatch": ["keto.json", "keto.yml", "keto.yaml", "keto.toml"],
       "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
     },
     {
       "name": "Knowledge Unit",
       "description": "Verified knowledge artifact produced through multi-model deliberation (IETF Internet-Draft: draft-farley-acta-knowledge-units)",
-      "fileMatch": [
-        "ku-*.json",
-        "knowledge-unit.json",
-        "**/ku/*.json"
-      ],
+      "fileMatch": ["ku-*.json", "knowledge-unit.json", "**/ku/*.json"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/knowledge-unit.json"
     },
     {
@@ -5879,20 +4854,13 @@
     {
       "name": "kontinuous-config.yaml",
       "description": "Kontinuous config.yaml configuration files",
-      "fileMatch": [
-        "**/.kontinuous/config.yaml"
-      ],
+      "fileMatch": ["**/.kontinuous/config.yaml"],
       "url": "https://raw.githubusercontent.com/socialgouv/kontinuous/v1/docs/config.schema.json"
     },
     {
       "name": "Kubri Configuration",
       "description": "Kubri configuration file",
-      "fileMatch": [
-        ".kubri.yaml",
-        ".kubri.yml",
-        "kubri.yaml",
-        "kubri.yml"
-      ],
+      "fileMatch": [".kubri.yaml", ".kubri.yml", "kubri.yaml", "kubri.yml"],
       "url": "https://kubri.dev/schema.json"
     },
     {
@@ -5909,26 +4877,19 @@
     {
       "name": "kustomization.yaml",
       "description": "Kubernetes native configuration management",
-      "fileMatch": [
-        "kustomization.yaml",
-        "kustomization.yml"
-      ],
+      "fileMatch": ["kustomization.yaml", "kustomization.yml"],
       "url": "https://www.schemastore.org/kustomization.json"
     },
     {
       "name": "label-commenter-config.yml",
       "description": "A the configuration of the Label Commenter GitHub Action",
-      "fileMatch": [
-        "**/.github/label-commenter-config.yml"
-      ],
+      "fileMatch": ["**/.github/label-commenter-config.yml"],
       "url": "https://www.schemastore.org/label-commenter-config.json"
     },
     {
       "name": "launchsettings.json",
       "description": "A the ASP.NET LaunchSettings.json files",
-      "fileMatch": [
-        "launchsettings.json"
-      ],
+      "fileMatch": ["launchsettings.json"],
       "url": "https://www.schemastore.org/launchsettings.json"
     },
     {
@@ -5961,9 +4922,7 @@
     {
       "name": "lego.json",
       "description": "Config file for the lego-build CLI tool",
-      "fileMatch": [
-        "lego.json"
-      ],
+      "fileMatch": ["lego.json"],
       "url": "https://www.schemastore.org/lego.json",
       "versions": {
         "1.0": "https://www.schemastore.org/lego.json"
@@ -5972,59 +4931,43 @@
     {
       "name": "lerna.json",
       "description": "A lerna.json files",
-      "fileMatch": [
-        "lerna.json"
-      ],
+      "fileMatch": ["lerna.json"],
       "url": "https://www.schemastore.org/lerna.json"
     },
     {
       "name": "lgtm.yml",
       "description": "A lgtm configuration files",
-      "fileMatch": [
-        "lgtm.yml",
-        ".lgtm.yml"
-      ],
+      "fileMatch": ["lgtm.yml", ".lgtm.yml"],
       "url": "https://www.schemastore.org/lgtm.json"
     },
     {
       "name": "liblab.config.json",
       "description": "Liblab configuration file",
-      "fileMatch": [
-        "liblab.config.json",
-        "*.liblab.config.json"
-      ],
+      "fileMatch": ["liblab.config.json", "*.liblab.config.json"],
       "url": "https://cdn.jsdelivr.net/npm/liblab@latest/liblab.config.schema.json"
     },
     {
       "name": "libman.json",
       "description": "client-side library config files",
-      "fileMatch": [
-        "libman.json"
-      ],
+      "fileMatch": ["libman.json"],
       "url": "https://www.schemastore.org/libman.json"
     },
     {
       "name": "license-report-config.json",
       "description": "license report tool configuration file",
-      "fileMatch": [
-        "license-report-config.json"
-      ],
+      "fileMatch": ["license-report-config.json"],
       "url": "https://www.schemastore.org/license-report-config.json"
     },
     {
       "name": "Liferay client-extension.yaml",
       "description": "Liferay Client Extension Definition File",
-      "fileMatch": [
-        "client-extension.yaml"
-      ],
+      "fileMatch": ["client-extension.yaml"],
       "url": "https://raw.githubusercontent.com/liferay/liferay-portal/master/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json"
     },
     {
       "name": "linkinator.config.json",
       "description": "Linkinator config file",
-      "fileMatch": [
-        "linkinator.config.json"
-      ],
+      "fileMatch": ["linkinator.config.json"],
       "url": "https://www.schemastore.org/linkinator-config.json"
     },
     {
@@ -6054,75 +4997,55 @@
     {
       "name": "Lively Properties",
       "description": "Lively Wallpaper configuration file. Documentation: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#lively-properties",
-      "fileMatch": [
-        "LivelyProperties.json"
-      ],
+      "fileMatch": ["LivelyProperties.json"],
       "url": "https://raw.githubusercontent.com/rocksdanister/lively/core-separation/schemas/livelyPropertiesSchema.json"
     },
     {
       "name": "LOOBin",
       "description": "LOOBins macOS binaries. Documentation: https://github.com/infosecB/LOOBins",
-      "fileMatch": [
-        "**/LOOBins/*.yml"
-      ],
+      "fileMatch": ["**/LOOBins/*.yml"],
       "url": "https://www.schemastore.org/loobin-1.0.json"
     },
     {
       "name": "lotus.yaml",
       "description": "The configuration file used for Lotus definitions",
-      "fileMatch": [
-        "lotus.yaml"
-      ],
+      "fileMatch": ["lotus.yaml"],
       "url": "https://grnhse-vpc-assets.s3.amazonaws.com/jsonschemas/lotus.yaml.json"
     },
     {
       "name": "local.settings.json",
       "description": "Azure Functions local.settings.json files",
-      "fileMatch": [
-        "local.settings.json"
-      ],
+      "fileMatch": ["local.settings.json"],
       "url": "https://www.schemastore.org/local.settings.json"
     },
     {
       "name": "localazy.json",
       "description": "Localazy CLI configuration file. Documentation: https://localazy.com/docs/cli",
-      "fileMatch": [
-        "localazy.json"
-      ],
+      "fileMatch": ["localazy.json"],
       "url": "https://raw.githubusercontent.com/localazy/cli-schema/master/localazy.json"
     },
     {
       "name": "lsdlschema.json",
       "description": "Power BI linguistic schema definition",
-      "fileMatch": [
-        "*.lsdl.yaml",
-        "*.lsdl.json"
-      ],
+      "fileMatch": ["*.lsdl.yaml", "*.lsdl.json"],
       "url": "https://www.schemastore.org/lsdlschema.json"
     },
     {
       "name": ".luaurc",
       "description": "Luau language configuration file",
-      "fileMatch": [
-        ".luaurc"
-      ],
+      "fileMatch": [".luaurc"],
       "url": "https://www.schemastore.org/luaurc.json"
     },
     {
       "name": "Madge configuration",
       "description": "Madge module dependency analysis configuration file",
-      "fileMatch": [
-        ".madgerc"
-      ],
+      "fileMatch": [".madgerc"],
       "url": "https://www.schemastore.org/madge.json"
     },
     {
       "name": "Mado configuration",
       "description": "Mado markdown linter configuration file",
-      "fileMatch": [
-        ".mado.toml",
-        "mado.toml"
-      ],
+      "fileMatch": [".mado.toml", "mado.toml"],
       "url": "https://raw.githubusercontent.com/akiomik/mado/refs/heads/main/pkg/json-schema/mado.json"
     },
     {
@@ -6139,19 +5062,13 @@
     {
       "name": "MapEHR Mapping",
       "description": "Mapping for MapEHR.com",
-      "fileMatch": [
-        ".map.yml",
-        ".map.yaml",
-        ".map.json"
-      ],
+      "fileMatch": [".map.yml", ".map.yaml", ".map.json"],
       "url": "https://www.schemastore.org/mapehr.json"
     },
     {
       "name": "A micro editor config",
       "description": "A micro editor config",
-      "fileMatch": [
-        "**/micro/settings.json"
-      ],
+      "fileMatch": ["**/micro/settings.json"],
       "url": "https://www.schemastore.org/micro.json"
     },
     {
@@ -6168,17 +5085,13 @@
     {
       "name": "MegaLinter Custom Flavor",
       "description": "MegaLinter Custom Flavor definition file",
-      "fileMatch": [
-        "megalinter-custom-flavor.yml"
-      ],
+      "fileMatch": ["megalinter-custom-flavor.yml"],
       "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-custom-flavor.jsonschema.json"
     },
     {
       "name": "MegaLinter descriptor",
       "description": "MegaLinter descriptor files (for MegaLinter contributors)",
-      "fileMatch": [
-        "*.megalinter-descriptor.yml"
-      ],
+      "fileMatch": ["*.megalinter-descriptor.yml"],
       "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
     },
     {
@@ -6194,27 +5107,19 @@
     {
       "name": "Metadata for a Bazel module",
       "description": "Metadata file for a Bazel module",
-      "fileMatch": [
-        "**/modules/*/metadata.json"
-      ],
+      "fileMatch": ["**/modules/*/metadata.json"],
       "url": "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/metadata.schema.json"
     },
     {
       "name": "Metatype Configuration",
       "description": "Metatype configuration file",
-      "fileMatch": [
-        "metatype.yml",
-        "metatype.yaml"
-      ],
+      "fileMatch": ["metatype.yml", "metatype.yaml"],
       "url": "https://raw.githubusercontent.com/metatypedev/metatype/main/tools/schema/metatype.json"
     },
     {
       "name": "MetricsHub Configuration",
       "description": "MetricsHub configuration file",
-      "fileMatch": [
-        "*metricshub.yaml",
-        "*metricshub.yml"
-      ],
+      "fileMatch": ["*metricshub.yaml", "*metricshub.yml"],
       "url": "https://www.schemastore.org/metricshub.json"
     },
     {
@@ -6238,169 +5143,127 @@
     {
       "name": "mimetypes.json",
       "description": "mime type collections",
-      "fileMatch": [
-        "mimetypes.json"
-      ],
+      "fileMatch": ["mimetypes.json"],
       "url": "https://www.schemastore.org/mimetypes.json"
     },
     {
       "name": "Minecraft Data Pack Advancement",
       "description": "Configuration file defining an advancement for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/advancements/*.json"
-      ],
+      "fileMatch": ["**/data/*/advancements/*.json"],
       "url": "https://www.schemastore.org/minecraft-advancement.json"
     },
     {
       "name": "Minecraft Data Pack Biome",
       "description": "Configuration file defining a biome for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/worldgen/biome/*.json"
-      ],
+      "fileMatch": ["**/data/*/worldgen/biome/*.json"],
       "url": "https://www.schemastore.org/minecraft-biome.json"
     },
     {
       "name": "Minecraft Data Pack Configured Carver",
       "description": "Configuration file defining a configured carver for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/worldgen/configured_carver/*.json"
-      ],
+      "fileMatch": ["**/data/*/worldgen/configured_carver/*.json"],
       "url": "https://www.schemastore.org/minecraft-configured-carver.json"
     },
     {
       "name": "Minecraft Data Pack Damage Type",
       "description": "Configuration file defining a damage type for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/damage_type/*.json"
-      ],
+      "fileMatch": ["**/data/*/damage_type/*.json"],
       "url": "https://www.schemastore.org/minecraft-damage-type.json"
     },
     {
       "name": "Minecraft Data Pack Dimension Type",
       "description": "Configuration file defining a dimension type for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/dimension_type/*.json"
-      ],
+      "fileMatch": ["**/data/*/dimension_type/*.json"],
       "url": "https://www.schemastore.org/minecraft-dimension-type.json"
     },
     {
       "name": "Minecraft Data Pack Dimension",
       "description": "Configuration file defining a dimension for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/dimension/*.json"
-      ],
+      "fileMatch": ["**/data/*/dimension/*.json"],
       "url": "https://www.schemastore.org/minecraft-dimension.json"
     },
     {
       "name": "Minecraft Data Pack Item Modifier",
       "description": "Configuration file defining an item modifier for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/item_modifiers/*.json"
-      ],
+      "fileMatch": ["**/data/*/item_modifiers/*.json"],
       "url": "https://www.schemastore.org/minecraft-item-modifier.json"
     },
     {
       "name": "Minecraft Data Pack Loot Table",
       "description": "Configuration file defining a loot table for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/loot_tables/**/*.json"
-      ],
+      "fileMatch": ["**/data/*/loot_tables/**/*.json"],
       "url": "https://www.schemastore.org/minecraft-loot-table.json"
     },
     {
       "name": "Minecraft Data Pack Metadata",
       "description": "Configuration file defining the metadata of a data pack for Minecraft",
-      "fileMatch": [
-        "**/pack.mcmeta"
-      ],
+      "fileMatch": ["**/pack.mcmeta"],
       "url": "https://www.schemastore.org/minecraft-pack-mcmeta.json"
     },
     {
       "name": "Minecraft Data Pack Predicate",
       "description": "Configuration file defining a predicate for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/predicates/*.json"
-      ],
+      "fileMatch": ["**/data/*/predicates/*.json"],
       "url": "https://www.schemastore.org/minecraft-predicate.json"
     },
     {
       "name": "Minecraft Data Pack Recipe",
       "description": "Configuration file defining a recipe for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/recipes/*.json"
-      ],
+      "fileMatch": ["**/data/*/recipes/*.json"],
       "url": "https://www.schemastore.org/minecraft-recipe.json"
     },
     {
       "name": "Minecraft Data Pack Tag",
       "description": "Configuration file defining a tag for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/tags/**/*.json"
-      ],
+      "fileMatch": ["**/data/*/tags/**/*.json"],
       "url": "https://www.schemastore.org/minecraft-tag.json"
     },
     {
       "name": "Minecraft Data Pack Template Pool",
       "description": "Configuration file defining a template pool for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/worldgen/template_pool/*.json"
-      ],
+      "fileMatch": ["**/data/*/worldgen/template_pool/*.json"],
       "url": "https://www.schemastore.org/minecraft-template-pool.json"
     },
     {
       "name": "Minecraft Resource Pack Lang",
       "description": "Configuration file defining a language for a resource pack for Minecraft",
-      "fileMatch": [
-        "**/assets/*/lang/*.json"
-      ],
+      "fileMatch": ["**/assets/*/lang/*.json"],
       "url": "https://www.schemastore.org/minecraft-lang.json"
     },
     {
       "name": "Minecraft Resource Pack Particle",
       "description": "Configuration file defining a particle for a resource pack for Minecraft",
-      "fileMatch": [
-        "**/assets/*/particles/*.json"
-      ],
+      "fileMatch": ["**/assets/*/particles/*.json"],
       "url": "https://www.schemastore.org/minecraft-particle.json"
     },
     {
       "name": "Minecraft Resourcepack Sounds",
       "description": "Configuration file defining what sounds play when sound event is triggered for a resourcepack for Minecraft",
-      "fileMatch": [
-        "**/assets/*/sounds.json"
-      ],
+      "fileMatch": ["**/assets/*/sounds.json"],
       "url": "https://raw.githubusercontent.com/AxoCode/json-schema/master/minecraft/sounds.json"
     },
     {
       "name": "Minecraft Resource Pack Texture Mcmeta",
       "description": "Configuration file defining an mcmeta file for a texture for a resource pack for Minecraft",
-      "fileMatch": [
-        "**/assets/*/textures/**/*.png.mcmeta"
-      ],
+      "fileMatch": ["**/assets/*/textures/**/*.png.mcmeta"],
       "url": "https://www.schemastore.org/minecraft-texture-mcmeta.json"
     },
     {
       "name": "Minecraft Data Pack Trim Material",
       "description": "Configuration file defining a trim material for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/trim_material/*.json"
-      ],
+      "fileMatch": ["**/data/*/trim_material/*.json"],
       "url": "https://www.schemastore.org/minecraft-trim-material.json"
     },
     {
       "name": "Minecraft Data Pack Trim Pattern",
       "description": "Configuration file defining a trim pattern for a data pack for Minecraft",
-      "fileMatch": [
-        "**/data/*/trim_pattern/*.json"
-      ],
+      "fileMatch": ["**/data/*/trim_pattern/*.json"],
       "url": "https://www.schemastore.org/minecraft-trim-pattern.json"
     },
     {
       "name": "mkdocs.yml",
       "description": "MkDocs configuration file",
-      "fileMatch": [
-        "mkdocs.yml"
-      ],
+      "fileMatch": ["mkdocs.yml"],
       "url": "https://www.schemastore.org/mkdocs-1.6.json",
       "versions": {
         "1.0": "https://www.schemastore.org/mkdocs-1.0.json",
@@ -6410,9 +5273,7 @@
     {
       "name": "ModuleAssembler",
       "description": "ModuleAssembler configuration file",
-      "fileMatch": [
-        "**/.moduleassembler/moduleproject.json"
-      ],
+      "fileMatch": ["**/.moduleassembler/moduleproject.json"],
       "url": "https://raw.githubusercontent.com/ModuleAssembler/ModuleAssembler-Schema/refs/tags/v1.0.0/schema/moduleassembler.schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/ModuleAssembler/ModuleAssembler-Schema/refs/tags/v1.0.0/schema/moduleassembler.schema.json"
@@ -6421,19 +5282,13 @@
     {
       "name": "mrdocs.yml",
       "description": "MrDocs configuration file",
-      "fileMatch": [
-        "mrdocs.yml"
-      ],
+      "fileMatch": ["mrdocs.yml"],
       "url": "https://raw.githubusercontent.com/cppalliance/mrdocs/refs/heads/master/docs/mrdocs.schema.json"
     },
     {
       "name": "MLOS Config (*.mlos.jsonc, *.mlos.json5, *.mlos.json)",
       "description": "Config files for the mlos_bench utility in MLOS. See Also: https://aka.ms/MLOS",
-      "fileMatch": [
-        "*.mlos.jsonc",
-        "*.mlos.json5",
-        "*.mlos.json"
-      ],
+      "fileMatch": ["*.mlos.jsonc", "*.mlos.json5", "*.mlos.json"],
       "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
     },
     {
@@ -6480,9 +5335,7 @@
     {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
-      "fileMatch": [
-        "monospace.yml"
-      ],
+      "fileMatch": ["monospace.yml"],
       "url": "https://raw.githubusercontent.com/software-t-rex/monospace/main/apps/monospace/schemas/monospace.schema.json"
     },
     {
@@ -6513,10 +5366,7 @@
     {
       "name": "MSTest testconfig.json",
       "description": "Configuration file for MSTest and Microsoft.Testing.Platform",
-      "fileMatch": [
-        "testconfig.json",
-        "*.testconfig.json"
-      ],
+      "fileMatch": ["testconfig.json", "*.testconfig.json"],
       "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
     },
     {
@@ -6543,144 +5393,97 @@
     {
       "name": ".modernizrrc",
       "description": "Webpack modernizr-loader configuration file",
-      "fileMatch": [
-        ".modernizrrc"
-      ],
+      "fileMatch": [".modernizrrc"],
       "url": "https://www.schemastore.org/modernizrrc.json"
     },
     {
       "name": "Monade CLI Stack Configuration",
       "description": "The configuration file to get a local stack up and running with Monade CLI",
-      "fileMatch": [
-        "monade.yaml",
-        "monade.yml",
-        ".monade.yaml",
-        ".monade.yml"
-      ],
+      "fileMatch": ["monade.yaml", "monade.yml", ".monade.yaml", ".monade.yml"],
       "url": "https://www.schemastore.org/monade-stack-config.json"
     },
     {
       "name": "mycode.json",
       "description": "mycode.js files",
-      "fileMatch": [
-        "mycode.json"
-      ],
+      "fileMatch": ["mycode.json"],
       "url": "https://www.schemastore.org/mycode.json"
     },
     {
       "name": "napari plugin manifest",
       "description": "a napari plugin manifest",
-      "fileMatch": [
-        "napari.yml",
-        "napari.yaml",
-        ".napari.yml",
-        ".napari.yaml"
-      ],
+      "fileMatch": ["napari.yml", "napari.yaml", ".napari.yml", ".napari.yaml"],
       "url": "https://github.com/napari/npe2/releases/latest/download/schema.json"
     },
     {
       "name": "Netlify config",
       "description": "Netlify YAML config",
-      "fileMatch": [
-        "**/admin/config*.yml"
-      ],
+      "fileMatch": ["**/admin/config*.yml"],
       "url": "https://www.schemastore.org/netlify.json"
     },
     {
       "name": "Network-as-Code Data Model",
       "description": "Cisco Network-as-Code Data Model",
-      "fileMatch": [
-        "*.nac.yml",
-        "*.nac.yaml",
-        "*.aac.yml",
-        "*.aac.yaml"
-      ],
+      "fileMatch": ["*.nac.yml", "*.nac.yaml", "*.aac.yml", "*.aac.yaml"],
       "url": "https://raw.githubusercontent.com/netascode/schema/main/schema.json"
     },
     {
       "name": "Next Gen UI Agent A2A Server Configuration",
       "description": "Next Gen UI Agent A2A Server configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/spec/a2a/#agent-configuration",
-      "fileMatch": [
-        "ngui-a2a_*.yaml",
-        "ngui-a2a_*.yml",
-        "ngui-a2a_*.json"
-      ],
+      "fileMatch": ["ngui-a2a_*.yaml", "ngui-a2a_*.yml", "ngui-a2a_*.json"],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/a2a/a2a_agent_config.schema.json"
     },
     {
       "name": "Next Gen UI Agent MCP Server Configuration",
       "description": "Next Gen UI Agent MCP Server configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/spec/mcp/#agent-configuration",
-      "fileMatch": [
-        "ngui-mcp_*.yaml",
-        "ngui-mcp_*.yml",
-        "ngui-mcp_*.json"
-      ],
+      "fileMatch": ["ngui-mcp_*.yaml", "ngui-mcp_*.yml", "ngui-mcp_*.json"],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/mcp/mcp_agent_config.schema.json"
     },
     {
       "name": "Next Gen UI Agent Configuration",
       "description": "NextGen UI Agent configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/guide/configuration/",
-      "fileMatch": [
-        "ngui_*.yaml",
-        "ngui_*.yml",
-        "ngui_*.json"
-      ],
+      "fileMatch": ["ngui_*.yaml", "ngui_*.yml", "ngui_*.json"],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/config/agent_config.schema.json"
     },
     {
       "name": "cargo-nextest repository configuration",
       "description": "Repository configuration for cargo-nextest. Documentation: https://nexte.st/docs/configuration/",
-      "fileMatch": [
-        "**/.config/nextest.toml"
-      ],
+      "fileMatch": ["**/.config/nextest.toml"],
       "url": "https://nexte.st/schemas/repo-config.json"
     },
     {
       "name": "cargo-nextest user configuration",
       "description": "User configuration for cargo-nextest. Documentation: https://nexte.st/docs/user-config/",
-      "fileMatch": [
-        "**/nextest/config.toml"
-      ],
+      "fileMatch": ["**/nextest/config.toml"],
       "url": "https://nexte.st/schemas/user-config.json"
     },
     {
       "name": "nf-core module environment.yml",
       "description": "Conda environment file for an nf-core Nextflow module",
-      "fileMatch": [
-        "**/modules/nf-core/**/environment.yml"
-      ],
+      "fileMatch": ["**/modules/nf-core/**/environment.yml"],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json"
     },
     {
       "name": "nf-core module meta.yml",
       "description": "Metadata file for an nf-core Nextflow module",
-      "fileMatch": [
-        "**/modules/nf-core/**/meta.yml"
-      ],
+      "fileMatch": ["**/modules/nf-core/**/meta.yml"],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json"
     },
     {
       "name": "nf-core subworkflow meta.yml",
       "description": "Metadata file for an nf-core Nextflow subworkflow",
-      "fileMatch": [
-        "**/subworkflows/nf-core/**/meta.yml"
-      ],
+      "fileMatch": ["**/subworkflows/nf-core/**/meta.yml"],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json"
     },
     {
       "name": "nFPM",
       "description": "nFPM configuration file",
-      "fileMatch": [
-        "nfpm.yaml"
-      ],
+      "fileMatch": ["nfpm.yaml"],
       "url": "https://nfpm.goreleaser.com/static/schema.json"
     },
     {
       "name": "Nightwatch.js",
       "description": "nightwatch.js config",
-      "fileMatch": [
-        "nightwatch.json"
-      ],
+      "fileMatch": ["nightwatch.json"],
       "url": "https://www.schemastore.org/nightwatch.json"
     },
     {
@@ -6710,53 +5513,37 @@
     {
       "name": "nlu.json",
       "description": "NPM-Link-Up",
-      "fileMatch": [
-        "nlu.json",
-        ".nlu.json"
-      ],
+      "fileMatch": ["nlu.json", ".nlu.json"],
       "url": "https://raw.githubusercontent.com/oresoftware/npm-link-up/master/assets/nlu.schema.json"
     },
     {
       "name": ".nodehawkrc",
       "description": ".nodehawkrc configuration files",
-      "fileMatch": [
-        ".nodehawkrc"
-      ],
+      "fileMatch": [".nodehawkrc"],
       "url": "https://www.schemastore.org/nodehawkrc.json"
     },
     {
       "name": "Nika workflow",
       "description": "Nika workflow language (*.nika.yaml) · the nika: v1 envelope, four verbs, stdlib builtins",
-      "fileMatch": [
-        "*.nika.yaml",
-        "*.nika.yml"
-      ],
+      "fileMatch": ["*.nika.yaml", "*.nika.yml"],
       "url": "https://raw.githubusercontent.com/supernovae-st/nika-spec/main/schemas/workflow.schema.json"
     },
     {
       "name": "nodemon.json",
       "description": "nodemon.json configuration files",
-      "fileMatch": [
-        "nodemon.json"
-      ],
+      "fileMatch": ["nodemon.json"],
       "url": "https://www.schemastore.org/nodemon.json"
     },
     {
       "name": "notebook.mod.json",
       "description": "Metadata file for notebook mods",
-      "fileMatch": [
-        "notebook.mod.json"
-      ],
+      "fileMatch": ["notebook.mod.json"],
       "url": "https://raw.githubusercontent.com/BookkeepersMC/notebook-schemas/master/notebook.mod.json/schemas/main.json"
     },
     {
       "name": "NOX Framework (Service)",
       "description": "NOX service definition",
-      "fileMatch": [
-        "service.nox.yaml",
-        "service.nox.yml",
-        "service.nox.json"
-      ],
+      "fileMatch": ["service.nox.yaml", "service.nox.yml", "service.nox.json"],
       "url": "https://noxorg.dev/schemas/NoxConfiguration.json"
     },
     {
@@ -6777,9 +5564,7 @@
     {
       "name": "nuclei-template.yaml",
       "description": "Nuclei Template YAML files",
-      "fileMatch": [
-        "**/nuclei-templates/**/*.yaml"
-      ],
+      "fileMatch": ["**/nuclei-templates/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/projectdiscovery/nuclei/master/nuclei-jsonschema.json"
     },
     {
@@ -6799,18 +5584,13 @@
     {
       "name": "nswag.json",
       "description": "nswag configuration",
-      "fileMatch": [
-        "nswag.json"
-      ],
+      "fileMatch": ["nswag.json"],
       "url": "https://www.schemastore.org/nswag.json"
     },
     {
       "name": "Nullstone config",
       "description": "Nullstone config.yml file",
-      "fileMatch": [
-        "**/.nullstone/*.yml",
-        "**/.nullstone/*.yaml"
-      ],
+      "fileMatch": ["**/.nullstone/*.yml", "**/.nullstone/*.yaml"],
       "url": "https://raw.githubusercontent.com/nullstone-io/iac/master/.schema/config.0.1.json",
       "versions": {
         "0.1": "https://raw.githubusercontent.com/nullstone-io/iac/master/.schema/config.0.1.json"
@@ -6841,91 +5621,61 @@
     {
       "name": "ocelot.json",
       "description": "the Ocelot Api Gateway",
-      "fileMatch": [
-        "ocelot.json"
-      ],
+      "fileMatch": ["ocelot.json"],
       "url": "https://www.schemastore.org/ocelot.json"
     },
     {
       "name": "October CMS columns",
       "description": "October CMS columns files",
-      "fileMatch": [
-        "columns.yaml",
-        "*_columns.yaml"
-      ],
+      "fileMatch": ["columns.yaml", "*_columns.yaml"],
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/columns.json"
     },
     {
       "name": "October CMS fields",
       "description": "October CMS fields files",
-      "fileMatch": [
-        "fields.yaml",
-        "*_fields.yaml"
-      ],
+      "fileMatch": ["fields.yaml", "*_fields.yaml"],
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/fields.json"
     },
     {
       "name": "ODGS Standard Metrics",
       "description": "Open Data Governance Standard (ODGS) metric definitions — KPI logic, lineage, and compliance mappings",
-      "fileMatch": [
-        "*.odgs-metrics.json"
-      ],
+      "fileMatch": ["*.odgs-metrics.json"],
       "url": "https://www.schemastore.org/odgs-standard-metrics.json"
     },
     {
       "name": "ODGS Data Rules",
       "description": "ODGS validation and permissibility rules — mechanically executable data governance constraints",
-      "fileMatch": [
-        "*.odgs-rules.json"
-      ],
+      "fileMatch": ["*.odgs-rules.json"],
       "url": "https://www.schemastore.org/odgs-data-rules.json"
     },
     {
       "name": "ODGS Ontology Graph",
       "description": "ODGS business-entity ontology graph for AI graph traversal",
-      "fileMatch": [
-        "*.odgs-ontology.json"
-      ],
+      "fileMatch": ["*.odgs-ontology.json"],
       "url": "https://www.schemastore.org/odgs-ontology-graph.json"
     },
     {
       "name": "ogen",
       "description": "ogen code generator configuration, see https://ogen.dev/docs/config",
-      "fileMatch": [
-        "ogen.yml",
-        "ogen.yaml",
-        ".ogen.yml",
-        ".ogen.yaml"
-      ],
+      "fileMatch": ["ogen.yml", "ogen.yaml", ".ogen.yml", ".ogen.yaml"],
       "url": "https://www.schemastore.org/ogen.json"
     },
     {
       "name": "Oh My Posh",
       "description": "Oh My Posh configuration file",
-      "fileMatch": [
-        "*.omp.json",
-        "*.omp.toml",
-        "*.omp.yaml",
-        "*.omp.yml"
-      ],
+      "fileMatch": ["*.omp.json", "*.omp.toml", "*.omp.yaml", "*.omp.yml"],
       "url": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json"
     },
     {
       "name": "Okteto",
       "description": "The Okteto Manifest",
-      "fileMatch": [
-        "okteto.yml",
-        "okteto.yaml",
-        "okteto.json"
-      ],
+      "fileMatch": ["okteto.yml", "okteto.yaml", "okteto.json"],
       "url": "https://raw.githubusercontent.com/okteto/okteto/refs/heads/master/schema.json"
     },
     {
       "name": "omnisharp.json",
       "description": "Omnisharp Configuration file",
-      "fileMatch": [
-        "omnisharp.json"
-      ],
+      "fileMatch": ["omnisharp.json"],
       "url": "https://www.schemastore.org/omnisharp.json"
     },
     {
@@ -6994,42 +5744,31 @@
     {
       "name": "OpenUtau character yaml",
       "description": "OpenUtau voicebank configuration file, character.yaml",
-      "fileMatch": [
-        "character.yaml"
-      ],
+      "fileMatch": ["character.yaml"],
       "url": "https://www.schemastore.org/openutau-character.json"
     },
     {
       "name": "OpenUtau ustx",
       "description": "OpenUtau project file, ustx",
-      "fileMatch": [
-        "*.ustx"
-      ],
+      "fileMatch": ["*.ustx"],
       "url": "https://www.schemastore.org/openutau-ustx.json"
     },
     {
       "name": "ops.yaml",
       "description": "Ops configuration file (ops.yaml)",
-      "fileMatch": [
-        "ops.yml",
-        "ops.yaml"
-      ],
+      "fileMatch": ["ops.yml", "ops.yaml"],
       "url": "https://raw.githubusercontent.com/LeShaunJ/ops-schema/main/ops.schema.json"
     },
     {
       "name": "ONe's service descriptor",
       "description": "ONe's service descriptor",
-      "fileMatch": [
-        "service-descriptor.yml"
-      ],
+      "fileMatch": ["service-descriptor.yml"],
       "url": "https://www.schemastore.org/one-service-descriptor-schema-0.1.json"
     },
     {
       "name": "ONe's changelog entry",
       "description": "ONe's changelog entry",
-      "fileMatch": [
-        "**/changelogs/*.yml"
-      ],
+      "fileMatch": ["**/changelogs/*.yml"],
       "url": "https://www.schemastore.org/one-changelog-schema-0.1.json"
     },
     {
@@ -7040,9 +5779,7 @@
     {
       "name": "OpenRewrite Resource",
       "description": "OpenRewrite resource descriptors",
-      "fileMatch": [
-        "**/META-INF/rewrite/*.yml"
-      ],
+      "fileMatch": ["**/META-INF/rewrite/*.yml"],
       "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
     },
     {
@@ -7063,10 +5800,7 @@
     {
       "name": "Open Data Contract Standard (ODCS)",
       "description": "Open Data Contract Standard contract file, from the Bitol project at The Linux Foundation",
-      "fileMatch": [
-        "*.odcs.yaml",
-        "*.odcs.yml"
-      ],
+      "fileMatch": ["*.odcs.yaml", "*.odcs.yml"],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-contract-standard/main/schema/odcs-json-schema-latest.json",
       "versions": {
         "v3.0.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.2.json",
@@ -7078,10 +5812,7 @@
     {
       "name": "Open Data Product Standard (ODPS)",
       "description": "Open Data Product Standard descriptor file, from the Bitol project at The Linux Foundation",
-      "fileMatch": [
-        "*.odps.yaml",
-        "*.odps.yml"
-      ],
+      "fileMatch": ["*.odps.yaml", "*.odps.yml"],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-product-standard/main/schema/odps-json-schema-latest.json",
       "versions": {
         "v0.9.0": "https://github.com/bitol-io/open-data-product-standard/blob/main/schema/odps-json-schema-v0.9.0.json"
@@ -7090,9 +5821,7 @@
     {
       "name": "Open Pentest Format",
       "description": "OPF finding library or engagement export (*.opf.json): portable penetration test findings",
-      "fileMatch": [
-        "*.opf.json"
-      ],
+      "fileMatch": ["*.opf.json"],
       "url": "https://cairnsecurity.com/opf/schema/opf-1.1.schema.json"
     },
     {
@@ -7111,10 +5840,7 @@
     {
       "name": "Outblocks project configuration",
       "description": "Outblocks project configuration files",
-      "fileMatch": [
-        "project.outblocks.yaml",
-        "project.outblocks.yml"
-      ],
+      "fileMatch": ["project.outblocks.yaml", "project.outblocks.yml"],
       "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-project.json"
     },
     {
@@ -7142,30 +5868,19 @@
     {
       "name": "ORT Server repository environment configuration",
       "description": "Repository environment configuration to configure infrastructure services, environment variables, and package-manager specific settings",
-      "fileMatch": [
-        ".ort.env.yml",
-        ".ort.env.yaml"
-      ],
+      "fileMatch": [".ort.env.yml", ".ort.env.yaml"],
       "url": "https://raw.githubusercontent.com/eclipse-apoapsis/ort-server/refs/heads/main/integrations/schemas/repository-environment-config.json"
     },
     {
       "name": "Ory Kratos configuration",
       "description": "Ory Kratos configuration file",
-      "fileMatch": [
-        "kratos.json",
-        "kratos.yml",
-        "kratos.yaml",
-        "kratos.toml"
-      ],
+      "fileMatch": ["kratos.json", "kratos.yml", "kratos.yaml", "kratos.toml"],
       "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
     },
     {
       "name": "OSCAL Assessment Plan (AP)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Plan. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*assessment-plan.json",
-        "oscal*assessment_plan.json"
-      ],
+      "fileMatch": ["oscal*assessment-plan.json", "oscal*assessment_plan.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
@@ -7204,9 +5919,7 @@
     {
       "name": "OSCAL Catalog",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Catalog. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*catalog.json"
-      ],
+      "fileMatch": ["oscal*catalog.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
@@ -7224,10 +5937,7 @@
     {
       "name": "OSCAL Component Definition (CDef)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Component Definition. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*component.json",
-        "oscal*cdef.json"
-      ],
+      "fileMatch": ["oscal*component.json", "oscal*cdef.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
@@ -7245,9 +5955,7 @@
     {
       "name": "OSCAL Plan of Action and Milestones (POA&M)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Plan of Action and Milestones. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*poam.json"
-      ],
+      "fileMatch": ["oscal*poam.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
@@ -7265,9 +5973,7 @@
     {
       "name": "OSCAL Profile",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Profile. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*profile.json"
-      ],
+      "fileMatch": ["oscal*profile.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
@@ -7285,9 +5991,7 @@
     {
       "name": "OSCAL System Security Plan (SSP)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) System Security Plan. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": [
-        "oscal*ssp.json"
-      ],
+      "fileMatch": ["oscal*ssp.json"],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
@@ -7305,10 +6009,7 @@
     {
       "name": "OSS Review Toolkit configuration",
       "description": "ORT's main configuration file",
-      "fileMatch": [
-        "**/.ort/config/config.yml",
-        "**/.ort/config/config.yaml"
-      ],
+      "fileMatch": ["**/.ort/config/config.yml", "**/.ort/config/config.yaml"],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/ort-configuration-schema.json"
     },
     {
@@ -7349,43 +6050,31 @@
     {
       "name": "OSS Review Toolkit repository configuration",
       "description": "ORT's repository configuration file",
-      "fileMatch": [
-        "*.ort.yml",
-        "*.ort.yaml"
-      ],
+      "fileMatch": ["*.ort.yml", "*.ort.yaml"],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/repository-configuration-schema.json"
     },
     {
       "name": "OSS Review Toolkit resolutions",
       "description": "ORT's resolutions file",
-      "fileMatch": [
-        "resolutions.yml",
-        "resolutions.yaml"
-      ],
+      "fileMatch": ["resolutions.yml", "resolutions.yaml"],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/resolutions-schema.json"
     },
     {
       "name": "package.json",
       "description": "NPM configuration file",
-      "fileMatch": [
-        "package.json"
-      ],
+      "fileMatch": ["package.json"],
       "url": "https://www.schemastore.org/package.json"
     },
     {
       "name": "package.yaml",
       "description": "PNPM configuration file",
-      "fileMatch": [
-        "package.yaml"
-      ],
+      "fileMatch": ["package.yaml"],
       "url": "https://www.schemastore.org/package.json"
     },
     {
       "name": "package.manifest",
       "description": "Umbraco package configuration file",
-      "fileMatch": [
-        "package.manifest"
-      ],
+      "fileMatch": ["package.manifest"],
       "url": "https://www.schemastore.org/package.manifest.json",
       "versions": {
         "8.0.0": "https://www.schemastore.org/package.manifest-8.0.0.json",
@@ -7395,77 +6084,55 @@
     {
       "name": "Packer",
       "description": "Packer template JSON configuration",
-      "fileMatch": [
-        "packer.json"
-      ],
+      "fileMatch": ["packer.json"],
       "url": "https://www.schemastore.org/packer.json"
     },
     {
       "name": "PactSpec",
       "description": "AI agent capability declaration (pactspec.dev)",
-      "fileMatch": [
-        "*.pactspec.json",
-        "*.pactspec.yaml"
-      ],
+      "fileMatch": ["*.pactspec.json", "*.pactspec.yaml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pactspec.json"
     },
     {
       "name": "Panache",
       "description": "Configuration file for Panache, a language server, formatter, and linter for Markdown, Quarto, and R Markdown documents",
-      "fileMatch": [
-        "panache.toml",
-        ".panache.toml"
-      ],
+      "fileMatch": ["panache.toml", ".panache.toml"],
       "url": "https://panache.bz/panache.schema.json"
     },
     {
       "name": "Paper paper-plugin.yml",
       "description": "Paper Plugins YAML",
-      "fileMatch": [
-        "paper-plugin.yml"
-      ],
+      "fileMatch": ["paper-plugin.yml"],
       "url": "https://www.schemastore.org/paper-plugin.json"
     },
     {
       "name": "PDM",
       "description": "A modern Python package and dependency manager supporting the latest PEP standard (pdm.toml config file)",
-      "fileMatch": [
-        "pdm.toml"
-      ],
+      "fileMatch": ["pdm.toml"],
       "url": "https://www.schemastore.org/pdm.json"
     },
     {
       "name": "pgap_yaml_input_reader",
       "description": "NCBI Prokaryotic Genome Annotation Pipeline (PGAP) input metadata (submol) JSON/YAML configuration file",
-      "fileMatch": [
-        "submol*.json",
-        "submol*.yml",
-        "submol*.yaml"
-      ],
+      "fileMatch": ["submol*.json", "submol*.yml", "submol*.yaml"],
       "url": "https://www.schemastore.org/pgap_yaml_input_reader.json"
     },
     {
       "name": "pgrls",
       "description": "Configuration for pgrls, the Postgres Row-Level Security linter (pgrls.toml)",
-      "fileMatch": [
-        "pgrls.toml"
-      ],
+      "fileMatch": ["pgrls.toml"],
       "url": "https://www.schemastore.org/pgrls.json"
     },
     {
       "name": "pattern.json",
       "description": "Patternplate pattern manifest file",
-      "fileMatch": [
-        "pattern.json"
-      ],
+      "fileMatch": ["pattern.json"],
       "url": "https://www.schemastore.org/pattern.json"
     },
     {
       "name": "pixi.toml",
       "description": "Pixi configuration file",
-      "fileMatch": [
-        "pixi.toml"
-      ],
+      "fileMatch": ["pixi.toml"],
       "url": "https://raw.githubusercontent.com/prefix-dev/pixi/main/schema/schema.json"
     },
     {
@@ -7477,26 +6144,19 @@
     {
       "name": ".pmbot.yml",
       "description": "Pmbot configuration file",
-      "fileMatch": [
-        ".pmbot.yml"
-      ],
+      "fileMatch": [".pmbot.yml"],
       "url": "https://raw.githubusercontent.com/pmbot-io/config/master/pmbot.yml.schema.json"
     },
     {
       "name": "PocketMine plugin.yml",
       "description": "PocketMine plugin manifest file",
-      "fileMatch": [
-        "plugin.yml"
-      ],
+      "fileMatch": ["plugin.yml"],
       "url": "https://www.schemastore.org/pocketmine-plugin.json"
     },
     {
       "name": "plagiarize.yaml",
       "description": "Yaml Plagiarize",
-      "fileMatch": [
-        "plagiarize.yaml",
-        "plagiarize.json"
-      ],
+      "fileMatch": ["plagiarize.yaml", "plagiarize.json"],
       "url": "https://www.schemastore.org/plagiarize.json",
       "versions": {
         "0.0": "https://www.schemastore.org/plagiarize-0.0.json"
@@ -7505,10 +6165,7 @@
     {
       "name": "plagiarize-me.yaml",
       "description": "Yaml Plagiarize MEe",
-      "fileMatch": [
-        "plagiarize-me.yaml",
-        "plagiarize-me.json"
-      ],
+      "fileMatch": ["plagiarize-me.yaml", "plagiarize-me.json"],
       "url": "https://www.schemastore.org/plagiarize-me.json",
       "versions": {
         "0.0": "https://www.schemastore.org/plagiarize-me-0.0.json"
@@ -7523,36 +6180,25 @@
     {
       "name": "podbard.yaml",
       "description": "Configuration file for Podbard - a podcast site generator",
-      "fileMatch": [
-        "podbard.yaml"
-      ],
+      "fileMatch": ["podbard.yaml"],
       "url": "https://raw.githubusercontent.com/Songmu/podbard/main/schema.yaml"
     },
     {
       "name": "POPxf",
       "description": "Polynomial Observable Predictions in High-Energy Physics",
-      "fileMatch": [
-        "*.popxf",
-        "*.popxf.json"
-      ],
+      "fileMatch": ["*.popxf", "*.popxf.json"],
       "url": "https://www.schemastore.org/popxf-1.0.json"
     },
     {
       "name": "POPxf Correlations",
       "description": "Correlations for Polynomial Observable Predictions in High-Energy Physics",
-      "fileMatch": [
-        "*.popxf-corr",
-        "*.popxf-corr.json"
-      ],
+      "fileMatch": ["*.popxf-corr", "*.popxf-corr.json"],
       "url": "https://www.schemastore.org/popxf-corr-1.0.json"
     },
     {
       "name": "portman.json",
       "description": "Portman's configuration file",
-      "fileMatch": [
-        "portman-config.json",
-        "portman.json"
-      ],
+      "fileMatch": ["portman-config.json", "portman.json"],
       "url": "https://raw.githubusercontent.com/apideck-libraries/portman/main/src/utils/portman-config-schema.json"
     },
     {
@@ -7569,9 +6215,7 @@
     {
       "name": "Postman collection",
       "description": "Postman collections",
-      "fileMatch": [
-        "*.postman_collection.json"
-      ],
+      "fileMatch": ["*.postman_collection.json"],
       "url": "https://schema.postman.com/collection/json/v2.1.0/draft-07/collection.json",
       "versions": {
         "1.0.0": "https://schema.postman.com/collection/json/v1.0.0/draft-07/collection.json",
@@ -7582,27 +6226,19 @@
     {
       "name": ".powerpages-web-template-manifest",
       "description": "Custom manifest declaration for Web templates",
-      "fileMatch": [
-        ".powerpages-web-template-manifest"
-      ],
+      "fileMatch": [".powerpages-web-template-manifest"],
       "url": "https://www.schemastore.org/powerpages-web-template-manifest.json"
     },
     {
       "name": ".pre-commit-config.yml",
       "description": "pre-commit configuration file",
-      "fileMatch": [
-        ".pre-commit-config.yml",
-        ".pre-commit-config.yaml"
-      ],
+      "fileMatch": [".pre-commit-config.yml", ".pre-commit-config.yaml"],
       "url": "https://www.schemastore.org/pre-commit-config.json"
     },
     {
       "name": ".pre-commit-hooks.yml",
       "description": "pre-commit hooks definition file",
-      "fileMatch": [
-        ".pre-commit-hooks.yml",
-        ".pre-commit-hooks.yaml"
-      ],
+      "fileMatch": [".pre-commit-hooks.yml", ".pre-commit-hooks.yaml"],
       "url": "https://www.schemastore.org/pre-commit-hooks.json"
     },
     {
@@ -7624,42 +6260,31 @@
     {
       "name": ".phrase.yml",
       "description": "Phrase configuration file",
-      "fileMatch": [
-        ".phrase.yml"
-      ],
+      "fileMatch": [".phrase.yml"],
       "url": "https://www.schemastore.org/phrase.json"
     },
     {
       "name": ".phraseapp.yml",
       "description": "PhraseApp configuration file",
-      "fileMatch": [
-        ".phraseapp.yml"
-      ],
+      "fileMatch": [".phraseapp.yml"],
       "url": "https://www.schemastore.org/phraseapp.json"
     },
     {
       "name": "prefect.toml",
       "description": "Prefect configuration file",
-      "fileMatch": [
-        "prefect.toml"
-      ],
+      "fileMatch": ["prefect.toml"],
       "url": "https://raw.githubusercontent.com/PrefectHQ/prefect/refs/heads/main/schemas/settings.schema.json"
     },
     {
       "name": "prefect.yaml",
       "description": "Prefect deployment configuration file",
-      "fileMatch": [
-        "prefect.yaml",
-        "prefect.yml"
-      ],
+      "fileMatch": ["prefect.yaml", "prefect.yml"],
       "url": "https://raw.githubusercontent.com/PrefectHQ/prefect/refs/heads/main/schemas/prefect.yaml.schema.json"
     },
     {
       "name": "prek",
       "description": "Configuration file for prek, a tool for managing git hooks",
-      "fileMatch": [
-        "prek.toml"
-      ],
+      "fileMatch": ["prek.toml"],
       "url": "https://www.schemastore.org/prek.json"
     },
     {
@@ -7681,101 +6306,73 @@
     {
       "name": "prisma.yml",
       "description": "prisma.yml service definition file",
-      "fileMatch": [
-        "prisma.yml"
-      ],
+      "fileMatch": ["prisma.yml"],
       "url": "https://www.schemastore.org/prisma.json"
     },
     {
       "name": "ProActions AI-Kit Configuration",
       "description": "Eidosmedia ProActions AI-Kit main configuration file",
-      "fileMatch": [
-        "*.ai-kit.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/ai-kit.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Services",
       "description": "Eidosmedia ProActions AI-Kit services configuration files",
-      "fileMatch": [
-        "*.ai-kit.serv.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.serv.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-services.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Menus",
       "description": "Eidosmedia ProActions AI-Kit menu configuration files",
-      "fileMatch": [
-        "*.ai-kit.menu.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.menu.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-floatingMenu.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Templates",
       "description": "Eidosmedia ProActions AI-Kit template configuration files",
-      "fileMatch": [
-        "*.ai-kit.templ.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.templ.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-templates.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Sections",
       "description": "Eidosmedia ProActions AI-Kit section configuration files",
-      "fileMatch": [
-        "*.ai-kit.sect.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.sect.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-section.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Steps",
       "description": "Eidosmedia ProActions AI-Kit step configuration files",
-      "fileMatch": [
-        "*.ai-kit.step.yaml"
-      ],
+      "fileMatch": ["*.ai-kit.step.yaml"],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-step.schema.json"
     },
     {
       "name": "Problem package format",
       "description": "Problem package metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": [
-        "problem.yml",
-        "problem.yaml"
-      ],
+      "fileMatch": ["problem.yml", "problem.yaml"],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/problem_yaml_schema.json"
     },
     {
       "name": "Problem package generators",
       "description": "Generators for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": [
-        "generators.yml",
-        "generators.yaml"
-      ],
+      "fileMatch": ["generators.yml", "generators.yaml"],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/generators_yaml_schema.json"
     },
     {
       "name": "Problem package submissions",
       "description": "Submissions metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": [
-        "submissions.yml",
-        "submissions.yaml"
-      ],
+      "fileMatch": ["submissions.yml", "submissions.yaml"],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/submissions_yaml_schema.json"
     },
     {
       "name": "Problem package test group metadata",
       "description": "Test group metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": [
-        "test_group.yml",
-        "test_group.yaml"
-      ],
+      "fileMatch": ["test_group.yml", "test_group.yaml"],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/test_group_yaml_schema.json"
     },
     {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
-      "fileMatch": [
-        "project.json"
-      ],
+      "fileMatch": ["project.json"],
       "url": "https://www.schemastore.org/project.json",
       "versions": {
         "1.0.0-beta3": "https://www.schemastore.org/project-1.0.0-beta3.json",
@@ -7826,18 +6423,13 @@
     {
       "name": "project.owasp.yaml",
       "description": "OWASP project",
-      "fileMatch": [
-        "project.owasp.yaml"
-      ],
+      "fileMatch": ["project.owasp.yaml"],
       "url": "https://raw.githubusercontent.com/OWASP/nest-schema/main/project.json"
     },
     {
       "name": "prometheus.json",
       "description": "Prometheus configuration file",
-      "fileMatch": [
-        "prometheus.yml",
-        "prometheus.yaml"
-      ],
+      "fileMatch": ["prometheus.yml", "prometheus.yaml"],
       "url": "https://www.schemastore.org/prometheus.json"
     },
     {
@@ -7869,42 +6461,31 @@
     {
       "name": "prometheus-alertmanager.json",
       "description": "Prometheus Alertmanager configuration file",
-      "fileMatch": [
-        "alertmanager.yml",
-        "alertmanager.yaml"
-      ],
+      "fileMatch": ["alertmanager.yml", "alertmanager.yaml"],
       "url": "https://www.schemastore.org/prometheus-alertmanager.json"
     },
     {
       "name": "proxies.json",
       "description": "Azure Function Proxies proxies.json files",
-      "fileMatch": [
-        "proxies.json"
-      ],
+      "fileMatch": ["proxies.json"],
       "url": "https://www.schemastore.org/proxies.json"
     },
     {
       "name": "publiccode.yml",
       "description": "publiccode.yml",
-      "fileMatch": [
-        "publiccode.yml"
-      ],
+      "fileMatch": ["publiccode.yml"],
       "url": "https://www.schemastore.org/publiccode.json"
     },
     {
       "name": "pubspec.yaml",
       "description": "pubspecs, the format used by Dart's dependency manager",
-      "fileMatch": [
-        "pubspec.yaml"
-      ],
+      "fileMatch": ["pubspec.yaml"],
       "url": "https://www.schemastore.org/pubspec.json"
     },
     {
       "name": "Pull Request Labeler",
       "description": "A GitHub Action for automatically labelling pull requests",
-      "fileMatch": [
-        "**/.github/labeler.yml"
-      ],
+      "fileMatch": ["**/.github/labeler.yml"],
       "url": "https://www.schemastore.org/pull-request-labeler.json",
       "versions": {
         "4": "https://www.schemastore.org/pull-request-labeler-4.json",
@@ -7914,25 +6495,19 @@
     {
       "name": ".putout.json",
       "description": "🐊Putout configuration file",
-      "fileMatch": [
-        ".putout.json"
-      ],
+      "fileMatch": [".putout.json"],
       "url": "https://www.schemastore.org/putout.json"
     },
     {
       "name": "pyrseas-0.8.json",
       "description": "Pyrseas database versioning for Postgres databases, v0.8",
-      "fileMatch": [
-        "pyrseas-0.8.json"
-      ],
+      "fileMatch": ["pyrseas-0.8.json"],
       "url": "https://www.schemastore.org/pyrseas-0.8.json"
     },
     {
       "name": "RadioHound",
       "description": "RadioHound data format for spectrum monitoring",
-      "fileMatch": [
-        "*.rh.json"
-      ],
+      "fileMatch": ["*.rh.json"],
       "url": "https://www.schemastore.org/radiohound-v0.json",
       "versions": {
         "v0": "https://www.schemastore.org/radiohound-v0.json"
@@ -7941,26 +6516,19 @@
     {
       "name": "PyGTA Config",
       "description": "Configuration file used by pyglotaran and pyglotaran-extras",
-      "fileMatch": [
-        "pygta_config.yaml",
-        "pygta_config.yml"
-      ],
+      "fileMatch": ["pygta_config.yaml", "pygta_config.yml"],
       "url": "https://pyglotaran-extras.readthedocs.io/en/latest/_static/pygta_config.schema.json"
     },
     {
       "name": "Rancher Fleet",
       "description": "Rancher Fleet fleet.yaml configuration file",
-      "fileMatch": [
-        "**/fleet.yaml"
-      ],
+      "fileMatch": ["**/fleet.yaml"],
       "url": "https://raw.githubusercontent.com/rancher/fleet/main/schemas/fleet.yaml.json"
     },
     {
       "name": "config.yaml",
       "description": "Projektor settings",
-      "fileMatch": [
-        "**/.projektor/config.yaml"
-      ],
+      "fileMatch": ["**/.projektor/config.yaml"],
       "url": "https://www.schemastore.org/projektor.json"
     },
     {
@@ -7977,26 +6545,19 @@
     {
       "name": "Pulumi",
       "description": "Pulumi project metadata and configuration",
-      "fileMatch": [
-        "Pulumi.yaml",
-        "pulumi.yaml"
-      ],
+      "fileMatch": ["Pulumi.yaml", "pulumi.yaml"],
       "url": "https://www.schemastore.org/pulumi.json"
     },
     {
       "name": "PyProject",
       "description": "Python project metadata and configuration",
-      "fileMatch": [
-        "pyproject.toml"
-      ],
+      "fileMatch": ["pyproject.toml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pyproject.json"
     },
     {
       "name": "Pyright",
       "description": "Pyright Configuration",
-      "fileMatch": [
-        "pyrightconfig.json"
-      ],
+      "fileMatch": ["pyrightconfig.json"],
       "url": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"
     },
     {
@@ -8020,101 +6581,73 @@
     {
       "name": "QType AI DSL",
       "description": "A DSL for rapid prototyping of AI applications",
-      "fileMatch": [
-        "qtype.config.yaml",
-        "*.qtype.yaml"
-      ],
+      "fileMatch": ["qtype.config.yaml", "*.qtype.yaml"],
       "url": "https://raw.githubusercontent.com/bazaarvoice/qtype/refs/heads/main/schema/qtype.schema.json"
     },
     {
       "name": "Railway",
       "description": "Use Railway config as code to define settings for building and deploying your services",
-      "fileMatch": [
-        "railway.toml",
-        "railway.json"
-      ],
+      "fileMatch": ["railway.toml", "railway.json"],
       "url": "https://railway.com/railway.schema.json"
     },
     {
       "name": "Railpack",
       "description": "Configuration file for Railpack deployment tool",
-      "fileMatch": [
-        "railpack.json"
-      ],
+      "fileMatch": ["railpack.json"],
       "url": "https://schema.railpack.com"
     },
     {
       "name": "Rattler-build",
       "description": "Rattler-build recipe",
-      "fileMatch": [
-        "recipe.yaml",
-        "recipe.yml"
-      ],
+      "fileMatch": ["recipe.yaml", "recipe.yml"],
       "url": "https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json"
     },
     {
       "name": "rc3 auth",
       "description": "RC auth that can be stored at Collection, Folder, or Request levels",
-      "fileMatch": [
-        "rc-auth.json"
-      ],
+      "fileMatch": ["rc-auth.json"],
       "url": "https://www.schemastore.org/rc3-auth-0.0.3.json"
     },
     {
       "name": "rc3 collection",
       "description": "RC collection information",
-      "fileMatch": [
-        "rc-collection.json"
-      ],
+      "fileMatch": ["rc-collection.json"],
       "url": "https://www.schemastore.org/rc3-collection-0.0.3.json"
     },
     {
       "name": "rc3 environment",
       "description": "RC environment for both Global and per Collection environments",
-      "fileMatch": [
-        "**/environments/*.json",
-        "rc-global.json"
-      ],
+      "fileMatch": ["**/environments/*.json", "rc-global.json"],
       "url": "https://www.schemastore.org/rc3-environment-0.0.3.json"
     },
     {
       "name": "rc3 folder",
       "description": "RC folder information",
-      "fileMatch": [
-        "rc-folder.json"
-      ],
+      "fileMatch": ["rc-folder.json"],
       "url": "https://www.schemastore.org/rc3-folder-0.0.3.json"
     },
     {
       "name": "rc3 request",
       "description": "RC request information",
-      "fileMatch": [
-        "**/*.request"
-      ],
+      "fileMatch": ["**/*.request"],
       "url": "https://www.schemastore.org/rc3-request-0.0.3.json"
     },
     {
       "name": "rc3 settings",
       "description": "RC settings stored in the users RC_HOME directory",
-      "fileMatch": [
-        "rc-settings.json"
-      ],
+      "fileMatch": ["rc-settings.json"],
       "url": "https://www.schemastore.org/rc3-settings-0.0.3.json"
     },
     {
       "name": "Red-DiscordBot Cog",
       "description": "Red-DiscordBot Cog metadata file",
-      "fileMatch": [
-        "info.json"
-      ],
+      "fileMatch": ["info.json"],
       "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json"
     },
     {
       "name": "Red-DiscordBot Cog Repo",
       "description": "Red-DiscordBot Cog Repo metadata file",
-      "fileMatch": [
-        "info.json"
-      ],
+      "fileMatch": ["info.json"],
       "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog_repo.schema.json"
     },
     {
@@ -8136,26 +6669,19 @@
     {
       "name": "release-please-config.json",
       "description": "Release Please manifest configuration file",
-      "fileMatch": [
-        "release-please-config.json"
-      ],
+      "fileMatch": ["release-please-config.json"],
       "url": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
     },
     {
       "name": "release-please-manifest.json",
       "description": "Release Please manifest versions file",
-      "fileMatch": [
-        ".release-please-manifest.json"
-      ],
+      "fileMatch": [".release-please-manifest.json"],
       "url": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json"
     },
     {
       "name": "release-plz.toml",
       "description": "Release-plz configuration file",
-      "fileMatch": [
-        "release-plz.toml",
-        ".release-plz.toml"
-      ],
+      "fileMatch": ["release-plz.toml", ".release-plz.toml"],
       "url": "https://raw.githubusercontent.com/MarcoIeni/release-plz/main/.schema/latest.json"
     },
     {
@@ -8172,68 +6698,49 @@
     {
       "name": "Replit config",
       "description": "replit.com, a cloud IDE and code runner",
-      "fileMatch": [
-        "replit.toml"
-      ],
+      "fileMatch": ["replit.toml"],
       "url": "https://www.schemastore.org/replit.json"
     },
     {
       "name": "github-settings-as-code",
       "description": "Declarative GitHub repository settings applied by the github-settings-as-code action; accepts Probot Settings app files as-is. Documentation: https://github.com/Vivswan/github-settings-as-code",
-      "fileMatch": [
-        "**/.github/settings.yml"
-      ],
+      "fileMatch": ["**/.github/settings.yml"],
       "url": "https://raw.githubusercontent.com/Vivswan/github-settings-as-code/main/lib/settings.schema.json"
     },
     {
       "name": "reposets Configuration",
       "description": "Configuration for the reposets CLI tool for syncing GitHub repository settings",
-      "fileMatch": [
-        "reposets.config.toml",
-        "reposets.config.json"
-      ],
+      "fileMatch": ["reposets.config.toml", "reposets.config.json"],
       "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json"
     },
     {
       "name": "reposets Credentials",
       "description": "Authentication profiles for the reposets CLI tool",
-      "fileMatch": [
-        "reposets.credentials.toml",
-        "reposets.credentials.json"
-      ],
+      "fileMatch": ["reposets.credentials.toml", "reposets.credentials.json"],
       "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json"
     },
     {
       "name": "*.resjson",
       "description": "Windows App localization file",
-      "fileMatch": [
-        "*.resjson"
-      ],
+      "fileMatch": ["*.resjson"],
       "url": "https://www.schemastore.org/resjson.json"
     },
     {
       "name": "Rubocop",
       "description": "A Ruby code style checker (linter) and formatter",
-      "fileMatch": [
-        "*.rubocop.yml"
-      ],
+      "fileMatch": ["*.rubocop.yml"],
       "url": "https://www.rubyschema.org/rubocop.json"
     },
     {
       "name": "Ruff",
       "description": "Ruff, a fast Python linter",
-      "fileMatch": [
-        "ruff.toml",
-        ".ruff.toml"
-      ],
+      "fileMatch": ["ruff.toml", ".ruff.toml"],
       "url": "https://www.schemastore.org/ruff.json"
     },
     {
       "name": "Rust Project",
       "description": "non-Cargo based Rust projects",
-      "fileMatch": [
-        "rust-project.json"
-      ],
+      "fileMatch": ["rust-project.json"],
       "url": "https://www.schemastore.org/rust-project.json"
     },
     {
@@ -8314,18 +6821,13 @@
     {
       "name": "renv.lock",
       "description": "Lockfile for recording R project dependencies with renv package",
-      "fileMatch": [
-        "renv.lock"
-      ],
+      "fileMatch": ["renv.lock"],
       "url": "https://raw.githubusercontent.com/rstudio/renv/refs/heads/main/inst/schema/draft-07.renv.lock.schema.json"
     },
     {
       "name": "RoadRunner",
       "description": "Spiral Roadrunner config file",
-      "fileMatch": [
-        ".rr*.yml",
-        ".rr*.yaml"
-      ],
+      "fileMatch": [".rr*.yml", ".rr*.yaml"],
       "url": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/3.0.schema.json",
       "versions": {
         "1.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/1.0.schema.json",
@@ -8336,9 +6838,7 @@
     {
       "name": "Rockcraft",
       "description": "Rockcraft project. Documentation: https://documentation.ubuntu.com/rockcraft/stable/",
-      "fileMatch": [
-        "rockcraft.yaml"
-      ],
+      "fileMatch": ["rockcraft.yaml"],
       "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
     },
     {
@@ -8355,70 +6855,49 @@
     {
       "name": "runny",
       "description": "runny, a rool for running things",
-      "fileMatch": [
-        ".runny.yaml",
-        ".runny.yml"
-      ],
+      "fileMatch": [".runny.yaml", ".runny.yml"],
       "url": "https://raw.githubusercontent.com/simonwhitaker/runny/main/schema/runny.schema.json"
     },
     {
       "name": "rumdl",
       "description": "Configuration file for rumdl, a fast Markdown linter and formatter",
-      "fileMatch": [
-        ".rumdl.toml",
-        "rumdl.toml"
-      ],
+      "fileMatch": [".rumdl.toml", "rumdl.toml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/rumdl.json"
     },
     {
       "name": "rustfmt",
       "description": "rustfmt, a tool to format Rust code. Documentation: https://rust-lang.github.io/rustfmt",
-      "fileMatch": [
-        "rustfmt.toml",
-        ".rustfmt.toml"
-      ],
+      "fileMatch": ["rustfmt.toml", ".rustfmt.toml"],
       "url": "https://www.schemastore.org/rustfmt.json"
     },
     {
       "name": "ryl",
       "description": "ryl, a fast YAML linter written in Rust",
-      "fileMatch": [
-        "ryl.toml",
-        ".ryl.toml"
-      ],
+      "fileMatch": ["ryl.toml", ".ryl.toml"],
       "url": "https://www.schemastore.org/ryl.json"
     },
     {
       "name": "Rust toolchain",
       "description": "A declarative managing the Rust toolchain",
-      "fileMatch": [
-        "rust-toolchain.toml"
-      ],
+      "fileMatch": ["rust-toolchain.toml"],
       "url": "https://www.schemastore.org/rust-toolchain.json"
     },
     {
       "name": "samt",
       "description": "SAMT configuration files",
-      "fileMatch": [
-        "samt.yaml"
-      ],
+      "fileMatch": ["samt.yaml"],
       "url": "https://www.schemastore.org/samt.json"
     },
     {
       "name": "samtrc",
       "description": "SAMT linter configuration files",
-      "fileMatch": [
-        ".samtrc.yaml"
-      ],
+      "fileMatch": [".samtrc.yaml"],
       "url": "https://www.schemastore.org/samtrc.json"
     },
     {
       "name": "Sapphire CLI Config",
       "description": "Scheme for Sapphire CLI Config (@sapphire/cli)",
-      "fileMatch": [
-        ".sapphirerc.json",
-        ".sapphirerc.yml"
-      ],
+      "fileMatch": [".sapphirerc.json", ".sapphirerc.yml"],
       "url": "https://raw.githubusercontent.com/sapphiredev/cli/main/templates/schemas/.sapphirerc.scheme.json"
     },
     {
@@ -8489,9 +6968,7 @@
     {
       "name": "scalingo.json configuration",
       "description": "scalingo.json configuration files",
-      "fileMatch": [
-        "scalingo.json"
-      ],
+      "fileMatch": ["scalingo.json"],
       "url": "https://raw.githubusercontent.com/Scalingo/developers-documentation/refs/heads/master/scalingo.schema.json"
     },
     {
@@ -8522,17 +6999,13 @@
     {
       "name": "Scarb",
       "description": "Scarb manifest file (Scarb.toml)",
-      "fileMatch": [
-        "Scarb.toml"
-      ],
+      "fileMatch": ["Scarb.toml"],
       "url": "https://www.schemastore.org/scarb.json"
     },
     {
       "name": "Scoop manifest",
       "description": "Scoop bucket app manifest",
-      "fileMatch": [
-        "**/bucket/**.json"
-      ],
+      "fileMatch": ["**/bucket/**.json"],
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
@@ -8568,17 +7041,13 @@
     {
       "name": "Secure SDLC Evidence Bundle",
       "description": "Auditable release-readiness evidence bundle produced by the Secure SDLC Evidence Collector",
-      "fileMatch": [
-        "**/*.evidence-bundle.json"
-      ],
+      "fileMatch": ["**/*.evidence-bundle.json"],
       "url": "https://www.schemastore.org/evidence-bundle.json"
     },
     {
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
-      "fileMatch": [
-        "*.sdf.yml"
-      ],
+      "fileMatch": ["*.sdf.yml"],
       "url": "https://cdn.sdf.com/schemas/sdf-schema-1.3.json",
       "versions": {
         "1.0": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json",
@@ -8643,28 +7112,19 @@
     {
       "name": "Serenity Code Generator (Sergen)",
       "description": "Serenity code generator (sergen) configuration file",
-      "fileMatch": [
-        "sergen.json",
-        "sergen.*.json",
-        "*.sergen.json"
-      ],
+      "fileMatch": ["sergen.json", "sergen.*.json", "*.sergen.json"],
       "url": "https://www.schemastore.org/sergen.json"
     },
     {
       "name": "settings.job",
       "description": "Azure Webjob settings file",
-      "fileMatch": [
-        "settings.job"
-      ],
+      "fileMatch": ["settings.job"],
       "url": "https://www.schemastore.org/settings.job.json"
     },
     {
       "name": "Settings.paf",
       "description": "Qualisys Project Automation Framework settings file",
-      "fileMatch": [
-        "settings.paf",
-        "Settings.paf"
-      ],
+      "fileMatch": ["settings.paf", "Settings.paf"],
       "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/paf-module.schema.json"
     },
     {
@@ -8681,17 +7141,13 @@
     {
       "name": "Sigma Detection Rule",
       "description": "The Sigma detection rule format. Documentation: https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md and https://github.com/SigmaHQ/sigma",
-      "fileMatch": [
-        "**/sigma/**/*.yml"
-      ],
+      "fileMatch": ["**/sigma/**/*.yml"],
       "url": "https://raw.githubusercontent.com/SigmaHQ/sigma-specification/main/json-schema/sigma-detection-rule-schema.json"
     },
     {
       "name": "Sigrid scope configuration file",
       "description": "Analysis scope configuration file used by Sigrid (sigrid-says.com)",
-      "fileMatch": [
-        "sigrid.yaml"
-      ],
+      "fileMatch": ["sigrid.yaml"],
       "url": "https://www.schemastore.org/sigrid-scope-file.schema.json"
     },
     {
@@ -8721,9 +7177,7 @@
     {
       "name": "size-limit configuration",
       "description": "Configuration file for size-limit",
-      "fileMatch": [
-        ".size-limit.json"
-      ],
+      "fileMatch": [".size-limit.json"],
       "url": "https://www.schemastore.org/size-limit.json"
     },
     {
@@ -8751,9 +7205,7 @@
     {
       "name": "skill-map provider kind",
       "description": "Node-kind descriptor a skill-map Provider plugin declares",
-      "fileMatch": [
-        "**/.skill-map/plugins/*/kinds/*/kind.json"
-      ],
+      "fileMatch": ["**/.skill-map/plugins/*/kinds/*/kind.json"],
       "url": "https://skill-map.ai/spec/v1/extensions/provider-kind.schema.json"
     },
     {
@@ -8764,28 +7216,19 @@
     {
       "name": "skyuxconfig.json",
       "description": "SKY UX CLI configuration file",
-      "fileMatch": [
-        "skyuxconfig.json",
-        "skyuxconfig.*.json"
-      ],
+      "fileMatch": ["skyuxconfig.json", "skyuxconfig.*.json"],
       "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/4.x.x/skyuxconfig-schema.json"
     },
     {
       "name": "Snapcraft",
       "description": "Snapcraft project. Documentation: https://documentation.ubuntu.com/snapcraft/stable/",
-      "fileMatch": [
-        ".snapcraft.yaml",
-        "snapcraft.yaml"
-      ],
+      "fileMatch": [".snapcraft.yaml", "snapcraft.yaml"],
       "url": "https://raw.githubusercontent.com/canonical/snapcraft/main/schema/snapcraft.json"
     },
     {
       "name": "snowflake-config",
       "description": "Configuration file for Snowflake",
-      "fileMatch": [
-        "**/.snowflake/config.toml",
-        "**/snowflake/config.toml"
-      ],
+      "fileMatch": ["**/.snowflake/config.toml", "**/snowflake/config.toml"],
       "url": "https://www.schemastore.org/snowflake-config.json"
     },
     {
@@ -8800,227 +7243,169 @@
     {
       "name": "Solarxy project config",
       "description": "Solarxy 3D model viewer and validator project configuration",
-      "fileMatch": [
-        "solarxy.toml"
-      ],
+      "fileMatch": ["solarxy.toml"],
       "url": "https://www.schemastore.org/solarxy-config.json"
     },
     {
       "name": "Solidarity",
       "description": "CLI config for enforcing environment settings",
-      "fileMatch": [
-        ".solidarity",
-        ".solidarity.json"
-      ],
+      "fileMatch": [".solidarity", ".solidarity.json"],
       "url": "https://www.schemastore.org/solidaritySchema.json"
     },
     {
       "name": "Solution filters",
       "description": "File that specifies which MSBuild solution to launch and which projects to load",
-      "fileMatch": [
-        "*.slnf"
-      ],
+      "fileMatch": ["*.slnf"],
       "url": "https://www.schemastore.org/solution-filter.json"
     },
     {
       "name": "Source Maps v3",
       "description": "Source Map files version 3",
-      "fileMatch": [
-        "*.map"
-      ],
+      "fileMatch": ["*.map"],
       "url": "https://www.schemastore.org/sourcemap-v3.json"
     },
     {
       "name": "Sourcery",
       "description": "Sourcery YAML files",
-      "fileMatch": [
-        ".sourcery.yaml"
-      ],
+      "fileMatch": [".sourcery.yaml"],
       "url": "https://www.schemastore.org/sourcery_yaml_schema.json"
     },
     {
       "name": "Spack bootstrap.yaml",
       "description": "Spack package manager bootstrap.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/bootstrap.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/bootstrap.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/bootstrap.json"
     },
     {
       "name": "Spack cdash.yaml",
       "description": "Spack package manager cdash.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/cdash.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/cdash.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/cdash.json"
     },
     {
       "name": "Spack ci.yaml",
       "description": "Spack package manager ci.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/ci.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/ci.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/ci.json"
     },
     {
       "name": "Spack compilers.yaml",
       "description": "Spack package manager compilers.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/compilers.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/compilers.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/compilers.json"
     },
     {
       "name": "Spack concretizer.yaml",
       "description": "Spack package manager concretizer.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/concretizer.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/concretizer.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/concretizer.json"
     },
     {
       "name": "Spack config.yaml",
       "description": "Spack package manager config.yaml file",
-      "fileMatch": [
-        "**/*spack/**/config.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/config.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/config.json"
     },
     {
       "name": "Spack definitions.yaml",
       "description": "Spack package manager definitions.yaml config",
-      "fileMatch": [
-        "**/*spack/**/definitions.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/definitions.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/definitions.json"
     },
     {
       "name": "Spack develop.yaml",
       "description": "Spack package manager develop.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/develop.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/develop.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/develop.json"
     },
     {
       "name": "Spack env_vars.yaml",
       "description": "Spack package manager env_vars.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/env_vars.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/env_vars.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/env_vars.json"
     },
     {
       "name": "Spack include.yaml",
       "description": "Spack package manager include.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/include.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/include.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/include.json"
     },
     {
       "name": "Spack mirrors.yaml",
       "description": "Spack package manager mirrors.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/mirrors.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/mirrors.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/mirrors.json"
     },
     {
       "name": "Spack modules.yaml",
       "description": "Spack package manager modules.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/modules.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/modules.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/modules.json"
     },
     {
       "name": "Spack packages.yaml",
       "description": "Spack package manager packages.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/packages.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/packages.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/packages.json"
     },
     {
       "name": "Spack repos.yaml",
       "description": "Spack package manager repos.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/repos.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/repos.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/repos.json"
     },
     {
       "name": "Spack environment",
       "description": "Spack package manager environment file",
-      "fileMatch": [
-        "spack.yaml"
-      ],
+      "fileMatch": ["spack.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/spack.json"
     },
     {
       "name": "Spack toolchains.yaml",
       "description": "Spack package manager toolchains.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/toolchains.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/toolchains.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/toolchains.json"
     },
     {
       "name": "Spack upstreams.yaml",
       "description": "Spack package manager upstreams.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/upstreams.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/upstreams.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/upstreams.json"
     },
     {
       "name": "Spack view.yaml",
       "description": "Spack package manager view.yaml config file",
-      "fileMatch": [
-        "**/*spack/**/view.yaml"
-      ],
+      "fileMatch": ["**/*spack/**/view.yaml"],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/view.json"
     },
     {
       "name": "Speakeasy Lint Configuration File",
       "description": "Configuration file for Speakeasy's OpenAPI document linting. Find out more at https://www.speakeasy.com/docs/linting",
-      "fileMatch": [
-        "**/.speakeasy/lint.yaml"
-      ],
+      "fileMatch": ["**/.speakeasy/lint.yaml"],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/lint.schema.json"
     },
     {
       "name": "Speakeasy Test Generation Configuration File",
       "description": "Configuration file for Speakeasy's test generation",
-      "fileMatch": [
-        "**/.speakeasy/tests.yaml"
-      ],
+      "fileMatch": ["**/.speakeasy/tests.yaml"],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/tests.schema.json"
     },
     {
       "name": "Speakeasy Workflow File",
       "description": "Workflow configuration file. Read more at https://www.speakeasy.com/docs/workflow-file-reference",
-      "fileMatch": [
-        "**/.speakeasy/workflow.yaml"
-      ],
+      "fileMatch": ["**/.speakeasy/workflow.yaml"],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/workflow.schema.json"
     },
     {
       "name": "Speakeasy Generation Config File",
       "description": "Speakeasy generation configuration file. Read more at https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml",
-      "fileMatch": [
-        "**/.speakeasy/gen.yaml"
-      ],
+      "fileMatch": ["**/.speakeasy/gen.yaml"],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/gen.config.schema.json"
     },
     {
       "name": "SpecIF",
       "description": "The Specification Integration Facility (SpecIF) integrates partial system models from different methods and tools in a semantic net. Documentation: https://specif.de and https://github.com/GfSE",
-      "fileMatch": [
-        "*.specif",
-        "*.specif.json"
-      ],
+      "fileMatch": ["*.specif", "*.specif.json"],
       "url": "https://www.schemastore.org/specif-1.1.json",
       "versions": {
         "1.0": "https://www.schemastore.org/specif-1.0.json",
@@ -9030,19 +7415,13 @@
     {
       "name": "Specmatic Configuration",
       "description": "Configuration file for Specmatic, a contract-driven testing tool",
-      "fileMatch": [
-        "specmatic.json",
-        "specmatic.yaml",
-        "specmatic.yml"
-      ],
+      "fileMatch": ["specmatic.json", "specmatic.yaml", "specmatic.yml"],
       "url": "https://www.schemastore.org/specmatic.json"
     },
     {
       "name": "Sponge Mixin configuration",
       "description": "Configuration file for SpongePowered's Mixin library",
-      "fileMatch": [
-        "*.mixins.json"
-      ],
+      "fileMatch": ["*.mixins.json"],
       "url": "https://www.schemastore.org/sponge-mixins.json"
     },
     {
@@ -9061,78 +7440,55 @@
     {
       "name": ".sprite files",
       "description": "image sprite generation files",
-      "fileMatch": [
-        "*.sprite"
-      ],
+      "fileMatch": ["*.sprite"],
       "url": "https://www.schemastore.org/sprite.json"
     },
     {
       "name": "SPDX 2.3",
       "description": "System Package Data Exchange (SPDX) definition",
-      "fileMatch": [
-        "*.spdx.json",
-        "*.spdx.yaml",
-        "*.spdx.yml"
-      ],
+      "fileMatch": ["*.spdx.json", "*.spdx.yaml", "*.spdx.yml"],
       "url": "https://raw.githubusercontent.com/spdx/spdx-spec/refs/tags/v2.3/schemas/spdx-schema.json"
     },
     {
       "name": "sqlc configuration",
       "description": "Configuration file for sqlc v2",
-      "fileMatch": [
-        "sqlc.yaml",
-        "sqlc.json",
-        "*.sqlc.yaml"
-      ],
+      "fileMatch": ["sqlc.yaml", "sqlc.json", "*.sqlc.yaml"],
       "url": "https://www.schemastore.org/sqlc-2.0.json"
     },
     {
       "name": "Azure Static Web Apps configuration file",
       "description": "Documentation: https://learn.microsoft.com/en-us/azure/static-web-apps/configuration",
-      "fileMatch": [
-        "staticwebapp.config.json"
-      ],
+      "fileMatch": ["staticwebapp.config.json"],
       "url": "https://www.schemastore.org/staticwebapp.config.json"
     },
     {
       "name": "Azure Static Web Apps CLI configuration file",
       "description": "Documentation: https://github.com/Azure/static-web-apps-cli#swa-cliconfigjson-file",
-      "fileMatch": [
-        "swa-cli.config.json"
-      ],
+      "fileMatch": ["swa-cli.config.json"],
       "url": "https://www.schemastore.org/swa-cli.config.json"
     },
     {
       "name": "StackBlitz",
       "description": "WebContainer project configuration",
-      "fileMatch": [
-        ".stackblitzrc",
-        "**/.stackblitz/config.json"
-      ],
+      "fileMatch": [".stackblitzrc", "**/.stackblitz/config.json"],
       "url": "https://www.schemastore.org/stackblitzrc.json"
     },
     {
       "name": "Stale",
       "description": "Configuration file for Stale for closing abandoned issues and pull requests. Documentation: https://probot.github.io/apps/stale/",
-      "fileMatch": [
-        "**/.github/stale.yml"
-      ],
+      "fileMatch": ["**/.github/stale.yml"],
       "url": "https://www.schemastore.org/stale.json"
     },
     {
       "name": "Starfish",
       "description": "Configuration file for Starfish",
-      "fileMatch": [
-        "starfish.yml"
-      ],
+      "fileMatch": ["starfish.yml"],
       "url": "https://raw.githubusercontent.com/veepee-oss/json-schema/refs/heads/main/starfish/1-latest/starfish-schema.json"
     },
     {
       "name": "Starship",
       "description": "Configuration file for Starship. Documentation: https://starship.rs",
-      "fileMatch": [
-        "starship.toml"
-      ],
+      "fileMatch": ["starship.toml"],
       "url": "https://starship.rs/config-schema.json"
     },
     {
@@ -9147,51 +7503,37 @@
     {
       "name": "Stella configuration file",
       "description": "Configuration file for stella. Documentation: https://github.com/Shravan-1908/stellapy",
-      "fileMatch": [
-        "stella.yml",
-        "stella.json"
-      ],
+      "fileMatch": ["stella.yml", "stella.json"],
       "url": "https://raw.githubusercontent.com/Shravan-1908/stellapy/master/schema.json"
     },
     {
       "name": "Streamlit configuration file",
       "description": "Streamlit configuration file",
-      "fileMatch": [
-        "**/.streamlit/config.toml"
-      ],
+      "fileMatch": ["**/.streamlit/config.toml"],
       "url": "https://www.schemastore.org/streamlit-config.json"
     },
     {
       "name": "stripe-app.json",
       "description": "Stripe Apps manifest file",
-      "fileMatch": [
-        "stripe-app.json"
-      ],
+      "fileMatch": ["stripe-app.json"],
       "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
     },
     {
       "name": "stripe-app-local.json",
       "description": "Stripe Apps local manifest file",
-      "fileMatch": [
-        "stripe-app.*.json"
-      ],
+      "fileMatch": ["stripe-app.*.json"],
       "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app-local.schema.json"
     },
     {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. Documentation: https://stryker-mutator.io",
-      "fileMatch": [
-        "stryker.conf.json",
-        "stryker-*.conf.json"
-      ],
+      "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],
       "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
     },
     {
       "name": "StyleCop Analyzers Configuration",
       "description": "Configuration file for StyleCop Analyzers",
-      "fileMatch": [
-        "stylecop.json"
-      ],
+      "fileMatch": ["stylecop.json"],
       "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
@@ -9208,52 +7550,37 @@
     {
       "name": "SWADL",
       "description": "Symphony Workflow Automation Definition Language. Documentation: https://developers.symphony.com/",
-      "fileMatch": [
-        "*.swadl.yaml",
-        "*.swadl.yml"
-      ],
+      "fileMatch": ["*.swadl.yaml", "*.swadl.yml"],
       "url": "https://raw.githubusercontent.com/SymphonyPlatformSolutions/symphony-wdk/master/workflow-language/src/main/resources/swadl-schema-1.0.json"
     },
     {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0",
-      "fileMatch": [
-        "swagger.json"
-      ],
+      "fileMatch": ["swagger.json"],
       "url": "https://spec.openapis.org/oas/2.0/schema/2017-08-27"
     },
     {
       "name": "Symfony Routing Configuration",
       "description": "Symfony routing configuration file (config/routes)",
-      "fileMatch": [
-        "**/config/routes.yaml",
-        "**/config/routes/**/*.yaml"
-      ],
+      "fileMatch": ["**/config/routes.yaml", "**/config/routes/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Routing/Loader/schema/routing.schema.json"
     },
     {
       "name": "Symfony Serializer Mapping",
       "description": "Symfony serializer mapping configuration file",
-      "fileMatch": [
-        "**/config/serializer/**/*.yaml"
-      ],
+      "fileMatch": ["**/config/serializer/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json"
     },
     {
       "name": "Symfony Services Configuration",
       "description": "Symfony parameters and services configuration file (config/services)",
-      "fileMatch": [
-        "**/config/services.yaml",
-        "**/config/services_*.yaml"
-      ],
+      "fileMatch": ["**/config/services.yaml", "**/config/services_*.yaml"],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
     },
     {
       "name": "Symfony Validation Mapping",
       "description": "Symfony validation mapping configuration file",
-      "fileMatch": [
-        "**/config/validator/**/*.yaml"
-      ],
+      "fileMatch": ["**/config/validator/**/*.yaml"],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Validator/Mapping/Loader/schema/validation.schema.json"
     },
     {
@@ -9269,103 +7596,73 @@
     {
       "name": "Tach",
       "description": "Tach configuration file",
-      "fileMatch": [
-        "tach.toml"
-      ],
+      "fileMatch": ["tach.toml"],
       "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-toml-schema.json"
     },
     {
       "name": "Tach Domain",
       "description": "Tach domain configuration file",
-      "fileMatch": [
-        "tach.domain.toml"
-      ],
+      "fileMatch": ["tach.domain.toml"],
       "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-domain-toml-schema.json"
     },
     {
       "name": "task.json",
       "description": "VSCode Task file",
-      "fileMatch": [
-        "task.json",
-        "tasks.json"
-      ],
+      "fileMatch": ["task.json", "tasks.json"],
       "url": "https://www.schemastore.org/task.json"
     },
     {
       "name": "Talhelper",
       "description": "A helper tool to help creating Talos Kubernetes cluster",
-      "fileMatch": [
-        "talconfig.yaml",
-        "talconfig.yml"
-      ],
+      "fileMatch": ["talconfig.yaml", "talconfig.yml"],
       "url": "https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json"
     },
     {
       "name": "Talisman configuration",
       "description": "Configuration for .talismanrc",
-      "fileMatch": [
-        ".talismanrc"
-      ],
+      "fileMatch": [".talismanrc"],
       "url": "https://raw.githubusercontent.com/thoughtworks/talisman/main/examples/schema-store-talismanrc.json"
     },
     {
       "name": "Taurus",
       "description": "Taurus bzt cli framework config",
-      "fileMatch": [
-        "bzt.yml",
-        "bzt.yaml",
-        "taurus.yml",
-        "taurus.yaml"
-      ],
+      "fileMatch": ["bzt.yml", "bzt.yaml", "taurus.yml", "taurus.yaml"],
       "url": "https://www.schemastore.org/taurus.json"
     },
     {
       "name": "Tauticord",
       "description": "Tauticord configuration (v2)",
-      "fileMatch": [
-        "tauticord.yml",
-        "tauticord.yaml"
-      ],
+      "fileMatch": ["tauticord.yml", "tauticord.yaml"],
       "url": "https://raw.githubusercontent.com/nwithan8/tauticord/master/.schema/config_v2.schema.json"
     },
     {
       "name": "template.json",
       "description": ".NET template files",
-      "fileMatch": [
-        "**/.template.config/template.json"
-      ],
+      "fileMatch": ["**/.template.config/template.json"],
       "url": "https://www.schemastore.org/template.json"
     },
     {
       "name": "templatsources.json",
       "description": "SideWaffle template source",
-      "fileMatch": [
-        "templatesources.json"
-      ],
+      "fileMatch": ["templatesources.json"],
       "url": "https://www.schemastore.org/templatesources.json"
     },
     {
       "name": "Tier.run pricing.json",
       "description": "Tier.run pricing model configuration",
-      "fileMatch": [
-        "pricing.json"
-      ],
+      "fileMatch": ["pricing.json"],
       "url": "https://raw.githubusercontent.com/tierrun/tier/main/pricing/schema.json"
     },
     {
       "name": "Tikibase",
       "description": "Tikibase configuration file",
-      "fileMatch": [
-        "tikibase.json"
-      ],
+      "fileMatch": ["tikibase.json"],
       "url": "https://raw.githubusercontent.com/kevgo/tikibase/main/doc/tikibase.schema.json"
     },
     {
       "name": "theme.json",
       "description": "WordPress block theme global settings and styles configuration file",
-      "fileMatch": [
-        "theme.json"
-      ],
+      "fileMatch": ["theme.json"],
       "url": "https://schemas.wp.org/trunk/theme.json",
       "versions": {
         "v1": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json",
@@ -9375,43 +7672,31 @@
     {
       "name": "Threagile",
       "description": "Threagile Threat Model file",
-      "fileMatch": [
-        "threagile.yaml",
-        "threat-model.yaml"
-      ],
+      "fileMatch": ["threagile.yaml", "threat-model.yaml"],
       "url": "https://raw.githubusercontent.com/Threagile/threagile/refs/heads/master/support/schema.json"
     },
     {
       "name": "tizen_workspace.json",
       "description": "Tizen project workspace configuration file",
-      "fileMatch": [
-        "tizen_workspace.yaml"
-      ],
+      "fileMatch": ["tizen_workspace.yaml"],
       "url": "https://www.schemastore.org/tizen_workspace.json"
     },
     {
       "name": "tldr",
       "description": "tldr configuration file",
-      "fileMatch": [
-        ".tldr.json"
-      ],
+      "fileMatch": [".tldr.json"],
       "url": "https://www.schemastore.org/tldr.json"
     },
     {
       "name": "Tombi",
       "description": "Tombi (鳶) is a toolkit for TOML; providing a formatter/linter and language server",
-      "fileMatch": [
-        "tombi.toml",
-        "**/tombi/config.toml"
-      ],
+      "fileMatch": ["tombi.toml", "**/tombi/config.toml"],
       "url": "https://www.schemastore.org/tombi.json"
     },
     {
       "name": "tox",
       "description": "tox configuration for automating Python testing and task management",
-      "fileMatch": [
-        "tox.toml"
-      ],
+      "fileMatch": ["tox.toml"],
       "url": "https://raw.githubusercontent.com/tox-dev/tox/main/src/tox/tox.schema.json"
     },
     {
@@ -9428,34 +7713,25 @@
     {
       "name": "TestEnvironment.json",
       "description": "Visual Studio's test environment config",
-      "fileMatch": [
-        "testEnvironments.json"
-      ],
+      "fileMatch": ["testEnvironments.json"],
       "url": "https://www.schemastore.org/testenvironments.json"
     },
     {
       "name": "Turborepo",
       "description": "Turborepo, a tool for managing monorepos",
-      "fileMatch": [
-        "turbo.json"
-      ],
+      "fileMatch": ["turbo.json"],
       "url": "https://turborepo.org/schema.json"
     },
     {
       "name": "Travis CI (.travis.yml)",
       "description": "Travis CI configuration file",
-      "fileMatch": [
-        ".travis.yml"
-      ],
+      "fileMatch": [".travis.yml"],
       "url": "https://www.schemastore.org/travis.json"
     },
     {
       "name": "Traefik v2",
       "description": "Traefik v2 YAML configuration file",
-      "fileMatch": [
-        "traefik.yml",
-        "traefik.yaml"
-      ],
+      "fileMatch": ["traefik.yml", "traefik.yaml"],
       "url": "https://www.schemastore.org/traefik-v2.json"
     },
     {
@@ -9476,42 +7752,25 @@
     {
       "name": "transcend.yml",
       "description": "Configure as Code for Transcend",
-      "fileMatch": [
-        "transcend.yml",
-        "transcend.yaml"
-      ],
+      "fileMatch": ["transcend.yml", "transcend.yaml"],
       "url": "https://raw.githubusercontent.com/transcend-io/tools/refs/heads/main/packages/cli/schema/transcend-yml-schema-latest.json"
     },
     {
       "name": "trime.yaml",
       "description": "trime configuration file",
-      "fileMatch": [
-        "trime.yaml",
-        "trime.yml",
-        "*.trime.yaml",
-        "*.trime.yml"
-      ],
+      "fileMatch": ["trime.yaml", "trime.yml", "*.trime.yaml", "*.trime.yml"],
       "url": "https://raw.githubusercontent.com/osfans/trime/develop/doc/trime-schema.json"
     },
     {
       "name": "Trivy",
       "description": "Configuration file for Trivy security scanner (trivy.yaml)",
-      "fileMatch": [
-        "trivy.yaml",
-        "trivy.yml",
-        ".trivy.yaml",
-        ".trivy.yml"
-      ],
+      "fileMatch": ["trivy.yaml", "trivy.yml", ".trivy.yaml", ".trivy.yml"],
       "url": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json"
     },
     {
       "name": "TrueScript for *.tscript files",
       "description": "The Ultimate Script Language for monday.com - © 2024 MakeITSimple",
-      "fileMatch": [
-        "*.tscript",
-        "*.tscript.yaml",
-        "*.tscript.yml"
-      ],
+      "fileMatch": ["*.tscript", "*.tscript.yaml", "*.tscript.yml"],
       "url": "https://www.schemastore.org/truescript.json",
       "versions": {
         "latest": "https://www.schemastore.org/truescript.json"
@@ -9520,129 +7779,91 @@
     {
       "name": "trunk.yaml",
       "description": "Configuration trunk, a powerful linter runner. Documentation: https://docs.trunk.io",
-      "fileMatch": [
-        "trunk.yaml"
-      ],
+      "fileMatch": ["trunk.yaml"],
       "url": "https://static.trunk.io/pub/trunk-yaml-schema.json"
     },
     {
       "name": "tsbuild",
       "description": "Configuration for the tsbuild TypeScript build system",
-      "fileMatch": [
-        "tsbuild.json"
-      ],
+      "fileMatch": ["tsbuild.json"],
       "url": "https://www.schemastore.org/tsbuild.json"
     },
     {
       "name": "tsconfig.json",
       "description": "TypeScript compiler configuration file",
-      "fileMatch": [
-        "tsconfig*.json"
-      ],
+      "fileMatch": ["tsconfig*.json"],
       "url": "https://www.schemastore.org/tsconfig.json"
     },
     {
       "name": "tsd.json",
       "description": "DefinitelyTyped description manager (TSD)",
-      "fileMatch": [
-        "tsd.json"
-      ],
+      "fileMatch": ["tsd.json"],
       "url": "https://www.schemastore.org/tsd.json"
     },
     {
       "name": "tsdoc.json",
       "description": "TSDoc configuration file",
-      "fileMatch": [
-        "tsdoc.json"
-      ],
+      "fileMatch": ["tsdoc.json"],
       "url": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json"
     },
     {
       "name": "tsdrc.json",
       "description": "TypeScript Definition manager (tsd) global settings file",
-      "fileMatch": [
-        ".tsdrc"
-      ],
+      "fileMatch": [".tsdrc"],
       "url": "https://www.schemastore.org/tsdrc.json"
     },
     {
       "name": "ts-force-config.json",
       "description": "Generated Typescript classes for Salesforce",
-      "fileMatch": [
-        "ts-force-config.json"
-      ],
+      "fileMatch": ["ts-force-config.json"],
       "url": "https://www.schemastore.org/ts-force-config.json"
     },
     {
       "name": "tslint.json",
       "description": "TypeScript Lint configuration file",
-      "fileMatch": [
-        "tslint.json",
-        "tslint.yaml",
-        "tslint.yml"
-      ],
+      "fileMatch": ["tslint.json", "tslint.yaml", "tslint.yml"],
       "url": "https://www.schemastore.org/tslint.json"
     },
     {
       "name": "TSON",
       "description": "TSON (Tuning-Spectrum Object Notation) data",
-      "fileMatch": [
-        "*.tson",
-        "*.tson.yaml",
-        "*.tson.yml",
-        "*.tson.json"
-      ],
+      "fileMatch": ["*.tson", "*.tson.yaml", "*.tson.yml", "*.tson.json"],
       "url": "https://raw.githubusercontent.com/spectral-discord/TSON/main/schema/tson.json"
     },
     {
       "name": "TSTyche",
       "description": "TSTyche configuration file",
-      "fileMatch": [
-        "tstyche.json",
-        "tstyche.config.json"
-      ],
+      "fileMatch": ["tstyche.json", "tstyche.config.json"],
       "url": "https://tstyche.org/schemas/config.json"
     },
     {
       "name": "tsup",
       "description": "Configuration options for tsup",
-      "fileMatch": [
-        "tsup.config.json"
-      ],
+      "fileMatch": ["tsup.config.json"],
       "url": "https://cdn.jsdelivr.net/npm/tsup/schema.json"
     },
     {
       "name": "tusk.yml",
       "description": "tusk CLI configuration file",
-      "fileMatch": [
-        "tusk.yml",
-        "tusk.yaml"
-      ],
+      "fileMatch": ["tusk.yml", "tusk.yaml"],
       "url": "https://raw.githubusercontent.com/rliebz/tusk/main/tusk.schema.json"
     },
     {
       "name": "twee-ts",
       "description": "twee-ts compiler configuration file",
-      "fileMatch": [
-        "twee-ts.config.json"
-      ],
+      "fileMatch": ["twee-ts.config.json"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/twee-ts.config.json"
     },
     {
       "name": "typewiz.json",
       "description": "Typewiz configuration file",
-      "fileMatch": [
-        "typewiz.json"
-      ],
+      "fileMatch": ["typewiz.json"],
       "url": "https://www.schemastore.org/typewiz.json"
     },
     {
       "name": "typo3.json",
       "description": "the Typo3 CMS",
-      "fileMatch": [
-        "**/sites/*/config.yaml",
-        "**/sites/*/config.yml"
-      ],
+      "fileMatch": ["**/sites/*/config.yaml", "**/sites/*/config.yml"],
       "url": "https://www.schemastore.org/typo3.json"
     },
     {
@@ -9658,44 +7879,31 @@
     {
       "name": "typos.toml",
       "description": "typos configuration file",
-      "fileMatch": [
-        "typos.toml",
-        "_typos.toml",
-        ".typos.toml"
-      ],
+      "fileMatch": ["typos.toml", "_typos.toml", ".typos.toml"],
       "url": "https://raw.githubusercontent.com/crate-ci/typos/master/config.schema.json"
     },
     {
       "name": "typings.json",
       "description": "Typings TypeScript definitions manager definition file",
-      "fileMatch": [
-        "typings.json"
-      ],
+      "fileMatch": ["typings.json"],
       "url": "https://www.schemastore.org/typings.json"
     },
     {
       "name": "typingsrc.json",
       "description": "Typings TypeScript definitions manager configuration file",
-      "fileMatch": [
-        ".typingsrc"
-      ],
+      "fileMatch": [".typingsrc"],
       "url": "https://www.schemastore.org/typingsrc.json"
     },
     {
       "name": "Ubuntu Server Autoinstall",
       "description": "Settings file for Ubuntu Autoinstall",
-      "fileMatch": [
-        "user-data",
-        "autoinstall.yaml"
-      ],
+      "fileMatch": ["user-data", "autoinstall.yaml"],
       "url": "https://www.schemastore.org/ubuntu-server-autoinstall.json"
     },
     {
       "name": "up.json",
       "description": "Up configuration file",
-      "fileMatch": [
-        "up.json"
-      ],
+      "fileMatch": ["up.json"],
       "url": "https://www.schemastore.org/up.json"
     },
     {
@@ -9737,10 +7945,7 @@
     {
       "name": "UTAM Page Object",
       "description": "UI Test Automation Model page object. Documentation: https://utam.dev/",
-      "fileMatch": [
-        "*.utam.json",
-        ".utam.json"
-      ],
+      "fileMatch": ["*.utam.json", ".utam.json"],
       "url": "https://www.schemastore.org/utam-page-object.json",
       "versions": {
         "current": "https://www.schemastore.org/utam-page-object.json",
@@ -9752,9 +7957,7 @@
     {
       "name": "umpire.json",
       "description": "Umpire form-logic configuration",
-      "fileMatch": [
-        "*.umpire.json"
-      ],
+      "fileMatch": ["*.umpire.json"],
       "url": "https://spec.umpire.tools/umpire.schema.json"
     },
     {
@@ -9788,28 +7991,19 @@
     {
       "name": "uv",
       "description": "uv, a fast Python package installer",
-      "fileMatch": [
-        "uv.toml"
-      ],
+      "fileMatch": ["uv.toml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/uv.json"
     },
     {
       "name": "Vector",
       "description": "Configuration file for Vector, an observability data pipeline agent and aggregator",
-      "fileMatch": [
-        "vector.json",
-        "vector.toml",
-        "vector.yaml"
-      ],
+      "fileMatch": ["vector.json", "vector.toml", "vector.yaml"],
       "url": "https://www.schemastore.org/vector.json"
     },
     {
       "name": "vega.json",
       "description": "Vega visualization specification file",
-      "fileMatch": [
-        "*.vg",
-        "*.vg.json"
-      ],
+      "fileMatch": ["*.vg", "*.vg.json"],
       "url": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega/v6.4.0.json",
       "versions": {
         "v2.0.0": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega/v2.0.0.json",
@@ -9976,10 +8170,7 @@
     {
       "name": "vega-lite.json",
       "description": "Vega-Lite visualization specification file",
-      "fileMatch": [
-        "*.vl",
-        "*.vl.json"
-      ],
+      "fileMatch": ["*.vl", "*.vl.json"],
       "url": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega-lite/v6.4.3.json",
       "versions": {
         "v0.0.4": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega-lite/v0.0.4.json",
@@ -10188,10 +8379,7 @@
     {
       "name": "Vela Pipeline Configuration",
       "description": "Vela Pipeline Configuration File",
-      "fileMatch": [
-        ".vela.yml",
-        ".vela.yaml"
-      ],
+      "fileMatch": [".vela.yml", ".vela.yaml"],
       "url": "https://github.com/go-vela/server/releases/latest/download/schema.json"
     },
     {
@@ -10254,18 +8442,13 @@
     {
       "name": "version.json",
       "description": "A project version descriptor file used by Nerdbank.GitVersioning",
-      "fileMatch": [
-        "version.json"
-      ],
+      "fileMatch": ["version.json"],
       "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": ".versionrc.json",
       "description": "Conventional Changelog Configuration file",
-      "fileMatch": [
-        ".versionrc",
-        ".versionrc.json"
-      ],
+      "fileMatch": [".versionrc", ".versionrc.json"],
       "url": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/1.0.0/schema.json",
@@ -10288,17 +8471,13 @@
     {
       "name": "vim-addon-info",
       "description": "vim plugin addon-info.json metadata files",
-      "fileMatch": [
-        "**/*vim*/addon-info.json"
-      ],
+      "fileMatch": ["**/*vim*/addon-info.json"],
       "url": "https://www.schemastore.org/vim-addon-info.json"
     },
     {
       "name": "Vogi",
       "description": "Repository configuration for Vogi agents",
-      "fileMatch": [
-        ".vogi.yaml"
-      ],
+      "fileMatch": [".vogi.yaml"],
       "url": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json",
       "versions": {
         "1": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json"
@@ -10307,68 +8486,49 @@
     {
       "name": "vsls.json",
       "description": "Visual Studio Live Share configuration file",
-      "fileMatch": [
-        ".vsls.json"
-      ],
+      "fileMatch": [".vsls.json"],
       "url": "https://www.schemastore.org/vsls.json"
     },
     {
       "name": "vs-2017.3.host.json",
       "description": "Visual Studio template host file",
-      "fileMatch": [
-        "vs-2017.3.host.json"
-      ],
+      "fileMatch": ["vs-2017.3.host.json"],
       "url": "https://www.schemastore.org/vs-2017.3.host.json"
     },
     {
       "name": "vs-nesting.json",
       "description": "Visual Studio's file nesting feature",
-      "fileMatch": [
-        "*.filenesting.json",
-        ".filenesting.json"
-      ],
+      "fileMatch": ["*.filenesting.json", ".filenesting.json"],
       "url": "https://www.schemastore.org/vs-nesting.json"
     },
     {
       "name": ".vsconfig",
       "description": "Visual Studio component configuration files",
-      "fileMatch": [
-        "*.vsconfig"
-      ],
+      "fileMatch": ["*.vsconfig"],
       "url": "https://www.schemastore.org/vsconfig.json"
     },
     {
       "name": ".vsext",
       "description": "Visual Studio extension pack manifests",
-      "fileMatch": [
-        "*.vsext"
-      ],
+      "fileMatch": ["*.vsext"],
       "url": "https://www.schemastore.org/vsext.json"
     },
     {
       "name": "VSIX CLI publishing",
       "description": "Visual Studio extension publishing",
-      "fileMatch": [
-        "vs-publish.json"
-      ],
+      "fileMatch": ["vs-publish.json"],
       "url": "https://www.schemastore.org/vsix-publish.json"
     },
     {
       "name": "vss-extension.json",
       "description": "Azure DevOps Extensions",
-      "fileMatch": [
-        "vss-extension.json"
-      ],
+      "fileMatch": ["vss-extension.json"],
       "url": "https://www.schemastore.org/vss-extension.json"
     },
     {
       "name": "vtesttree.yaml",
       "description": "Vector test execution tree description",
-      "fileMatch": [
-        "*.vtesttree.yaml",
-        "*.vtesttree.yml",
-        "*.vtesttree.json"
-      ],
+      "fileMatch": ["*.vtesttree.yaml", "*.vtesttree.yml", "*.vtesttree.json"],
       "url": "https://www.schemastore.org/vtesttree-schema-v2.4.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/vtesttree-schema-v1.0.0.json",
@@ -10382,83 +8542,55 @@
     {
       "name": "vtestunit.yaml",
       "description": "Vector test unit description",
-      "fileMatch": [
-        "*.vtestunit.yaml",
-        "*.vtestunit.yml",
-        "*.vtestunit.json"
-      ],
+      "fileMatch": ["*.vtestunit.yaml", "*.vtestunit.yml", "*.vtestunit.json"],
       "url": "https://www.schemastore.org/vtestunit-schema.json"
     },
     {
       "name": "v8r",
       "description": "v8r configuration file",
-      "fileMatch": [
-        ".v8rrc.json",
-        ".v8rrc.yaml",
-        ".v8rrc.yml"
-      ],
+      "fileMatch": [".v8rrc.json", ".v8rrc.yaml", ".v8rrc.yml"],
       "url": "https://raw.githubusercontent.com/chris48s/v8r/main/config-schema.json"
     },
     {
       "name": "WebExtensions",
       "description": "WebExtension manifest files",
-      "fileMatch": [
-        "manifest.json"
-      ],
+      "fileMatch": ["manifest.json"],
       "url": "https://www.schemastore.org/webextension.json"
     },
     {
       "name": "Web App Manifest",
       "description": "Web Application manifest file",
-      "fileMatch": [
-        "manifest.json",
-        "*.webmanifest"
-      ],
+      "fileMatch": ["manifest.json", "*.webmanifest"],
       "url": "https://www.schemastore.org/web-manifest-combined.json"
     },
     {
       "name": "webjobs-list.json",
       "description": "Azure Webjob list file",
-      "fileMatch": [
-        "webjobs-list.json"
-      ],
+      "fileMatch": ["webjobs-list.json"],
       "url": "https://www.schemastore.org/webjobs-list.json"
     },
     {
       "name": "webjobpublishsettings.json",
       "description": "Azure Webjobs publish settings file",
-      "fileMatch": [
-        "webjobpublishsettings.json"
-      ],
+      "fileMatch": ["webjobpublishsettings.json"],
       "url": "https://www.schemastore.org/webjob-publish-settings.json"
     },
     {
       "name": "Web types",
       "description": "JSON standard for web component libraries metadata",
-      "fileMatch": [
-        "web-types.json",
-        "*.web-types.json"
-      ],
+      "fileMatch": ["web-types.json", "*.web-types.json"],
       "url": "https://www.schemastore.org/web-types.json"
     },
     {
       "name": "WP-CLI",
       "description": "WP-CLI is the official command-line tool for WordPress",
-      "fileMatch": [
-        "wp-cli.local.yml",
-        "wp-cli.yml",
-        "**/.wp-cli/config.yml"
-      ],
+      "fileMatch": ["wp-cli.local.yml", "wp-cli.yml", "**/.wp-cli/config.yml"],
       "url": "https://raw.githubusercontent.com/wp-cli/wp-cli/refs/heads/main/schemas/wp-cli-config.json"
     },
     {
       "name": "Wrangler CLI",
       "description": "Wrangler is a command-line tool for building with Cloudflare developer products",
-      "fileMatch": [
-        "wrangler.json",
-        "wrangler.jsonc",
-        "wrangler.toml"
-      ],
+      "fileMatch": ["wrangler.json", "wrangler.jsonc", "wrangler.toml"],
       "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },
     {
@@ -10475,26 +8607,19 @@
     {
       "name": "KSP-AVC",
       "description": "The .version file format for KSP-AVC",
-      "fileMatch": [
-        "*.version"
-      ],
+      "fileMatch": ["*.version"],
       "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
     },
     {
       "name": "KSP-CKAN",
       "description": "Metadata spec for CKAN meta files",
-      "fileMatch": [
-        "*.ckan"
-      ],
+      "fileMatch": ["*.ckan"],
       "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
     },
     {
       "name": "KSP-NetKAN",
       "description": "Metadata spec for NetKAN files",
-      "fileMatch": [
-        "*.netkan",
-        "*.frozen"
-      ],
+      "fileMatch": ["*.netkan", "*.frozen"],
       "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/NetKAN.schema"
     },
     {
@@ -10505,9 +8630,7 @@
     {
       "name": "JSON Schema Draft 7",
       "description": "Meta-validation JSON Schema Draft 7",
-      "fileMatch": [
-        "*.schema.json"
-      ],
+      "fileMatch": ["*.schema.json"],
       "url": "https://json-schema.org/draft-07/schema"
     },
     {
@@ -10523,10 +8646,7 @@
     {
       "name": "xunit.runner.json",
       "description": "Configuration file for unit test projects using xUnit.net",
-      "fileMatch": [
-        "xunit.runner.json",
-        "*.xunit.runner.json"
-      ],
+      "fileMatch": ["xunit.runner.json", "*.xunit.runner.json"],
       "url": "https://www.schemastore.org/xunit.runner.schema.json",
       "versions": {
         "v2.2": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
@@ -10537,25 +8657,19 @@
     {
       "name": "servicehub.service.json",
       "description": "Microsoft ServiceHub Service",
-      "fileMatch": [
-        "*.servicehub.service.json"
-      ],
+      "fileMatch": ["*.servicehub.service.json"],
       "url": "https://www.schemastore.org/servicehub.service.schema.json"
     },
     {
       "name": "servicehub.config.json",
       "description": "Microsoft ServiceHub Configuration",
-      "fileMatch": [
-        "servicehub.config.json"
-      ],
+      "fileMatch": ["servicehub.config.json"],
       "url": "https://www.schemastore.org/servicehub.config.schema.json"
     },
     {
       "name": ".cryproj (generic)",
       "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": [
-        "*.cryproj"
-      ],
+      "fileMatch": ["*.cryproj"],
       "url": "https://www.schemastore.org/cryproj.json",
       "versions": {
         "dev": "https://www.schemastore.org/cryproj.dev.schema.json",
@@ -10568,9 +8682,7 @@
     {
       "name": "typedoc.json",
       "description": "A the Typedoc configuration file",
-      "fileMatch": [
-        "typedoc.json"
-      ],
+      "fileMatch": ["typedoc.json"],
       "url": "https://typedoc.org/schema.json"
     },
     {
@@ -10589,19 +8701,13 @@
     {
       "name": "huskyrc",
       "description": "Husky can prevent bad `git commit`, `git push` and more 🐶 woof!",
-      "fileMatch": [
-        ".huskyrc",
-        ".huskyrc.json"
-      ],
+      "fileMatch": [".huskyrc", ".huskyrc.json"],
       "url": "https://www.schemastore.org/huskyrc.json"
     },
     {
       "name": "lychee",
       "description": "lychee link checker configuration file",
-      "fileMatch": [
-        "lychee.toml",
-        ".lychee.toml"
-      ],
+      "fileMatch": ["lychee.toml", ".lychee.toml"],
       "url": "https://www.schemastore.org/lychee.json"
     },
     {
@@ -10668,61 +8774,43 @@
     {
       "name": "mta.yaml",
       "description": "A MTA projects v3.3",
-      "fileMatch": [
-        "mta.yaml",
-        "mta.yml"
-      ],
+      "fileMatch": ["mta.yaml", "mta.yml"],
       "url": "https://www.schemastore.org/mta.json"
     },
     {
       "name": "mtad.yaml",
       "description": "A MTA deployment descriptors v3.3",
-      "fileMatch": [
-        "mtad.yaml",
-        "mtad.yml"
-      ],
+      "fileMatch": ["mtad.yaml", "mtad.yml"],
       "url": "https://www.schemastore.org/mtad.json"
     },
     {
       "name": "Motif config",
       "description": "A Motif config file",
-      "fileMatch": [
-        "motif.json"
-      ],
+      "fileMatch": ["motif.json"],
       "url": "https://motif.land/api/motif.schema.json"
     },
     {
       "name": ".mtaext",
       "description": "A MTA extension descriptors v3.3",
-      "fileMatch": [
-        "*.mtaext"
-      ],
+      "fileMatch": ["*.mtaext"],
       "url": "https://www.schemastore.org/mtaext.json"
     },
     {
       "name": "xs-app.json",
       "description": "the SAP Application Router v8.2.2",
-      "fileMatch": [
-        "xs-app.json"
-      ],
+      "fileMatch": ["xs-app.json"],
       "url": "https://www.schemastore.org/xs-app.json"
     },
     {
       "name": "Opctl",
       "description": "Opctl describing an op",
-      "fileMatch": [
-        "**/.opspec/*/*.yml",
-        "**/.opspec/*/*.yaml"
-      ],
+      "fileMatch": ["**/.opspec/*/*.yml", "**/.opspec/*/*.yaml"],
       "url": "https://www.schemastore.org/opspec-io-0.1.7.json"
     },
     {
       "name": "HEMTT",
       "description": "HEMTT Project File",
-      "fileMatch": [
-        "hemtt.json",
-        "hemtt.toml"
-      ],
+      "fileMatch": ["hemtt.json", "hemtt.toml"],
       "url": "https://www.schemastore.org/hemtt-0.6.2.json",
       "versions": {
         "0.6.2": "https://www.schemastore.org/hemtt-0.6.2.json"
@@ -10731,42 +8819,31 @@
     {
       "name": "Node.js configuration",
       "description": "The Node.js configuration file",
-      "fileMatch": [
-        "node.config.json"
-      ],
+      "fileMatch": ["node.config.json"],
       "url": "https://nodejs.org/docs/latest/node-config-schema.json"
     },
     {
       "name": "now",
       "description": "ZEIT Now project configuration file",
-      "fileMatch": [
-        "now.json"
-      ],
+      "fileMatch": ["now.json"],
       "url": "https://www.schemastore.org/now.json"
     },
     {
       "name": "taskcat",
       "description": "taskcat",
-      "fileMatch": [
-        ".taskcat.yml"
-      ],
+      "fileMatch": [".taskcat.yml"],
       "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
     },
     {
       "name": "BizTalkServerApplicationSchema",
       "description": "BizTalk server application inventory json file",
-      "fileMatch": [
-        "BizTalkServerInventory.json"
-      ],
+      "fileMatch": ["BizTalkServerInventory.json"],
       "url": "https://www.schemastore.org/BizTalkServerApplicationSchema.json"
     },
     {
       "name": "httpmockrc",
       "description": "Http-mocker is a tool for mock local requests or proxy remote requests",
-      "fileMatch": [
-        ".httpmockrc",
-        ".httpmock.json"
-      ],
+      "fileMatch": [".httpmockrc", ".httpmock.json"],
       "url": "https://www.schemastore.org/httpmockrc.json"
     },
     {
@@ -10791,51 +8868,37 @@
     {
       "name": "release drafter",
       "description": "Release Drafter configuration file",
-      "fileMatch": [
-        "**/.github/release-drafter.yml"
-      ],
+      "fileMatch": ["**/.github/release-drafter.yml"],
       "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/refs/heads/main/drafter/schema.json"
     },
     {
       "name": "zuul",
       "description": "Zuul CI configuration file",
-      "fileMatch": [
-        "**/*zuul.d/*.yaml",
-        ".zuul.yaml"
-      ],
+      "fileMatch": ["**/*zuul.d/*.yaml", ".zuul.yaml"],
       "url": "https://www.schemastore.org/zuul.json"
     },
     {
       "name": "Briefcase",
       "description": "Microsoft Briefcase configuration file",
-      "fileMatch": [
-        "briefcase.yaml"
-      ],
+      "fileMatch": ["briefcase.yaml"],
       "url": "https://raw.githubusercontent.com/microsoft/Briefcase/master/mlbriefcase/briefcase-schema.json"
     },
     {
       "name": "httparchive",
       "description": "HTTP Archive",
-      "fileMatch": [
-        "*.har"
-      ],
+      "fileMatch": ["*.har"],
       "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
     },
     {
       "name": "jsdoc",
       "description": "JSDoc configuration file",
-      "fileMatch": [
-        "conf.json",
-        "jsdoc.json"
-      ],
+      "fileMatch": ["conf.json", "jsdoc.json"],
       "url": "https://www.schemastore.org/jsdoc-1.0.0.json"
     },
     {
       "name": "Ray",
       "description": "Ray autocluster configuration file",
-      "fileMatch": [
-        "ray-*-cluster.yaml"
-      ],
+      "fileMatch": ["ray-*-cluster.yaml"],
       "url": "https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/ray-schema.json"
     },
     {
@@ -10852,51 +8915,37 @@
     {
       "name": "Hatch",
       "description": "Python package build tool",
-      "fileMatch": [
-        "hatch.toml"
-      ],
+      "fileMatch": ["hatch.toml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/hatch.json"
     },
     {
       "name": "helmfile",
       "description": "Helmfile is a declarative spec for deploying helm charts",
-      "fileMatch": [
-        "helmfile.yaml",
-        "**/helmfile.d/**/*.yaml"
-      ],
+      "fileMatch": ["helmfile.yaml", "**/helmfile.d/**/*.yaml"],
       "url": "https://www.schemastore.org/helmfile.json"
     },
     {
       "name": "helmwave",
       "description": "Helmwave is a declarative spec for deploying helm charts",
-      "fileMatch": [
-        "helmwave.yml"
-      ],
+      "fileMatch": ["helmwave.yml"],
       "url": "https://github.com/helmwave/helmwave/releases/latest/download/schema.json"
     },
     {
       "name": "Container Structure Test",
       "description": "The Container Structure Tests provide a powerful framework to validate the structure of a container image",
-      "fileMatch": [
-        "container-structure-test.yaml",
-        "structure-test.yaml"
-      ],
+      "fileMatch": ["container-structure-test.yaml", "structure-test.yaml"],
       "url": "https://www.schemastore.org/container-structure-test.json"
     },
     {
       "name": "Žinoma",
       "description": "Žinoma incremental build configuration",
-      "fileMatch": [
-        "zinoma.yml"
-      ],
+      "fileMatch": ["zinoma.yml"],
       "url": "https://github.com/fbecart/zinoma/releases/latest/download/zinoma-schema.json"
     },
     {
       "name": "Windows Package Manager Singleton Manifest",
       "description": "Windows Package Manager Singleton Manifest file",
-      "fileMatch": [
-        "**/manifests/?/*/*/*/*.*.yaml"
-      ],
+      "fileMatch": ["**/manifests/?/*/*/*/*.*.yaml"],
       "url": "https://www.schemastore.org/winget-pkgs-singleton-1.0.0.json",
       "versions": {
         "0.1": "https://www.schemastore.org/winget-pkgs-singleton-0.1.json",
@@ -10906,9 +8955,7 @@
     {
       "name": "Windows Package Manager Installer Manifest",
       "description": "Windows Package Manager Installer Manifest file, used for detailing installer specific metadata",
-      "fileMatch": [
-        "**/manifests/?/*/*/*/*.*.installer.yaml"
-      ],
+      "fileMatch": ["**/manifests/?/*/*/*/*.*.installer.yaml"],
       "url": "https://www.schemastore.org/winget-pkgs-installer-1.0.0.json"
     },
     {
@@ -10941,9 +8988,7 @@
     {
       "name": "Uniswap Token List",
       "description": "A list of tokens compatible with the Uniswap Interface",
-      "fileMatch": [
-        "*.tokenlist.json"
-      ],
+      "fileMatch": ["*.tokenlist.json"],
       "url": "https://uniswap.org/tokenlist.schema.json"
     },
     {
@@ -10961,28 +9006,19 @@
     {
       "name": "yamllint",
       "description": "yamllint uses a set of rules to check source files for problems",
-      "fileMatch": [
-        "**/.yamllint",
-        "**/.yamllint.yaml",
-        "**/.yamllint.yml"
-      ],
+      "fileMatch": ["**/.yamllint", "**/.yamllint.yaml", "**/.yamllint.yml"],
       "url": "https://www.schemastore.org/yamllint.json"
     },
     {
       "name": "yap.json",
       "description": "YAP (Yet Another Packager) multi-package project file",
-      "fileMatch": [
-        "yap.json"
-      ],
+      "fileMatch": ["yap.json"],
       "url": "https://www.schemastore.org/yap.json"
     },
     {
       "name": "Yippee-Ki-JSON configuration YML",
       "description": "Action and rule configuration descriptor for Yippee-Ki-JSON transformations",
-      "fileMatch": [
-        "**/yippee-*.yml",
-        "**/*.yippee.yml"
-      ],
+      "fileMatch": ["**/yippee-*.yml", "**/*.yippee.yml"],
       "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
       "versions": {
         "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
@@ -11007,10 +9043,7 @@
     {
       "name": "devinit",
       "description": "Devinit configuration file",
-      "fileMatch": [
-        "devinit.json",
-        ".devinit.json"
-      ],
+      "fileMatch": ["devinit.json", ".devinit.json"],
       "url": "https://www.schemastore.org/devinit.schema-6.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/devinit.schema-1.0.json",
@@ -11024,33 +9057,25 @@
     {
       "name": "djlint",
       "description": "djLint configuration file",
-      "fileMatch": [
-        ".djlintrc"
-      ],
+      "fileMatch": [".djlintrc"],
       "url": "https://www.schemastore.org/djlint.json"
     },
     {
       "name": "tsoa",
       "description": "the tsoa configuration file",
-      "fileMatch": [
-        "**/tsoa.json"
-      ],
+      "fileMatch": ["**/tsoa.json"],
       "url": "https://www.schemastore.org/tsoa.json"
     },
     {
       "name": "API Builder",
       "description": "apibuilder.io",
-      "fileMatch": [
-        "**/api.json"
-      ],
+      "fileMatch": ["**/api.json"],
       "url": "https://www.schemastore.org/apibuilder.json"
     },
     {
       "name": "Apollo Router",
       "description": "Apollo Router: The runtime for graph-based API orchestration",
-      "fileMatch": [
-        "apollo-router-*.json"
-      ],
+      "fileMatch": ["apollo-router-*.json"],
       "url": "https://www.schemastore.org/apollo-router-2.9.0.json",
       "versions": {
         "2.8.1": "https://www.schemastore.org/apollo-router-2.8.1.json",
@@ -11061,10 +9086,7 @@
     {
       "name": "Gradle Enterprise",
       "description": "Gradle Enterprise configuration",
-      "fileMatch": [
-        "*gradle-enterprise.yml",
-        "*gradle-enterprise.yaml"
-      ],
+      "fileMatch": ["*gradle-enterprise.yml", "*gradle-enterprise.yaml"],
       "url": "https://docs.gradle.com/downloads/gradle-enterprise-config-schema/gradle-enterprise-config-schema-16.json",
       "versions": {
         "1.0": "https://docs.gradle.com/develocity/helm-admin/schema/gradle-enterprise-config-schema-1.json",
@@ -11101,33 +9123,25 @@
     {
       "name": "Yarn Config (.yarnrc.yml)",
       "description": "Yarnrc configuration files",
-      "fileMatch": [
-        ".yarnrc.yml"
-      ],
+      "fileMatch": [".yarnrc.yml"],
       "url": "https://yarnpkg.com/configuration/yarnrc.json"
     },
     {
       "name": "Better Code Hub",
       "description": "Configuration file for Better Code Hub to override the default configuration",
-      "fileMatch": [
-        ".bettercodehub.yml"
-      ],
+      "fileMatch": [".bettercodehub.yml"],
       "url": "https://www.schemastore.org/bettercodehub.json"
     },
     {
       "name": "Starlake Data Pipeline",
       "description": "Starlake Data Pipeline",
-      "fileMatch": [
-        "*.sl.yml"
-      ],
+      "fileMatch": ["*.sl.yml"],
       "url": "https://www.schemastore.org/starlake.json"
     },
     {
       "name": "swcrc",
       "description": "swc configuration files",
-      "fileMatch": [
-        ".swcrc"
-      ],
+      "fileMatch": [".swcrc"],
       "url": "https://swc.rs/schema.json"
     },
     {
@@ -11162,12 +9176,7 @@
     {
       "name": ".taskrc.yaml",
       "description": "Taskfile configuration files",
-      "fileMatch": [
-        ".taskrc.yaml",
-        ".taskrc.yml",
-        "taskrc.yaml",
-        "taskrc.yml"
-      ],
+      "fileMatch": [".taskrc.yaml", ".taskrc.yml", "taskrc.yaml", "taskrc.yml"],
       "url": "https://taskfile.dev/schema-taskrc.json"
     },
     {
@@ -11184,54 +9193,37 @@
     {
       "name": "Containerlab",
       "description": "Containerlab topology definition files",
-      "fileMatch": [
-        "*-clab.yaml",
-        "*-clab.yml",
-        "*.clab.yaml",
-        "*.clab.yml"
-      ],
+      "fileMatch": ["*-clab.yaml", "*-clab.yml", "*.clab.yaml", "*.clab.yml"],
       "url": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/clab.schema.json"
     },
     {
       "name": "ContractGuard",
       "description": "ContractGuard API contract prescribing the signatures a built .NET assembly must expose",
-      "fileMatch": [
-        "*.contract.json"
-      ],
+      "fileMatch": ["*.contract.json"],
       "url": "https://raw.githubusercontent.com/lxman/ContractGuard/main/schema/contractguard.schema.json"
     },
     {
       "name": "User Journey Map",
       "description": "user journey map definition files",
-      "fileMatch": [
-        "*.jm.yaml",
-        "*.jm.yml"
-      ],
+      "fileMatch": ["*.jm.yaml", "*.jm.yml"],
       "url": "https://raw.githubusercontent.com/arvinxx/components/master/packages/journey-map/schema/journey-map.schema.json"
     },
     {
       "name": "Render Blueprints",
       "description": "Blueprints are Render’s infrastructure-as-code model for defining, deploying, and managing multiple resources with a single YAML file",
-      "fileMatch": [
-        "**/*render.yaml"
-      ],
+      "fileMatch": ["**/*render.yaml"],
       "url": "https://render.com/schema/render.yaml.json"
     },
     {
       "name": "RKE Cluster Configuration YAML",
       "description": "the cluster.yml configuration file for RKE",
-      "fileMatch": [
-        "cluster.yml",
-        "cluster.yaml"
-      ],
+      "fileMatch": ["cluster.yml", "cluster.yaml"],
       "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.yml.json"
     },
     {
       "name": "RKE Cluster Configuration JSON",
       "description": "the cluster.json configuration file for RKE",
-      "fileMatch": [
-        "cluster.json"
-      ],
+      "fileMatch": ["cluster.json"],
       "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.json"
     },
     {
@@ -11251,10 +9243,7 @@
     {
       "name": "Liquibase Flow File",
       "description": "liquibase flow JSON/YAML files",
-      "fileMatch": [
-        "*.flowfile.yaml",
-        "*.flowfile.yml"
-      ],
+      "fileMatch": ["*.flowfile.yaml", "*.flowfile.yml"],
       "url": "https://www.liquibase.org/json/schema/liquibase-flow-file-latest.json"
     },
     {
@@ -11270,10 +9259,7 @@
     {
       "name": "skaffold.yaml",
       "description": "the skaffold.yaml configuration file for Skaffold. Documentation: https://skaffold.dev",
-      "fileMatch": [
-        "skaffold.yaml",
-        "skaffold.yml"
-      ],
+      "fileMatch": ["skaffold.yaml", "skaffold.yml"],
       "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json",
       "versions": {
         "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v1/content/en/schemas/v1alpha1.json",
@@ -11363,42 +9349,31 @@
     {
       "name": "markdown-link-check",
       "description": "markdown-link-check",
-      "fileMatch": [
-        ".markdown-link-check.json"
-      ],
+      "fileMatch": [".markdown-link-check.json"],
       "url": "https://www.schemastore.org/markdown-link-check.json"
     },
     {
       "name": "maturin",
       "description": "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages",
-      "fileMatch": [
-        "maturin.toml"
-      ],
+      "fileMatch": ["maturin.toml"],
       "url": "https://www.schemastore.org/maturin.json"
     },
     {
       "name": "Mason Registry",
       "description": "Package definitions for Mason, a package manager for Neovim",
-      "fileMatch": [
-        "**/packages/*/package.yaml"
-      ],
+      "fileMatch": ["**/packages/*/package.yaml"],
       "url": "https://github.com/mason-org/registry-schema/releases/latest/download/package.schema.json"
     },
     {
       "name": "SauceCTL Configuration",
       "description": "SauceCTL configuration files",
-      "fileMatch": [
-        "**/.sauce/*.yml"
-      ],
+      "fileMatch": ["**/.sauce/*.yml"],
       "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/saucectl.schema.json"
     },
     {
       "name": "fulibWorkflows",
       "description": "fulibWorkflows",
-      "fileMatch": [
-        "*.es.yaml",
-        "*.es.yml"
-      ],
+      "fileMatch": ["*.es.yaml", "*.es.yml"],
       "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schemas/fulibWorkflows.schema.json"
     },
     {
@@ -11415,28 +9390,19 @@
     {
       "name": "Netin Diagnostic System Template",
       "description": "Device template",
-      "fileMatch": [
-        "*.ndst.yml",
-        "*.ndst.yaml",
-        "*.ndst.json"
-      ],
+      "fileMatch": ["*.ndst.yml", "*.ndst.yaml", "*.ndst.json"],
       "url": "https://s3.eu-central-1.amazonaws.com/files.netin.io/spider-schemas/template.schema.json"
     },
     {
       "name": "noodl config",
       "description": "NOODL application config",
-      "fileMatch": [
-        "*.noodl.yml"
-      ],
+      "fileMatch": ["*.noodl.yml"],
       "url": "https://noodl.s3.us-west-1.amazonaws.com/noodl.schema.json"
     },
     {
       "name": "mboats",
       "description": "MBOATS Configuration",
-      "fileMatch": [
-        "*.mboats.yaml",
-        "*.mboats.yml"
-      ],
+      "fileMatch": ["*.mboats.yaml", "*.mboats.yml"],
       "url": "https://www.schemastore.org/mboats-config-0.2.json",
       "versions": {
         "0.1": "https://www.schemastore.org/mboats-config-0.1.json",
@@ -11457,28 +9423,19 @@
     {
       "name": "Serverless Framework Configuration",
       "description": "Serverless framework configuration files",
-      "fileMatch": [
-        "serverless.yml"
-      ],
+      "fileMatch": ["serverless.yml"],
       "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
     },
     {
       "name": "Alacritty Configuration",
       "description": "Alacritty configuration yaml file",
-      "fileMatch": [
-        ".alacritty.yml",
-        "alacritty.yml",
-        "alacritty.toml"
-      ],
+      "fileMatch": [".alacritty.yml", "alacritty.yml", "alacritty.toml"],
       "url": "https://raw.githubusercontent.com/distinction-dev/alacritty-schema/main/alacritty/reference.json"
     },
     {
       "name": "Serverless Workflow",
       "description": "serverless workflows",
-      "fileMatch": [
-        "*.sw.json",
-        "*.sw.yml"
-      ],
+      "fileMatch": ["*.sw.json", "*.sw.yml"],
       "url": "https://raw.githubusercontent.com/serverlessworkflow/specification/main/schema/workflow.yaml",
       "versions": {
         "v0.9": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.9.x/schema/workflow.json",
@@ -11491,19 +9448,13 @@
     {
       "name": "Shopware 6 Configuration",
       "description": "Shopware 6 custom configurations",
-      "fileMatch": [
-        "shopware.yml",
-        "shopware.yaml"
-      ],
+      "fileMatch": ["shopware.yml", "shopware.yaml"],
       "url": "https://raw.githubusercontent.com/shopware/platform/trunk/config-schema.json"
     },
     {
       "name": "Shopware CLI Extension Store Configuration",
       "description": "Shopware CLI Extension Store Configuration",
-      "fileMatch": [
-        ".shopware-extension.yml",
-        ".shopware-extension.yaml"
-      ],
+      "fileMatch": [".shopware-extension.yml", ".shopware-extension.yaml"],
       "url": "https://shopware.github.io/shopware-cli/shopware-extension-schema.json"
     },
     {
@@ -11520,19 +9471,13 @@
     {
       "name": "Qodana",
       "description": "A standard qodana.yaml (or qodana.yml) format for Qodana configuration. Documentation: https://jetbrains.com/qodana",
-      "fileMatch": [
-        "qodana.yaml",
-        "qodana.yml"
-      ],
+      "fileMatch": ["qodana.yaml", "qodana.yml"],
       "url": "https://www.schemastore.org/qodana-1.0.json"
     },
     {
       "name": "Tye",
       "description": "Tye configuration files",
-      "fileMatch": [
-        "tye.yaml",
-        "tye.yml"
-      ],
+      "fileMatch": ["tye.yaml", "tye.yml"],
       "url": "https://raw.githubusercontent.com/dotnet/tye/main/src/schema/tye-schema.json"
     },
     {
@@ -11550,11 +9495,7 @@
     {
       "name": "Hugo",
       "description": "Hugo static site generator config file",
-      "fileMatch": [
-        "hugo.toml",
-        "hugo.json",
-        "hugo.yaml"
-      ],
+      "fileMatch": ["hugo.toml", "hugo.json", "hugo.yaml"],
       "url": "https://www.schemastore.org/hugo.json"
     },
     {
@@ -11587,9 +9528,7 @@
     {
       "name": "Butane Config",
       "description": "Fedora CoreOS Butane config file",
-      "fileMatch": [
-        "*.bu"
-      ],
+      "fileMatch": ["*.bu"],
       "url": "https://relativ-it.github.io/Butane-Schemas/Butane-Schema.json"
     },
     {
@@ -11619,9 +9558,7 @@
     {
       "name": "Updatecli Policy Metadata",
       "description": "Updatecli Policy Metadata",
-      "fileMatch": [
-        "**/updatecli/**/Policy.yaml"
-      ],
+      "fileMatch": ["**/updatecli/**/Policy.yaml"],
       "url": "https://www.updatecli.io/schema/latest/policy/metadata/config.json"
     },
     {
@@ -11632,9 +9569,7 @@
     {
       "name": "clang-format (.clang-format)",
       "description": "yaml clang-format config",
-      "fileMatch": [
-        ".clang-format"
-      ],
+      "fileMatch": [".clang-format"],
       "url": "https://www.schemastore.org/clang-format-21.x.json",
       "versions": {
         "18.x": "https://www.schemastore.org/clang-format-18.x.json",
@@ -11644,20 +9579,13 @@
     {
       "name": "Estuary Flow Catalog",
       "description": "Flow catalog files. Documentation: https://github.com/estuary/flow",
-      "fileMatch": [
-        "flow.yaml",
-        "*.flow.yaml",
-        "flow.json",
-        "*.flow.json"
-      ],
+      "fileMatch": ["flow.yaml", "*.flow.yaml", "flow.json", "*.flow.json"],
       "url": "https://raw.githubusercontent.com/estuary/flow/master/flow.schema.json"
     },
     {
       "name": "V2Ray",
       "description": "V2Ray jsonv4/jsonv5 configuration format",
-      "fileMatch": [
-        "**/v2ray/*.json"
-      ],
+      "fileMatch": ["**/v2ray/*.json"],
       "url": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
       "versions": {
         "jsonv4": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
@@ -11667,29 +9595,19 @@
     {
       "name": "GherKing",
       "description": "GherKing configuration",
-      "fileMatch": [
-        ".gherking.json",
-        ".gherkingrc",
-        "gherking.json"
-      ],
+      "fileMatch": [".gherking.json", ".gherkingrc", "gherking.json"],
       "url": "https://raw.githubusercontent.com/gherking/gherking/master/schema/gherking.schema.json"
     },
     {
       "name": "CICS TS region tagging",
       "description": "CICS region tagging in IBM CICS Transaction Server for z/OS",
-      "fileMatch": [
-        "cicstags.yaml",
-        "cicstags.yml"
-      ],
+      "fileMatch": ["cicstags.yaml", "cicstags.yml"],
       "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicstags.json"
     },
     {
       "name": "CICS TS resource import",
       "description": "resource import in IBM CICS Transaction Server for z/OS",
-      "fileMatch": [
-        "*.cicsresourceimport.yaml",
-        "*.cicsresourceimport.yml"
-      ],
+      "fileMatch": ["*.cicsresourceimport.yaml", "*.cicsresourceimport.yml"],
       "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourceimport.json"
     },
     {
@@ -11717,146 +9635,103 @@
     {
       "name": "Webman package recipe",
       "description": "YAML a webman package",
-      "fileMatch": [
-        "*.webman-pkg.yml"
-      ],
+      "fileMatch": ["*.webman-pkg.yml"],
       "url": "https://raw.githubusercontent.com/candrewlee14/webman/main/schema/pkg_schema.json"
     },
     {
       "name": "webhint.io",
       "description": "A configuration file for hint",
-      "fileMatch": [
-        ".hintrc"
-      ],
+      "fileMatch": [".hintrc"],
       "url": "https://raw.githubusercontent.com/webhintio/hint/main/packages/hint/src/lib/config/config-schema.json"
     },
     {
       "name": "AVA Configuration",
       "description": "configuring AVA, the Node.js test runner",
-      "fileMatch": [
-        "ava.config.json"
-      ],
+      "fileMatch": ["ava.config.json"],
       "url": "https://www.schemastore.org/ava.json"
     },
     {
       "name": "Datahub Ingestion Recipe",
       "description": "Datahub Ingestion recipe. Documentation: https://datahubproject.io/docs/metadata-ingestion",
-      "fileMatch": [
-        "*.dhub.yml",
-        "*.dhub.yaml",
-        "*.dhub.json"
-      ],
+      "fileMatch": ["*.dhub.yml", "*.dhub.yaml", "*.dhub.json"],
       "url": "https://datahubproject.io/schemas/datahub_ingestion_schema.json"
     },
     {
       "name": "Quali Torque Blueprint Spec 2",
       "description": "Torque bluerpint",
-      "fileMatch": [
-        "**/blueprints/**.yaml"
-      ],
+      "fileMatch": ["**/blueprints/**.yaml"],
       "url": "https://raw.githubusercontent.com/QualiTorque/torque-vs-code-extensions/master/client/schemas/blueprint-spec2-schema.json"
     },
     {
       "name": "jscpd Configuration",
       "description": "Copy/paste detector for programming source code",
-      "fileMatch": [
-        ".jscpd.json"
-      ],
+      "fileMatch": [".jscpd.json"],
       "url": "https://www.schemastore.org/jscpd.json"
     },
     {
       "name": "Pterodactyl",
       "description": "Pterodactyl, a free game server control panel",
-      "fileMatch": [
-        "egg-*.json"
-      ],
+      "fileMatch": ["egg-*.json"],
       "url": "https://www.schemastore.org/pterodactyl.json"
     },
     {
       "name": "Hardware Sentry Configuration",
       "description": "Hardware Sentry configuration file",
-      "fileMatch": [
-        "*hws-config*.yaml",
-        "*hws-config*.yml"
-      ],
+      "fileMatch": ["*hws-config*.yaml", "*hws-config*.yml"],
       "url": "https://www.schemastore.org/hws-config.json"
     },
     {
       "name": "devspace.yaml",
       "description": "yaml devspace.yaml",
-      "fileMatch": [
-        "devspace.yaml"
-      ],
+      "fileMatch": ["devspace.yaml"],
       "url": "https://raw.githubusercontent.com/loft-sh/devspace/main/devspace-schema.json"
     },
     {
       "name": "macro.json",
       "description": "Macro configuration file",
-      "fileMatch": [
-        "macro.json"
-      ],
+      "fileMatch": ["macro.json"],
       "url": "https://raw.githubusercontent.com/rebaz94/macro_kit/refs/heads/main/macro_schema.json"
     },
     {
       "name": "Monika Configuration",
       "description": "Monika configuration file",
-      "fileMatch": [
-        "*monika*.yaml",
-        "*monika*.yml",
-        "monika.json"
-      ],
+      "fileMatch": ["*monika*.yaml", "*monika*.yml", "monika.json"],
       "url": "https://www.schemastore.org/monika-config-schema.json"
     },
     {
       "name": "Istanbul",
       "description": "Istanbul, a JavaScript code coverage tool",
-      "fileMatch": [
-        ".nycrc",
-        ".nycrc.json",
-        ".nycrc.yaml",
-        ".nycrc.yml"
-      ],
+      "fileMatch": [".nycrc", ".nycrc.json", ".nycrc.yaml", ".nycrc.yml"],
       "url": "https://www.schemastore.org/nycrc.json"
     },
     {
       "name": "MongoDB Atlas Search Index Definition",
       "description": "MongoDB Atlas Search index",
-      "fileMatch": [
-        "*-index.json"
-      ],
+      "fileMatch": ["*-index.json"],
       "url": "https://www.schemastore.org/mongodb-atlas-search-index-definition.json"
     },
     {
       "name": "KODE/CI build.yaml",
       "description": "yaml kode/ci build",
-      "fileMatch": [
-        "**/.kode/*.yaml"
-      ],
+      "fileMatch": ["**/.kode/*.yaml"],
       "url": "https://www.schemastore.org/kode-ci-build-1.0.0.json"
     },
     {
       "name": "Kong DBLess config",
       "description": "dbless configuration YAML",
-      "fileMatch": [
-        "kong.yaml",
-        "kong.yml"
-      ],
+      "fileMatch": ["kong.yaml", "kong.yml"],
       "url": "https://www.schemastore.org/kong_json_schema.json"
     },
     {
       "name": "Embrace Config",
       "description": "Embrace configuration file",
-      "fileMatch": [
-        "embrace-config.json"
-      ],
+      "fileMatch": ["embrace-config.json"],
       "url": "https://www.schemastore.org/embrace-config-schema-1.0.0.json"
     },
     {
       "name": "petstore-v1.0",
       "description": "petstore yaml validation",
-      "fileMatch": [
-        "petstore-v1.0.json"
-      ],
+      "fileMatch": ["petstore-v1.0.json"],
       "url": "https://www.schemastore.org/petstore-v1.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/petstore-v1.0.json",
@@ -11875,18 +9750,13 @@
     {
       "name": "Safebox Config",
       "description": "Documentation: https://github.com/monebag/safebox",
-      "fileMatch": [
-        "*safebox*.yaml",
-        "*safebox*.yml"
-      ],
+      "fileMatch": ["*safebox*.yaml", "*safebox*.yml"],
       "url": "https://www.schemastore.org/safebox-schema-v1.0.0.json"
     },
     {
       "name": "Sublime Syntax",
       "description": "Sublime Text/Merge syntax highlighting definition",
-      "fileMatch": [
-        "*.sublime-syntax"
-      ],
+      "fileMatch": ["*.sublime-syntax"],
       "url": "https://www.schemastore.org/sublime-syntax.json"
     },
     {
@@ -11903,9 +9773,7 @@
     {
       "name": "ize.toml",
       "description": "ize Infra Tool",
-      "fileMatch": [
-        "ize.toml"
-      ],
+      "fileMatch": ["ize.toml"],
       "url": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
       "versions": {
         "1.1.5": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
@@ -11915,20 +9783,13 @@
     {
       "name": "Uplift",
       "description": "Uplift configuration file",
-      "fileMatch": [
-        ".uplift.yml",
-        ".uplift.yaml",
-        "uplift.yml",
-        "uplift.yaml"
-      ],
+      "fileMatch": [".uplift.yml", ".uplift.yaml", "uplift.yml", "uplift.yaml"],
       "url": "https://upliftci.dev/static/schema.json"
     },
     {
       "name": "QueryFirst config file",
       "description": "Config options for QueryFirst, SQL wrapper generator",
-      "fileMatch": [
-        "qfconfig.json"
-      ],
+      "fileMatch": ["qfconfig.json"],
       "url": "https://www.schemastore.org/qfconfig.json",
       "versions": {
         "1.0": "https://www.schemastore.org/qfconfig.json"
@@ -11937,33 +9798,25 @@
     {
       "name": "UET BuildConfig.json",
       "description": "UET is an unofficial tool for Unreal Engine. The BuildConfig.json file allows you to specify how UET should build an Unreal Engine plugin, project or the engine itself",
-      "fileMatch": [
-        "BuildConfig.json"
-      ],
+      "fileMatch": ["BuildConfig.json"],
       "url": "https://raw.githubusercontent.com/RedpointGames/uet-schema/main/root.json"
     },
     {
       "name": "Unreal Engine Uplugin",
       "description": "Unreal Engine plugin configuration file",
-      "fileMatch": [
-        ".uplugin"
-      ],
+      "fileMatch": [".uplugin"],
       "url": "https://www.schemastore.org/uplugin.json"
     },
     {
       "name": "Unreal Engine Uproject",
       "description": "Unreal Engine project configuration file",
-      "fileMatch": [
-        ".uproject"
-      ],
+      "fileMatch": [".uproject"],
       "url": "https://www.schemastore.org/uproject.json"
     },
     {
       "name": "Pantsbuild",
       "description": "Pantsbuild configuration file",
-      "fileMatch": [
-        "pants*.toml"
-      ],
+      "fileMatch": ["pants*.toml"],
       "url": "https://www.schemastore.org/pantsbuild-2.32.0.json",
       "versions": {
         "2.14.0": "https://www.schemastore.org/pantsbuild-2.14.0.json",
@@ -11984,186 +9837,133 @@
     {
       "name": "All Contributors configuration file",
       "description": "The configuration file used by the All Contributors CLI and GitHub bot",
-      "fileMatch": [
-        ".all-contributorsrc"
-      ],
+      "fileMatch": [".all-contributorsrc"],
       "url": "https://www.schemastore.org/all-contributors.json"
     },
     {
       "name": "ES6 Import Sorter (.es6importsorterrc.json)",
       "description": "The configuration file used for ES6 Import Sorter, a VSCode extension",
-      "fileMatch": [
-        ".es6importsorterrc.json"
-      ],
+      "fileMatch": [".es6importsorterrc.json"],
       "url": "https://www.schemastore.org/es6importsorterrc.json"
     },
     {
       "name": "completely.yml",
       "description": "Completely completion",
-      "fileMatch": [
-        "completely.yml",
-        "completely.yaml"
-      ],
+      "fileMatch": ["completely.yml", "completely.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/completely/master/schemas/completely.json"
     },
     {
       "name": "Madness (madness.yml)",
       "description": "Madness settings",
-      "fileMatch": [
-        "madness.yml",
-        "madness.yaml"
-      ],
+      "fileMatch": ["madness.yml", "madness.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/madness/master/schemas/madness.json"
     },
     {
       "name": "Bashly (bashly.yml)",
       "description": "Bashly CLI",
-      "fileMatch": [
-        "bashly.yml",
-        "bashly.yaml"
-      ],
+      "fileMatch": ["bashly.yml", "bashly.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     },
     {
       "name": "Bashly Settings (bashly-settings.yml)",
       "description": "Bashly settings",
-      "fileMatch": [
-        "bashly-settings.yml",
-        "bashly-settings.yaml"
-      ],
+      "fileMatch": ["bashly-settings.yml", "bashly-settings.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/settings.json"
     },
     {
       "name": "bashly-strings.yml",
       "description": "Bashly strings",
-      "fileMatch": [
-        "bashly-strings.yml",
-        "bashly-strings.yaml"
-      ],
+      "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"
     },
     {
       "name": "bpkg",
       "description": "A lightweight Bash package manager",
-      "fileMatch": [
-        "bpkg.json"
-      ],
+      "fileMatch": ["bpkg.json"],
       "url": "https://www.schemastore.org/bpkg.json"
     },
     {
       "name": "micro-settings.json",
       "description": "Micro settings",
-      "fileMatch": [
-        "**/.config/micro/settings.json"
-      ],
+      "fileMatch": ["**/.config/micro/settings.json"],
       "url": "https://raw.githubusercontent.com/zyedidia/micro/master/data/micro.json"
     },
     {
       "name": "quilt.mod.json",
       "description": "Metadata file used by the QuiltMC mod loader",
-      "fileMatch": [
-        "quilt.mod.json"
-      ],
+      "fileMatch": ["quilt.mod.json"],
       "url": "https://raw.githubusercontent.com/QuiltMC/quilt-json-schemas/main/quilt.mod.json/schemas/main.json"
     },
     {
       "name": "AutoAPICase",
       "description": "auto api case",
-      "fileMatch": [
-        "**/test_data/**/*.yml"
-      ],
+      "fileMatch": ["**/test_data/**/*.yml"],
       "url": "https://www.schemastore.org/case_schema.json"
     },
     {
       "name": "secrethub.yml",
       "description": "secrethub",
-      "fileMatch": [
-        "secrethub.yml",
-        "secrethub.yaml"
-      ],
+      "fileMatch": ["secrethub.yml", "secrethub.yaml"],
       "url": "https://raw.githubusercontent.com/DannyBen/secret_hub/master/schemas/secrethub.json"
     },
     {
       "name": "Dynamic Bash Aliases (.aliases)",
       "description": "Dynamic Bash aliases",
-      "fileMatch": [
-        ".aliases"
-      ],
+      "fileMatch": [".aliases"],
       "url": "https://www.schemastore.org/aliases.json"
     },
     {
       "name": "Micro Editor Syntax",
       "description": "Micro Editor syntaxes",
-      "fileMatch": [
-        "**/micro/runtime/syntax/*.yaml"
-      ],
+      "fileMatch": ["**/micro/runtime/syntax/*.yaml"],
       "url": "https://www.schemastore.org/micro-syntax.json"
     },
     {
       "name": "lazygit",
       "description": "lazygit settings",
-      "fileMatch": [
-        "**/lazygit/config.yml",
-        "lazygit.yml",
-        ".lazygit.yml"
-      ],
+      "fileMatch": ["**/lazygit/config.yml", "lazygit.yml", ".lazygit.yml"],
       "url": "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json"
     },
     {
       "name": "lazydocker",
       "description": "lazydocker settings",
-      "fileMatch": [
-        "**/lazydocker/config.yml"
-      ],
+      "fileMatch": ["**/lazydocker/config.yml"],
       "url": "https://www.schemastore.org/lazydocker.json"
     },
     {
       "name": "custom-elements.json",
       "description": "A file format for describing custom elements",
-      "fileMatch": [
-        "custom-elements.json"
-      ],
+      "fileMatch": ["custom-elements.json"],
       "url": "https://raw.githubusercontent.com/webcomponents/custom-elements-manifest/main/schema.json"
     },
     {
       "name": "warp-keysets.json",
       "description": "Warp keyboard shortcut presets",
-      "fileMatch": [
-        "**/.warp/keybindings.yaml"
-      ],
+      "fileMatch": ["**/.warp/keybindings.yaml"],
       "url": "https://www.schemastore.org/warp-keysets.json"
     },
     {
       "name": "warp-themes.json",
       "description": "Warp themes",
-      "fileMatch": [
-        "**/.warp/themes/*.yaml"
-      ],
+      "fileMatch": ["**/.warp/themes/*.yaml"],
       "url": "https://www.schemastore.org/warp-themes.json"
     },
     {
       "name": "warp-workflows.json",
       "description": "Warp workflows",
-      "fileMatch": [
-        "**/.warp/workflows/*.yaml"
-      ],
+      "fileMatch": ["**/.warp/workflows/*.yaml"],
       "url": "https://www.schemastore.org/warp-workflows.json"
     },
     {
       "name": "Goblet",
       "description": "Goblet serverless framework config",
-      "fileMatch": [
-        "**/.goblet/config.json"
-      ],
+      "fileMatch": ["**/.goblet/config.json"],
       "url": "https://raw.githubusercontent.com/goblet/goblet/main/goblet.schema.json"
     },
     {
       "name": "Declarative Automation Bundles",
       "description": "Declarative Automation Bundles config",
-      "fileMatch": [
-        "databricks.yml",
-        "databricks.yaml"
-      ],
+      "fileMatch": ["databricks.yml", "databricks.yaml"],
       "url": "https://github.com/databricks/cli/releases/latest/download/jsonschema.json"
     },
     {
@@ -12192,26 +9992,19 @@
     {
       "name": "Endurica",
       "description": "Endurica Input File",
-      "fileMatch": [
-        "*.ki.json"
-      ],
+      "fileMatch": ["*.ki.json"],
       "url": "https://enduricastorage.blob.core.windows.net/public/endurica-cl-schema.json"
     },
     {
       "name": "TunnelHub",
       "description": "TunnelHub Automation Configuration File",
-      "fileMatch": [
-        "tunnelhub.yml",
-        "tunnelhub.yaml"
-      ],
+      "fileMatch": ["tunnelhub.yml", "tunnelhub.yaml"],
       "url": "https://www.schemastore.org/tunnelhub.json"
     },
     {
       "name": "ty",
       "description": "ty, a fast Python type checker",
-      "fileMatch": [
-        "ty.toml"
-      ],
+      "fileMatch": ["ty.toml"],
       "url": "https://www.schemastore.org/ty.json"
     },
     {
@@ -12249,22 +10042,13 @@
     {
       "name": "Minecraft Custom Main Menu Mod",
       "description": "Minecraft 1.12 Forge mod 'Custom Main Menu' config",
-      "fileMatch": [
-        "mainmenu.yml",
-        "mainmenu.yaml",
-        "mainmenu.json"
-      ],
+      "fileMatch": ["mainmenu.yml", "mainmenu.yaml", "mainmenu.json"],
       "url": "https://www.schemastore.org/minecraft-custom-main-menu-mod.json"
     },
     {
       "name": "rivet.yaml (legacy)",
       "description": "Legacy Rivet game configuration file",
-      "fileMatch": [
-        "rivet.yaml",
-        "rivet.*.yaml",
-        "rivet.toml",
-        "rivet.*.toml"
-      ],
+      "fileMatch": ["rivet.yaml", "rivet.*.yaml", "rivet.toml", "rivet.*.toml"],
       "url": "https://rivet.gg/rivet.schema.json"
     },
     {
@@ -12281,27 +10065,19 @@
     {
       "name": "nixd configuration",
       "description": "Configuration file for nixd",
-      "fileMatch": [
-        ".nixd.json"
-      ],
+      "fileMatch": [".nixd.json"],
       "url": "https://raw.githubusercontent.com/nix-community/nixd/main/nixd/docs/nixd-schema.json"
     },
     {
       "name": "Rudder techniques",
       "description": "Rudder techniques",
-      "fileMatch": [
-        "technique.yml",
-        "technique.ids.yml"
-      ],
+      "fileMatch": ["technique.yml", "technique.ids.yml"],
       "url": "https://www.schemastore.org/rudder-techniques.json"
     },
     {
       "name": "SkyPilot Task JSON",
       "description": "SkyPilot Task JSON to specify a task (resource requirements, setup commands, run commands, file mounts, storage mounts, and so on)",
-      "fileMatch": [
-        "skypilot-task.yml",
-        "skypilot-task.yaml"
-      ],
+      "fileMatch": ["skypilot-task.yml", "skypilot-task.yaml"],
       "url": "https://www.schemastore.org/skypilot-task.json"
     },
     {
@@ -12316,20 +10092,13 @@
     {
       "name": "Subsquid squid manifest",
       "description": "Squid manifest for Subsquid Cloud deployments",
-      "fileMatch": [
-        "squid.yaml",
-        "*.squid.yaml",
-        "squid.yml",
-        "*.squid.yml"
-      ],
+      "fileMatch": ["squid.yaml", "*.squid.yaml", "squid.yml", "*.squid.yml"],
       "url": "https://cdn.subsquid.io/schemas/squid_manifest.json"
     },
     {
       "name": "GitLab Agent for Kubernetes configuration",
       "description": "GitLab Agent for Kubernetes configuration file",
-      "fileMatch": [
-        "**/.gitlab/agents/*/config.yaml"
-      ],
+      "fileMatch": ["**/.gitlab/agents/*/config.yaml"],
       "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/gitlab.agent.agentcfg.ConfigurationFile.jsonschema.bundle.json"
     },
     {
@@ -12341,35 +10110,25 @@
     {
       "name": "GlazeWM settings",
       "description": "GlazeWM settings",
-      "fileMatch": [
-        "**/.glaze-wm/config.yaml",
-        "**/glazewm/config.yaml"
-      ],
+      "fileMatch": ["**/.glaze-wm/config.yaml", "**/glazewm/config.yaml"],
       "url": "https://www.schemastore.org/glazewm.json"
     },
     {
       "name": "CGS Card Game Specification (cgs.json)",
       "description": "Card Game Simulator (CGS) Card Game Specification",
-      "fileMatch": [
-        "cgs.json"
-      ],
+      "fileMatch": ["cgs.json"],
       "url": "https://www.cardgamesimulator.com/schema/cgs.json"
     },
     {
       "name": "Custom Machinery Machine",
       "description": "Custom machinery machine specification (Minecraft mod)",
-      "fileMatch": [
-        "**/data/*/machines/*.json",
-        "**/data/*/machine/*.json"
-      ],
+      "fileMatch": ["**/data/*/machines/*.json", "**/data/*/machine/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_machine.json"
     },
     {
       "name": "Custom Machinery Recipe",
       "description": "Custom machinery recipes specification (Minecraft mod)",
-      "fileMatch": [
-        "**/data/*/recipes/**/*.json"
-      ],
+      "fileMatch": ["**/data/*/recipes/**/*.json"],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     },
     {
@@ -12384,10 +10143,7 @@
     {
       "name": "bioimageio resource description",
       "description": "Bioimage.io resource descriptions may be produced or consumed by bioimage.io-compatible software",
-      "fileMatch": [
-        "bioimageio.yaml",
-        "*.bioimageio.yaml"
-      ],
+      "fileMatch": ["bioimageio.yaml", "*.bioimageio.yaml"],
       "url": "https://bioimage-io.github.io/spec-bioimage-io/bioimageio_schema_latest.json"
     },
     {
@@ -12399,17 +10155,13 @@
     {
       "name": "CWL",
       "description": "The Common Workflow Language Configuration",
-      "fileMatch": [
-        "*.cwl"
-      ],
+      "fileMatch": ["*.cwl"],
       "url": "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.json"
     },
     {
       "name": "shard.yml",
       "description": "Shards configuration file",
-      "fileMatch": [
-        "shard.yml"
-      ],
+      "fileMatch": ["shard.yml"],
       "url": "https://raw.githubusercontent.com/crystal-lang/shards/master/docs/shard.yml.schema.json"
     },
     {
@@ -12428,18 +10180,13 @@
     {
       "name": "Erda Runtime",
       "description": "Erda Runtime Configuration File",
-      "fileMatch": [
-        "dice.yaml",
-        "erda.yml"
-      ],
+      "fileMatch": ["dice.yaml", "erda.yml"],
       "url": "https://raw.githubusercontent.com/erda-project/erda/master/.erda/schemas/dice.yaml.json"
     },
     {
       "name": "KSY",
       "description": "Kaitai Struct format description file",
-      "fileMatch": [
-        "*.ksy"
-      ],
+      "fileMatch": ["*.ksy"],
       "url": "https://raw.githubusercontent.com/kaitai-io/ksy_schema/master/ksy_schema.json"
     },
     {
@@ -12503,45 +10250,31 @@
     {
       "name": "changelogging",
       "description": "changelogging configuration file",
-      "fileMatch": [
-        "**/changelogging.toml"
-      ],
+      "fileMatch": ["**/changelogging.toml"],
       "url": "https://raw.githubusercontent.com/nekitdev/changelogging/main/changelogging.schema.json"
     },
     {
       "name": "Configu .cfgu files",
       "description": "A human-readable format for declaring configurations and their characteristics",
-      "fileMatch": [
-        "*.cfgu.json",
-        "*.cfgu.yaml",
-        "*.cfgu.yml"
-      ],
+      "fileMatch": ["*.cfgu.json", "*.cfgu.yaml", "*.cfgu.yml"],
       "url": "https://raw.githubusercontent.com/configu/configu/main/packages/schema/.cfgu.json"
     },
     {
       "name": "Configu .configu file",
       "description": "An optional configuration file used by the various Configu interfaces to customize its behavior",
-      "fileMatch": [
-        ".configu"
-      ],
+      "fileMatch": [".configu"],
       "url": "https://raw.githubusercontent.com/configu/configu/main/packages/schema/.configu.json"
     },
     {
       "name": "Qt Creator workspace file",
       "description": "Qt Creator project json file",
-      "fileMatch": [
-        "**/.qtcreator/project.json"
-      ],
+      "fileMatch": ["**/.qtcreator/project.json"],
       "url": "https://download.qt.io/official_releases/qtcreator/latest/installer_source/jsonschemas/project.json"
     },
     {
       "name": "mprocs Configuration file",
       "description": "mprocs (https://github.com/pvolok/mprocs) Configuration file using JSON/YAML",
-      "fileMatch": [
-        "mprocs.json",
-        "mprocs.yaml",
-        "mprocs.yml"
-      ],
+      "fileMatch": ["mprocs.json", "mprocs.yaml", "mprocs.yml"],
       "url": "https://www.schemastore.org/mprocs-0.6.4.json"
     },
     {
@@ -12574,10 +10307,7 @@
     {
       "name": "zerops.yml",
       "description": "Zerops build, deploy and run configuration YAML file",
-      "fileMatch": [
-        "zerops.yml",
-        "zerops.yaml"
-      ],
+      "fileMatch": ["zerops.yml", "zerops.yaml"],
       "url": "https://api.app-prg1.zerops.io/api/rest/public/settings/zerops-yml-json-schema.json"
     },
     {
@@ -12594,27 +10324,19 @@
     {
       "name": "Microsoft RulesEngine workflow rules",
       "description": "Microsoft RulesEngine workflow rules definition https://github.com/microsoft/RulesEngine",
-      "fileMatch": [
-        "*.workflow-rules.json",
-        "**/workflow-rules/*.json"
-      ],
+      "fileMatch": ["*.workflow-rules.json", "**/workflow-rules/*.json"],
       "url": "https://raw.githubusercontent.com/microsoft/RulesEngine/main/schema/workflow-schema.json"
     },
     {
       "name": "Microsoft RulesEngine workflow rules list",
       "description": "Microsoft RulesEngine workflow list definition https://github.com/microsoft/RulesEngine",
-      "fileMatch": [
-        "*.workflow-rules-list.json"
-      ],
+      "fileMatch": ["*.workflow-rules-list.json"],
       "url": "https://raw.githubusercontent.com/microsoft/RulesEngine/main/schema/workflow-list-schema.json"
     },
     {
       "name": "spicepod.yaml",
       "description": "Spice.ai OSS Spicepod Manifest file",
-      "fileMatch": [
-        "spicepod.yml",
-        "spicepod.yaml"
-      ],
+      "fileMatch": ["spicepod.yml", "spicepod.yaml"],
       "url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/.schema/spicepod.schema.json"
     },
     {
@@ -12635,11 +10357,7 @@
     {
       "name": "CRS WAF test file",
       "description": "Definition of a test for verifying WAF behavior",
-      "fileMatch": [
-        "*.waft",
-        ".waft.yaml",
-        ".waft.yml"
-      ],
+      "fileMatch": ["*.waft", ".waft.yaml", ".waft.yml"],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.2.0/waf-tests-schema-v2.2.0.json",
       "versions": {
         "2.0.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.0.0/waf-tests-schema-v2.0.0.json",
@@ -12650,11 +10368,7 @@
     {
       "name": "CRS WAF test platform overrides file",
       "description": "Definition of platform specific overrides for WAF tests",
-      "fileMatch": [
-        "*.wafto",
-        ".wafto.yaml",
-        ".wafto.yml"
-      ],
+      "fileMatch": ["*.wafto", ".wafto.yaml", ".wafto.yml"],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.2.0/waf-platform-overrides-schema-v2.2.0.json",
       "versions": {
         "2.0.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.0.0/waf-platform-overrides-schema-v2.0.0.json",
@@ -12680,18 +10394,13 @@
     {
       "name": "Tycho",
       "description": "Tycho.yaml file",
-      "fileMatch": [
-        "**/tycho.yml",
-        "**/tycho.yaml"
-      ],
+      "fileMatch": ["**/tycho.yml", "**/tycho.yaml"],
       "url": "https://deployments.allegrogroup.com/tycho/schema"
     },
     {
       "name": "Elm",
       "description": "elm.json file",
-      "fileMatch": [
-        "elm.json"
-      ],
+      "fileMatch": ["elm.json"],
       "url": "https://www.schemastore.org/elm.json"
     },
     {
@@ -12702,10 +10411,7 @@
     {
       "name": "Cloud Run Spec v1",
       "description": "Specification for Cloud Run Admin API v1",
-      "fileMatch": [
-        "cloud-run-v1.yml",
-        "cloud-run-v1.yaml"
-      ],
+      "fileMatch": ["cloud-run-v1.yml", "cloud-run-v1.yaml"],
       "url": "https://www.schemastore.org/cloud-run-v1.json"
     },
     {
@@ -12717,75 +10423,55 @@
     {
       "name": "Settings for a Cinnamon spice",
       "description": "Settings for a Cinnamon spice",
-      "fileMatch": [
-        "**/*@*/**/settings-schema.json"
-      ],
+      "fileMatch": ["**/*@*/**/settings-schema.json"],
       "url": "https://www.schemastore.org/cinnamon-spice-settings.json"
     },
     {
       "name": "Metadata for a Cinnamon spice",
       "description": "Metadata for a Cinnamon spice",
-      "fileMatch": [
-        "**/*@*/**/metadata.json"
-      ],
+      "fileMatch": ["**/*@*/**/metadata.json"],
       "url": "https://www.schemastore.org/cinnamon-spice-metadata.json"
     },
     {
       "name": "Yandex Workflow Language",
       "description": "YaWL specification file",
-      "fileMatch": [
-        "*.yawl.yaml",
-        "*.yawl.yml"
-      ],
+      "fileMatch": ["*.yawl.yaml", "*.yawl.yml"],
       "url": "https://raw.githubusercontent.com/yandex-cloud/json-schema-store/master/serverless/workflows/yawl.json"
     },
     {
       "name": "Application list for a WinUtil",
       "description": "Application list for a WinUtil",
-      "fileMatch": [
-        "**/*winutil*/config/applications.json"
-      ],
+      "fileMatch": ["**/*winutil*/config/applications.json"],
       "url": "https://www.schemastore.org/winutil-applications.json"
     },
     {
       "name": "Preset list for a \"ChrisTitusTech/winutil\"",
       "description": "Preset list for a WinUtil",
-      "fileMatch": [
-        "**/*winutil*/config/preset.json"
-      ],
+      "fileMatch": ["**/*winutil*/config/preset.json"],
       "url": "https://www.schemastore.org/winutil-presets.json"
     },
     {
       "name": "GitHub Actions typing",
       "description": "Describe types of inputs and outputs for GitHub Actions' actions",
-      "fileMatch": [
-        "action-types.yml",
-        "action-types.yaml"
-      ],
+      "fileMatch": ["action-types.yml", "action-types.yaml"],
       "url": "https://raw.githubusercontent.com/typesafegithub/github-actions-typing/refs/heads/schema-latest/github-actions-typing.schema.json"
     },
     {
       "name": "Tab list for a LinUtil",
       "description": "Tab list for a LinUtil",
-      "fileMatch": [
-        "**/*linutil*/**/tabs.toml"
-      ],
+      "fileMatch": ["**/*linutil*/**/tabs.toml"],
       "url": "https://www.schemastore.org/linutil-tabs.json"
     },
     {
       "name": "Tab data for a LinUtil",
       "description": "Tab data for a LinUtil",
-      "fileMatch": [
-        "**/*linutil*/**/tab_data.toml"
-      ],
+      "fileMatch": ["**/*linutil*/**/tab_data.toml"],
       "url": "https://www.schemastore.org/linutil-tab-data.json"
     },
     {
       "name": "ArchitectFX",
       "description": "Grammar for ArchitectFX's trees",
-      "fileMatch": [
-        "*.jdsl"
-      ],
+      "fileMatch": ["*.jdsl"],
       "url": "https://www.schemastore.org/architectfx.json"
     },
     {
@@ -12815,17 +10501,13 @@
     {
       "name": "ccmod.json",
       "description": "Mod manifset file for the CCLoader mod loader for the game CrossCode",
-      "fileMatch": [
-        "ccmod.json"
-      ],
+      "fileMatch": ["ccmod.json"],
       "url": "https://raw.githubusercontent.com/CCDirectLink/CCModDB/refs/heads/master/ccmod-json-schema.json"
     },
     {
       "name": "moon.yml",
       "description": "Moonrepo project configuration file",
-      "fileMatch": [
-        "moon.yml"
-      ],
+      "fileMatch": ["moon.yml"],
       "url": "https://raw.githubusercontent.com/moonrepo/moon/master/website/static/schemas/project.json"
     },
     {
@@ -12857,27 +10539,19 @@
     {
       "name": "WireMock CLI local service configuration",
       "description": "WireMock CLI and Runner local service config file format",
-      "fileMatch": [
-        "wiremock.yaml"
-      ],
+      "fileMatch": ["wiremock.yaml"],
       "url": "https://static.wiremock.io/schemas/wiremock.yaml-schema.json"
     },
     {
       "name": "WireMock CLI import configuration",
       "description": "WireMock CLI import and record config file format",
-      "fileMatch": [
-        "wiremock-import-config.yaml"
-      ],
+      "fileMatch": ["wiremock-import-config.yaml"],
       "url": "https://static.wiremock.io/schemas/wiremock-import-config.yaml-schema.json"
     },
     {
       "name": "Bitmovin Encoding Template",
       "description": "An encoding workflow from a single configuration template",
-      "fileMatch": [
-        "*.bitmovin.json",
-        "*.bitmovin.yml",
-        "*.bitmovin.yaml"
-      ],
+      "fileMatch": ["*.bitmovin.json", "*.bitmovin.yml", "*.bitmovin.yaml"],
       "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
     },
     {
@@ -12896,41 +10570,31 @@
     {
       "name": "pnpm Workspace (pnpm-workspace.yaml)",
       "description": "Workspace file for pnpm",
-      "fileMatch": [
-        "pnpm-workspace.yaml"
-      ],
+      "fileMatch": ["pnpm-workspace.yaml"],
       "url": "https://www.schemastore.org/pnpm-workspace.json"
     },
     {
       "name": "Chamaleon template",
       "description": "Chamaleon template",
-      "fileMatch": [
-        "template.chamaleon.json"
-      ],
+      "fileMatch": ["template.chamaleon.json"],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/template-schema.json"
     },
     {
       "name": "Chamaleon environment",
       "description": "Chamaleon environment",
-      "fileMatch": [
-        "*.environment.chamaleon.json"
-      ],
+      "fileMatch": ["*.environment.chamaleon.json"],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/environment-schema.json"
     },
     {
       "name": "Chamaleon properties",
       "description": "Chamaleon properties",
-      "fileMatch": [
-        "properties.chamaleon.json"
-      ],
+      "fileMatch": ["properties.chamaleon.json"],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/properties-schema.json"
     },
     {
       "name": "ctfd-setup configuration file",
       "description": "CTFer.io ctfd-setup utility configuration file",
-      "fileMatch": [
-        ".ctfd.yaml"
-      ],
+      "fileMatch": [".ctfd.yaml"],
       "url": "https://www.schemastore.org/ctfd.json"
     },
     {
@@ -12942,10 +10606,7 @@
     {
       "name": "DonateCaseBetterCasino menu",
       "description": "Configuration file for dcbc addon menus",
-      "fileMatch": [
-        "*dcbc.yml",
-        "*dcbc.yaml"
-      ],
+      "fileMatch": ["*dcbc.yml", "*dcbc.yaml"],
       "url": "https://raw.githubusercontent.com/Jodexx/DCBetterCasinoMenuSchema/refs/heads/main/schema.json"
     },
     {
@@ -12960,10 +10621,7 @@
     {
       "name": "gematik health care provider list",
       "description": "A list of health care providers in german telemedicine",
-      "fileMatch": [
-        "**/testdata/hcp/hcp.yml",
-        "**/testdata/hcp/hcp.yaml"
-      ],
+      "fileMatch": ["**/testdata/hcp/hcp.yml", "**/testdata/hcp/hcp.yaml"],
       "url": "https://www.schemastore.org/gematik-test-hcps.json"
     },
     {
@@ -12987,95 +10645,67 @@
     {
       "name": "gematik tiger test environment configuration",
       "description": "A configuration file for the test environment of the gematik Tiger test platform",
-      "fileMatch": [
-        "**/tiger.yml",
-        "**/tiger.yaml"
-      ],
+      "fileMatch": ["**/tiger.yml", "**/tiger.yaml"],
       "url": "https://www.schemastore.org/gematik-tiger.json"
     },
     {
       "name": "Tugboat QA config.yml",
       "description": "Configuration file for Tugboat QA",
-      "fileMatch": [
-        "**/.tugboat/config.yml"
-      ],
+      "fileMatch": ["**/.tugboat/config.yml"],
       "url": "https://raw.githubusercontent.com/TugboatQA/docs/refs/heads/main/static/config-schema.json"
     },
     {
       "name": "C4InterFlow",
       "description": "C4InterFlow Architecture as Code file",
-      "fileMatch": [
-        "**/*.c4interflow.yaml",
-        "**/*.c4interflow.json"
-      ],
+      "fileMatch": ["**/*.c4interflow.yaml", "**/*.c4interflow.json"],
       "url": "https://raw.githubusercontent.com/SlavaVedernikov/C4InterFlow/refs/heads/master/C4InterFlow/schema.json"
     },
     {
       "name": "Wake",
       "description": "Wake - development, testing, and static analysis framework for Solidity",
-      "fileMatch": [
-        "**/*wake.toml",
-        "**/*.wake.toml"
-      ],
+      "fileMatch": ["**/*wake.toml", "**/*.wake.toml"],
       "url": "https://raw.githubusercontent.com/Ackee-Blockchain/wake/refs/heads/main/docs/wake-schema.json"
     },
     {
       "name": "Trident",
       "description": "Trident - Rust-based fuzzing framework for Solana programs to help ship secure code",
-      "fileMatch": [
-        "**/*Trident.toml",
-        "**/*.Trident.toml"
-      ],
+      "fileMatch": ["**/*Trident.toml", "**/*.Trident.toml"],
       "url": "https://raw.githubusercontent.com/Ackee-Blockchain/trident/refs/heads/master/trident-spec.json"
     },
     {
       "name": "Unified Tenant Configuration Management (UTCM) Monitor",
       "description": "Configuration file for the Unified Tenant Configuration Management (UTCM) Monitor",
-      "fileMatch": [
-        "*.utcm-monitor.json"
-      ],
+      "fileMatch": ["*.utcm-monitor.json"],
       "url": "https://www.schemastore.org/utcm-monitor.json"
     },
     {
       "name": "UpCloud CLI (upctl) configuration",
       "description": "Configuration file for the UpCloud CLI (upctl)",
-      "fileMatch": [
-        "**/upctl.yaml"
-      ],
+      "fileMatch": ["**/upctl.yaml"],
       "url": "https://raw.githubusercontent.com/UpCloudLtd/upcloud-cli/refs/heads/main/docs/upctl.schema.json"
     },
     {
       "name": "Restate",
       "description": "Restate Server configuration file",
-      "fileMatch": [
-        "**/restate.toml",
-        "**/restate-server.toml"
-      ],
+      "fileMatch": ["**/restate.toml", "**/restate-server.toml"],
       "url": "https://docs.restate.dev/schemas/restate-server-configuration-schema.json"
     },
     {
       "name": "Telefonistka",
       "description": "Telefonistka - Safe and Controlled GitOps Promotion Across Environments/Failure-Domains",
-      "fileMatch": [
-        "**/telefonistka.yaml"
-      ],
+      "fileMatch": ["**/telefonistka.yaml"],
       "url": "https://raw.githubusercontent.com/commercetools/telefonistka/refs/heads/main/schema/telefonistka.json"
     },
     {
       "name": "version",
       "description": "Project version information",
-      "fileMatch": [
-        ".version.json"
-      ],
+      "fileMatch": [".version.json"],
       "url": "https://raw.githubusercontent.com/ljonesfl/bump/refs/heads/master/version-schema.json"
     },
     {
       "name": "Viash Component Config",
       "description": "Viash component config file",
-      "fileMatch": [
-        "*.vsh.yaml",
-        "*.vsh.yml"
-      ],
+      "fileMatch": ["*.vsh.yaml", "*.vsh.yml"],
       "url": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/latest/config.schema.json",
       "versions": {
         "0.7.5": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/0.7.5/config.schema.json",
@@ -13094,10 +10724,7 @@
     {
       "name": "Viash Package Config",
       "description": "Viash package config file",
-      "fileMatch": [
-        "_viash.yaml",
-        "_viash.yml"
-      ],
+      "fileMatch": ["_viash.yaml", "_viash.yml"],
       "url": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/latest/package.schema.json",
       "versions": {
         "0.7.5": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/0.7.5/package.schema.json",
@@ -13127,9 +10754,7 @@
     {
       "name": "Tyk Gateway - Open Source v5.7+",
       "description": "Tyk Gateway Open Source Configuration File",
-      "fileMatch": [
-        "tyk.conf"
-      ],
+      "fileMatch": ["tyk.conf"],
       "url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/refs/heads/main/JSON/draft-07/schema_tyk.oss.conf"
     },
     {
@@ -13141,9 +10766,7 @@
     {
       "name": "vtcfg",
       "description": "Vector VT System Configuration",
-      "fileMatch": [
-        "*.vtcfg"
-      ],
+      "fileMatch": ["*.vtcfg"],
       "url": "https://www.schemastore.org/vtcfg-v19.0.0.json",
       "versions": {
         "19.0.0": "https://www.schemastore.org/vtcfg-v19.0.0.json"
@@ -13152,9 +10775,7 @@
     {
       "name": "sake",
       "description": "Configuration for Sake, Swift-based utility for managing project commands",
-      "fileMatch": [
-        ".sake.yml"
-      ],
+      "fileMatch": [".sake.yml"],
       "url": "https://www.schemastore.org/sake.json"
     },
     {
@@ -13185,44 +10806,31 @@
     {
       "name": "Google Digital Assetlinks",
       "description": "JSON-encoded statement list in a well-known location on a principal",
-      "fileMatch": [
-        "assetlinks.json"
-      ],
+      "fileMatch": ["assetlinks.json"],
       "url": "https://www.schemastore.org/assetlinks.json"
     },
     {
       "name": "Pylock",
       "description": "PEP 751 lock file",
-      "fileMatch": [
-        "pylock.toml",
-        "pylock.*.toml"
-      ],
+      "fileMatch": ["pylock.toml", "pylock.*.toml"],
       "url": "https://www.schemastore.org/pylock.json"
     },
     {
       "name": "Stylua Config",
       "description": "Stylua configuration",
-      "fileMatch": [
-        ".stylua.toml",
-        "stylua.toml"
-      ],
+      "fileMatch": [".stylua.toml", "stylua.toml"],
       "url": "https://www.schemastore.org/stylua.json"
     },
     {
       "name": "Taplo",
       "description": "Taplo configuration file",
-      "fileMatch": [
-        ".taplo.toml",
-        "taplo.toml"
-      ],
+      "fileMatch": [".taplo.toml", "taplo.toml"],
       "url": "https://www.schemastore.org/taplo.json"
     },
     {
       "name": "Aider",
       "description": "Aider configuration file",
-      "fileMatch": [
-        ".aider.conf.yml"
-      ],
+      "fileMatch": [".aider.conf.yml"],
       "url": "https://www.schemastore.org/aider-0.82.json"
     },
     {
@@ -13258,11 +10866,7 @@
     {
       "name": "tm_devices configuration file",
       "description": "Definition of the configuration file of the tm_devices Python package. Documentation: https://tm-devices.readthedocs.io/stable/configuration/",
-      "fileMatch": [
-        "tm_devices.yml",
-        "tm_devices.yaml",
-        "tm_devices.toml"
-      ],
+      "fileMatch": ["tm_devices.yml", "tm_devices.yaml", "tm_devices.toml"],
       "url": "https://raw.githubusercontent.com/tektronix/tm_devices/main/src/tm_devices/tm_devices_config_schema.json"
     },
     {
@@ -13279,9 +10883,7 @@
     {
       "name": "Power Pages Configuration",
       "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
-      "fileMatch": [
-        "powerpages.config.json"
-      ],
+      "fileMatch": ["powerpages.config.json"],
       "url": "https://www.schemastore.org/powerpages.config.json"
     },
     {
@@ -13298,69 +10900,49 @@
     {
       "name": "Revel Digital Gadget Definition File",
       "description": "Revel Digital gadget definition file. See https://developer.reveldigital.com/gadgets for more information",
-      "fileMatch": [
-        "gadget.yml",
-        "gadget.yaml"
-      ],
+      "fileMatch": ["gadget.yml", "gadget.yaml"],
       "url": "https://www.schemastore.org/gadget-yaml.json"
     },
     {
       "name": "Jujutsu (jj) VCS config",
       "description": "Jujutsu (jj) configuration file",
-      "fileMatch": [
-        "**/.jj/repo/config.toml",
-        "**/jj/config.toml"
-      ],
+      "fileMatch": ["**/.jj/repo/config.toml", "**/jj/config.toml"],
       "url": "https://jj-vcs.github.io/jj/latest/config-schema.json"
     },
     {
       "name": "AWS Copilot Manifest",
       "description": "Manifest YAML files for AWS Copilot services, environments, and pipelines. Documentation: https://aws.github.io/copilot-cli/docs/manifest/overview/",
-      "fileMatch": [
-        "**/copilot/**/manifest.yml"
-      ],
+      "fileMatch": ["**/copilot/**/manifest.yml"],
       "url": "https://sootyowl.github.io/aws-copilot-schemas/copilot-schema.json"
     },
     {
       "name": "Terrateam config",
       "description": "Terrateam configuration file",
-      "fileMatch": [
-        "**/.terrateam/config.yaml",
-        "**/.terrateam/config.yml"
-      ],
+      "fileMatch": ["**/.terrateam/config.yaml", "**/.terrateam/config.yml"],
       "url": "https://raw.githubusercontent.com/terrateamio/terrateam/refs/heads/main/api_schemas/terrat/config-schema.json"
     },
     {
       "name": "Lake configuration file",
       "description": "`lakefile.toml`, the .toml configuration file for Lake, the package manager of the Lean programming language and theorem prover",
-      "fileMatch": [
-        "lakefile.toml"
-      ],
+      "fileMatch": ["lakefile.toml"],
       "url": "https://raw.githubusercontent.com/leanprover/lean4/refs/heads/master/src/lake/schemas/lakefile-toml-schema.json"
     },
     {
       "name": "Zarf Package Configuration",
       "description": "Zarf Packages contain a comprehensive description of system software and all of it's components for declaratively deploying in a disconnected environment",
-      "fileMatch": [
-        "**/zarf.yaml",
-        "**/zarf.yml"
-      ],
+      "fileMatch": ["**/zarf.yaml", "**/zarf.yml"],
       "url": "https://www.schemastore.org/zarf.json"
     },
     {
       "name": "Robust Station Image",
       "description": "Space Station 14 RSI validation",
-      "fileMatch": [
-        "**/*.rsi/meta.json"
-      ],
+      "fileMatch": ["**/*.rsi/meta.json"],
       "url": "https://raw.githubusercontent.com/space-wizards/RobustToolbox/refs/heads/master/Schemas/rsi.json"
     },
     {
       "name": "EUDR IOP Standard Exchange Format (EUDR-X)",
       "description": "structured exchange of data related to the EU Deforestation Regulation (EUDR)",
-      "fileMatch": [
-        "*eudr-x.json"
-      ],
+      "fileMatch": ["*eudr-x.json"],
       "url": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/heads/main/json/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/tags/v1.0.0/json/schema.json",
@@ -13384,12 +10966,7 @@
     {
       "name": "Evolving Resolutive Process notation",
       "description": "For describing contradiction-based processes with storing changes and authors",
-      "fileMatch": [
-        "*.erpn.yml",
-        "*.erpn.yaml",
-        "*.erpn.toml",
-        "*.erpn.json"
-      ],
+      "fileMatch": ["*.erpn.yml", "*.erpn.yaml", "*.erpn.toml", "*.erpn.json"],
       "url": "https://www.schemastore.org/evolving-resolutive-process-notation-1.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/evolving-resolutive-process-notation-1.0.json"
@@ -13441,25 +11018,19 @@
     {
       "name": "git-town.toml",
       "description": "Git Town configuration file",
-      "fileMatch": [
-        "git-town.toml"
-      ],
+      "fileMatch": ["git-town.toml"],
       "url": "https://raw.githubusercontent.com/git-town/git-town/refs/heads/main/docs/git-town.schema.json"
     },
     {
       "name": "Jarl",
       "description": "Configuration for R linter",
-      "fileMatch": [
-        "jarl.toml"
-      ],
+      "fileMatch": ["jarl.toml"],
       "url": "https://github.com/etiennebacher/jarl/releases/latest/download/jarl.schema.json"
     },
     {
       "name": "Zola Configuration",
       "description": "A fast static site generator in a single binary with everything built-in",
-      "fileMatch": [
-        "zola.toml"
-      ],
+      "fileMatch": ["zola.toml"],
       "url": "https://cscnk52.github.io/json-schemas/zola.schema.json"
     },
     {
@@ -13516,25 +11087,19 @@
     {
       "name": "Changepacks",
       "description": "Changepacks are a way to package changes to a project",
-      "fileMatch": [
-        "**/.changepacks/config.json"
-      ],
+      "fileMatch": ["**/.changepacks/config.json"],
       "url": "https://www.schemastore.org/changepacks.json"
     },
     {
       "name": "Devup",
       "description": "JSX Zero-Runtime UI Styling Library",
-      "fileMatch": [
-        "devup.json"
-      ],
+      "fileMatch": ["devup.json"],
       "url": "https://www.schemastore.org/devup.json"
     },
     {
       "name": "Vespertide",
       "description": "Vespertide configuration",
-      "fileMatch": [
-        "**/vespertide.json"
-      ],
+      "fileMatch": ["**/vespertide.json"],
       "url": "https://www.schemastore.org/vespertide.json"
     },
     {
@@ -13560,10 +11125,7 @@
     {
       "name": "openHAB",
       "description": "Configuration files for openHAB",
-      "fileMatch": [
-        "**/conf/yaml/**/*.yml",
-        "**/conf/yaml/**/*.yaml"
-      ],
+      "fileMatch": ["**/conf/yaml/**/*.yml", "**/conf/yaml/**/*.yaml"],
       "url": "https://www.schemastore.org/openhab-5.1.json",
       "versions": {
         "5.1": "https://www.schemastore.org/openhab-5.1.json"
@@ -13572,39 +11134,25 @@
     {
       "name": "unqueryvet",
       "description": "Configuration for unqueryvet - a Go linter for SQL queries",
-      "fileMatch": [
-        ".unqueryvet.yaml",
-        ".unqueryvet.yml"
-      ],
+      "fileMatch": [".unqueryvet.yaml", ".unqueryvet.yml"],
       "url": "https://raw.githubusercontent.com/MirrexOne/unqueryvet/main/schema.json"
     },
     {
       "name": "Bento",
       "description": "Bento stream configuration file",
-      "fileMatch": [
-        "bento.json",
-        "bento.yml",
-        "bento.yaml"
-      ],
+      "fileMatch": ["bento.json", "bento.yml", "bento.yaml"],
       "url": "https://raw.githubusercontent.com/warpstreamlabs/bento/refs/heads/main/resources/schemastore/bento.json"
     },
     {
       "name": "BMML",
       "description": "Business Model Markup Language - a YAML format for describing business models based on Alexander Osterwalder's Business Model Canvas",
-      "fileMatch": [
-        "*.bmml",
-        "*.bmml.yaml",
-        "*.bmml.yml"
-      ],
+      "fileMatch": ["*.bmml", "*.bmml.yaml", "*.bmml.yml"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bmml.json"
     },
     {
       "name": "pgxgen",
       "description": "pgxgen configuration file",
-      "fileMatch": [
-        "pgxgen.yml",
-        "pgxgen.yaml"
-      ],
+      "fileMatch": ["pgxgen.yml", "pgxgen.yaml"],
       "url": "https://raw.githubusercontent.com/tkcrm/pgxgen/refs/heads/master/schemas/pgxgen-schema.json"
     },
     {
@@ -13620,19 +11168,13 @@
     {
       "name": "pitcms",
       "description": "Configuration file for pitcms - a Git-based headless CMS",
-      "fileMatch": [
-        "pitcms.json",
-        "pitcms.jsonc"
-      ],
+      "fileMatch": ["pitcms.json", "pitcms.jsonc"],
       "url": "https://pitcms.net/schema/pitcms.schema.json"
     },
     {
       "name": "Bluebricks blueprint config",
       "description": "Bluebricks config for blueprints",
-      "fileMatch": [
-        "bricks.json",
-        "bricks.yaml"
-      ],
+      "fileMatch": ["bricks.json", "bricks.yaml"],
       "url": "https://api.bluebricks.co/docs/schemas/latest/bricks.schema.json"
     },
     {
@@ -13654,19 +11196,13 @@
     {
       "name": "oxfmt",
       "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem",
-      "fileMatch": [
-        "**/.oxfmtrc.json",
-        "**/.oxfmtrc.jsonc"
-      ],
+      "fileMatch": ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json"
     },
     {
       "name": "oxlint",
       "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack",
-      "fileMatch": [
-        "**/.oxlintrc.json",
-        "**/.oxlintrc.jsonc"
-      ],
+      "fileMatch": ["**/.oxlintrc.json", "**/.oxlintrc.jsonc"],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxlint/configuration_schema.json"
     },
     {
@@ -13683,18 +11219,13 @@
     {
       "name": "Cursor Agent Environment",
       "description": "Cursor cloud agent environment configuration",
-      "fileMatch": [
-        "**/.cursor/environment.json"
-      ],
+      "fileMatch": ["**/.cursor/environment.json"],
       "url": "https://cursor.com/schemas/environment.schema.json"
     },
     {
       "name": "nexus-rpc-gen",
       "description": "nexus-rpc-gen configuration for generating Nexus RPC service stubs",
-      "fileMatch": [
-        "*.nexusrpc.yaml",
-        "*.nexusrpc.yml"
-      ],
+      "fileMatch": ["*.nexusrpc.yaml", "*.nexusrpc.yml"],
       "url": "https://raw.githubusercontent.com/nexus-rpc/nexus-rpc-gen/main/schemas/nexus-rpc-gen.json"
     },
     {
@@ -13709,9 +11240,7 @@
     {
       "name": "AgentCore CLI",
       "description": "Configuration file for Amazon Bedrock AgentCore CLI projects",
-      "fileMatch": [
-        "**/agentcore/agentcore.json"
-      ],
+      "fileMatch": ["**/agentcore/agentcore.json"],
       "url": "https://schema.agentcore.aws.dev/v1/agentcore.json",
       "versions": {
         "1.0": "https://schema.agentcore.aws.dev/v1/agentcore.json"
@@ -13720,36 +11249,25 @@
     {
       "name": "AgentCtl config",
       "description": "agentctl config file (.ai/config.yaml): runtimes, project name, and sync settings for AI coding-agent configuration",
-      "fileMatch": [
-        "**/.ai/config.yaml",
-        "**/.ai/config.yml"
-      ],
+      "fileMatch": ["**/.ai/config.yaml", "**/.ai/config.yml"],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/config.schema.json"
     },
     {
       "name": "AgentCtl MCP",
       "description": "agentctl MCP server declarations (.ai/mcp.yaml): Model Context Protocol servers rendered into each runtime's format",
-      "fileMatch": [
-        "**/.ai/mcp.yaml",
-        "**/.ai/mcp.yml"
-      ],
+      "fileMatch": ["**/.ai/mcp.yaml", "**/.ai/mcp.yml"],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/mcp.schema.json"
     },
     {
       "name": "AgentCtl permissions",
       "description": "agentctl runtime-neutral permissions (.ai/permissions.yaml): filesystem and shell rules using deny-over-allow precedence",
-      "fileMatch": [
-        "**/.ai/permissions.yaml",
-        "**/.ai/permissions.yml"
-      ],
+      "fileMatch": ["**/.ai/permissions.yaml", "**/.ai/permissions.yml"],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/permissions.schema.json"
     },
     {
       "name": "AgentLoopKit",
       "description": "Configuration file for AgentLoopKit, a repo-level engineering loop for coding agents",
-      "fileMatch": [
-        "agentloop.config.json"
-      ],
+      "fileMatch": ["agentloop.config.json"],
       "url": "https://raw.githubusercontent.com/abhiyoheswaran1/AgentLoopKit/main/schema/agentloop.config.schema.json"
     },
     {
@@ -13765,29 +11283,19 @@
     {
       "name": "Qwen Code Settings",
       "description": "Configuration file for Qwen Code",
-      "fileMatch": [
-        "**/.qwen/settings.json"
-      ],
+      "fileMatch": ["**/.qwen/settings.json"],
       "url": "https://www.schemastore.org/qwen-code-settings.json"
     },
     {
       "name": "Raid Profile",
       "description": "Definition for one or more Raid Profiles",
-      "fileMatch": [
-        "*.raid.yaml",
-        "*.raid.yml",
-        "*.raid.json"
-      ],
+      "fileMatch": ["*.raid.yaml", "*.raid.yml", "*.raid.json"],
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-profile.schema.json"
     },
     {
       "name": "Raid Repo Configuration",
       "description": "Definition for a single repository",
-      "fileMatch": [
-        "raid.yaml",
-        "raid.yml",
-        "raid.json"
-      ],
+      "fileMatch": ["raid.yaml", "raid.yml", "raid.json"],
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-repo.schema.json"
     },
     {
@@ -13821,35 +11329,25 @@
     {
       "name": "Envelope Team Definition",
       "description": "Open standard for AI agent team definitions — declare agents, roles, tools, access policies, and pipelines in a single versioned document",
-      "fileMatch": [
-        "*.envelope.json",
-        "team.envelope.json"
-      ],
+      "fileMatch": ["*.envelope.json", "team.envelope.json"],
       "url": "https://schema.openenvelope.org/team/v1.json"
     },
     {
       "name": "Acton",
       "description": "Configuration file for Acton projects",
-      "fileMatch": [
-        "Acton.toml"
-      ],
+      "fileMatch": ["Acton.toml"],
       "url": "https://raw.githubusercontent.com/ton-blockchain/acton/master/crates/acton-config/schemas/acton.schema.json"
     },
     {
       "name": "act3",
       "description": "act3 configuration file",
-      "fileMatch": [
-        "**/act3/act3.yml"
-      ],
+      "fileMatch": ["**/act3/act3.yml"],
       "url": "https://www.schemastore.org/act3.json"
     },
     {
       "name": "memnex",
       "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://memnex.org",
-      "fileMatch": [
-        "*.memnex.json",
-        "meeting-output.json"
-      ],
+      "fileMatch": ["*.memnex.json", "meeting-output.json"],
       "url": "https://memnex.org/schema/v0.2/meeting-output.schema.json",
       "versions": {
         "0.1": "https://memnex.org/schema/v0.1/meeting-output.schema.json",
@@ -13859,107 +11357,79 @@
     {
       "name": "runspec",
       "description": "Interface specification for anything runnable — scripts, apps, and MCP tools",
-      "fileMatch": [
-        "runspec.toml"
-      ],
+      "fileMatch": ["runspec.toml"],
       "url": "https://raw.githubusercontent.com/JasonFinestone/runspec/main/schema/runspec.schema.json"
     },
     {
       "name": "dacier.yml",
       "description": "Dacier configuration file",
-      "fileMatch": [
-        "*.dacier.yml",
-        "*.dacier.yaml"
-      ],
+      "fileMatch": ["*.dacier.yml", "*.dacier.yaml"],
       "url": "https://raw.githubusercontent.com/daciertech/SchedulerStartup/refs/heads/main/.schemas/dacier-schema-vscode.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Project",
       "description": "QTCP project definition",
-      "fileMatch": [
-        "**/qtcp_project.yaml"
-      ],
+      "fileMatch": ["**/qtcp_project.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/project.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Task",
       "description": "Task definition within QTCP project",
-      "fileMatch": [
-        "**/qtcp_tasks/*/task.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/task.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Dataset",
       "description": "Dataset definition within QTCP task",
-      "fileMatch": [
-        "**/qtcp_tasks/*/datasets/*.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/datasets/*.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.dataset.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Schedule",
       "description": "Scheduling definition for QTCP tasks",
-      "fileMatch": [
-        "**/qtcp_tasks/*/schedule.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/schedule.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.schedule.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Data Model",
       "description": "Data model definition for QTCP tasks",
-      "fileMatch": [
-        "**/qtcp_tasks/*/model.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/model.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.model.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Source Selection",
       "description": "Source selection definition for QTCP tasks",
-      "fileMatch": [
-        "**/qtcp_tasks/*/sourceSelection.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/sourceSelection.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.sourceselection.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Transformation Rules",
       "description": "Transformation rules definition for QTCP tasks",
-      "fileMatch": [
-        "**/qtcp_tasks/*/transformationRules.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/transformationRules.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.transformationrules.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Transformation Data Flow",
       "description": "Transformation data flow definition for QTCP tasks",
-      "fileMatch": [
-        "**/qtcp_tasks/*/transformationDataFlows/*.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/*/transformationDataFlows/*.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.transformationdataflow.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - New Task Defaults",
       "description": "Default configurations for creating new QTCP tasks (via the UI)",
-      "fileMatch": [
-        "**/qtcp_tasks/newTaskDefaults.yaml"
-      ],
+      "fileMatch": ["**/qtcp_tasks/newTaskDefaults.yaml"],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/newtaskdefaults.schema.json"
     },
     {
       "name": "QuikRun Configuration",
       "description": "Configuration for QuikRun",
-      "fileMatch": [
-        "quikrun.toml"
-      ],
+      "fileMatch": ["quikrun.toml"],
       "url": "https://www.schemastore.org/quikrun.json"
     },
     {
       "name": "Caido Proxy Configuration",
       "description": "Caido Proxy configuration file",
-      "fileMatch": [
-        "caido.yml",
-        "caido.yaml"
-      ],
+      "fileMatch": ["caido.yml", "caido.yaml"],
       "url": "https://raw.githubusercontent.com/caido/schemas/main/.schemastore/proxy/config.schema.json"
     },
     {
@@ -14000,26 +11470,19 @@
     {
       "name": "Slang Server Configuration",
       "description": "Configuration file for the slang-server SystemVerilog language server. Documentation: https://hudson-trading.github.io/slang-server",
-      "fileMatch": [
-        "**/.slang/server.json",
-        "**/.slang/local/server.json"
-      ],
+      "fileMatch": ["**/.slang/server.json", "**/.slang/local/server.json"],
       "url": "https://raw.githubusercontent.com/hudson-trading/slang-server/refs/heads/main/clients/vscode/resources/config.schema.json"
     },
     {
       "name": "Heloisa Assistant Plugins Marketplace",
       "description": "Validation rules for the Heloísa assistant's plugin catalog",
-      "fileMatch": [
-        "heloisa-marketplace.json"
-      ],
+      "fileMatch": ["heloisa-marketplace.json"],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/heloisa-marketplace.json"
     },
     {
       "name": "OKF Graph",
       "description": "Graph generated for an OKF bundle",
-      "fileMatch": [
-        "okf.json"
-      ],
+      "fileMatch": ["okf.json"],
       "url": "https://www.schemastore.org/okf-0.2.json",
       "versions": {
         "0.1": "https://www.schemastore.org/okf-0.1.json",
@@ -14029,17 +11492,13 @@
     {
       "name": "Claude Code Launch Preview",
       "description": "Configuration for preview servers in Claude Code Desktop",
-      "fileMatch": [
-        "**/.claude/launch.json"
-      ],
+      "fileMatch": ["**/.claude/launch.json"],
       "url": "https://www.schemastore.org/claude-code-launch.json"
     },
     {
       "name": "ArchSmith diagram IR",
       "description": "Intermediate representation consumed by ArchSmith to validate and render architecture diagrams",
-      "fileMatch": [
-        "*.archsmith.json"
-      ],
+      "fileMatch": ["*.archsmith.json"],
       "url": "https://ayeshlk.github.io/archsmith/schema/latest/diagram-schema.json",
       "versions": {
         "0.3.0": "https://ayeshlk.github.io/archsmith/schema/0.3.0/diagram-schema.json"
@@ -14048,28 +11507,19 @@
     {
       "name": "yaml-workflow",
       "description": "Workflow definition for the yaml-workflow engine — params, tasks, steps, imports, and flows",
-      "fileMatch": [
-        "**/*.yaml-workflow.yaml",
-        "**/*.yaml-workflow.yml"
-      ],
+      "fileMatch": ["**/*.yaml-workflow.yaml", "**/*.yaml-workflow.yml"],
       "url": "https://raw.githubusercontent.com/orieg/yaml-workflow/main/schema/workflow-schema.json"
     },
     {
       "name": "servercn",
       "description": "Servercn is the backend component registry for node.js inspired by shadcn/ui",
-      "fileMatch": [
-        "servercn.config.json",
-        "servercn.json"
-      ],
+      "fileMatch": ["servercn.config.json", "servercn.json"],
       "url": "https://www.akkaldhami.com.np/schema/servercn.config.json"
     },
     {
       "name": "hitf-cli-md",
       "description": "hitf-cli translation toolkit    configuration file",
-      "fileMatch": [
-        ".hias-hitf.json",
-        ".hias-hitf.jsonc"
-      ],
+      "fileMatch": [".hias-hitf.json", ".hias-hitf.jsonc"],
       "url": "https://www.schemastore.org/hias-hitf.json"
     }
   ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -3,33 +3,54 @@
   "version": 1,
   "schemas": [
     {
+      "name": "Context Passport",
+      "description": "Tamper-evident record of an AI agent event: what an agent was asked, what it decided, and a SHA-256 chain linking it to the record before it",
+      "fileMatch": [
+        "*.passport.json"
+      ],
+      "url": "https://contextpassport.com/schema/v2.json"
+    },
+    {
       "name": "glslint config",
       "description": "glslint project config and shader-dialect preset (glslint.toml): ecosystem detection, #pragma expansion, shared-library and injected-define declarations",
-      "fileMatch": ["glslint.toml"],
+      "fileMatch": [
+        "glslint.toml"
+      ],
       "url": "https://raw.githubusercontent.com/johncarmack1984/glslint/main/schema/glslint.schema.json"
     },
     {
       "name": "Mermaid config",
       "description": "Configuration for Mermaid diagrams and charts",
-      "fileMatch": ["mermaid.config.json", ".mermaidrc.json", "mermaidrc.json"],
+      "fileMatch": [
+        "mermaid.config.json",
+        ".mermaidrc.json",
+        "mermaidrc.json"
+      ],
       "url": "https://mermaid.js.org/schemas/config.schema.json"
     },
     {
       "name": "Specpin spec file",
       "description": "Specpin business-spec file (.specs/*.spec.json): rules, descriptions, and acceptance criteria pinned to UI elements",
-      "fileMatch": ["**/.specs/*.spec.json"],
+      "fileMatch": [
+        "**/.specs/*.spec.json"
+      ],
       "url": "https://specpin.ohnice.app/schema/v1.json"
     },
     {
       "name": "Burnless SRE config",
       "description": "Burnless sre.yaml — SLOs, error budgets, runbooks, on-call, and dashboards as code",
-      "fileMatch": ["sre.yaml", "sre.yml"],
+      "fileMatch": [
+        "sre.yaml",
+        "sre.yml"
+      ],
       "url": "https://raw.githubusercontent.com/Custos-com/Burnless/main/schema/sre.schema.json"
     },
     {
       "name": "SigmaCV CV",
       "description": "SigmaCV canonical academic-CV object — open, machine-readable CV metadata (publications, positions, education, funding and narrative sections) generated from open research information",
-      "fileMatch": ["**/*.sigmacv.json"],
+      "fileMatch": [
+        "**/*.sigmacv.json"
+      ],
       "url": "https://www.schemastore.org/sigmacv.json"
     },
     {
@@ -67,25 +88,35 @@
     {
       "name": "ReleaseKit",
       "description": "Configuration for ReleaseKit release automation",
-      "fileMatch": ["releasekit.config.json"],
+      "fileMatch": [
+        "releasekit.config.json"
+      ],
       "url": "https://goosewobbler.github.io/releasekit/schema.json"
     },
     {
       "name": "Releasaurus Config",
       "description": "Configuration file for Releasaurus",
-      "fileMatch": ["releasaurus.toml"],
+      "fileMatch": [
+        "releasaurus.toml"
+      ],
       "url": "https://raw.githubusercontent.com/robgonnella/releasaurus/refs/heads/main/schema/schema.json"
     },
     {
       "name": "Bacon config",
       "description": "Bacon configuration file",
-      "fileMatch": ["bacon.toml", "**/bacon/prefs.toml"],
+      "fileMatch": [
+        "bacon.toml",
+        "**/bacon/prefs.toml"
+      ],
       "url": "https://dystroy.org/bacon/.bacon.schema.json"
     },
     {
       "name": "Upsun config",
       "description": "Upsun configuration file",
-      "fileMatch": ["**/.upsun/config.yml", "**/.upsun/config.yaml"],
+      "fileMatch": [
+        "**/.upsun/config.yml",
+        "**/.upsun/config.yaml"
+      ],
       "url": "https://meta.upsun.com/schema/upsun"
     },
     {
@@ -103,19 +134,27 @@
     {
       "name": "Platform.sh routes",
       "description": "Platform.sh routes configuration file",
-      "fileMatch": ["**/.platform/routes.yml", "**/.platform/routes.yaml"],
+      "fileMatch": [
+        "**/.platform/routes.yml",
+        "**/.platform/routes.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/platformsh.routes.json"
     },
     {
       "name": "Platform.sh services",
       "description": "Platform.sh services configuration file",
-      "fileMatch": ["**/.platform/services.yml", "**/.platform/services.yaml"],
+      "fileMatch": [
+        "**/.platform/services.yml",
+        "**/.platform/services.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/platformsh/platformify/refs/heads/main/validator/schema/platformsh.services.json"
     },
     {
       "name": "1Password SSH Agent Config",
       "description": "Configuration file for the 1Password SSH agent",
-      "fileMatch": ["**/1password/ssh/agent.toml"],
+      "fileMatch": [
+        "**/1password/ssh/agent.toml"
+      ],
       "url": "https://developer.1password.com/schema/ssh-agent-config.json"
     },
     {
@@ -131,7 +170,9 @@
     {
       "name": "Application Accelerator",
       "description": "Application Accelerator for VMware Tanzu",
-      "fileMatch": ["accelerator.yaml"],
+      "fileMatch": [
+        "accelerator.yaml"
+      ],
       "url": "https://www.schemastore.org/accelerator.json"
     },
     {
@@ -147,13 +188,18 @@
     {
       "name": "amplify.yml",
       "description": "AWS Amplify Console build settings file",
-      "fileMatch": ["amplify.yml", "amplify.yaml"],
+      "fileMatch": [
+        "amplify.yml",
+        "amplify.yaml"
+      ],
       "url": "https://www.schemastore.org/amplify.json"
     },
     {
       "name": "Applicant Profile Protocol",
       "description": "Structured JSON format for professional profiles, resumes, and CVs with skills, experience, education, and certifications",
-      "fileMatch": ["*.app-profile.json"],
+      "fileMatch": [
+        "*.app-profile.json"
+      ],
       "url": "https://app-protocol.org/schema/app-1.0.json"
     },
     {
@@ -175,7 +221,9 @@
     {
       "name": ".NET Aspire 8.0 Manifest",
       "description": "Manifest generated by .NET Aspire AppHosts to support deployment automation",
-      "fileMatch": ["aspire-manifest.json"],
+      "fileMatch": [
+        "aspire-manifest.json"
+      ],
       "url": "https://www.schemastore.org/aspire-8.0.json",
       "versions": {
         "8.0": "https://www.schemastore.org/aspire-8.0.json"
@@ -184,7 +232,13 @@
     {
       "name": "AnyWork Automation Configuration",
       "description": "AnyWork Automation Configuration used to configure automation scripts on AnyWork",
-      "fileMatch": [".awc.yaml", ".awc.yml", ".awc.json", ".awc.jsonc", ".awc"],
+      "fileMatch": [
+        ".awc.yaml",
+        ".awc.yml",
+        ".awc.json",
+        ".awc.jsonc",
+        ".awc"
+      ],
       "url": "https://www.schemastore.org/anywork-ac-1.1.json",
       "versions": {
         "1.1": "https://www.schemastore.org/anywork-ac-1.1.json",
@@ -194,37 +248,50 @@
     {
       "name": "@factorial/drupal-breakpoints-css",
       "description": "@factorial/drupal-breakpoints-css config file",
-      "fileMatch": ["breakpoints.config.yml"],
+      "fileMatch": [
+        "breakpoints.config.yml"
+      ],
       "url": "https://www.schemastore.org/factorial-drupal-breakpoints-css-0.2.0.json"
     },
     {
       "name": ".adonisrc.json",
       "description": "AdonisJS configuration file",
-      "fileMatch": [".adonisrc.json"],
+      "fileMatch": [
+        ".adonisrc.json"
+      ],
       "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
     },
     {
       "name": "aerleon.yml",
       "description": "Aerleon configuration file",
-      "fileMatch": ["aerleon.yml"],
+      "fileMatch": [
+        "aerleon.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-config.schema.json"
     },
     {
       "name": "Aerleon Network & Service Definitions",
       "description": "Aerleon network & service definition file",
-      "fileMatch": ["**/def/**/*.yaml"],
+      "fileMatch": [
+        "**/def/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-definitions.schema.json"
     },
     {
       "name": "Aerleon Policy",
       "description": "Aerleon policy file",
-      "fileMatch": ["**/policies/**/*.yaml"],
+      "fileMatch": [
+        "**/policies/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-policies.schema.json"
     },
     {
       "name": ".agripparc.json",
       "description": "the Agrippa config file",
-      "fileMatch": [".agripparc.json", "agripparc.json"],
+      "fileMatch": [
+        ".agripparc.json",
+        "agripparc.json"
+      ],
       "url": "https://www.schemastore.org/agripparc-1.4.json",
       "versions": {
         "1.2": "https://www.schemastore.org/agripparc-1.2.json",
@@ -235,13 +302,18 @@
     {
       "name": "Air",
       "description": "R formatter and language server",
-      "fileMatch": ["air.toml", ".air.toml"],
+      "fileMatch": [
+        "air.toml",
+        ".air.toml"
+      ],
       "url": "https://github.com/posit-dev/air/releases/latest/download/air.schema.json"
     },
     {
       "name": ".aiproj.json",
       "description": "Settings for project analysis by the Application Inspector",
-      "fileMatch": [".aiproj.json"],
+      "fileMatch": [
+        ".aiproj.json"
+      ],
       "url": "https://www.schemastore.org/aiproj-1.11.json",
       "versions": {
         "1.0": "https://www.schemastore.org/aiproj-1.0.json",
@@ -261,13 +333,17 @@
     {
       "name": "abtop",
       "description": "abtop configuration file",
-      "fileMatch": ["**/abtop/config.toml"],
+      "fileMatch": [
+        "**/abtop/config.toml"
+      ],
       "url": "https://www.schemastore.org/abtop.json"
     },
     {
       "name": "ABCInventoryModuleData",
       "description": "ABCInventoryModuleData defining the structure of ABCInventoryModuleData including Principal Data, inventory, and transaction data in ABC-Plan's Inventory Management Module",
-      "fileMatch": ["abc-inventory-module-data-*.json"],
+      "fileMatch": [
+        "abc-inventory-module-data-*.json"
+      ],
       "url": "https://www.schemastore.org/abc-inventory-module-data-5.4.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-inventory-module-data-1.0.0.json",
@@ -283,7 +359,9 @@
     {
       "name": "ABCClinicalDemandForecast",
       "description": "ABCClinicalDemandForecast defining the structure of clinical trial demand forecasting data in ABC-Plan",
-      "fileMatch": ["abc-clinical-demand-forecast-*.json"],
+      "fileMatch": [
+        "abc-clinical-demand-forecast-*.json"
+      ],
       "url": "https://www.schemastore.org/abc-clinical-demand-forecast-5.1.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-clinical-demand-forecast-1.0.0.json",
@@ -297,7 +375,9 @@
     {
       "name": "ABCSupplyPlan",
       "description": "ABCSupplyPlan representing all the state for performing inventory optimization and expiry analysis in ABC-Plan MasterPlanner",
-      "fileMatch": ["abc-supply-plan-*.json"],
+      "fileMatch": [
+        "abc-supply-plan-*.json"
+      ],
       "url": "https://www.schemastore.org/abc-supply-plan-14.1.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/abc-supply-plan-1.0.0.json",
@@ -325,55 +405,78 @@
     {
       "name": "ACP Attempts",
       "description": "AI Context Protocol debug session tracking file",
-      "fileMatch": ["**/.acp/acp.attempts.json", "acp.attempts.json"],
+      "fileMatch": [
+        "**/.acp/acp.attempts.json",
+        "acp.attempts.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/attempts.schema.json"
     },
     {
       "name": "ACP Cache File",
       "description": "AI Context Protocol cache file format for storing indexed codebase metadata",
-      "fileMatch": [".acp.cache.json"],
+      "fileMatch": [
+        ".acp.cache.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/cache.schema.json"
     },
     {
       "name": "ACP Configuration File",
       "description": "AI Context Protocol configuration file for project-level settings",
-      "fileMatch": [".acp.config.json"],
+      "fileMatch": [
+        ".acp.config.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/config.schema.json"
     },
     {
       "name": "ACP Primer",
       "description": "AI Context Protocol primer definition for AI context bootstrapping",
-      "fileMatch": ["primer.json", "*.primer.json", "primer.defaults.json"],
+      "fileMatch": [
+        "primer.json",
+        "*.primer.json",
+        "primer.defaults.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/primer.schema.json"
     },
     {
       "name": "ACP Sync",
       "description": "AI Context Protocol tool synchronization configuration",
-      "fileMatch": ["**/.acp/acp.sync.json", "acp.sync.json"],
+      "fileMatch": [
+        "**/.acp/acp.sync.json",
+        "acp.sync.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/sync.schema.json"
     },
     {
       "name": "ACP Variables File",
       "description": "AI Context Protocol variables file for reusable context variables",
-      "fileMatch": [".acp.vars.json"],
+      "fileMatch": [
+        ".acp.vars.json"
+      ],
       "url": "https://acp-protocol.dev/schemas/v1/vars.schema.json"
     },
     {
       "name": "actionlint",
       "description": "Configuration file for actionlint",
-      "fileMatch": ["actionlint.yaml", "actionlint.yml"],
+      "fileMatch": [
+        "actionlint.yaml",
+        "actionlint.yml"
+      ],
       "url": "https://www.schemastore.org/actionlint.json"
     },
     {
       "name": "AI Harness config",
       "description": "Repository bootstrap-intent marker for ai-harness, including context directory, resolved AI coding targets, and posture",
-      "fileMatch": [".aih-config.json"],
+      "fileMatch": [
+        ".aih-config.json"
+      ],
       "url": "https://www.schemastore.org/aih-config.json"
     },
     {
       "name": "AI Harness org policy",
       "description": "Repository governance policy for ai-harness command guardrails, MCP policy, and trust gates",
-      "fileMatch": ["aih-org-policy.json"],
+      "fileMatch": [
+        "aih-org-policy.json"
+      ],
       "url": "https://www.schemastore.org/aih-org-policy.json"
     },
     {
@@ -410,19 +513,26 @@
     {
       "name": "angular.json",
       "description": "Angular configuration file",
-      "fileMatch": ["angular.json"],
+      "fileMatch": [
+        "angular.json"
+      ],
       "url": "https://raw.githubusercontent.com/angular/angular-cli/master/packages/angular/cli/lib/config/workspace-schema.json"
     },
     {
       "name": ".angular-cli.json",
       "description": "Angular CLI configuration file",
-      "fileMatch": [".angular-cli.json", "angular-cli.json"],
+      "fileMatch": [
+        ".angular-cli.json",
+        "angular-cli.json"
+      ],
       "url": "https://raw.githubusercontent.com/angular/angular-cli/v10.1.6/packages/angular/cli/lib/config/schema.json"
     },
     {
       "name": "apple-app-site-association",
       "description": "Apple Universal Link, App Site Association",
-      "fileMatch": ["apple-app-site-association"],
+      "fileMatch": [
+        "apple-app-site-association"
+      ],
       "url": "https://www.schemastore.org/apple-app-site-association.json"
     },
     {
@@ -441,55 +551,78 @@
     {
       "name": "app-definition.yaml",
       "description": "Appsemble app definition",
-      "fileMatch": ["app-definition.yaml"],
+      "fileMatch": [
+        "app-definition.yaml"
+      ],
       "url": "https://appsemble.app/api.json#/components/schemas/AppDefinition"
     },
     {
       "name": ".appsemblerc.yaml",
       "description": "Appsemble RC file",
-      "fileMatch": [".appsemblerc.yaml"],
+      "fileMatch": [
+        ".appsemblerc.yaml"
+      ],
       "url": "https://gitlab.com/appsemble/appsemble/-/raw/HEAD/packages/cli/assets/appsemblerc.schema.json"
     },
     {
       "name": "appsscript.json",
       "description": "Google Apps Script manifest file",
-      "fileMatch": ["appsscript.json"],
+      "fileMatch": [
+        "appsscript.json"
+      ],
       "url": "https://www.schemastore.org/appsscript.json"
     },
     {
       "name": "appsettings.json",
       "description": "ASP.NET Core's configuration file",
-      "fileMatch": ["appsettings.json", "appsettings.*.json"],
+      "fileMatch": [
+        "appsettings.json",
+        "appsettings.*.json"
+      ],
       "url": "https://www.schemastore.org/appsettings.json"
     },
     {
       "name": "appveyor.yml",
       "description": "AppVeyor CI configuration file",
-      "fileMatch": ["appveyor.yml"],
+      "fileMatch": [
+        "appveyor.yml"
+      ],
       "url": "https://www.schemastore.org/appveyor.json"
     },
     {
       "name": "appsettings.StormPetrel.json",
       "description": "Scand.StormPetrel.Generator NuGet package appsettings.StormPetrel.json file",
-      "fileMatch": ["appsettings.StormPetrel.json"],
+      "fileMatch": [
+        "appsettings.StormPetrel.json"
+      ],
       "url": "https://raw.githubusercontent.com/Scandltd/storm-petrel/main/generator/assets/appsettings.StormPetrel.Schema.json"
     },
     {
       "name": "aqua.yaml",
       "description": "aqua configuration file",
-      "fileMatch": [".aqua.yaml", ".aqua.yml", "aqua.yaml", "aqua.yml"],
+      "fileMatch": [
+        ".aqua.yaml",
+        ".aqua.yml",
+        "aqua.yaml",
+        "aqua.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json"
     },
     {
       "name": "aqua-generate-registry.yaml",
       "description": "aqua generate registry configuration file",
-      "fileMatch": ["aqua-generate-registry.yaml"],
+      "fileMatch": [
+        "aqua-generate-registry.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-generate-registry.json"
     },
     {
       "name": "aqua-policy.yaml",
       "description": "aqua policy configuration file",
-      "fileMatch": [".aqua-policy.yaml", "aqua-policy.yaml"],
+      "fileMatch": [
+        ".aqua-policy.yaml",
+        "aqua-policy.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/policy.json"
     },
     {
@@ -501,13 +634,19 @@
     {
       "name": "arazzo.json",
       "description": "An OpenAPI Arazzo document",
-      "fileMatch": ["arazzo.json", "arazzo.yml", "arazzo.yaml"],
+      "fileMatch": [
+        "arazzo.json",
+        "arazzo.yml",
+        "arazzo.yaml"
+      ],
       "url": "https://www.schemastore.org/openapi-arazzo-1.X.json"
     },
     {
       "name": "arb.json",
       "description": "Application Resource Bundle",
-      "fileMatch": ["arb.json"],
+      "fileMatch": [
+        "arb.json"
+      ],
       "url": "https://raw.githubusercontent.com/google/app-resource-bundle/main/schema/arb.json"
     },
     {
@@ -524,31 +663,43 @@
     {
       "name": "arc.json",
       "description": "A OpenJS Architect",
-      "fileMatch": ["arc.json", "arc.yml", "arc.yaml"],
+      "fileMatch": [
+        "arc.json",
+        "arc.yml",
+        "arc.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/architect/parser/v2.3.0/arc-schema.json"
     },
     {
       "name": "Archival editor configuration",
       "description": "Per-object editor configuration for an archival site",
-      "fileMatch": ["archival_editor.toml"],
+      "fileMatch": [
+        "archival_editor.toml"
+      ],
       "url": "https://archival.dev/schemas/archival_editor.schema.json"
     },
     {
       "name": "Archival object definitions",
       "description": "Object definitions for an archival site",
-      "fileMatch": ["archival_objects.toml"],
+      "fileMatch": [
+        "archival_objects.toml"
+      ],
       "url": "https://archival.dev/schemas/objects.schema.json"
     },
     {
       "name": "Archival site configuration",
       "description": "Site configuration for an archival site",
-      "fileMatch": ["archival.toml"],
+      "fileMatch": [
+        "archival.toml"
+      ],
       "url": "https://archival.dev/schemas/manifest.schema.json"
     },
     {
       "name": "Archival template definition",
       "description": "Metadata describing an archival site template",
-      "fileMatch": ["archival_template.toml"],
+      "fileMatch": [
+        "archival_template.toml"
+      ],
       "url": "https://archival.dev/schemas/archival_template.schema.json"
     },
     {
@@ -569,31 +720,43 @@
     {
       "name": "artifacthub-repo.yml",
       "description": "Artifact Hub repository metadata file",
-      "fileMatch": ["artifacthub-repo.yml"],
+      "fileMatch": [
+        "artifacthub-repo.yml"
+      ],
       "url": "https://www.schemastore.org/artifacthub-repo.json"
     },
     {
       "name": "Are The Types Wrong?",
       "description": "Configuration for the Are The Types Wrong? CLI",
-      "fileMatch": [".attw.json"],
+      "fileMatch": [
+        ".attw.json"
+      ],
       "url": "https://www.schemastore.org/attw.json"
     },
     {
       "name": "asm-lsp",
       "description": "Configuration file for asm-lsp",
-      "fileMatch": [".asm-lsp.toml", "asm-lsp.toml"],
+      "fileMatch": [
+        ".asm-lsp.toml",
+        "asm-lsp.toml"
+      ],
       "url": "https://raw.githubusercontent.com/bergercookie/asm-lsp/master/asm-lsp_config_schema.json"
     },
     {
       "name": "AssemblyScript",
       "description": "AssemblyScript is TypeScript-like language that is compiled to WebAssembly (wasm)",
-      "fileMatch": ["asconfig.json"],
+      "fileMatch": [
+        "asconfig.json"
+      ],
       "url": "https://www.schemastore.org/asconfig-schema.json"
     },
     {
       "name": "ast-grep sgconfig.yml",
       "description": "ast-grep project config",
-      "fileMatch": ["sgconfig.yml", "sgconfig.yaml"],
+      "fileMatch": [
+        "sgconfig.yml",
+        "sgconfig.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/project.json"
     },
     {
@@ -614,13 +777,19 @@
     {
       "name": "AsyncAPI",
       "description": "AsyncAPI documentation files",
-      "fileMatch": ["*asyncapi*.json", "*asyncapi*.yml", "*asyncapi*.yaml"],
+      "fileMatch": [
+        "*asyncapi*.json",
+        "*asyncapi*.yml",
+        "*asyncapi*.yaml"
+      ],
       "url": "https://www.asyncapi.com/schema-store/all.schema-store.json"
     },
     {
       "name": "AsyncAPI Tool File",
       "description": "A validating AsyncAPI tool files",
-      "fileMatch": [".asyncapi-tool"],
+      "fileMatch": [
+        ".asyncapi-tool"
+      ],
       "url": "https://raw.githubusercontent.com/asyncapi/website/master/scripts/tools/tools-schema.json"
     },
     {
@@ -632,7 +801,10 @@
     {
       "name": "Aurora Agile Meta-Framework",
       "description": "Yaml for Aurora Agile Meta-Framework",
-      "fileMatch": ["*.aurora.yaml", "*.aurora.yml"],
+      "fileMatch": [
+        "*.aurora.yaml",
+        "*.aurora.yml"
+      ],
       "url": "https://www.schemastore.org/aurora-2.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/aurora-1.0.json",
@@ -645,7 +817,9 @@
     {
       "name": "Avro Avsc",
       "description": "Avro Avsc file",
-      "fileMatch": ["*.avsc"],
+      "fileMatch": [
+        "*.avsc"
+      ],
       "url": "https://www.schemastore.org/avro-avsc.json"
     },
     {
@@ -661,13 +835,18 @@
     {
       "name": "AWS AppConfig Feature Flags-v1",
       "description": "AWS CDK AppConfig Feature Flags",
-      "fileMatch": ["*.appConfig.featureFlags.json"],
+      "fileMatch": [
+        "*.appConfig.featureFlags.json"
+      ],
       "url": "https://www.schemastore.org/aws-cdk-appconfig-featureflags-1.0.0.json"
     },
     {
       "name": "azure.yaml",
       "description": "Azure Developer CLI (azd) configuration file",
-      "fileMatch": ["azure.yaml", "azure.yml"],
+      "fileMatch": [
+        "azure.yaml",
+        "azure.yml"
+      ],
       "url": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json",
       "versions": {
         "alpha": "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json",
@@ -677,13 +856,17 @@
     {
       "name": "Azure Container App template for defining an immutable revision",
       "description": "Azure Container App template for defining an immutable revision",
-      "fileMatch": ["*.containerapp-template.json"],
+      "fileMatch": [
+        "*.containerapp-template.json"
+      ],
       "url": "https://www.schemastore.org/azure-containerapp-template.json"
     },
     {
       "name": "Azure Device Update for IoT Hub import manifest",
       "description": "Azure Device Update for IoT Hub import manifest",
-      "fileMatch": ["*.importmanifest.json"],
+      "fileMatch": [
+        "*.importmanifest.json"
+      ],
       "url": "https://www.schemastore.org/azure-deviceupdate-import-manifest-5.0.json",
       "versions": {
         "4.0": "https://www.schemastore.org/azure-deviceupdate-import-manifest-4.0.json",
@@ -693,7 +876,9 @@
     {
       "name": "Azure Device Update for IoT Hub update manifest",
       "description": "Azure Device Update for IoT Hub update manifest",
-      "fileMatch": ["*.updatemanifest.json"],
+      "fileMatch": [
+        "*.updatemanifest.json"
+      ],
       "url": "https://www.schemastore.org/azure-deviceupdate-update-manifest-5.json",
       "versions": {
         "4": "https://www.schemastore.org/azure-deviceupdate-update-manifest-4.json",
@@ -754,7 +939,9 @@
     {
       "name": "Azure Landing Zones Library metadata",
       "description": "Azure Landing Zones Library metadata",
-      "fileMatch": ["alz_library_metadata.json"],
+      "fileMatch": [
+        "alz_library_metadata.json"
+      ],
       "url": "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/main/schemas/library_metadata.json"
     },
     {
@@ -800,19 +987,26 @@
     {
       "name": "Barba-CV",
       "description": "Deterministic CV / resume data format",
-      "fileMatch": ["barba-cv.json"],
+      "fileMatch": [
+        "barba-cv.json"
+      ],
       "url": "https://raw.githubusercontent.com/Eurobotics-Association/barba-cv/main/schema/barba-cv.schema.json"
     },
     {
       "name": "Biome Formatter Config",
       "description": "Configuration file for the Biome formatter",
-      "fileMatch": ["biome.json", "biome.jsonc"],
+      "fileMatch": [
+        "biome.json",
+        "biome.jsonc"
+      ],
       "url": "https://biomejs.dev/schemas/latest/schema.json"
     },
     {
       "name": "bottom configuration",
       "description": "Configuration file for bottom",
-      "fileMatch": ["bottom.toml"],
+      "fileMatch": [
+        "bottom.toml"
+      ],
       "url": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/v0.10/bottom.json",
       "versions": {
         "nightly": "https://raw.githubusercontent.com/ClementTsang/bottom/main/schema/nightly/bottom.json",
@@ -842,43 +1036,57 @@
     {
       "name": "buf.yaml",
       "description": "buf.yaml is used to define a module. It's the primary configuration file, and is responsible for the module's name, dependencies, and lint and breaking configuration",
-      "fileMatch": ["buf.yaml"],
+      "fileMatch": [
+        "buf.yaml"
+      ],
       "url": "https://www.schemastore.org/buf.json"
     },
     {
       "name": "buf.gen.yaml",
       "description": "buf.gen.yaml is a configuration file used by the buf generate command to generate integration code for the languages of your choice",
-      "fileMatch": ["buf.gen.yaml"],
+      "fileMatch": [
+        "buf.gen.yaml"
+      ],
       "url": "https://www.schemastore.org/buf.gen.json"
     },
     {
       "name": "buf.lock",
       "description": "buf.lock is a dependency lock file generated by buf via 'buf dep update'. It represents a single, reproducible build of the workspace's external dependencies and should never be hand-edited",
-      "fileMatch": ["buf.lock"],
+      "fileMatch": [
+        "buf.lock"
+      ],
       "url": "https://www.schemastore.org/buf.lock.json"
     },
     {
       "name": "buf.plugin.yaml",
       "description": "A `buf.plugin.yaml` file captures metadata about the plugin. It includes mandatory and optional fields that are displayed on the individual plugin page and the BSR plugin. Documentation: https://buf.build/plugins",
-      "fileMatch": ["buf.plugin.yaml"],
+      "fileMatch": [
+        "buf.plugin.yaml"
+      ],
       "url": "https://www.schemastore.org/buf.plugin.json"
     },
     {
       "name": "buf.policy.yaml",
       "description": "buf.policy.yaml defines a policy containing lint, breaking change detection, and plugin configuration that can be shared across BSR modules",
-      "fileMatch": ["buf.policy.yaml"],
+      "fileMatch": [
+        "buf.policy.yaml"
+      ],
       "url": "https://www.schemastore.org/buf.policy.json"
     },
     {
       "name": "buf.work.yaml",
       "description": "buf.work.yaml is used to define a workspace, which is an advanced local development feature. Workspaces make it possible to consolidate one or more modules into a single buildable unit. They also allow users to run buf operations across multiple modules with a single execution (such as buf lint)",
-      "fileMatch": ["buf.work.yaml"],
+      "fileMatch": [
+        "buf.work.yaml"
+      ],
       "url": "https://www.schemastore.org/buf.work.json"
     },
     {
       "name": "cargo-mutants-config.yaml",
       "description": "cargo-mutants configuration file",
-      "fileMatch": ["**/.cargo/mutants.toml"],
+      "fileMatch": [
+        "**/.cargo/mutants.toml"
+      ],
       "url": "https://www.schemastore.org/cargo-mutants-config.json"
     },
     {
@@ -890,19 +1098,29 @@
     {
       "name": "Cloud.gov Workshop Configuration",
       "description": "Configuration for IaC managed resources in Cloud.gov Workshop",
-      "fileMatch": ["cg-workshop.yml", "**/cg-workshop/*.yml"],
+      "fileMatch": [
+        "cg-workshop.yml",
+        "**/cg-workshop/*.yml"
+      ],
       "url": "https://workshop.cloud.gov/workshop/workshop-schemas/-/raw/main/cg-workshop.schema.json"
     },
     {
       "name": "cmdx.yaml",
       "description": "cmdx configuration file",
-      "fileMatch": [".cmdx.yaml", ".cmdx.yml", "cmdx.yaml", "cmdx.yml"],
+      "fileMatch": [
+        ".cmdx.yaml",
+        ".cmdx.yml",
+        "cmdx.yaml",
+        "cmdx.yml"
+      ],
       "url": "https://raw.githubusercontent.com/suzuki-shunsuke/cmdx/refs/heads/main/json-schema/cmdx.json"
     },
     {
       "name": "CodeRabbit",
       "description": "Supercharge your entire team with AI-driven contextual feedback & smart chat",
-      "fileMatch": [".coderabbit.yaml"],
+      "fileMatch": [
+        ".coderabbit.yaml"
+      ],
       "url": "https://coderabbit.ai/integrations/schema.v2.json"
     },
     {
@@ -1071,67 +1289,93 @@
     {
       "name": "Lando (landofile)",
       "description": "The configuration file for a Lando app. Documentation: https://github.com/lando-community/lando-spec",
-      "fileMatch": [".lando.yml", ".lando.*.yml"],
+      "fileMatch": [
+        ".lando.yml",
+        ".lando.*.yml"
+      ],
       "url": "https://lando-community.github.io/lando-spec/landofile-spec.json"
     },
     {
       "name": "latexindent configuration",
       "description": "Configuration file for latexindent",
-      "fileMatch": ["latexindent.yaml", ".latexindent.yaml"],
+      "fileMatch": [
+        "latexindent.yaml",
+        ".latexindent.yaml"
+      ],
       "url": "https://github.com/cmhughes/latexindent.pl/raw/main/documentation/latexindent-yaml-schema.json"
     },
     {
       "name": "Lobe AI Agent",
       "description": "Lobe Agents is an AI agent for LobeChat",
-      "fileMatch": ["lobe-agent.json"],
+      "fileMatch": [
+        "lobe-agent.json"
+      ],
       "url": "https://chat-agents.lobehub.com/schema/lobeAgentSchema_v1.json"
     },
     {
       "name": "Loki",
       "description": "Like Prometheus, but for logs",
-      "fileMatch": ["loki.yml", "loki.yaml"],
+      "fileMatch": [
+        "loki.yml",
+        "loki.yaml"
+      ],
       "url": "https://www.schemastore.org/loki.json"
     },
     {
       "name": "lsd config",
       "description": "Configuration for lsd, the next-generation ls command",
-      "fileMatch": ["**/.config/lsd/config.yaml"],
+      "fileMatch": [
+        "**/.config/lsd/config.yaml"
+      ],
       "url": "https://www.schemastore.org/lsd-config.json"
     },
     {
       "name": "lsd colors",
       "description": "Color theme configuration for lsd",
-      "fileMatch": ["**/.config/lsd/colors.yaml"],
+      "fileMatch": [
+        "**/.config/lsd/colors.yaml"
+      ],
       "url": "https://www.schemastore.org/lsd-colors.json"
     },
     {
       "name": "lsd icons",
       "description": "Icon theme configuration for lsd",
-      "fileMatch": ["**/.config/lsd/icons.yaml"],
+      "fileMatch": [
+        "**/.config/lsd/icons.yaml"
+      ],
       "url": "https://www.schemastore.org/lsd-icons.json"
     },
     {
       "name": "Azure Pipelines",
       "description": "Azure Pipelines YAML pipelines definition",
-      "fileMatch": ["azure-pipelines.yml", "azure-pipelines.yaml"],
+      "fileMatch": [
+        "azure-pipelines.yml",
+        "azure-pipelines.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/azure-pipelines-vscode/master/service-schema.json"
     },
     {
       "name": "FasterCI Configuration",
       "description": "FasterCI repository configuration file",
-      "fileMatch": ["**/.fasterci/config.yaml"],
+      "fileMatch": [
+        "**/.fasterci/config.yaml"
+      ],
       "url": "https://fasterci.com/config.schema.json"
     },
     {
       "name": "Fence configuration",
       "description": "Configuration file for fence, a lightweight, container-free sandbox for running commands with network and filesystem restrictions",
-      "fileMatch": ["fence.json"],
+      "fileMatch": [
+        "fence.json"
+      ],
       "url": "https://raw.githubusercontent.com/Use-Tusk/fence/refs/heads/main/docs/schema/fence.schema.json"
     },
     {
       "name": "Foxx Manifest",
       "description": "ArangoDB Foxx service manifest file",
-      "fileMatch": ["manifest.json"],
+      "fileMatch": [
+        "manifest.json"
+      ],
       "url": "https://www.schemastore.org/foxx-manifest.json"
     },
     {
@@ -1154,13 +1398,17 @@
     {
       "name": "fly.io Configuration",
       "description": "fly.io, a cloud provider, configuration",
-      "fileMatch": ["fly.toml"],
+      "fileMatch": [
+        "fly.toml"
+      ],
       "url": "https://www.schemastore.org/fly.json"
     },
     {
       "name": "Freifunk.de Community API",
       "description": "Freifunk.de Community API. Documentation: https://github.com/freifunk/directory.api.freifunk.net",
-      "fileMatch": ["*.freifunk-api.json"],
+      "fileMatch": [
+        "*.freifunk-api.json"
+      ],
       "url": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/0.5.2.json",
       "versions": {
         "development": "https://raw.githubusercontent.com/freifunk/api.freifunk.net/master/specs/development.json",
@@ -1182,43 +1430,61 @@
     {
       "name": "Frogbot Config",
       "description": "The Frogbot configuration required to scan Git repositories",
-      "fileMatch": ["frogbot-config.yml"],
+      "fileMatch": [
+        "frogbot-config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/jfrog/frogbot/master/schema/frogbot-schema.json"
     },
     {
       "name": ".asmdef",
       "description": "Unity 3D assembly definition file",
-      "fileMatch": ["*.asmdef"],
+      "fileMatch": [
+        "*.asmdef"
+      ],
       "url": "https://www.schemastore.org/asmdef.json"
     },
     {
       "name": "babelrc.json",
       "description": "Babel configuration file",
-      "fileMatch": [".babelrc", ".babelrc.json", "babel.config.json"],
+      "fileMatch": [
+        ".babelrc",
+        ".babelrc.json",
+        "babel.config.json"
+      ],
       "url": "https://www.schemastore.org/babelrc.json"
     },
     {
       "name": ".backportrc.json",
       "description": "Backport configuration file",
-      "fileMatch": [".backportrc.json"],
+      "fileMatch": [
+        ".backportrc.json"
+      ],
       "url": "https://www.schemastore.org/backportrc.json"
     },
     {
       "name": "basedpyright",
       "description": "Basedpyright configuration file",
-      "fileMatch": ["basedpyrightconfig.json"],
+      "fileMatch": [
+        "basedpyrightconfig.json"
+      ],
       "url": "https://raw.githubusercontent.com/DetachHead/basedpyright/refs/heads/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"
     },
     {
       "name": "batect.yml",
       "description": "Batect configuration file",
-      "fileMatch": ["batect.yml", "batect-bundle.yml"],
+      "fileMatch": [
+        "batect.yml",
+        "batect-bundle.yml"
+      ],
       "url": "https://ide-integration.batect.dev/v1/configSchema.json"
     },
     {
       "name": "bamboo-spec",
       "description": "The Bamboo Specs allows you to define Bamboo configuration as code, and have corresponding plans/deployments created or updated automatically in Bamboo",
-      "fileMatch": ["**/bamboo-specs/*.yaml", "**/bamboo-specs/*.yml"],
+      "fileMatch": [
+        "**/bamboo-specs/*.yaml",
+        "**/bamboo-specs/*.yml"
+      ],
       "url": "https://www.schemastore.org/bamboo-spec.json"
     },
     {
@@ -1288,55 +1554,77 @@
     {
       "name": "bigquery-table",
       "description": "BigQuery table",
-      "fileMatch": ["*.bigquery.json"],
+      "fileMatch": [
+        "*.bigquery.json"
+      ],
       "url": "https://www.schemastore.org/bigquery-table.json"
     },
     {
       "name": "Bigconfig",
       "description": "Bigconfig is a yaml-based declarative monitoring as code solution. Data engineers can deploy Bigeye metrics from the command-line for convenient and scalable data quality monitoring",
-      "fileMatch": ["bigconfig.yml", "bigconfig.yaml"],
+      "fileMatch": [
+        "bigconfig.yml",
+        "bigconfig.yaml"
+      ],
       "url": "https://www.schemastore.org/bigconfig.json"
     },
     {
       "name": "bitbucket-pipelines",
       "description": "Bitbucket Pipelines CI/CD manifest",
-      "fileMatch": ["bitbucket-pipelines.yml"],
+      "fileMatch": [
+        "bitbucket-pipelines.yml"
+      ],
       "url": "https://api.bitbucket.org/schemas/pipelines-configuration"
     },
     {
       "name": "bitrise",
       "description": "The configuration format of the Bitrise CLI. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps",
-      "fileMatch": ["bitrise.yml", "bitrise.yaml", "bitrise.json"],
+      "fileMatch": [
+        "bitrise.yml",
+        "bitrise.yaml",
+        "bitrise.json"
+      ],
       "url": "https://www.schemastore.org/bitrise.json"
     },
     {
       "name": "bitrise-step",
       "description": "Steps and Workflows are the heart of how Bitrise works. A Bitrise build is simply a series of Steps. Bitrise is a collection of tools and services to help you with the development and automation of your software projects, with a main focus on mobile apps",
-      "fileMatch": ["step.yml"],
+      "fileMatch": [
+        "step.yml"
+      ],
       "url": "https://www.schemastore.org/bitrise-step.json"
     },
     {
       "name": ".bootstraprc",
       "description": "Webpack bootstrap-loader configuration file",
-      "fileMatch": [".bootstraprc"],
+      "fileMatch": [
+        ".bootstraprc"
+      ],
       "url": "https://www.schemastore.org/bootstraprc.json"
     },
     {
       "name": "bower.json",
       "description": "Bower package description file",
-      "fileMatch": ["bower.json", ".bower.json"],
+      "fileMatch": [
+        "bower.json",
+        ".bower.json"
+      ],
       "url": "https://www.schemastore.org/bower.json"
     },
     {
       "name": ".bowerrc",
       "description": "Bower configuration file",
-      "fileMatch": [".bowerrc"],
+      "fileMatch": [
+        ".bowerrc"
+      ],
       "url": "https://www.schemastore.org/bowerrc.json"
     },
     {
       "name": "BOSH BPM Config",
       "description": "Config for Jobs in BOSH Releases to utilize BPM",
-      "fileMatch": ["**/jobs/*/config/bpm.yml"],
+      "fileMatch": [
+        "**/jobs/*/config/bpm.yml"
+      ],
       "url": "https://www.schemastore.org/bosh-bpm-config.json"
     },
     {
@@ -1352,13 +1640,17 @@
     {
       "name": "BOSH Job Spec",
       "description": "Job Spec for BOSH Releases",
-      "fileMatch": ["**/jobs/*/spec"],
+      "fileMatch": [
+        "**/jobs/*/spec"
+      ],
       "url": "https://www.schemastore.org/bosh-job-spec.json"
     },
     {
       "name": "BOSH Package Spec",
       "description": "Package Spec for BOSH Releases",
-      "fileMatch": ["**/packages/*/spec"],
+      "fileMatch": [
+        "**/packages/*/spec"
+      ],
       "url": "https://www.schemastore.org/bosh-package-spec.json"
     },
     {
@@ -1369,13 +1661,18 @@
     {
       "name": "Boyka Framework",
       "description": "Boyka Framework config file",
-      "fileMatch": ["boyka-config.json"],
+      "fileMatch": [
+        "boyka-config.json"
+      ],
       "url": "https://www.schemastore.org/boyka-config.json"
     },
     {
       "name": "behat.yml",
       "description": "Behat configuration file",
-      "fileMatch": ["behat.yml", "*.behat.yml"],
+      "fileMatch": [
+        "behat.yml",
+        "*.behat.yml"
+      ],
       "url": "https://www.schemastore.org/behat.json"
     },
     {
@@ -1399,25 +1696,34 @@
     {
       "name": "bozr.suite.json",
       "description": "Bozr test suite file",
-      "fileMatch": [".suite.json", ".xsuite.json"],
+      "fileMatch": [
+        ".suite.json",
+        ".xsuite.json"
+      ],
       "url": "https://www.schemastore.org/bozr.json"
     },
     {
       "name": "browser.i18n.json",
       "description": "browser.i18n messages.json translation file",
-      "fileMatch": ["messages.json"],
+      "fileMatch": [
+        "messages.json"
+      ],
       "url": "https://www.schemastore.org/browser.i18n.json"
     },
     {
       "name": "browsh configuration",
       "description": "Configuration file for browsh",
-      "fileMatch": ["**/browsh/config.toml"],
+      "fileMatch": [
+        "**/browsh/config.toml"
+      ],
       "url": "https://raw.githubusercontent.com/browsh-org/browsh/master/webext/assets/browsh-schema.json"
     },
     {
       "name": "bucklescript",
       "description": "BuckleScript configuration file",
-      "fileMatch": ["bsconfig.json"],
+      "fileMatch": [
+        "bsconfig.json"
+      ],
       "url": "https://raw.githubusercontent.com/rescript-lang/rescript-compiler/master/docs/docson/build-schema.json"
     },
     {
@@ -1433,13 +1739,19 @@
     {
       "name": "Build Info",
       "description": "Build Info is the metadata of a build. It includes all the details about the build broken down into segments that include version history, artifacts, project modules, dependencies, and everything that was required to create the build",
-      "fileMatch": ["*buildinfo*.json", "*build-info*.json", "*.buildinfo"],
+      "fileMatch": [
+        "*buildinfo*.json",
+        "*build-info*.json",
+        "*.buildinfo"
+      ],
       "url": "https://raw.githubusercontent.com/jfrog/build-info-go/main/buildinfo-schema.json"
     },
     {
       "name": "Bukkit plugin.yml",
       "description": "Minecraft Bukkit plugin description files",
-      "fileMatch": ["plugin.yml"],
+      "fileMatch": [
+        "plugin.yml"
+      ],
       "url": "https://www.schemastore.org/bukkit-plugin.json"
     },
     {
@@ -1464,7 +1776,9 @@
     {
       "name": ".build.yml",
       "description": "Sourcehut Build Manifest",
-      "fileMatch": [".build.yml"],
+      "fileMatch": [
+        ".build.yml"
+      ],
       "url": "https://www.schemastore.org/sourcehut-build-0.65.0.json",
       "versions": {
         "0.41.2": "https://www.schemastore.org/sourcehut-build-0.41.2.json",
@@ -1474,31 +1788,42 @@
     {
       "name": "bun.lock",
       "description": "bun.lock file",
-      "fileMatch": ["bun.lock"],
+      "fileMatch": [
+        "bun.lock"
+      ],
       "url": "https://www.schemastore.org/bun-lock.json"
     },
     {
       "name": "bundleconfig.json",
       "description": "bundleconfig.json files",
-      "fileMatch": ["bundleconfig.json"],
+      "fileMatch": [
+        "bundleconfig.json"
+      ],
       "url": "https://www.schemastore.org/bundleconfig.json"
     },
     {
       "name": "bunfig.toml",
       "description": "bunfig.toml file",
-      "fileMatch": ["bunfig.toml"],
+      "fileMatch": [
+        "bunfig.toml"
+      ],
       "url": "https://www.schemastore.org/bunfig.json"
     },
     {
       "name": "BungeeCord plugin.yml",
       "description": "BungeeCord plugin description files",
-      "fileMatch": ["plugin.yml", "bungee.yml"],
+      "fileMatch": [
+        "plugin.yml",
+        "bungee.yml"
+      ],
       "url": "https://www.schemastore.org/bungee-plugin.json"
     },
     {
       "name": "block.json",
       "description": "WordPress block.json files",
-      "fileMatch": ["block.json"],
+      "fileMatch": [
+        "block.json"
+      ],
       "url": "https://schemas.wp.org/trunk/block.json",
       "versions": {
         "trunk": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
@@ -1507,13 +1832,18 @@
     {
       "name": "Block Protocol Metadata",
       "description": "Block Metadata in Block Protocol",
-      "fileMatch": ["block-metadata.json"],
+      "fileMatch": [
+        "block-metadata.json"
+      ],
       "url": "https://blockprotocol.org/schemas/block-metadata.json"
     },
     {
       "name": "BX CI",
       "description": "CI configuration for Amdocs Bill Experience projects",
-      "fileMatch": ["**/bxci.yaml", "**/bxci.yml"],
+      "fileMatch": [
+        "**/bxci.yaml",
+        "**/bxci.yml"
+      ],
       "url": "https://www.schemastore.org/bxci.schema-3.x.json",
       "versions": {
         "1.0": "https://www.schemastore.org/bxci.schema-1.0.json",
@@ -1537,13 +1867,19 @@
     {
       "name": "Bleep",
       "description": "A bleeping fast Scala build tool",
-      "fileMatch": ["bleep.yaml", "bleep.yml"],
+      "fileMatch": [
+        "bleep.yaml",
+        "bleep.yml"
+      ],
       "url": "https://raw.githubusercontent.com/oyvindberg/bleep/master/schema.json"
     },
     {
       "name": "CMake Presets",
       "description": "CMake Presets",
-      "fileMatch": ["CMakePresets.json", "CMakeUserPresets.json"],
+      "fileMatch": [
+        "CMakePresets.json",
+        "CMakeUserPresets.json"
+      ],
       "url": "https://raw.githubusercontent.com/Kitware/CMake/master/Help/manual/presets/schema.json"
     },
     {
@@ -1559,7 +1895,10 @@
     {
       "name": "Calqulus pipeline",
       "description": "Qualisys Calqulus pipeline",
-      "fileMatch": ["*.calqulus.yaml", "*.calqulus.yml"],
+      "fileMatch": [
+        "*.calqulus.yaml",
+        "*.calqulus.yml"
+      ],
       "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/calqulus-pipeline.schema.json"
     },
     {
@@ -1602,31 +1941,43 @@
     {
       "name": "Cargo Manifest",
       "description": "Manifest for Cargo, the Rust package manager and build tool",
-      "fileMatch": ["Cargo.toml"],
+      "fileMatch": [
+        "Cargo.toml"
+      ],
       "url": "https://www.schemastore.org/cargo.json"
     },
     {
       "name": "Cargo Make",
       "description": "cargo-make, a Rust task runner and build tool",
-      "fileMatch": ["Makefile.toml"],
+      "fileMatch": [
+        "Makefile.toml"
+      ],
       "url": "https://www.schemastore.org/cargo-make.json"
     },
     {
       "name": "Catalog Info Backstage",
       "description": "Backstage Catalog Info",
-      "fileMatch": ["catalog-info.yaml", "*.catalog-info.yaml"],
+      "fileMatch": [
+        "catalog-info.yaml",
+        "*.catalog-info.yaml"
+      ],
       "url": "https://www.schemastore.org/catalog-info.json"
     },
     {
       "name": "Changie",
       "description": "Changie configuration file",
-      "fileMatch": [".changie.yaml", ".changie.yml"],
+      "fileMatch": [
+        ".changie.yaml",
+        ".changie.yml"
+      ],
       "url": "https://changie.dev/schema.json"
     },
     {
       "name": "Charmcraft",
       "description": "Charmcraft project. Documentation: https://documentation.ubuntu.com/charmcraft/stable/",
-      "fileMatch": ["charmcraft.yaml"],
+      "fileMatch": [
+        "charmcraft.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/canonical/charmcraft/main/schema/charmcraft.json"
     },
     {
@@ -1657,25 +2008,35 @@
     {
       "name": "Chromia Model",
       "description": "Chromia Model Config File",
-      "fileMatch": ["chromia.yml", "chromia.yaml"],
+      "fileMatch": [
+        "chromia.yml",
+        "chromia.yaml"
+      ],
       "url": "https://gitlab.com/chromaway/core-tools/chromia-cli-tools/-/raw/dev/chromia-build-tools/src/main/resources/chromia-model-schema.json"
     },
     {
       "name": "Chromia Seeder Root Config",
       "description": "Chromia Seeder Root Config File",
-      "fileMatch": ["**/.chromia/seeder/**/seeder.yml"],
+      "fileMatch": [
+        "**/.chromia/seeder/**/seeder.yml"
+      ],
       "url": "https://gitlab.com/chromaway/core-tools/rell-toolbox/-/raw/dev/seeder/src/main/resources/chromia-seeder-config-schema.json"
     },
     {
       "name": "Chromia Seeder Module Config",
       "description": "Chromia Seeder Module Config File",
-      "fileMatch": ["**/.chromia/seeder/**/modules/**/*.yml"],
+      "fileMatch": [
+        "**/.chromia/seeder/**/modules/**/*.yml"
+      ],
       "url": "https://gitlab.com/chromaway/core-tools/rell-toolbox/-/raw/dev/seeder/src/main/resources/chromia-seeder-module-schema.json"
     },
     {
       "name": "cibuildwheel",
       "description": "cibuildwheel, a Python redistributable wheel builder",
-      "fileMatch": ["cibuildwheel.toml", ".cibuildwheel.toml"],
+      "fileMatch": [
+        "cibuildwheel.toml",
+        ".cibuildwheel.toml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/cibuildwheel.json"
     },
     {
@@ -1704,25 +2065,33 @@
     {
       "name": "conda-forge",
       "description": "Conda-forge configuration file",
-      "fileMatch": ["conda-forge.yml"],
+      "fileMatch": [
+        "conda-forge.yml"
+      ],
       "url": "https://raw.githubusercontent.com/conda-forge/conda-smithy/main/conda_smithy/data/conda-forge.json"
     },
     {
       "name": "Convex",
       "description": "Configuration for Convex project settings",
-      "fileMatch": ["convex.json"],
+      "fileMatch": [
+        "convex.json"
+      ],
       "url": "https://raw.githubusercontent.com/get-convex/convex-backend/refs/heads/main/npm-packages/convex/schemas/convex.schema.json"
     },
     {
       "name": "Conjure",
       "description": "Conjure Human-Readable Format",
-      "fileMatch": ["**/conjure/**.yml"],
+      "fileMatch": [
+        "**/conjure/**.yml"
+      ],
       "url": "https://raw.githubusercontent.com/palantir/conjure/master/conjure.schema.json"
     },
     {
       "name": "CNC Codes",
       "description": "G/M codes for Machine Tools or 3D Printers",
-      "fileMatch": ["*.cncc.json"],
+      "fileMatch": [
+        "*.cncc.json"
+      ],
       "url": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
       "versions": {
         "latest": "https://appliedengdesign.github.io/cnccodes-json-schema/draft/2022-07/schema",
@@ -1733,7 +2102,10 @@
     {
       "name": "Cog config file",
       "description": "cog.yaml files",
-      "fileMatch": ["cog.yaml", "cog.yml"],
+      "fileMatch": [
+        "cog.yaml",
+        "cog.yml"
+      ],
       "url": "https://raw.githubusercontent.com/replicate/cog/main/pkg/config/data/config_schema_v1.0.json",
       "versions": {
         "1.0": "https://raw.githubusercontent.com/replicate/cog/main/pkg/config/data/config_schema_v1.0.json"
@@ -1752,127 +2124,175 @@
     {
       "name": "Common Package Specification",
       "description": "A cross-tool mechanism for locating software dependencies",
-      "fileMatch": ["*.cps"],
+      "fileMatch": [
+        "*.cps"
+      ],
       "url": "https://cps-org.github.io/cps/cps.schema.json"
     },
     {
       "name": "CumulusCI Config",
       "description": "cumulusci.yml file for configuring CumulusCI, a Salesforce automation framework",
-      "fileMatch": ["cumulusci.yml"],
+      "fileMatch": [
+        "cumulusci.yml"
+      ],
       "url": "https://raw.githubusercontent.com/SFDO-Tooling/CumulusCI/main/cumulusci/schema/cumulusci.jsonschema.json"
     },
     {
       "name": "Clawject config",
       "description": "Clawject configuration file",
-      "fileMatch": [".clawjectrc", ".clawjectrc.json"],
+      "fileMatch": [
+        ".clawjectrc",
+        ".clawjectrc.json"
+      ],
       "url": "https://raw.githubusercontent.com/clawject/clawject/main/packages/core/src/config/schema.json"
     },
     {
       "name": "Claude Code Keybindings",
       "description": "Keyboard shortcut configuration for Claude Code",
-      "fileMatch": ["**/.claude/keybindings.json"],
+      "fileMatch": [
+        "**/.claude/keybindings.json"
+      ],
       "url": "https://www.schemastore.org/claude-code-keybindings.json"
     },
     {
       "name": "Claude Code Plugin Manifest",
       "description": "Manifest (.claude-plugin/plugin.json) for a Claude Code plugin",
-      "fileMatch": ["**/.claude-plugin/plugin.json"],
+      "fileMatch": [
+        "**/.claude-plugin/plugin.json"
+      ],
       "url": "https://www.schemastore.org/claude-code-plugin-manifest.json"
     },
     {
       "name": "Claude Code Plugin Marketplace",
       "description": "Marketplace manifest (.claude-plugin/marketplace.json) listing Claude Code plugins",
-      "fileMatch": ["**/.claude-plugin/marketplace.json"],
+      "fileMatch": [
+        "**/.claude-plugin/marketplace.json"
+      ],
       "url": "https://www.schemastore.org/claude-code-marketplace.json"
     },
     {
       "name": "Claude Code Settings",
       "description": "Configuration file for Claude Code",
-      "fileMatch": ["**/.claude/settings.json"],
+      "fileMatch": [
+        "**/.claude/settings.json"
+      ],
       "url": "https://www.schemastore.org/claude-code-settings.json"
     },
     {
       "name": "cmakefmt",
       "description": "Configuration file for cmakefmt, a fast native CMake formatter",
-      "fileMatch": [".cmakefmt.yaml", ".cmakefmt.yml", ".cmakefmt.toml"],
+      "fileMatch": [
+        ".cmakefmt.yaml",
+        ".cmakefmt.yml",
+        ".cmakefmt.toml"
+      ],
       "url": "https://cmakefmt.dev/schemas/latest/schema.json"
     },
     {
       "name": "CVE Record Format",
       "description": "CVE record format to describe security vulnerabilities",
-      "fileMatch": ["CVE-*.json"],
+      "fileMatch": [
+        "CVE-*.json"
+      ],
       "url": "https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/docs/CVE_Record_Format_bundled.json"
     },
     {
       "name": "CVX personal.yaml",
       "description": "Identity and contact details for a CVX CV (name, title, contact rows)",
-      "fileMatch": ["**/cv-content/personal.yaml"],
+      "fileMatch": [
+        "**/cv-content/personal.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/personal.schema.json"
     },
     {
       "name": "CVX summary.yaml",
       "description": "Professional-summary bullets for a CVX CV",
-      "fileMatch": ["**/cv-content/summary.yaml"],
+      "fileMatch": [
+        "**/cv-content/summary.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/summary.schema.json"
     },
     {
       "name": "CVX experience.yaml",
       "description": "Work history entries for a CVX CV (roles, progression, impact bullets)",
-      "fileMatch": ["**/cv-content/experience.yaml"],
+      "fileMatch": [
+        "**/cv-content/experience.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/experience.schema.json"
     },
     {
       "name": "CVX education.yaml",
       "description": "Education entries for a CVX CV",
-      "fileMatch": ["**/cv-content/education.yaml"],
+      "fileMatch": [
+        "**/cv-content/education.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/education.schema.json"
     },
     {
       "name": "CVX competencies.yaml",
       "description": "Skill tags for a CVX CV",
-      "fileMatch": ["**/cv-content/competencies.yaml"],
+      "fileMatch": [
+        "**/cv-content/competencies.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/competencies.schema.json"
     },
     {
       "name": "CVX achievements.yaml",
       "description": "Awards and recognitions for a CVX CV",
-      "fileMatch": ["**/cv-content/achievements.yaml"],
+      "fileMatch": [
+        "**/cv-content/achievements.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/achievements.schema.json"
     },
     {
       "name": "CVX referees.yaml",
       "description": "References for a CVX CV",
-      "fileMatch": ["**/cv-content/referees.yaml"],
+      "fileMatch": [
+        "**/cv-content/referees.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/referees.schema.json"
     },
     {
       "name": "CVX keywords.yaml",
       "description": "ATS keywords embedded in CVX PDF metadata",
-      "fileMatch": ["**/cv-content/keywords.yaml"],
+      "fileMatch": [
+        "**/cv-content/keywords.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/keywords.schema.json"
     },
     {
       "name": "CVX config.yaml",
       "description": "CVX build configuration (theme, layout, pagination, ATS keywords)",
-      "fileMatch": ["**/cv-content/config.yaml"],
+      "fileMatch": [
+        "**/cv-content/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/config.schema.json"
     },
     {
       "name": "CVX layout",
       "description": "Custom page layout for a CVX CV (section placement per page)",
-      "fileMatch": ["**/cv-content/layouts/*.yaml"],
+      "fileMatch": [
+        "**/cv-content/layouts/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/hrtips/cvx/main/schema/v1/layout.schema.json"
     },
     {
       "name": "Cycle Stack File",
       "description": "A Cycle.io stack file for environments as code",
-      "fileMatch": ["cycle.json", "cycle.yml", "cycle.yaml"],
+      "fileMatch": [
+        "cycle.json",
+        "cycle.yml",
+        "cycle.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/cycleplatform/api-spec/main/stackspec/stackspec.json"
     },
     {
       "name": "CycloneDX",
       "description": "CycloneDX Bill of Materials (BOM) file",
-      "fileMatch": ["bom.json", "*.cdx.json"],
+      "fileMatch": [
+        "bom.json",
+        "*.cdx.json"
+      ],
       "url": "https://raw.githubusercontent.com/CycloneDX/specification/refs/heads/master/schema/bom-1.6.schema.json",
       "versions": {
         "1.2": "https://raw.githubusercontent.com/CycloneDX/specification/refs/heads/master/schema/bom-1.2.schema.json",
@@ -1887,49 +2307,71 @@
     {
       "name": "Dark Factory consumer config",
       "description": "Unified darkfactory.yaml for the Cerebe / Dark Factory CLI (doctrine, deny, hooks, MCP, critics, policy)",
-      "fileMatch": ["darkfactory.yaml", "darkfactory.yml"],
+      "fileMatch": [
+        "darkfactory.yaml",
+        "darkfactory.yml"
+      ],
       "url": "https://raw.githubusercontent.com/momentiq-ai/cerebe/main/schemas/darkfactory/v1.json"
     },
     {
       "name": "DataYoga Connections",
       "description": "Collection of defined source and target connections used within DataYoga jobs",
-      "fileMatch": ["connections.dy.yaml"],
+      "fileMatch": [
+        "connections.dy.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/connections.schema.json"
     },
     {
       "name": "DataYoga Job",
       "description": "Declarative definition of sequential pipeline steps within a DataYoga job",
-      "fileMatch": ["**/jobs/**/*.dy.yaml"],
+      "fileMatch": [
+        "**/jobs/**/*.dy.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/datayoga-io/datayoga/main/schemas/job.schema.json"
     },
     {
       "name": "dbt-bouncer",
       "description": "dbt-bouncer configuration file for enforcing conventions in dbt projects",
-      "fileMatch": ["dbt-bouncer.yml", "dbt-bouncer.yaml"],
+      "fileMatch": [
+        "dbt-bouncer.yml",
+        "dbt-bouncer.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/godatadriven/dbt-bouncer/main/schema.json"
     },
     {
       "name": "dbt Dependencies",
       "description": "dbt's dependencies.yml file for external packages and cross-project refs",
-      "fileMatch": ["**/*dbt*/dependencies.yaml", "**/*dbt*/dependencies.yml"],
+      "fileMatch": [
+        "**/*dbt*/dependencies.yaml",
+        "**/*dbt*/dependencies.yml"
+      ],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dependencies-latest-fusion.json"
     },
     {
       "name": "dbt Project",
       "description": "dbt's project configuration file",
-      "fileMatch": ["dbt_project.yaml", "dbt_project.yml"],
+      "fileMatch": [
+        "dbt_project.yaml",
+        "dbt_project.yml"
+      ],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/dbt_project-latest-fusion.json"
     },
     {
       "name": "dbt Packages",
       "description": "dbt's packages.yml file for external packages",
-      "fileMatch": ["**/*dbt*/packages.yaml", "**/*dbt*/packages.yml"],
+      "fileMatch": [
+        "**/*dbt*/packages.yaml",
+        "**/*dbt*/packages.yml"
+      ],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/packages-latest-fusion.json"
     },
     {
       "name": "dbt Selectors",
       "description": "dbt's selectors.yml file for configuring YAML selectors",
-      "fileMatch": ["**/*dbt*/selectors.yaml", "**/*dbt*/selectors.yml"],
+      "fileMatch": [
+        "**/*dbt*/selectors.yaml",
+        "**/*dbt*/selectors.yml"
+      ],
       "url": "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/latest_fusion/selectors-latest-fusion.json"
     },
     {
@@ -1950,13 +2392,18 @@
     {
       "name": "Debian Upstream Metadata file",
       "description": "Debian packaging file for describing metadata about the upstream project",
-      "fileMatch": ["**/debian/upstream/metadata"],
+      "fileMatch": [
+        "**/debian/upstream/metadata"
+      ],
       "url": "https://salsa.debian.org/debian/debian-json-schemas/-/raw/main/schemas/debian-upstream-metadata/debian-upstream-metadata-latest.json"
     },
     {
       "name": "DebtLens",
       "description": "Configuration file for the DebtLens maintainability scanner",
-      "fileMatch": ["debtlens.config.json", ".debtlensrc.json"],
+      "fileMatch": [
+        "debtlens.config.json",
+        ".debtlensrc.json"
+      ],
       "url": "https://raw.githubusercontent.com/ColumbusLabs/DebtLens/main/schema/debtlens.config.schema.json"
     },
     {
@@ -1984,13 +2431,17 @@
     {
       "name": "Dein Config",
       "description": "Dein.vim, a Vim/Neovim plugin manager",
-      "fileMatch": ["dein.toml"],
+      "fileMatch": [
+        "dein.toml"
+      ],
       "url": "https://www.schemastore.org/dein.json"
     },
     {
       "name": "Dependency cruiser",
       "description": "Configuration file for Dependency cruiser",
-      "fileMatch": ["dependency-cruiser.config.json"],
+      "fileMatch": [
+        "dependency-cruiser.config.json"
+      ],
       "url": "https://raw.githubusercontent.com/sverweij/dependency-cruiser/main/src/schema/configuration.schema.json"
     },
     {
@@ -2015,157 +2466,212 @@
     {
       "name": "Deta Spacefile",
       "description": "Configuration file for Space Apps",
-      "fileMatch": ["Spacefile"],
+      "fileMatch": [
+        "Spacefile"
+      ],
       "url": "https://deta.space/assets/spacefile.schema.json"
     },
     {
       "name": "Devbox Config",
       "description": "Configuration for a Devbox shell environment",
-      "fileMatch": ["devbox.json"],
+      "fileMatch": [
+        "devbox.json"
+      ],
       "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json"
     },
     {
       "name": "Devbox Plugin",
       "description": "Configuration for a Devbox plugin specification",
-      "fileMatch": ["devbox-plugin.json"],
+      "fileMatch": [
+        "devbox-plugin.json"
+      ],
       "url": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json"
     },
     {
       "name": "devconcurrent",
       "description": "Easily manage multiple, isolated development environments",
-      "fileMatch": ["**/devconcurrent/config.toml"],
+      "fileMatch": [
+        "**/devconcurrent/config.toml"
+      ],
       "url": "https://devconcurrent.paholg.com/devconcurrent.schema.json"
     },
     {
       "name": "Drupal Breakpoints",
       "description": "Drupal configuration for breakpoints",
-      "fileMatch": ["*.breakpoints.yml"],
+      "fileMatch": [
+        "*.breakpoints.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-breakpoints.json"
     },
     {
       "name": "Drupal Info",
       "description": "Drupal configuration for info",
-      "fileMatch": ["*.info.yml"],
+      "fileMatch": [
+        "*.info.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-info.json"
     },
     {
       "name": "Drupal Layouts",
       "description": "Drupal configuration for layouts",
-      "fileMatch": ["*.layouts.yml"],
+      "fileMatch": [
+        "*.layouts.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-layouts.json"
     },
     {
       "name": "Drupal Libraries",
       "description": "Drupal configuration for libraries",
-      "fileMatch": ["*.libraries.yml"],
+      "fileMatch": [
+        "*.libraries.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-libraries.json"
     },
     {
       "name": "Drupal Links Action",
       "description": "Drupal configuration for action links",
-      "fileMatch": ["*.links.action.yml"],
+      "fileMatch": [
+        "*.links.action.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-links-action.json"
     },
     {
       "name": "Drupal Links Contextual",
       "description": "Drupal configuration for contextual links",
-      "fileMatch": ["*.links.contextual.yml"],
+      "fileMatch": [
+        "*.links.contextual.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-links-contextual.json"
     },
     {
       "name": "Drupal Links Menu",
       "description": "Drupal configuration for menu links",
-      "fileMatch": ["*.links.menu.yml"],
+      "fileMatch": [
+        "*.links.menu.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-links-menu.json"
     },
     {
       "name": "Drupal Links Task",
       "description": "Drupal configuration for task links",
-      "fileMatch": ["*.links.task.yml"],
+      "fileMatch": [
+        "*.links.task.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-links-task.json"
     },
     {
       "name": "Drupal Migration",
       "description": "Drupal configuration for migration",
-      "fileMatch": ["*.migration.*.yml", "**/migrations/*.yml"],
+      "fileMatch": [
+        "*.migration.*.yml",
+        "**/migrations/*.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-migration.json"
     },
     {
       "name": "Drupal Permissions",
       "description": "Drupal configuration for permissions",
-      "fileMatch": ["*.permissions.yml"],
+      "fileMatch": [
+        "*.permissions.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-permissions.json"
     },
     {
       "name": "Drupal Recipe",
       "description": "Drupal configuration for recipe",
-      "fileMatch": ["drupal-recipe.yml", "drupal-recipe.yaml"],
+      "fileMatch": [
+        "drupal-recipe.yml",
+        "drupal-recipe.yaml"
+      ],
       "url": "https://www.schemastore.org/drupal-recipe.json"
     },
     {
       "name": "Drupal Routing",
       "description": "Drupal configuration for routing",
-      "fileMatch": ["*.routing.yml"],
+      "fileMatch": [
+        "*.routing.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-routing.json"
     },
     {
       "name": "Drupal Config",
       "description": "Drupal configuration for config",
-      "fileMatch": ["**/config/schema/*.schema.yml"],
+      "fileMatch": [
+        "**/config/schema/*.schema.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-config.json"
     },
     {
       "name": "Drupal Services",
       "description": "Drupal configuration for services",
-      "fileMatch": ["*.services.yml"],
+      "fileMatch": [
+        "*.services.yml"
+      ],
       "url": "https://www.schemastore.org/drupal-services.json"
     },
     {
       "name": "Helm Chart.yaml",
       "description": "The Chart.yaml file is required for a chart",
-      "fileMatch": ["Chart.yaml"],
+      "fileMatch": [
+        "Chart.yaml"
+      ],
       "url": "https://www.schemastore.org/chart.json"
     },
     {
       "name": "Helm Chart.lock",
       "description": "The Chart.lock file locks dependencies from Chart.yaml",
-      "fileMatch": ["Chart.lock"],
+      "fileMatch": [
+        "Chart.lock"
+      ],
       "url": "https://www.schemastore.org/chart-lock.json"
     },
     {
       "name": "Helm Unittest Test Suite",
       "description": "A Helm Unittest Test Suite file",
-      "fileMatch": ["**/charts/*/tests/*.yaml"],
+      "fileMatch": [
+        "**/charts/*/tests/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json"
     },
     {
       "name": "Hex file",
       "description": "Hex notebook file format - create and maintain data notebooks on Hex.tech",
-      "fileMatch": ["*.hex.yaml"],
+      "fileMatch": [
+        "*.hex.yaml"
+      ],
       "url": "https://static.hex.site/hex-file-schema.json"
     },
     {
       "name": "CircleCI config.yml",
       "description": "CircleCI config files",
-      "fileMatch": ["**/.circleci/config.yml"],
+      "fileMatch": [
+        "**/.circleci/config.yml"
+      ],
       "url": "https://www.schemastore.org/circleciconfig.json"
     },
     {
       "name": "Code Climate",
       "description": "Configuration file as an alternative for configuring your repository in the settings page",
-      "fileMatch": [".codeclimate.yml", ".codeclimate.json"],
+      "fileMatch": [
+        ".codeclimate.yml",
+        ".codeclimate.json"
+      ],
       "url": "https://www.schemastore.org/codeclimate.json"
     },
     {
       "name": ".cirrus.yml",
       "description": "Cirrus CI configuration files",
-      "fileMatch": [".cirrus.yml"],
+      "fileMatch": [
+        ".cirrus.yml"
+      ],
       "url": "https://raw.githubusercontent.com/cirruslabs/cirrus-cli/main/pkg/parser/testdata/cirrus.json"
     },
     {
       "name": ".clasp.json",
       "description": "Google Apps Script CLI project file",
-      "fileMatch": [".clasp.json"],
+      "fileMatch": [
+        ".clasp.json"
+      ],
       "url": "https://www.schemastore.org/clasp.json"
     },
     {
@@ -2182,19 +2688,27 @@
     {
       "name": "clang-tidy",
       "description": "clang-tidy linter from LLVM",
-      "fileMatch": [".clang-tidy", "clang-tidy.yml", "clang-tidy.yaml"],
+      "fileMatch": [
+        ".clang-tidy",
+        "clang-tidy.yml",
+        "clang-tidy.yaml"
+      ],
       "url": "https://www.schemastore.org/clang-tidy.json"
     },
     {
       "name": "clib",
       "description": "C package manager-ish",
-      "fileMatch": ["clib.json"],
+      "fileMatch": [
+        "clib.json"
+      ],
       "url": "https://www.schemastore.org/clib.json"
     },
     {
       "name": "cloudify",
       "description": "Cloudify Blueprint",
-      "fileMatch": ["*.cfy.yaml"],
+      "fileMatch": [
+        "*.cfy.yaml"
+      ],
       "url": "https://www.schemastore.org/cloudify.json"
     },
     {
@@ -2211,55 +2725,75 @@
     {
       "name": "Codex",
       "description": "OpenAI Codex configuration file",
-      "fileMatch": ["**/.codex/config.toml"],
+      "fileMatch": [
+        "**/.codex/config.toml"
+      ],
       "url": "https://developers.openai.com/codex/config-schema.json"
     },
     {
       "name": "Codex Hooks",
       "description": "OpenAI Codex hooks configuration file",
-      "fileMatch": ["**/.codex/hooks.json"],
+      "fileMatch": [
+        "**/.codex/hooks.json"
+      ],
       "url": "https://www.schemastore.org/codex-hooks.json"
     },
     {
       "name": "Codex Plugin Manifest",
       "description": "OpenAI Codex plugin manifest file",
-      "fileMatch": ["**/.codex-plugin/plugin.json"],
+      "fileMatch": [
+        "**/.codex-plugin/plugin.json"
+      ],
       "url": "https://www.schemastore.org/codex-plugin-manifest.json"
     },
     {
       "name": "Codex Skill Metadata",
       "description": "OpenAI Codex skill metadata file",
-      "fileMatch": ["**/agents/openai.yaml"],
+      "fileMatch": [
+        "**/agents/openai.yaml"
+      ],
       "url": "https://www.schemastore.org/codex-skill-metadata.json"
     },
     {
       "name": "codemagic",
       "description": "Codemagic CI/CD file configuration",
-      "fileMatch": ["codemagic.yaml", "codemagic.yml"],
+      "fileMatch": [
+        "codemagic.yaml",
+        "codemagic.yml"
+      ],
       "url": "https://codemagic.io/codemagic-schema.json"
     },
     {
       "name": "Codux",
       "description": "Codux configuration file",
-      "fileMatch": ["codux.config.json"],
+      "fileMatch": [
+        "codux.config.json"
+      ],
       "url": "https://wixplosives.github.io/codux-config-schema/codux.config.schema.json"
     },
     {
       "name": "devcontainer.json",
       "description": "dev container configuration files",
-      "fileMatch": ["devcontainer.json", ".devcontainer.json"],
+      "fileMatch": [
+        "devcontainer.json",
+        ".devcontainer.json"
+      ],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json"
     },
     {
       "name": "devcontainer-feature.json",
       "description": "Dev Container Feature metadata files",
-      "fileMatch": ["devcontainer-feature.json"],
+      "fileMatch": [
+        "devcontainer-feature.json"
+      ],
       "url": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json"
     },
     {
       "name": ".devprune.json",
       "description": "Per-repository configuration for dev-prune, the lockfile-verified workspace cleaner",
-      "fileMatch": [".devprune.json"],
+      "fileMatch": [
+        ".devprune.json"
+      ],
       "url": "https://devprune.vkrishna04.me/schemas/v1/devprune.schema.json"
     },
     {
@@ -2278,55 +2812,73 @@
     {
       "name": "CodeShip Pro services configuration files",
       "description": "codeship-services.yml files",
-      "fileMatch": ["codeship-services.yml"],
+      "fileMatch": [
+        "codeship-services.yml"
+      ],
       "url": "https://www.schemastore.org/codeship-services.json"
     },
     {
       "name": "CodeShip Pro steps configuration files",
       "description": "codeship-steps.yml files",
-      "fileMatch": ["codeship-steps.yml"],
+      "fileMatch": [
+        "codeship-steps.yml"
+      ],
       "url": "https://www.schemastore.org/codeship-steps.json"
     },
     {
       "name": "vcpkg manifest file",
       "description": "vcpkg manifest file",
-      "fileMatch": ["vcpkg.json"],
+      "fileMatch": [
+        "vcpkg.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json"
     },
     {
       "name": "vcpkg configuration file",
       "description": "vcpkg configuration file",
-      "fileMatch": ["vcpkg-configuration.json"],
+      "fileMatch": [
+        "vcpkg-configuration.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json"
     },
     {
       "name": "Vercel",
       "description": "Vercel configuration file",
-      "fileMatch": ["vercel.json"],
+      "fileMatch": [
+        "vercel.json"
+      ],
       "url": "https://openapi.vercel.sh/vercel.json"
     },
     {
       "name": "VSCode Code Snippets",
       "description": "code snippet files in visual studio code extensions",
-      "fileMatch": ["*.code-snippets"],
+      "fileMatch": [
+        "*.code-snippets"
+      ],
       "url": "https://raw.githubusercontent.com/Yash-Singh1/vscode-snippets-json-schema/main/schema.json"
     },
     {
       "name": "compilerconfig.json",
       "description": "compilerconfig.json files",
-      "fileMatch": ["compilerconfig.json"],
+      "fileMatch": [
+        "compilerconfig.json"
+      ],
       "url": "https://www.schemastore.org/compilerconfig.json"
     },
     {
       "name": "compile_commands.json",
       "description": "LLVM compilation database",
-      "fileMatch": ["compile_commands.json"],
+      "fileMatch": [
+        "compile_commands.json"
+      ],
       "url": "https://www.schemastore.org/compile-commands.json"
     },
     {
       "name": "commands.json",
       "description": "Config file for Command Task Runner",
-      "fileMatch": ["commands.json"],
+      "fileMatch": [
+        "commands.json"
+      ],
       "url": "https://www.schemastore.org/commands.json"
     },
     {
@@ -2343,7 +2895,9 @@
     {
       "name": "cosmos.config.json",
       "description": "React Cosmos configuration file",
-      "fileMatch": ["cosmos.config.json"],
+      "fileMatch": [
+        "cosmos.config.json"
+      ],
       "url": "https://www.schemastore.org/cosmos-config.json"
     },
     {
@@ -2354,25 +2908,33 @@
     {
       "name": "chrome-extension-locales-messages.json",
       "description": "Google Chrome extension localization file",
-      "fileMatch": ["**/_locales/*/messages.json"],
+      "fileMatch": [
+        "**/_locales/*/messages.json"
+      ],
       "url": "https://www.schemastore.org/chrome-extension-locales-messages.json"
     },
     {
       "name": "chutzpah.json",
       "description": "Chutzpah configuration file",
-      "fileMatch": ["chutzpah.json"],
+      "fileMatch": [
+        "chutzpah.json"
+      ],
       "url": "https://www.schemastore.org/chutzpah.json"
     },
     {
       "name": "contentmanifest.json",
       "description": "Visual Studio manifest injection file",
-      "fileMatch": ["contentmanifest.json"],
+      "fileMatch": [
+        "contentmanifest.json"
+      ],
       "url": "https://www.schemastore.org/vsix-manifestinjection.json"
     },
     {
       "name": "cloud-sdk-pipeline-configuration",
       "description": "SAP Cloud SDK Pipeline configuration",
-      "fileMatch": ["pipeline_config.yml"],
+      "fileMatch": [
+        "pipeline_config.yml"
+      ],
       "url": "https://www.schemastore.org/cloud-sdk-pipeline-config-schema.json"
     },
     {
@@ -2404,7 +2966,9 @@
     {
       "name": "AWS CDK cdk.json",
       "description": "AWS CDK context files",
-      "fileMatch": ["cdk.json"],
+      "fileMatch": [
+        "cdk.json"
+      ],
       "url": "https://www.schemastore.org/cdk.json"
     },
     {
@@ -2438,73 +3002,99 @@
     {
       "name": "AWS SAM CLI Samconfig",
       "description": "AWS SAM CLI samconfig configuration file",
-      "fileMatch": ["samconfig.toml", "samconfig.yaml", "samconfig.yml"],
+      "fileMatch": [
+        "samconfig.toml",
+        "samconfig.yaml",
+        "samconfig.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aws/aws-sam-cli/master/schema/samcli.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Accounts Config",
       "description": "Used to manage all of the AWS accounts within the AWS Organization",
-      "fileMatch": ["accounts-config.yaml"],
+      "fileMatch": [
+        "accounts-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Customizations Config",
       "description": "Used to manage configuration of custom applications, third-party firewall appliances, and CloudFormation stacks",
-      "fileMatch": ["customizations-config.yaml"],
+      "fileMatch": [
+        "customizations-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Global Config",
       "description": "Used to manage all of the global properties that can be inherited across the AWS Organization",
-      "fileMatch": ["global-config.yaml"],
+      "fileMatch": [
+        "global-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/global-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - IAM Config",
       "description": "Used to manage all of the IAM resources across the AWS Organization",
-      "fileMatch": ["iam-config.yaml"],
+      "fileMatch": [
+        "iam-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Network Config",
       "description": "Used to manage and implement network resources to establish a WAN/LAN architecture to support cloud operations and application workloads in AWS",
-      "fileMatch": ["network-config.yaml"],
+      "fileMatch": [
+        "network-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/network-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Organization Config",
       "description": "Used to manage all of the organization units in the AWS Organization",
-      "fileMatch": ["organization-config.yaml"],
+      "fileMatch": [
+        "organization-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/organization-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Replacements Config",
       "description": "Used to manage all of the replacement values across the configuration files",
-      "fileMatch": ["replacements-config.yaml"],
+      "fileMatch": [
+        "replacements-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/replacements-config.json"
     },
     {
       "name": "Landing Zone Accelerator on AWS - Security Config",
       "description": "Used to manage configuration of AWS security services",
-      "fileMatch": ["security-config.yaml"],
+      "fileMatch": [
+        "security-config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/awslabs/landing-zone-accelerator-on-aws/main/source/packages/@aws-accelerator/config/lib/schemas/security-config.json"
     },
     {
       "name": "Changesets",
       "description": "A way to manage your versioning and changelogs with a focus on monorepos",
-      "fileMatch": ["**/.changeset/config.json"],
+      "fileMatch": [
+        "**/.changeset/config.json"
+      ],
       "url": "https://unpkg.com/@changesets/config/schema.json"
     },
     {
       "name": "chisel-slices.json",
       "description": "Canonical Chisel slices definition file",
-      "fileMatch": ["**/slices/*.yaml"],
+      "fileMatch": [
+        "**/slices/*.yaml"
+      ],
       "url": "https://www.schemastore.org/chisel-slices.json"
     },
     {
       "name": "Citation File Format",
       "description": "A YAML file with citation metadata for software or datasets",
-      "fileMatch": ["CITATION.cff"],
+      "fileMatch": [
+        "CITATION.cff"
+      ],
       "url": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/1.2.0/schema.json",
       "versions": {
         "1.2.0": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/1.2.0/schema.json"
@@ -2513,7 +3103,9 @@
     {
       "name": "coffeelint.json",
       "description": "CoffeeLint configuration file",
-      "fileMatch": ["coffeelint.json"],
+      "fileMatch": [
+        "coffeelint.json"
+      ],
       "url": "https://www.schemastore.org/coffeelint.json"
     },
     {
@@ -2530,43 +3122,58 @@
     {
       "name": "committed.toml",
       "description": "committed configuration file",
-      "fileMatch": ["committed.toml"],
+      "fileMatch": [
+        "committed.toml"
+      ],
       "url": "https://raw.githubusercontent.com/crate-ci/committed/master/config.schema.json"
     },
     {
       "name": "composer.json",
       "description": "PHP Composer configuration file",
-      "fileMatch": ["composer.json"],
+      "fileMatch": [
+        "composer.json"
+      ],
       "url": "https://getcomposer.org/schema.json"
     },
     {
       "name": "component.json",
       "description": "Web component file",
-      "fileMatch": ["component.json"],
+      "fileMatch": [
+        "component.json"
+      ],
       "url": "https://www.schemastore.org/component.json"
     },
     {
       "name": "component-detection-manifest.json",
       "description": "Component Detection manifest",
-      "fileMatch": ["cdmanifest.json", "cgmanifest.json"],
+      "fileMatch": [
+        "cdmanifest.json",
+        "cgmanifest.json"
+      ],
       "url": "https://www.schemastore.org/component-detection-manifest.json"
     },
     {
       "name": "contribute.json",
       "description": "A open-source project contribution data by Mozilla",
-      "fileMatch": ["contribute.json"],
+      "fileMatch": [
+        "contribute.json"
+      ],
       "url": "https://raw.githubusercontent.com/mozilla/contribute.json/master/schema.json"
     },
     {
       "name": "crowdin.yml",
       "description": "Crowdin, a crowd-translation platform. Documentation: https://support.crowdin.com/configuration-file/",
-      "fileMatch": ["**/crowdin.yml"],
+      "fileMatch": [
+        "**/crowdin.yml"
+      ],
       "url": "https://www.schemastore.org/crowdin.json"
     },
     {
       "name": "Crowdsec collection config",
       "description": "A YAML Crowdsec collection configuration files",
-      "fileMatch": ["**/collections/*/*.yaml"],
+      "fileMatch": [
+        "**/collections/*/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/collection_schema.yaml"
     },
     {
@@ -2584,7 +3191,9 @@
     {
       "name": "Crowdsec scenario config",
       "description": "A YAML Crowdsec scenario configuration files",
-      "fileMatch": ["**/scenarios/*/*.yaml"],
+      "fileMatch": [
+        "**/scenarios/*/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-yaml-schemas/main/scenario_schema.yaml"
     },
     {
@@ -2599,13 +3208,17 @@
     {
       "name": "cypress.json",
       "description": "Cypress.io test runner configuration file",
-      "fileMatch": ["cypress.json"],
+      "fileMatch": [
+        "cypress.json"
+      ],
       "url": "https://on.cypress.io/cypress.schema.json"
     },
     {
       "name": ".creatomic",
       "description": "A config for Atomic Design 4 React generator",
-      "fileMatch": [".creatomic"],
+      "fileMatch": [
+        ".creatomic"
+      ],
       "url": "https://www.schemastore.org/creatomic.json"
     },
     {
@@ -2627,19 +3240,25 @@
     {
       "name": "CSS Comb (.csscomb.json)",
       "description": "CSS Comb's configuration file",
-      "fileMatch": [".csscomb.json"],
+      "fileMatch": [
+        ".csscomb.json"
+      ],
       "url": "https://www.schemastore.org/csscomb.json"
     },
     {
       "name": "CSS Lint (.csslintrc)",
       "description": "CSS Lint's configuration file",
-      "fileMatch": [".csslintrc"],
+      "fileMatch": [
+        ".csslintrc"
+      ],
       "url": "https://www.schemastore.org/csslintrc.json"
     },
     {
       "name": "Dagger module",
       "description": "Module metadata for the Dagger CI/CD engine: SDK, dependencies, and engine version",
-      "fileMatch": ["dagger.json"],
+      "fileMatch": [
+        "dagger.json"
+      ],
       "url": "https://docs.dagger.io/reference/dagger.schema.json"
     },
     {
@@ -2650,13 +3269,18 @@
     {
       "name": "Dart Test Config (dart-test.json)",
       "description": "Configuration for Dart's test package",
-      "fileMatch": ["dart_test.yaml"],
+      "fileMatch": [
+        "dart_test.yaml"
+      ],
       "url": "https://www.schemastore.org/dart-test.json"
     },
     {
       "name": "DashLord Configuration",
       "description": "Configuration for DashLord",
-      "fileMatch": ["dashlord.yaml", "dashlord.yml"],
+      "fileMatch": [
+        "dashlord.yaml",
+        "dashlord.yml"
+      ],
       "url": "https://raw.githubusercontent.com/socialgouv/dashlord/main/schema.json"
     },
     {
@@ -2700,37 +3324,52 @@
     {
       "name": "datalogic-scan2deploy-android",
       "description": "Datalogic Scan2Deploy Android file",
-      "fileMatch": [".dla.json"],
+      "fileMatch": [
+        ".dla.json"
+      ],
       "url": "https://www.schemastore.org/datalogic-scan2deploy-android.json"
     },
     {
       "name": "datalogic-scan2deploy-ce",
       "description": "Datalogic Scan2Deploy CE file",
-      "fileMatch": [".dlc.json"],
+      "fileMatch": [
+        ".dlc.json"
+      ],
       "url": "https://www.schemastore.org/datalogic-scan2deploy-ce.json"
     },
     {
       "name": "ddev-global",
       "description": "DDEV global configuration file",
-      "fileMatch": ["**/.ddev/global_config.yaml"],
+      "fileMatch": [
+        "**/.ddev/global_config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/globalconfig/schema.json"
     },
     {
       "name": "ddev-project",
       "description": "DDEV project configuration file",
-      "fileMatch": ["**/.ddev/config*.yaml"],
+      "fileMatch": [
+        "**/.ddev/config*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ddev/ddev/master/pkg/ddevapp/schema.json"
     },
     {
       "name": "debugsettings.json",
       "description": "A the ASP.NET DebugSettings.json files",
-      "fileMatch": ["debugsettings.json"],
+      "fileMatch": [
+        "debugsettings.json"
+      ],
       "url": "https://www.schemastore.org/debugsettings.json"
     },
     {
       "name": "Draugr Saga",
       "description": "Draugr Saga - a declarative account of an application's security surface and the controls that must pass",
-      "fileMatch": ["*.saga.yaml", "*.saga.yml", ".saga.yaml", ".saga.yml"],
+      "fileMatch": [
+        "*.saga.yaml",
+        "*.saga.yml",
+        ".saga.yaml",
+        ".saga.yml"
+      ],
       "url": "https://draugr.dev/schema/draugr.saga.schema.json"
     },
     {
@@ -2747,13 +3386,18 @@
     {
       "name": "Deno Config (deno.json)",
       "description": "A JSON representation of a Deno configuration file",
-      "fileMatch": ["deno.json", "deno.jsonc"],
+      "fileMatch": [
+        "deno.json",
+        "deno.jsonc"
+      ],
       "url": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"
     },
     {
       "name": "dependabot.json",
       "description": "Dependabot config.yml files",
-      "fileMatch": ["**/.dependabot/config.yml"],
+      "fileMatch": [
+        "**/.dependabot/config.yml"
+      ],
       "url": "https://www.schemastore.org/dependabot.json"
     },
     {
@@ -2776,7 +3420,10 @@
     {
       "name": "Detekt Config (detekt.yml)",
       "description": "Detekt Configuration File",
-      "fileMatch": ["detekt.yml", "detekt.yaml"],
+      "fileMatch": [
+        "detekt.yml",
+        "detekt.yaml"
+      ],
       "url": "https://www.schemastore.org/detekt-1.22.0.json",
       "versions": {
         "1.14.1": "https://www.schemastore.org/detekt-1.14.1.json",
@@ -2791,7 +3438,10 @@
     {
       "name": "dockerd.json",
       "description": "Docker daemon configuration",
-      "fileMatch": ["dockerd.json", "docker.json"],
+      "fileMatch": [
+        "dockerd.json",
+        "docker.json"
+      ],
       "url": "https://www.schemastore.org/dockerd.json"
     },
     {
@@ -2803,7 +3453,10 @@
     {
       "name": "docker bake",
       "description": "Docker Bake configuration file. Documentation: https://docs.docker.com/build/bake/reference",
-      "fileMatch": ["docker-bake.json", "docker-bake.override.json"],
+      "fileMatch": [
+        "docker-bake.json",
+        "docker-bake.override.json"
+      ],
       "url": "https://www.schemastore.org/docker-bake.json"
     },
     {
@@ -2822,13 +3475,17 @@
     {
       "name": "DocFx Config (docfx.json)",
       "description": "A DocFx configuration files",
-      "fileMatch": ["docfx.json"],
+      "fileMatch": [
+        "docfx.json"
+      ],
       "url": "https://www.schemastore.org/docfx.json"
     },
     {
       "name": "Docs MCP Manifest",
       "description": "Configuration file for Docs MCP",
-      "fileMatch": [".docs-mcp.json"],
+      "fileMatch": [
+        ".docs-mcp.json"
+      ],
       "url": "https://raw.githubusercontent.com/speakeasy-api/docs-mcp/refs/heads/main/schemas/docs-mcp.schema.json"
     },
     {
@@ -2847,67 +3504,89 @@
     {
       "name": "Dolittle Artifacts",
       "description": "A Dolittle bounded context's artifacts",
-      "fileMatch": ["**/.dolittle/artifacts.json"],
+      "fileMatch": [
+        "**/.dolittle/artifacts.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Artifacts.Configuration/artifacts.json"
     },
     {
       "name": "Dolittle Bounded Context Configuration",
       "description": "A Dolittle application's bounded context configuration",
-      "fileMatch": ["bounded-context.json"],
+      "fileMatch": [
+        "bounded-context.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Applications.Configuration/bounded-context.json"
     },
     {
       "name": "Dolittle Event Horizons Configuration",
       "description": "A Dolittle bounded context's event horizon configurations",
-      "fileMatch": ["**/.dolittle/event-horizons.json"],
+      "fileMatch": [
+        "**/.dolittle/event-horizons.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Events/event-horizons.json"
     },
     {
       "name": "Dolittle Resources Configuration",
       "description": "A Dolittle bounded context's resource configurations",
-      "fileMatch": ["**/.dolittle/resources.json"],
+      "fileMatch": [
+        "**/.dolittle/resources.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.Fundamentals/v5.1.0/Schemas/ResourceTypes.Configuration/resources.json"
     },
     {
       "name": "Dolittle Server Configuration",
       "description": "A Dolittle bounded context's event horizon's interaction server configuration",
-      "fileMatch": ["**/.dolittle/server.json"],
+      "fileMatch": [
+        "**/.dolittle/server.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Server/server.json"
     },
     {
       "name": "Dolittle Tenants Configuration",
       "description": "A Dolittle bounded context's tenant configuration",
-      "fileMatch": ["**/.dolittle/tenants.json"],
+      "fileMatch": [
+        "**/.dolittle/tenants.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/Runtime/master/Schemas/Tenancy/tenants.json"
     },
     {
       "name": "Dolittle Tenant Map Configuration",
       "description": "A Dolittle bounded context's tenant mapping configurations",
-      "fileMatch": ["**/.dolittle/tenant-map.json"],
+      "fileMatch": [
+        "**/.dolittle/tenant-map.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle-obsolete/DotNET.Fundamentals/v4.10.0/Schemas/Tenancy.Configuration/tenant-map.json"
     },
     {
       "name": "Dolittle Topology",
       "description": "A Dolittle bounded context's topology",
-      "fileMatch": ["**/.dolittle/topology.json"],
+      "fileMatch": [
+        "**/.dolittle/topology.json"
+      ],
       "url": "https://raw.githubusercontent.com/dolittle/DotNET.SDK/v5.0.0/Schemas/Applications.Configuration/topology.json"
     },
     {
       "name": "dotnet Release Index manifest",
       "description": ".NET product collection manifests",
-      "fileMatch": ["dotnet-release-index.json"],
+      "fileMatch": [
+        "dotnet-release-index.json"
+      ],
       "url": "https://www.schemastore.org/dotnet-releases-index.json"
     },
     {
       "name": "dotnet-tools.json",
       "description": ".NET tools manifest file",
-      "fileMatch": ["dotnet-tools.json"],
+      "fileMatch": [
+        "dotnet-tools.json"
+      ],
       "url": "https://www.schemastore.org/dotnet-tools.json"
     },
     {
       "name": "dotnetcli.host.json",
       "description": ".NET CLI template host files",
-      "fileMatch": ["dotnetcli.host.json"],
+      "fileMatch": [
+        "dotnetcli.host.json"
+      ],
       "url": "https://www.schemastore.org/dotnetcli.host.json"
     },
     {
@@ -2924,13 +3603,17 @@
     {
       "name": "drone.json",
       "description": "Drone CI configuration file",
-      "fileMatch": [".drone.yml"],
+      "fileMatch": [
+        ".drone.yml"
+      ],
       "url": "https://www.schemastore.org/drone.json"
     },
     {
       "name": "Drush site aliases",
       "description": "Drush 9 site aliases file",
-      "fileMatch": ["**/sites/*.site.yml"],
+      "fileMatch": [
+        "**/sites/*.site.yml"
+      ],
       "url": "https://www.schemastore.org/drush.site.yml.json"
     },
     {
@@ -2941,25 +3624,36 @@
     {
       "name": "dstack configuration",
       "description": "YAML dstack configurations",
-      "fileMatch": ["*.dstack.yml", "*.dstack.yaml"],
+      "fileMatch": [
+        "*.dstack.yml",
+        "*.dstack.yaml"
+      ],
       "url": "https://dstack-runner-downloads.s3.eu-west-1.amazonaws.com/latest/schemas/configuration.json"
     },
     {
       "name": "Dust configuration",
       "description": "TOML configuration for Dust",
-      "fileMatch": [".dust.toml", "**/.config/dust/config.toml"],
+      "fileMatch": [
+        ".dust.toml",
+        "**/.config/dust/config.toml"
+      ],
       "url": "https://www.schemastore.org/dust.json"
     },
     {
       "name": "dvc.yaml",
       "description": "dvc.yaml file",
-      "fileMatch": ["dvc.yaml"],
+      "fileMatch": [
+        "dvc.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/iterative/dvcyaml-schema/master/schema.json"
     },
     {
       "name": "Devfile",
       "description": "Devfiles",
-      "fileMatch": ["devfile.yaml", ".devfile.yaml"],
+      "fileMatch": [
+        "devfile.yaml",
+        ".devfile.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/devfile/api/v2.2.0/schemas/latest/devfile.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/eclipse-che/che-server/7.80.0/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json",
@@ -3013,13 +3707,18 @@
     {
       "name": "ECA - Editor Code Assistant",
       "description": "ECA AI coding agent configuration file",
-      "fileMatch": ["**/eca/config.json", "**/.eca/config.json"],
+      "fileMatch": [
+        "**/eca/config.json",
+        "**/.eca/config.json"
+      ],
       "url": "https://eca.dev/config.json"
     },
     {
       "name": "editorconfig-checker",
       "description": "editorconfig-checker configuration file",
-      "fileMatch": [".editorconfig-checker.json"],
+      "fileMatch": [
+        ".editorconfig-checker.json"
+      ],
       "url": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/main/.editorconfig-checker.schema.json",
       "versions": {
         "3.8.0": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/v3.8.0/.editorconfig-checker.schema.json"
@@ -3047,7 +3746,10 @@
     {
       "name": "Envilder Map File",
       "description": "Envilder secret mapping file that maps environment variable names to cloud secret paths",
-      "fileMatch": ["envilder.json", "envilder.*.json"],
+      "fileMatch": [
+        "envilder.json",
+        "envilder.*.json"
+      ],
       "url": "https://envilder.com/schema/map-file.v1.json"
     },
     {
@@ -3323,7 +4025,10 @@
     {
       "name": ".esmrc.json",
       "description": "Configuration files for the esm module/package in Node.js",
-      "fileMatch": [".esmrc", ".esmrc.json"],
+      "fileMatch": [
+        ".esmrc",
+        ".esmrc.json"
+      ],
       "url": "https://www.schemastore.org/esmrc.json"
     },
     {
@@ -3334,31 +4039,43 @@
     {
       "name": "estampo.toml",
       "description": "Configuration for estampo, the build system for reproducible 3D prints",
-      "fileMatch": ["estampo.toml", "estampo.*.toml"],
+      "fileMatch": [
+        "estampo.toml",
+        "estampo.*.toml"
+      ],
       "url": "https://raw.githubusercontent.com/estampo/estampo/main/docs/estampo.schema.json"
     },
     {
       "name": "epr-manifest.json",
       "description": "Entry Point Regulation manifest file",
-      "fileMatch": ["epr-manifest.json"],
+      "fileMatch": [
+        "epr-manifest.json"
+      ],
       "url": "https://www.schemastore.org/epr-manifest.json"
     },
     {
       "name": "electron-builder configuration file",
       "description": "electron-build configuration file",
-      "fileMatch": ["electron-builder.json"],
+      "fileMatch": [
+        "electron-builder.json"
+      ],
       "url": "https://www.schemastore.org/electron-builder.json"
     },
     {
       "name": "evcc.yaml",
       "description": "evcc configuration file",
-      "fileMatch": ["evcc*.yaml"],
+      "fileMatch": [
+        "evcc*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/andig/evcc/master/schema.json"
     },
     {
       "name": "EveryVoice TTS Toolkit Aligner Configuration",
       "description": "EveryVoice Text-to-Speech Toolkit Aligner Configuration",
-      "fileMatch": ["everyvoice-aligner.yaml", "everyvoice-aligner.json"],
+      "fileMatch": [
+        "everyvoice-aligner.yaml",
+        "everyvoice-aligner.json"
+      ],
       "url": "https://raw.githubusercontent.com/EveryVoiceTTS/everyvoice/main/everyvoice/.schema/everyvoice-aligner-0.3.json",
       "versions": {
         "0.1": "https://raw.githubusercontent.com/EveryVoiceTTS/everyvoice/main/everyvoice/.schema/everyvoice-aligner-0.1.json",
@@ -3457,25 +4174,36 @@
     {
       "name": "EAS config",
       "description": "The EAS config (eas.json) validation and documentation",
-      "fileMatch": ["eas.json"],
+      "fileMatch": [
+        "eas.json"
+      ],
       "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-json/schema/eas.schema.json"
     },
     {
       "name": "Expoot app config",
       "description": "The config for creating a React Native Desktop app with best-effort Expo support, used by the expoot CLI",
-      "fileMatch": ["expoot-app.json"],
+      "fileMatch": [
+        "expoot-app.json"
+      ],
       "url": "https://raw.githubusercontent.com/shirakaba/expoot/main/packages/expoot/schemas/expoot-app.schema.json"
     },
     {
       "name": "EasyVCR .NET",
       "description": "EasyVCR .NET recording file",
-      "fileMatch": ["*.easyvcr", "**/cassettes/*.json"],
+      "fileMatch": [
+        "*.easyvcr",
+        "**/cassettes/*.json"
+      ],
       "url": "https://www.schemastore.org/easyvcr-net.json"
     },
     {
       "name": "ezd task runner",
       "description": "ezd task runner. Documentation: https://gitlab.com/sbenv/veroxis/ezd-rs",
-      "fileMatch": ["ezd.yaml", "ezd.json", "ezd.yml"],
+      "fileMatch": [
+        "ezd.yaml",
+        "ezd.json",
+        "ezd.yml"
+      ],
       "url": "https://gitlab.com/sbenv/veroxis/ezd-rs/-/raw/HEAD/ezd.schema.json"
     },
     {
@@ -3492,37 +4220,49 @@
     {
       "name": "ESLint Suppressions",
       "description": "ESLint bulk suppressions file",
-      "fileMatch": ["eslint-suppressions.json"],
+      "fileMatch": [
+        "eslint-suppressions.json"
+      ],
       "url": "https://www.schemastore.org/eslint-suppressions.json"
     },
     {
       "name": "fabric.mod.json",
       "description": "Metadata file used by the Fabric mod loader",
-      "fileMatch": ["fabric.mod.json"],
+      "fileMatch": [
+        "fabric.mod.json"
+      ],
       "url": "https://www.schemastore.org/fabric.mod.json"
     },
     {
       "name": "F-Droid Data metadata",
       "description": "F-Droid Data app metadata files",
-      "fileMatch": ["**/metadata/*.yml"],
+      "fileMatch": [
+        "**/metadata/*.yml"
+      ],
       "url": "https://gitlab.com/fdroid/fdroiddata/-/raw/master/schemas/metadata.json"
     },
     {
       "name": ".ffizer.yaml",
       "description": "ffizer template configuration files",
-      "fileMatch": [".ffizer.yaml"],
+      "fileMatch": [
+        ".ffizer.yaml"
+      ],
       "url": "https://ffizer.github.io/ffizer/ffizer.schema.json"
     },
     {
       "name": "Firebase",
       "description": "firebase",
-      "fileMatch": ["firebase.json"],
+      "fileMatch": [
+        "firebase.json"
+      ],
       "url": "https://raw.githubusercontent.com/firebase/firebase-tools/master/schema/firebase-config.json"
     },
     {
       "name": "Google Chrome Related Website Sets",
       "description": "Google Chrome Related Website Sets (formerly First Party Sets)",
-      "fileMatch": ["**/.well-known/first-party-set.json"],
+      "fileMatch": [
+        "**/.well-known/first-party-set.json"
+      ],
       "url": "https://raw.githubusercontent.com/GoogleChrome/related-website-sets/main/SCHEMA.json"
     },
     {
@@ -3553,13 +4293,18 @@
     {
       "name": "FlexGet Config",
       "description": "FlexGet config file",
-      "fileMatch": ["**/.flexget/config.yml", "**/flexget/config.yml"],
+      "fileMatch": [
+        "**/.flexget/config.yml",
+        "**/flexget/config.yml"
+      ],
       "url": "https://github.com/Flexget/Flexget/releases/latest/download/flexget-config.schema.json"
     },
     {
       "name": "first-timers-bot",
       "description": "A bot that helps onboarding new open-source contributors",
-      "fileMatch": ["**/.github/first-timers.yml"],
+      "fileMatch": [
+        "**/.github/first-timers.yml"
+      ],
       "url": "https://www.schemastore.org/first-timers.json"
     },
     {
@@ -3571,49 +4316,67 @@
     {
       "name": "Foundry VTT - Module Manifest",
       "description": "Foundry VTT module.json files",
-      "fileMatch": ["**/modules/*/module.json"],
+      "fileMatch": [
+        "**/modules/*/module.json"
+      ],
       "url": "https://www.schemastore.org/foundryvtt-module-manifest.json"
     },
     {
       "name": "Foundry VTT - System Manifest",
       "description": "Foundry VTT system.json files",
-      "fileMatch": ["**/systems/*/system.json"],
+      "fileMatch": [
+        "**/systems/*/system.json"
+      ],
       "url": "https://www.schemastore.org/foundryvtt-system-manifest.json"
     },
     {
       "name": "Foundry VTT - World Manifest",
       "description": "Foundry VTT world.json files",
-      "fileMatch": ["**/worlds/*/world.json"],
+      "fileMatch": [
+        "**/worlds/*/world.json"
+      ],
       "url": "https://www.schemastore.org/foundryvtt-world-manifest.json"
     },
     {
       "name": "Foundry VTT - System Data Template",
       "description": "Foundry VTT template.json files",
-      "fileMatch": ["**/systems/*/template.json"],
+      "fileMatch": [
+        "**/systems/*/template.json"
+      ],
       "url": "https://www.schemastore.org/foundryvtt-template.json"
     },
     {
       "name": "Fossa configuration file",
       "description": "FOSSA CLI's .fossa.yml configuration file",
-      "fileMatch": [".fossa.yml"],
+      "fileMatch": [
+        ".fossa.yml"
+      ],
       "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json"
     },
     {
       "name": "Fossa's fossa-deps file",
       "description": "FOSSA CLI's fossa-deps file",
-      "fileMatch": ["fossa-deps.yml", "fossa-deps.yaml", "fossa-deps.json"],
+      "fileMatch": [
+        "fossa-deps.yml",
+        "fossa-deps.yaml",
+        "fossa-deps.json"
+      ],
       "url": "https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-deps.schema.json"
     },
     {
       "name": "Karakum configuration file",
       "description": "configuring Karakum, a converter of TypeScript declaration files to Kotlin declarations",
-      "fileMatch": ["karakum.config.json"],
+      "fileMatch": [
+        "karakum.config.json"
+      ],
       "url": "https://raw.githubusercontent.com/karakum-team/karakum/master/karakum-schema/karakum-schema.json"
     },
     {
       "name": "Knative Functions - func.yaml",
       "description": "Knative Functions func.yaml files",
-      "fileMatch": ["func.yaml"],
+      "fileMatch": [
+        "func.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/knative/func/latest-release/schema/func_yaml-schema.json",
       "versions": {
         "1.7": "https://raw.githubusercontent.com/knative/func/release-1.7/schema/func_yaml-schema.json",
@@ -3623,13 +4386,19 @@
     {
       "name": "Knip",
       "description": "Knip JSON configuration files",
-      "fileMatch": ["knip.json", ".knip.json"],
+      "fileMatch": [
+        "knip.json",
+        ".knip.json"
+      ],
       "url": "https://unpkg.com/knip@6/schema.json"
     },
     {
       "name": "Knip JSONC",
       "description": "Knip JSONC configuration files",
-      "fileMatch": ["knip.jsonc", ".knip.jsonc"],
+      "fileMatch": [
+        "knip.jsonc",
+        ".knip.jsonc"
+      ],
       "url": "https://unpkg.com/knip@6/schema-jsonc.json"
     },
     {
@@ -3656,13 +4425,18 @@
     {
       "name": "function.json",
       "description": "Azure Functions function.json files",
-      "fileMatch": ["function.json"],
+      "fileMatch": [
+        "function.json"
+      ],
       "url": "https://www.schemastore.org/function.json"
     },
     {
       "name": "G2P Mapping Configuration",
       "description": "defining mappings for Python-based grapheme-to-phoneme engine 'g2p'",
-      "fileMatch": ["config-g2p.yaml", "config-g2p.json"],
+      "fileMatch": [
+        "config-g2p.yaml",
+        "config-g2p.json"
+      ],
       "url": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.3.json",
       "versions": {
         "2.0": "https://raw.githubusercontent.com/roedoejet/g2p/main/g2p/mappings/.schema/g2p-config-schema-2.0.json",
@@ -3674,13 +4448,18 @@
     {
       "name": "GAMA",
       "description": "GAMA configuration file",
-      "fileMatch": ["**/gama/config.yaml", ".gama.yaml"],
+      "fileMatch": [
+        "**/gama/config.yaml",
+        ".gama.yaml"
+      ],
       "url": "https://www.schemastore.org/gama.json"
     },
     {
       "name": "Gaspar",
       "description": "Configuration for Gaspar",
-      "fileMatch": ["gaspar.config.json"],
+      "fileMatch": [
+        "gaspar.config.json"
+      ],
       "url": "https://www.schemastore.org/gaspar-3.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/gaspar-1.0.json",
@@ -3741,7 +4520,9 @@
     {
       "name": "Global Privacy Control",
       "description": "Configuration for GPC, so a site can convey its support for the Global Privacy Control",
-      "fileMatch": ["**/.well-known/gpc.json"],
+      "fileMatch": [
+        "**/.well-known/gpc.json"
+      ],
       "url": "https://www.schemastore.org/gpc.json"
     },
     {
@@ -3770,7 +4551,10 @@
     {
       "name": "Gitleaks",
       "description": "Gitleaks configuration file",
-      "fileMatch": ["gitleaks.toml", ".gitleaks.toml"],
+      "fileMatch": [
+        "gitleaks.toml",
+        ".gitleaks.toml"
+      ],
       "url": "https://www.schemastore.org/gitleaks.json"
     },
     {
@@ -3814,7 +4598,11 @@
     {
       "name": "gh-dash",
       "description": "Configuration for the gh-dash GitHub CLI dashboard",
-      "fileMatch": [".gh-dash.yml", ".gh-dash.yaml", "**/gh-dash/config.yml"],
+      "fileMatch": [
+        ".gh-dash.yml",
+        ".gh-dash.yaml",
+        "**/gh-dash/config.yml"
+      ],
       "url": "https://gh-dash.dev/schema.json"
     },
     {
@@ -3831,19 +4619,28 @@
     {
       "name": "GitHub Action",
       "description": "YAML GitHub Actions",
-      "fileMatch": ["action.yml", "action.yaml"],
+      "fileMatch": [
+        "action.yml",
+        "action.yaml"
+      ],
       "url": "https://www.schemastore.org/github-action.json"
     },
     {
       "name": "GitHub CLI configuration",
       "description": "Global configuration for the GitHub CLI",
-      "fileMatch": ["**/gh/config.yml", "**/GitHub CLI/config.yml"],
+      "fileMatch": [
+        "**/gh/config.yml",
+        "**/GitHub CLI/config.yml"
+      ],
       "url": "https://www.schemastore.org/github-cli-config.json"
     },
     {
       "name": "GitHub CLI hosts",
       "description": "Authentication and per-host configuration for the GitHub CLI",
-      "fileMatch": ["**/gh/hosts.yml", "**/GitHub CLI/hosts.yml"],
+      "fileMatch": [
+        "**/gh/hosts.yml",
+        "**/GitHub CLI/hosts.yml"
+      ],
       "url": "https://www.schemastore.org/github-cli-hosts.json"
     },
     {
@@ -3858,7 +4655,10 @@
     {
       "name": "GitHub Prompt",
       "description": "YAML prompt files for GitHub Models (.prompt.yml / .prompt.yaml)",
-      "fileMatch": ["**/*.prompt.yml", "**/*.prompt.yaml"],
+      "fileMatch": [
+        "**/*.prompt.yml",
+        "**/*.prompt.yaml"
+      ],
       "url": "https://www.schemastore.org/github-prompt.json"
     },
     {
@@ -3898,7 +4698,9 @@
     {
       "name": "GitHub Secret Scanning",
       "description": "YAML configuration for GitHub secret scanning exclusions",
-      "fileMatch": ["**/.github/secret_scanning.yml"],
+      "fileMatch": [
+        "**/.github/secret_scanning.yml"
+      ],
       "url": "https://www.schemastore.org/github-secret-scanning.json"
     },
     {
@@ -3917,13 +4719,17 @@
     {
       "name": "GitHub Workflow Template Properties",
       "description": "properties json file for a GitHub Workflow template",
-      "fileMatch": ["**/.github/workflow-templates/**.properties.json"],
+      "fileMatch": [
+        "**/.github/workflow-templates/**.properties.json"
+      ],
       "url": "https://www.schemastore.org/github-workflow-template-properties.json"
     },
     {
       "name": "GitHub automatically generated release notes configuration",
       "description": "YAML GitHub automatically generated release notes config",
-      "fileMatch": ["**/.github/release.yml"],
+      "fileMatch": [
+        "**/.github/release.yml"
+      ],
       "url": "https://www.schemastore.org/github-release-config.json"
     },
     {
@@ -3940,13 +4746,17 @@
     {
       "name": "GitLab Duo Workflow",
       "description": "YAML configuration for GitLab Duo Workflows",
-      "fileMatch": ["**/.gitlab/duo/flows/*.yaml"],
+      "fileMatch": [
+        "**/.gitlab/duo/flows/*.yaml"
+      ],
       "url": "https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/raw/main/duo_workflow_service/schemas/v1/flow_config.schema.json"
     },
     {
       "name": "Gitpod Configuration",
       "description": "configuring Gitpod.io",
-      "fileMatch": [".gitpod.yml"],
+      "fileMatch": [
+        ".gitpod.yml"
+      ],
       "url": "https://gitpod.io/schemas/gitpod-schema.json"
     },
     {
@@ -3963,31 +4773,41 @@
     {
       "name": "Ansible Execution Environment",
       "description": "Ansible execution-environment.yml file",
-      "fileMatch": ["**/execution-environment.yml"],
+      "fileMatch": [
+        "**/execution-environment.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/execution-environment.json"
     },
     {
       "name": "Ansible Meta",
       "description": "Ansible meta/main.yml file",
-      "fileMatch": ["**/meta/main.yml"],
+      "fileMatch": [
+        "**/meta/main.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta.json"
     },
     {
       "name": "Ansible Meta Runtime",
       "description": "Ansible meta/runtime.yml file",
-      "fileMatch": ["**/meta/runtime.yml"],
+      "fileMatch": [
+        "**/meta/runtime.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/meta-runtime.json"
     },
     {
       "name": "Ansible Argument Specs",
       "description": "Ansible meta/argument_specs.yml file",
-      "fileMatch": ["**/meta/argument_specs.yml"],
+      "fileMatch": [
+        "**/meta/argument_specs.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/role-arg-spec.json"
     },
     {
       "name": "Ansible Requirements",
       "description": "Ansible requirements file",
-      "fileMatch": ["requirements.yml"],
+      "fileMatch": [
+        "requirements.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/requirements.json"
     },
     {
@@ -4030,25 +4850,36 @@
     {
       "name": "Ansible Rulebook",
       "description": "Ansible rulebook files",
-      "fileMatch": ["**/rulebooks/*.yml", "**/rulebooks/*.yaml"],
+      "fileMatch": [
+        "**/rulebooks/*.yml",
+        "**/rulebooks/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-rulebook/main/ansible_rulebook/schema/ruleset_schema.json"
     },
     {
       "name": "Ansible Inventory",
       "description": "Ansible inventory files",
-      "fileMatch": ["inventory.yml", "inventory.yaml"],
+      "fileMatch": [
+        "inventory.yml",
+        "inventory.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/inventory.json"
     },
     {
       "name": "Ansible Collection Galaxy",
       "description": "Ansible Collection Galaxy metadata",
-      "fileMatch": ["galaxy.yml"],
+      "fileMatch": [
+        "galaxy.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/galaxy.json"
     },
     {
       "name": "Ansible-lint Configuration",
       "description": "Ansible-lint Configuration",
-      "fileMatch": [".ansible-lint", "**/.config/ansible-lint.yml"],
+      "fileMatch": [
+        ".ansible-lint",
+        "**/.config/ansible-lint.yml"
+      ],
       "url": "https://raw.githubusercontent.com/ansible/ansible-lint/main/src/ansiblelint/schemas/ansible-lint-config.json"
     },
     {
@@ -4067,7 +4898,9 @@
     {
       "name": "global.json",
       "description": "ASP.NET global configuration file",
-      "fileMatch": ["global.json"],
+      "fileMatch": [
+        "global.json"
+      ],
       "url": "https://www.schemastore.org/global.json"
     },
     {
@@ -4088,25 +4921,38 @@
     {
       "name": "Golangci-lint Custom Plugins Configuration",
       "description": "golangci-lint custom plugins configuration file",
-      "fileMatch": [".custom-gcl.yml", ".custom-gcl.yaml"],
+      "fileMatch": [
+        ".custom-gcl.yml",
+        ".custom-gcl.yaml"
+      ],
       "url": "https://golangci-lint.run/jsonschema/custom-gcl.jsonschema.json"
     },
     {
       "name": "gollama",
       "description": "gollama configuration file",
-      "fileMatch": ["**/gollama/config.json"],
+      "fileMatch": [
+        "**/gollama/config.json"
+      ],
       "url": "https://www.schemastore.org/gollama.json"
     },
     {
       "name": "go-feature-flag Flag Configuration",
       "description": "go-feature-flag flag configuration file",
-      "fileMatch": ["*.goff.yml", "*.goff.yaml", "*.goff.json", "*.goff.toml"],
+      "fileMatch": [
+        "*.goff.yml",
+        "*.goff.yaml",
+        "*.goff.json",
+        "*.goff.toml"
+      ],
       "url": "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/.schema/flag-schema.json"
     },
     {
       "name": "gojo.yaml",
       "description": "gojo project manifest (profiles, agents, schedules)",
-      "fileMatch": ["gojo.yaml", "**/.gojo/project.yaml"],
+      "fileMatch": [
+        "gojo.yaml",
+        "**/.gojo/project.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/detroitpro/gojo/main/packages/contracts/schemas/gojo.project.schema.json"
     },
     {
@@ -4128,13 +4974,20 @@
     {
       "name": "Anodizer",
       "description": "Anodizer Rust release-automation configuration file",
-      "fileMatch": [".anodizer.yaml", ".anodizer.yml"],
+      "fileMatch": [
+        ".anodizer.yaml",
+        ".anodizer.yml"
+      ],
       "url": "https://tj-smith47.github.io/anodizer/schema.json"
     },
     {
       "name": "Goss",
       "description": "Goss - Quick and Easy server validation",
-      "fileMatch": ["goss.yaml", "goss.yml", "goss.json"],
+      "fileMatch": [
+        "goss.yaml",
+        "goss.yml",
+        "goss.json"
+      ],
       "url": "https://github.com/goss-org/goss/raw/master/docs/schema.yaml"
     },
     {
@@ -4145,13 +4998,17 @@
     {
       "name": "tree-sitter grammar.json",
       "description": "tree-sitter grammar.json",
-      "fileMatch": ["grammar.json"],
+      "fileMatch": [
+        "grammar.json"
+      ],
       "url": "https://raw.githubusercontent.com/tree-sitter/tree-sitter/master/docs/src/assets/schemas/config.schema.json"
     },
     {
       "name": "Treefmt",
       "description": "Treefmt configuration file",
-      "fileMatch": ["treefmt.toml"],
+      "fileMatch": [
+        "treefmt.toml"
+      ],
       "url": "https://www.schemastore.org/treefmt.json"
     },
     {
@@ -4209,61 +5066,85 @@
     {
       "name": "Grunt copy task",
       "description": "Grunt copy task configuration file",
-      "fileMatch": ["copy.json"],
+      "fileMatch": [
+        "copy.json"
+      ],
       "url": "https://www.schemastore.org/grunt-copy-task.json"
     },
     {
       "name": "Grunt clean task",
       "description": "Grunt clean task configuration file",
-      "fileMatch": ["clean.json"],
+      "fileMatch": [
+        "clean.json"
+      ],
       "url": "https://www.schemastore.org/grunt-clean-task.json"
     },
     {
       "name": "Grunt cssmin task",
       "description": "Grunt cssmin task configuration file",
-      "fileMatch": ["cssmin.json"],
+      "fileMatch": [
+        "cssmin.json"
+      ],
       "url": "https://www.schemastore.org/grunt-cssmin-task.json"
     },
     {
       "name": "Grunt JSHint task",
       "description": "Grunt JSHint task configuration file",
-      "fileMatch": ["jshint.json"],
+      "fileMatch": [
+        "jshint.json"
+      ],
       "url": "https://www.schemastore.org/grunt-jshint-task.json"
     },
     {
       "name": "Grunt Watch task",
       "description": "Grunt Watch task configuration file",
-      "fileMatch": ["watch.json"],
+      "fileMatch": [
+        "watch.json"
+      ],
       "url": "https://www.schemastore.org/grunt-watch-task.json"
     },
     {
       "name": "Grunt base task",
       "description": "standard Grunt tasks",
-      "fileMatch": ["**/grunt/*.json", "*-tasks.json"],
+      "fileMatch": [
+        "**/grunt/*.json",
+        "*-tasks.json"
+      ],
       "url": "https://www.schemastore.org/grunt-task.json"
     },
     {
       "name": "HashiCorp Vault",
       "description": "HashiCorp's Vault configuration file",
-      "fileMatch": ["vault.json", "vault.config.json"],
+      "fileMatch": [
+        "vault.json",
+        "vault.config.json"
+      ],
       "url": "https://www.schemastore.org/vault.json"
     },
     {
       "name": "haxelib.json",
       "description": "Haxelib manifest",
-      "fileMatch": ["haxelib.json"],
+      "fileMatch": [
+        "haxelib.json"
+      ],
       "url": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json"
     },
     {
       "name": "Hayson",
       "description": "Project Haystack data",
-      "fileMatch": ["*.hayson.json", "*.hayson.yaml", "*.hayson.yml"],
+      "fileMatch": [
+        "*.hayson.json",
+        "*.hayson.yaml",
+        "*.hayson.yml"
+      ],
       "url": "https://raw.githubusercontent.com/j2inn/hayson/master/hayson-json-schema.json"
     },
     {
       "name": "Haystack Pipeline",
       "description": "Haystack Pipeline YAML file describing the nodes of the pipelines. Documentation: https://haystack.deepset.ai/components/pipelines#yaml-file-definitions",
-      "fileMatch": ["*.haystack-pipeline.yml"],
+      "fileMatch": [
+        "*.haystack-pipeline.yml"
+      ],
       "url": "https://raw.githubusercontent.com/deepset-ai/haystack-json-schema/main/json-schema/haystack-pipeline.schema.json"
     },
     {
@@ -4280,7 +5161,9 @@
     {
       "name": "hassette.toml",
       "description": "Configuration file for Hassette, an async Python framework for Home Assistant automations",
-      "fileMatch": ["hassette.toml"],
+      "fileMatch": [
+        "hassette.toml"
+      ],
       "url": "https://raw.githubusercontent.com/NodeJSmith/hassette/main/hassette.schema.json"
     },
     {
@@ -4301,25 +5184,33 @@
     {
       "name": "host.json",
       "description": "Azure Functions host.json files",
-      "fileMatch": ["host.json"],
+      "fileMatch": [
+        "host.json"
+      ],
       "url": "https://www.schemastore.org/host.json"
     },
     {
       "name": "host-meta.json",
       "description": "host-meta JDR files",
-      "fileMatch": ["host-meta.json"],
+      "fileMatch": [
+        "host-meta.json"
+      ],
       "url": "https://www.schemastore.org/host-meta.json"
     },
     {
       "name": ".htmlhintrc",
       "description": "HTML Hint configuration file",
-      "fileMatch": [".htmlhintrc"],
+      "fileMatch": [
+        ".htmlhintrc"
+      ],
       "url": "https://www.schemastore.org/htmlhint.json"
     },
     {
       "name": ".htmlvalidate",
       "description": "HTML-validate is an offline HTML5 validator",
-      "fileMatch": [".htmlvalidate.json"],
+      "fileMatch": [
+        ".htmlvalidate.json"
+      ],
       "url": "https://html-validate.org/schemas/config.json"
     },
     {
@@ -4331,25 +5222,40 @@
     {
       "name": "Ory Hydra configuration",
       "description": "Ory Hydra configuration file",
-      "fileMatch": ["hydra.json", "hydra.yml", "hydra.yaml", "hydra.toml"],
+      "fileMatch": [
+        "hydra.json",
+        "hydra.yml",
+        "hydra.yaml",
+        "hydra.toml"
+      ],
       "url": "https://raw.githubusercontent.com/ory/hydra/master/.schema/version.schema.json"
     },
     {
       "name": "Hyperfoil benchmark configuration",
       "description": "Benchmark definition format for the Hyperfoil HTTP benchmark framework",
-      "fileMatch": ["*.hf.yaml"],
+      "fileMatch": [
+        "*.hf.yaml"
+      ],
       "url": "https://hyperfoil.io/schema.json"
     },
     {
       "name": "Hulak Configuration",
       "description": "Hulak API client configuration file",
-      "fileMatch": ["**/*.hk.yaml", "**/*.hk.yml", "**/*.hk.json"],
+      "fileMatch": [
+        "**/*.hk.yaml",
+        "**/*.hk.yml",
+        "**/*.hk.json"
+      ],
       "url": "https://raw.githubusercontent.com/xaaha/hulak/refs/heads/main/assets/schema.json"
     },
     {
       "name": "IBM Zapp document",
       "description": "IBM Z APPlication configuration file for IBM zDevOps development tools such as Z Open Editor",
-      "fileMatch": ["zapp.yaml", "zapp.yml", "zapp.json"],
+      "fileMatch": [
+        "zapp.yaml",
+        "zapp.yml",
+        "zapp.json"
+      ],
       "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.11.0.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zapp/zapp-schema-1.0.0.json",
@@ -4371,19 +5277,27 @@
     {
       "name": "IBM zCodeFormatSettings",
       "description": "IBM Enterprise languages code formatter settings file for IBM zDevOps development tools such as Z Open Editor",
-      "fileMatch": ["zcodeformat.yaml", "zcodeformat.json"],
+      "fileMatch": [
+        "zcodeformat.yaml",
+        "zcodeformat.json"
+      ],
       "url": "https://raw.githubusercontent.com/IBM/zopeneditor-about/main/zcodeformat/zcodeformat-schema-0.0.1.json"
     },
     {
       "name": "ide.host.json",
       "description": "IDE template host file",
-      "fileMatch": ["ide.host.json"],
+      "fileMatch": [
+        "ide.host.json"
+      ],
       "url": "https://www.schemastore.org/ide.host.json"
     },
     {
       "name": "ifstate.yaml",
       "description": "IfState configuration file",
-      "fileMatch": ["ifstate.yaml", "**/ifstate/config.yml"],
+      "fileMatch": [
+        "ifstate.yaml",
+        "**/ifstate/config.yml"
+      ],
       "url": "https://ifstate.net/schema/2/ifstate.conf.schema.json",
       "versions": {
         "0.6": "https://ifstate.net/schema/0.6/ifstate.conf.schema.json",
@@ -4413,19 +5327,25 @@
     {
       "name": "imageoptimizer.json",
       "description": "imageoptimizer.json files",
-      "fileMatch": ["imageoptimizer.json"],
+      "fileMatch": [
+        "imageoptimizer.json"
+      ],
       "url": "https://www.schemastore.org/imageoptimizer.json"
     },
     {
       "name": ".imgbotconfig",
       "description": "Imgbot Configuration Files",
-      "fileMatch": [".imgbotconfig"],
+      "fileMatch": [
+        ".imgbotconfig"
+      ],
       "url": "https://www.schemastore.org/imgbotconfig.json"
     },
     {
       "name": "IMG Catapult PSP",
       "description": "Imagination Technologies Catapult platform support pack contents",
-      "fileMatch": ["contents.yaml"],
+      "fileMatch": [
+        "contents.yaml"
+      ],
       "url": "https://www.schemastore.org/img-catapult-psp-1.0.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/img-catapult-psp-1.0.0.json"
@@ -4434,13 +5354,21 @@
     {
       "name": "importmap.json",
       "description": "Import Maps files",
-      "fileMatch": ["importmap.json", "import_map.json", "import-map.json"],
+      "fileMatch": [
+        "importmap.json",
+        "import_map.json",
+        "import-map.json"
+      ],
       "url": "https://www.schemastore.org/importmap.json"
     },
     {
       "name": "Infinispan Configuration",
       "description": "Infinispan distributed cache configuration",
-      "fileMatch": ["infinispan.json", "infinispan.yaml", "infinispan.yml"],
+      "fileMatch": [
+        "infinispan.json",
+        "infinispan.yaml",
+        "infinispan.yml"
+      ],
       "url": "https://infinispan.org/schemas/infinispan-config.json"
     },
     {
@@ -4456,19 +5384,26 @@
     {
       "name": "Infrahub",
       "description": "Repository config definition for Infrahub by OpsMill",
-      "fileMatch": [".infrahub.yml", ".infrahub.yaml"],
+      "fileMatch": [
+        ".infrahub.yml",
+        ".infrahub.yaml"
+      ],
       "url": "https://schema.infrahub.app/python-sdk/repository-config/latest.json"
     },
     {
       "name": "instant_python_config",
       "description": "Instant Python Configuration",
-      "fileMatch": ["ipy.yml"],
+      "fileMatch": [
+        "ipy.yml"
+      ],
       "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/ipy-schemas.json"
     },
     {
       "name": "instant_python_custom_project",
       "description": "Instant Python Custom Project Structure",
-      "fileMatch": ["main_structure.yml"],
+      "fileMatch": [
+        "main_structure.yml"
+      ],
       "url": "https://raw.githubusercontent.com/instant-python/instant-python/main/schemas/main-structure-schema.json"
     },
     {
@@ -4485,25 +5420,36 @@
     {
       "name": "ioBroker Configuration",
       "description": "The configuration file of an ioBroker installation",
-      "fileMatch": ["iobroker.json", "iobroker-dist.json"],
+      "fileMatch": [
+        "iobroker.json",
+        "iobroker-dist.json"
+      ],
       "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/iobroker.json"
     },
     {
       "name": "ioBroker JSON UI",
       "description": "ioBroker JSON-based admin user interfaces - config, custom and tabs",
-      "fileMatch": ["jsonConfig.json", "jsonCustom.json", "jsonTab.json"],
+      "fileMatch": [
+        "jsonConfig.json",
+        "jsonCustom.json",
+        "jsonTab.json"
+      ],
       "url": "https://raw.githubusercontent.com/ioBroker/json-config/main/schemas/jsonConfig.json"
     },
     {
       "name": "ioBroker Package manifest",
       "description": "ioBroker adapters io-package file",
-      "fileMatch": ["io-package.json"],
+      "fileMatch": [
+        "io-package.json"
+      ],
       "url": "https://raw.githubusercontent.com/ioBroker/ioBroker.js-controller/master/schemas/io-package.json"
     },
     {
       "name": "ixpect.conf.yaml",
       "description": "IXpect configuration file",
-      "fileMatch": ["ixpect.conf.yaml"],
+      "fileMatch": [
+        "ixpect.conf.yaml"
+      ],
       "url": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json",
       "versions": {
         "0.1": "https://ixpect.net/0.1/schema/ixpect.conf.schema.json"
@@ -4512,61 +5458,88 @@
     {
       "name": "Jasmine",
       "description": "jasmine JSON config file",
-      "fileMatch": ["jasmine.json"],
+      "fileMatch": [
+        "jasmine.json"
+      ],
       "url": "https://www.schemastore.org/jasmine.json"
     },
     {
       "name": "Jekyll",
       "description": "Jekyll static site generator config file",
-      "fileMatch": ["_config.yml"],
+      "fileMatch": [
+        "_config.yml"
+      ],
       "url": "https://www.schemastore.org/jekyll.json"
     },
     {
       "name": "Jenkins X Pipelines",
       "description": "Jenkins X Pipeline YAML configuration files",
-      "fileMatch": ["jenkins-x*.yml"],
+      "fileMatch": [
+        "jenkins-x*.yml"
+      ],
       "url": "https://jenkins-x.io/schemas/jx-schema.json"
     },
     {
       "name": "Jenkins X Requirements",
       "description": "Jenkins X Requirements YAML configuration file",
-      "fileMatch": ["jx-requirements.yml"],
+      "fileMatch": [
+        "jx-requirements.yml"
+      ],
       "url": "https://jenkins-x.io/schemas/jx-requirements.json"
     },
     {
       "name": "Jest",
       "description": "A JavaScript Testing Framework",
-      "fileMatch": ["jest.config.json"],
+      "fileMatch": [
+        "jest.config.json"
+      ],
       "url": "https://www.schemastore.org/jest.json"
     },
     {
       "name": "JDownloader2 crawler single-rules",
       "description": "A validating a single jdownloader2 rule",
-      "fileMatch": ["*.jd2cr", "*.jd2cr.json"],
+      "fileMatch": [
+        "*.jd2cr",
+        "*.jd2cr.json"
+      ],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2cr.schema.json"
     },
     {
       "name": "JDownloader2 crawler multi-rules",
       "description": "A validating an array of jdownloader2 rules",
-      "fileMatch": ["*.jd2mcr", "*.jd2mcr.json", "*.linkcrawlerrules.json"],
+      "fileMatch": [
+        "*.jd2mcr",
+        "*.jd2mcr.json",
+        "*.linkcrawlerrules.json"
+      ],
       "url": "https://raw.githubusercontent.com/sergxerj/jdownloader2-crawler-rule-json-schema/main/jd2mcr.schema.json"
     },
     {
       "name": "JFrog Applications Config",
       "description": "Refines JFrog Advanced Security scans behavior",
-      "fileMatch": ["jfrog-apps-config.yml"],
+      "fileMatch": [
+        "jfrog-apps-config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/jfrog/jfrog-apps-config/main/schema.json"
     },
     {
       "name": "JFrog File Spec",
       "description": "JFrog File Spec",
-      "fileMatch": ["**/filespecs/*.json", "*filespec*.json", "*.filespec"],
+      "fileMatch": [
+        "**/filespecs/*.json",
+        "*filespec*.json",
+        "*.filespec"
+      ],
       "url": "https://raw.githubusercontent.com/jfrog/jfrog-cli/v2/schema/filespec-schema.json"
     },
     {
       "name": "JMeter DSL cli config",
       "description": "jmdsl JMeter DSL command line configuration file",
-      "fileMatch": ["*.jmdsl.yml", "*.jmdsl.yaml", "*.jmdsl.json"],
+      "fileMatch": [
+        "*.jmdsl.yml",
+        "*.jmdsl.yaml",
+        "*.jmdsl.json"
+      ],
       "url": "https://github.com/abstracta/jmeter-java-dsl/releases/latest/download/jmdsl-config-schema.json"
     },
     {
@@ -4588,7 +5561,10 @@
     {
       "name": "JReleaser",
       "description": "JReleaser config file",
-      "fileMatch": ["jreleaser.yml", "jreleaser.json"],
+      "fileMatch": [
+        "jreleaser.yml",
+        "jreleaser.json"
+      ],
       "url": "https://www.schemastore.org/jreleaser-1.25.0.json",
       "versions": {
         "1.25.0": "https://www.schemastore.org/jreleaser-1.25.0.json",
@@ -4617,37 +5593,51 @@
     {
       "name": "JSR Package Config (jsr.json)",
       "description": "JSR package configuration file",
-      "fileMatch": ["jsr.json", "jsr.jsonc"],
+      "fileMatch": [
+        "jsr.json",
+        "jsr.jsonc"
+      ],
       "url": "https://jsr.io/schema/config-file.v1.json"
     },
     {
       "name": ".jsbeautifyrc",
       "description": "js-beautify configuration file",
-      "fileMatch": [".jsbeautifyrc"],
+      "fileMatch": [
+        ".jsbeautifyrc"
+      ],
       "url": "https://www.schemastore.org/jsbeautifyrc.json"
     },
     {
       "name": ".jsbeautifyrc-nested",
       "description": "js-beautify configuration file allowing nested `js`, `css`, and `html` attributes",
-      "fileMatch": [".jsbeautifyrc"],
+      "fileMatch": [
+        ".jsbeautifyrc"
+      ],
       "url": "https://www.schemastore.org/jsbeautifyrc-nested.json"
     },
     {
       "name": ".jscsrc",
       "description": "JSCS configuration file",
-      "fileMatch": [".jscsrc", "jscsrc.json"],
+      "fileMatch": [
+        ".jscsrc",
+        "jscsrc.json"
+      ],
       "url": "https://www.schemastore.org/jscsrc.json"
     },
     {
       "name": ".jshintrc",
       "description": "JSHint configuration file",
-      "fileMatch": [".jshintrc"],
+      "fileMatch": [
+        ".jshintrc"
+      ],
       "url": "https://www.schemastore.org/jshintrc.json"
     },
     {
       "name": ".jsinspectrc",
       "description": "JSInspect configuration file",
-      "fileMatch": [".jsinspectrc"],
+      "fileMatch": [
+        ".jsinspectrc"
+      ],
       "url": "https://www.schemastore.org/jsinspectrc.json"
     },
     {
@@ -4663,7 +5653,9 @@
     {
       "name": "JSON Feed",
       "description": "the JSON Feed format",
-      "fileMatch": ["feed.json"],
+      "fileMatch": [
+        "feed.json"
+      ],
       "url": "https://www.schemastore.org/feed.json",
       "versions": {
         "1": "https://www.schemastore.org/feed-1.json",
@@ -4673,13 +5665,20 @@
     {
       "name": "*.jsonld",
       "description": "JSON Linked Data files",
-      "fileMatch": ["*.jsonld"],
+      "fileMatch": [
+        "*.jsonld"
+      ],
       "url": "https://www.schemastore.org/jsonld.json"
     },
     {
       "name": "JSONPatch",
       "description": "JSONPatch files",
-      "fileMatch": ["*.patch", "*.patch.json", "*.patch.yml", "*.patch.yaml"],
+      "fileMatch": [
+        "*.patch",
+        "*.patch.json",
+        "*.patch.yml",
+        "*.patch.yaml"
+      ],
       "url": "https://www.schemastore.org/json-patch.json"
     },
     {
@@ -4693,7 +5692,9 @@
     {
       "name": "jsconfig.json",
       "description": "JavaScript project configuration file",
-      "fileMatch": ["jsconfig.json"],
+      "fileMatch": [
+        "jsconfig.json"
+      ],
       "url": "https://www.schemastore.org/jsconfig.json"
     },
     {
@@ -4717,55 +5718,74 @@
     {
       "name": "k9s aliases.yaml",
       "description": "k9s CLI aliases.yaml file. Documentation: https://k9scli.io/topics/aliases",
-      "fileMatch": ["**/k9s/aliases.yaml"],
+      "fileMatch": [
+        "**/k9s/aliases.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/aliases.json"
     },
     {
       "name": "k9s config.yaml",
       "description": "k9s CLI config.yaml file. Documentation: https://k9scli.io/topics/config",
-      "fileMatch": ["**/k9s/config.yaml"],
+      "fileMatch": [
+        "**/k9s/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/k9s.json"
     },
     {
       "name": "k9s cluster-config.yaml",
       "description": "k9s CLI cluster-config.yaml file. Documentation: https://k9scli.io/topics/config",
-      "fileMatch": ["**/k9s/clusters/*/*/config.yaml"],
+      "fileMatch": [
+        "**/k9s/clusters/*/*/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/context.json"
     },
     {
       "name": "k9s hotkeys.yaml",
       "description": "k9s CLI hotkeys.yaml file. Documentation: https://k9scli.io/topics/hotkeys",
-      "fileMatch": ["**/k9s/hotkeys.yaml"],
+      "fileMatch": [
+        "**/k9s/hotkeys.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/hotkeys.json"
     },
     {
       "name": "k9s plugins.yaml",
       "description": "k9s CLI plugins.yaml file. Documentation: https://k9scli.io/topics/plugins",
-      "fileMatch": ["**/k9s/plugins.yaml"],
+      "fileMatch": [
+        "**/k9s/plugins.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/plugins.json"
     },
     {
       "name": "k9s skin.yaml",
       "description": "k9s CLI skin.yaml file. Documentation: https://k9scli.io/topics/skins",
-      "fileMatch": ["**/k9s/skins/*.yaml"],
+      "fileMatch": [
+        "**/k9s/skins/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/skin.json"
     },
     {
       "name": "k9s views.yaml",
       "description": "k9s CLI views.yaml file. Documentation: https://k9scli.io/topics/columns",
-      "fileMatch": ["**/k9s/views.yaml"],
+      "fileMatch": [
+        "**/k9s/views.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/derailed/k9s/master/internal/config/json/schemas/views.json"
     },
     {
       "name": "KIMMDY config file",
       "description": "KIMMDY config file, see: graeter-group.github.io/kimmdy",
-      "fileMatch": ["kimmdy.yml", "kimmdy.yaml"],
+      "fileMatch": [
+        "kimmdy.yml",
+        "kimmdy.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/graeter-group/kimmdy/main/src/kimmdy/kimmdy-yaml-schema.json"
     },
     {
       "name": "Kestra flow file",
       "description": "Kestra Flow definition file, see: kestra.io/docs/workflow-components/flow#flow-sample",
-      "fileMatch": ["**/flows/*.yml"],
+      "fileMatch": [
+        "**/flows/*.yml"
+      ],
       "url": "https://www.schemastore.org/kestra-0.19.0.json",
       "versions": {
         "0.18.0": "https://www.schemastore.org/kestra-0.18.0.json",
@@ -4801,7 +5821,9 @@
     {
       "name": "Datadog Continuous Testing",
       "description": "Datadog Continuous Testing Configuration file",
-      "fileMatch": ["*.synthetics.json"],
+      "fileMatch": [
+        "*.synthetics.json"
+      ],
       "url": "https://raw.githubusercontent.com/DataDog/schema/main/datadog-ci/synthetics/test-config.schema.json"
     },
     {
@@ -4827,13 +5849,22 @@
     {
       "name": "Ory Keto configuration",
       "description": "Ory Keto configuration file",
-      "fileMatch": ["keto.json", "keto.yml", "keto.yaml", "keto.toml"],
+      "fileMatch": [
+        "keto.json",
+        "keto.yml",
+        "keto.yaml",
+        "keto.toml"
+      ],
       "url": "https://raw.githubusercontent.com/ory/keto/master/.schema/version.schema.json"
     },
     {
       "name": "Knowledge Unit",
       "description": "Verified knowledge artifact produced through multi-model deliberation (IETF Internet-Draft: draft-farley-acta-knowledge-units)",
-      "fileMatch": ["ku-*.json", "knowledge-unit.json", "**/ku/*.json"],
+      "fileMatch": [
+        "ku-*.json",
+        "knowledge-unit.json",
+        "**/ku/*.json"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/knowledge-unit.json"
     },
     {
@@ -4848,13 +5879,20 @@
     {
       "name": "kontinuous-config.yaml",
       "description": "Kontinuous config.yaml configuration files",
-      "fileMatch": ["**/.kontinuous/config.yaml"],
+      "fileMatch": [
+        "**/.kontinuous/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/socialgouv/kontinuous/v1/docs/config.schema.json"
     },
     {
       "name": "Kubri Configuration",
       "description": "Kubri configuration file",
-      "fileMatch": [".kubri.yaml", ".kubri.yml", "kubri.yaml", "kubri.yml"],
+      "fileMatch": [
+        ".kubri.yaml",
+        ".kubri.yml",
+        "kubri.yaml",
+        "kubri.yml"
+      ],
       "url": "https://kubri.dev/schema.json"
     },
     {
@@ -4871,19 +5909,26 @@
     {
       "name": "kustomization.yaml",
       "description": "Kubernetes native configuration management",
-      "fileMatch": ["kustomization.yaml", "kustomization.yml"],
+      "fileMatch": [
+        "kustomization.yaml",
+        "kustomization.yml"
+      ],
       "url": "https://www.schemastore.org/kustomization.json"
     },
     {
       "name": "label-commenter-config.yml",
       "description": "A the configuration of the Label Commenter GitHub Action",
-      "fileMatch": ["**/.github/label-commenter-config.yml"],
+      "fileMatch": [
+        "**/.github/label-commenter-config.yml"
+      ],
       "url": "https://www.schemastore.org/label-commenter-config.json"
     },
     {
       "name": "launchsettings.json",
       "description": "A the ASP.NET LaunchSettings.json files",
-      "fileMatch": ["launchsettings.json"],
+      "fileMatch": [
+        "launchsettings.json"
+      ],
       "url": "https://www.schemastore.org/launchsettings.json"
     },
     {
@@ -4916,7 +5961,9 @@
     {
       "name": "lego.json",
       "description": "Config file for the lego-build CLI tool",
-      "fileMatch": ["lego.json"],
+      "fileMatch": [
+        "lego.json"
+      ],
       "url": "https://www.schemastore.org/lego.json",
       "versions": {
         "1.0": "https://www.schemastore.org/lego.json"
@@ -4925,43 +5972,59 @@
     {
       "name": "lerna.json",
       "description": "A lerna.json files",
-      "fileMatch": ["lerna.json"],
+      "fileMatch": [
+        "lerna.json"
+      ],
       "url": "https://www.schemastore.org/lerna.json"
     },
     {
       "name": "lgtm.yml",
       "description": "A lgtm configuration files",
-      "fileMatch": ["lgtm.yml", ".lgtm.yml"],
+      "fileMatch": [
+        "lgtm.yml",
+        ".lgtm.yml"
+      ],
       "url": "https://www.schemastore.org/lgtm.json"
     },
     {
       "name": "liblab.config.json",
       "description": "Liblab configuration file",
-      "fileMatch": ["liblab.config.json", "*.liblab.config.json"],
+      "fileMatch": [
+        "liblab.config.json",
+        "*.liblab.config.json"
+      ],
       "url": "https://cdn.jsdelivr.net/npm/liblab@latest/liblab.config.schema.json"
     },
     {
       "name": "libman.json",
       "description": "client-side library config files",
-      "fileMatch": ["libman.json"],
+      "fileMatch": [
+        "libman.json"
+      ],
       "url": "https://www.schemastore.org/libman.json"
     },
     {
       "name": "license-report-config.json",
       "description": "license report tool configuration file",
-      "fileMatch": ["license-report-config.json"],
+      "fileMatch": [
+        "license-report-config.json"
+      ],
       "url": "https://www.schemastore.org/license-report-config.json"
     },
     {
       "name": "Liferay client-extension.yaml",
       "description": "Liferay Client Extension Definition File",
-      "fileMatch": ["client-extension.yaml"],
+      "fileMatch": [
+        "client-extension.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/liferay/liferay-portal/master/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json"
     },
     {
       "name": "linkinator.config.json",
       "description": "Linkinator config file",
-      "fileMatch": ["linkinator.config.json"],
+      "fileMatch": [
+        "linkinator.config.json"
+      ],
       "url": "https://www.schemastore.org/linkinator-config.json"
     },
     {
@@ -4991,55 +6054,75 @@
     {
       "name": "Lively Properties",
       "description": "Lively Wallpaper configuration file. Documentation: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#lively-properties",
-      "fileMatch": ["LivelyProperties.json"],
+      "fileMatch": [
+        "LivelyProperties.json"
+      ],
       "url": "https://raw.githubusercontent.com/rocksdanister/lively/core-separation/schemas/livelyPropertiesSchema.json"
     },
     {
       "name": "LOOBin",
       "description": "LOOBins macOS binaries. Documentation: https://github.com/infosecB/LOOBins",
-      "fileMatch": ["**/LOOBins/*.yml"],
+      "fileMatch": [
+        "**/LOOBins/*.yml"
+      ],
       "url": "https://www.schemastore.org/loobin-1.0.json"
     },
     {
       "name": "lotus.yaml",
       "description": "The configuration file used for Lotus definitions",
-      "fileMatch": ["lotus.yaml"],
+      "fileMatch": [
+        "lotus.yaml"
+      ],
       "url": "https://grnhse-vpc-assets.s3.amazonaws.com/jsonschemas/lotus.yaml.json"
     },
     {
       "name": "local.settings.json",
       "description": "Azure Functions local.settings.json files",
-      "fileMatch": ["local.settings.json"],
+      "fileMatch": [
+        "local.settings.json"
+      ],
       "url": "https://www.schemastore.org/local.settings.json"
     },
     {
       "name": "localazy.json",
       "description": "Localazy CLI configuration file. Documentation: https://localazy.com/docs/cli",
-      "fileMatch": ["localazy.json"],
+      "fileMatch": [
+        "localazy.json"
+      ],
       "url": "https://raw.githubusercontent.com/localazy/cli-schema/master/localazy.json"
     },
     {
       "name": "lsdlschema.json",
       "description": "Power BI linguistic schema definition",
-      "fileMatch": ["*.lsdl.yaml", "*.lsdl.json"],
+      "fileMatch": [
+        "*.lsdl.yaml",
+        "*.lsdl.json"
+      ],
       "url": "https://www.schemastore.org/lsdlschema.json"
     },
     {
       "name": ".luaurc",
       "description": "Luau language configuration file",
-      "fileMatch": [".luaurc"],
+      "fileMatch": [
+        ".luaurc"
+      ],
       "url": "https://www.schemastore.org/luaurc.json"
     },
     {
       "name": "Madge configuration",
       "description": "Madge module dependency analysis configuration file",
-      "fileMatch": [".madgerc"],
+      "fileMatch": [
+        ".madgerc"
+      ],
       "url": "https://www.schemastore.org/madge.json"
     },
     {
       "name": "Mado configuration",
       "description": "Mado markdown linter configuration file",
-      "fileMatch": [".mado.toml", "mado.toml"],
+      "fileMatch": [
+        ".mado.toml",
+        "mado.toml"
+      ],
       "url": "https://raw.githubusercontent.com/akiomik/mado/refs/heads/main/pkg/json-schema/mado.json"
     },
     {
@@ -5056,13 +6139,19 @@
     {
       "name": "MapEHR Mapping",
       "description": "Mapping for MapEHR.com",
-      "fileMatch": [".map.yml", ".map.yaml", ".map.json"],
+      "fileMatch": [
+        ".map.yml",
+        ".map.yaml",
+        ".map.json"
+      ],
       "url": "https://www.schemastore.org/mapehr.json"
     },
     {
       "name": "A micro editor config",
       "description": "A micro editor config",
-      "fileMatch": ["**/micro/settings.json"],
+      "fileMatch": [
+        "**/micro/settings.json"
+      ],
       "url": "https://www.schemastore.org/micro.json"
     },
     {
@@ -5079,13 +6168,17 @@
     {
       "name": "MegaLinter Custom Flavor",
       "description": "MegaLinter Custom Flavor definition file",
-      "fileMatch": ["megalinter-custom-flavor.yml"],
+      "fileMatch": [
+        "megalinter-custom-flavor.yml"
+      ],
       "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-custom-flavor.jsonschema.json"
     },
     {
       "name": "MegaLinter descriptor",
       "description": "MegaLinter descriptor files (for MegaLinter contributors)",
-      "fileMatch": ["*.megalinter-descriptor.yml"],
+      "fileMatch": [
+        "*.megalinter-descriptor.yml"
+      ],
       "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
     },
     {
@@ -5101,19 +6194,27 @@
     {
       "name": "Metadata for a Bazel module",
       "description": "Metadata file for a Bazel module",
-      "fileMatch": ["**/modules/*/metadata.json"],
+      "fileMatch": [
+        "**/modules/*/metadata.json"
+      ],
       "url": "https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/metadata.schema.json"
     },
     {
       "name": "Metatype Configuration",
       "description": "Metatype configuration file",
-      "fileMatch": ["metatype.yml", "metatype.yaml"],
+      "fileMatch": [
+        "metatype.yml",
+        "metatype.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/metatypedev/metatype/main/tools/schema/metatype.json"
     },
     {
       "name": "MetricsHub Configuration",
       "description": "MetricsHub configuration file",
-      "fileMatch": ["*metricshub.yaml", "*metricshub.yml"],
+      "fileMatch": [
+        "*metricshub.yaml",
+        "*metricshub.yml"
+      ],
       "url": "https://www.schemastore.org/metricshub.json"
     },
     {
@@ -5137,127 +6238,169 @@
     {
       "name": "mimetypes.json",
       "description": "mime type collections",
-      "fileMatch": ["mimetypes.json"],
+      "fileMatch": [
+        "mimetypes.json"
+      ],
       "url": "https://www.schemastore.org/mimetypes.json"
     },
     {
       "name": "Minecraft Data Pack Advancement",
       "description": "Configuration file defining an advancement for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/advancements/*.json"],
+      "fileMatch": [
+        "**/data/*/advancements/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-advancement.json"
     },
     {
       "name": "Minecraft Data Pack Biome",
       "description": "Configuration file defining a biome for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/worldgen/biome/*.json"],
+      "fileMatch": [
+        "**/data/*/worldgen/biome/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-biome.json"
     },
     {
       "name": "Minecraft Data Pack Configured Carver",
       "description": "Configuration file defining a configured carver for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/worldgen/configured_carver/*.json"],
+      "fileMatch": [
+        "**/data/*/worldgen/configured_carver/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-configured-carver.json"
     },
     {
       "name": "Minecraft Data Pack Damage Type",
       "description": "Configuration file defining a damage type for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/damage_type/*.json"],
+      "fileMatch": [
+        "**/data/*/damage_type/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-damage-type.json"
     },
     {
       "name": "Minecraft Data Pack Dimension Type",
       "description": "Configuration file defining a dimension type for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/dimension_type/*.json"],
+      "fileMatch": [
+        "**/data/*/dimension_type/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-dimension-type.json"
     },
     {
       "name": "Minecraft Data Pack Dimension",
       "description": "Configuration file defining a dimension for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/dimension/*.json"],
+      "fileMatch": [
+        "**/data/*/dimension/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-dimension.json"
     },
     {
       "name": "Minecraft Data Pack Item Modifier",
       "description": "Configuration file defining an item modifier for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/item_modifiers/*.json"],
+      "fileMatch": [
+        "**/data/*/item_modifiers/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-item-modifier.json"
     },
     {
       "name": "Minecraft Data Pack Loot Table",
       "description": "Configuration file defining a loot table for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/loot_tables/**/*.json"],
+      "fileMatch": [
+        "**/data/*/loot_tables/**/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-loot-table.json"
     },
     {
       "name": "Minecraft Data Pack Metadata",
       "description": "Configuration file defining the metadata of a data pack for Minecraft",
-      "fileMatch": ["**/pack.mcmeta"],
+      "fileMatch": [
+        "**/pack.mcmeta"
+      ],
       "url": "https://www.schemastore.org/minecraft-pack-mcmeta.json"
     },
     {
       "name": "Minecraft Data Pack Predicate",
       "description": "Configuration file defining a predicate for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/predicates/*.json"],
+      "fileMatch": [
+        "**/data/*/predicates/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-predicate.json"
     },
     {
       "name": "Minecraft Data Pack Recipe",
       "description": "Configuration file defining a recipe for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/recipes/*.json"],
+      "fileMatch": [
+        "**/data/*/recipes/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-recipe.json"
     },
     {
       "name": "Minecraft Data Pack Tag",
       "description": "Configuration file defining a tag for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/tags/**/*.json"],
+      "fileMatch": [
+        "**/data/*/tags/**/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-tag.json"
     },
     {
       "name": "Minecraft Data Pack Template Pool",
       "description": "Configuration file defining a template pool for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/worldgen/template_pool/*.json"],
+      "fileMatch": [
+        "**/data/*/worldgen/template_pool/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-template-pool.json"
     },
     {
       "name": "Minecraft Resource Pack Lang",
       "description": "Configuration file defining a language for a resource pack for Minecraft",
-      "fileMatch": ["**/assets/*/lang/*.json"],
+      "fileMatch": [
+        "**/assets/*/lang/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-lang.json"
     },
     {
       "name": "Minecraft Resource Pack Particle",
       "description": "Configuration file defining a particle for a resource pack for Minecraft",
-      "fileMatch": ["**/assets/*/particles/*.json"],
+      "fileMatch": [
+        "**/assets/*/particles/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-particle.json"
     },
     {
       "name": "Minecraft Resourcepack Sounds",
       "description": "Configuration file defining what sounds play when sound event is triggered for a resourcepack for Minecraft",
-      "fileMatch": ["**/assets/*/sounds.json"],
+      "fileMatch": [
+        "**/assets/*/sounds.json"
+      ],
       "url": "https://raw.githubusercontent.com/AxoCode/json-schema/master/minecraft/sounds.json"
     },
     {
       "name": "Minecraft Resource Pack Texture Mcmeta",
       "description": "Configuration file defining an mcmeta file for a texture for a resource pack for Minecraft",
-      "fileMatch": ["**/assets/*/textures/**/*.png.mcmeta"],
+      "fileMatch": [
+        "**/assets/*/textures/**/*.png.mcmeta"
+      ],
       "url": "https://www.schemastore.org/minecraft-texture-mcmeta.json"
     },
     {
       "name": "Minecraft Data Pack Trim Material",
       "description": "Configuration file defining a trim material for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/trim_material/*.json"],
+      "fileMatch": [
+        "**/data/*/trim_material/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-trim-material.json"
     },
     {
       "name": "Minecraft Data Pack Trim Pattern",
       "description": "Configuration file defining a trim pattern for a data pack for Minecraft",
-      "fileMatch": ["**/data/*/trim_pattern/*.json"],
+      "fileMatch": [
+        "**/data/*/trim_pattern/*.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-trim-pattern.json"
     },
     {
       "name": "mkdocs.yml",
       "description": "MkDocs configuration file",
-      "fileMatch": ["mkdocs.yml"],
+      "fileMatch": [
+        "mkdocs.yml"
+      ],
       "url": "https://www.schemastore.org/mkdocs-1.6.json",
       "versions": {
         "1.0": "https://www.schemastore.org/mkdocs-1.0.json",
@@ -5267,7 +6410,9 @@
     {
       "name": "ModuleAssembler",
       "description": "ModuleAssembler configuration file",
-      "fileMatch": ["**/.moduleassembler/moduleproject.json"],
+      "fileMatch": [
+        "**/.moduleassembler/moduleproject.json"
+      ],
       "url": "https://raw.githubusercontent.com/ModuleAssembler/ModuleAssembler-Schema/refs/tags/v1.0.0/schema/moduleassembler.schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/ModuleAssembler/ModuleAssembler-Schema/refs/tags/v1.0.0/schema/moduleassembler.schema.json"
@@ -5276,13 +6421,19 @@
     {
       "name": "mrdocs.yml",
       "description": "MrDocs configuration file",
-      "fileMatch": ["mrdocs.yml"],
+      "fileMatch": [
+        "mrdocs.yml"
+      ],
       "url": "https://raw.githubusercontent.com/cppalliance/mrdocs/refs/heads/master/docs/mrdocs.schema.json"
     },
     {
       "name": "MLOS Config (*.mlos.jsonc, *.mlos.json5, *.mlos.json)",
       "description": "Config files for the mlos_bench utility in MLOS. See Also: https://aka.ms/MLOS",
-      "fileMatch": ["*.mlos.jsonc", "*.mlos.json5", "*.mlos.json"],
+      "fileMatch": [
+        "*.mlos.jsonc",
+        "*.mlos.json5",
+        "*.mlos.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/mlos-bench-config-schema.json"
     },
     {
@@ -5329,7 +6480,9 @@
     {
       "name": "monospace.yml",
       "description": "MonoSpace configuration file",
-      "fileMatch": ["monospace.yml"],
+      "fileMatch": [
+        "monospace.yml"
+      ],
       "url": "https://raw.githubusercontent.com/software-t-rex/monospace/main/apps/monospace/schemas/monospace.schema.json"
     },
     {
@@ -5360,7 +6513,10 @@
     {
       "name": "MSTest testconfig.json",
       "description": "Configuration file for MSTest and Microsoft.Testing.Platform",
-      "fileMatch": ["testconfig.json", "*.testconfig.json"],
+      "fileMatch": [
+        "testconfig.json",
+        "*.testconfig.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
     },
     {
@@ -5387,97 +6543,144 @@
     {
       "name": ".modernizrrc",
       "description": "Webpack modernizr-loader configuration file",
-      "fileMatch": [".modernizrrc"],
+      "fileMatch": [
+        ".modernizrrc"
+      ],
       "url": "https://www.schemastore.org/modernizrrc.json"
     },
     {
       "name": "Monade CLI Stack Configuration",
       "description": "The configuration file to get a local stack up and running with Monade CLI",
-      "fileMatch": ["monade.yaml", "monade.yml", ".monade.yaml", ".monade.yml"],
+      "fileMatch": [
+        "monade.yaml",
+        "monade.yml",
+        ".monade.yaml",
+        ".monade.yml"
+      ],
       "url": "https://www.schemastore.org/monade-stack-config.json"
     },
     {
       "name": "mycode.json",
       "description": "mycode.js files",
-      "fileMatch": ["mycode.json"],
+      "fileMatch": [
+        "mycode.json"
+      ],
       "url": "https://www.schemastore.org/mycode.json"
     },
     {
       "name": "napari plugin manifest",
       "description": "a napari plugin manifest",
-      "fileMatch": ["napari.yml", "napari.yaml", ".napari.yml", ".napari.yaml"],
+      "fileMatch": [
+        "napari.yml",
+        "napari.yaml",
+        ".napari.yml",
+        ".napari.yaml"
+      ],
       "url": "https://github.com/napari/npe2/releases/latest/download/schema.json"
     },
     {
       "name": "Netlify config",
       "description": "Netlify YAML config",
-      "fileMatch": ["**/admin/config*.yml"],
+      "fileMatch": [
+        "**/admin/config*.yml"
+      ],
       "url": "https://www.schemastore.org/netlify.json"
     },
     {
       "name": "Network-as-Code Data Model",
       "description": "Cisco Network-as-Code Data Model",
-      "fileMatch": ["*.nac.yml", "*.nac.yaml", "*.aac.yml", "*.aac.yaml"],
+      "fileMatch": [
+        "*.nac.yml",
+        "*.nac.yaml",
+        "*.aac.yml",
+        "*.aac.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/netascode/schema/main/schema.json"
     },
     {
       "name": "Next Gen UI Agent A2A Server Configuration",
       "description": "Next Gen UI Agent A2A Server configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/spec/a2a/#agent-configuration",
-      "fileMatch": ["ngui-a2a_*.yaml", "ngui-a2a_*.yml", "ngui-a2a_*.json"],
+      "fileMatch": [
+        "ngui-a2a_*.yaml",
+        "ngui-a2a_*.yml",
+        "ngui-a2a_*.json"
+      ],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/a2a/a2a_agent_config.schema.json"
     },
     {
       "name": "Next Gen UI Agent MCP Server Configuration",
       "description": "Next Gen UI Agent MCP Server configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/spec/mcp/#agent-configuration",
-      "fileMatch": ["ngui-mcp_*.yaml", "ngui-mcp_*.yml", "ngui-mcp_*.json"],
+      "fileMatch": [
+        "ngui-mcp_*.yaml",
+        "ngui-mcp_*.yml",
+        "ngui-mcp_*.json"
+      ],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/mcp/mcp_agent_config.schema.json"
     },
     {
       "name": "Next Gen UI Agent Configuration",
       "description": "NextGen UI Agent configuration. Documentation: https://redhat-ux.github.io/next-gen-ui-agent/guide/configuration/",
-      "fileMatch": ["ngui_*.yaml", "ngui_*.yml", "ngui_*.json"],
+      "fileMatch": [
+        "ngui_*.yaml",
+        "ngui_*.yml",
+        "ngui_*.json"
+      ],
       "url": "https://raw.githubusercontent.com/RedHat-UX/next-gen-ui-agent/refs/heads/main/spec/config/agent_config.schema.json"
     },
     {
       "name": "cargo-nextest repository configuration",
       "description": "Repository configuration for cargo-nextest. Documentation: https://nexte.st/docs/configuration/",
-      "fileMatch": ["**/.config/nextest.toml"],
+      "fileMatch": [
+        "**/.config/nextest.toml"
+      ],
       "url": "https://nexte.st/schemas/repo-config.json"
     },
     {
       "name": "cargo-nextest user configuration",
       "description": "User configuration for cargo-nextest. Documentation: https://nexte.st/docs/user-config/",
-      "fileMatch": ["**/nextest/config.toml"],
+      "fileMatch": [
+        "**/nextest/config.toml"
+      ],
       "url": "https://nexte.st/schemas/user-config.json"
     },
     {
       "name": "nf-core module environment.yml",
       "description": "Conda environment file for an nf-core Nextflow module",
-      "fileMatch": ["**/modules/nf-core/**/environment.yml"],
+      "fileMatch": [
+        "**/modules/nf-core/**/environment.yml"
+      ],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json"
     },
     {
       "name": "nf-core module meta.yml",
       "description": "Metadata file for an nf-core Nextflow module",
-      "fileMatch": ["**/modules/nf-core/**/meta.yml"],
+      "fileMatch": [
+        "**/modules/nf-core/**/meta.yml"
+      ],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json"
     },
     {
       "name": "nf-core subworkflow meta.yml",
       "description": "Metadata file for an nf-core Nextflow subworkflow",
-      "fileMatch": ["**/subworkflows/nf-core/**/meta.yml"],
+      "fileMatch": [
+        "**/subworkflows/nf-core/**/meta.yml"
+      ],
       "url": "https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json"
     },
     {
       "name": "nFPM",
       "description": "nFPM configuration file",
-      "fileMatch": ["nfpm.yaml"],
+      "fileMatch": [
+        "nfpm.yaml"
+      ],
       "url": "https://nfpm.goreleaser.com/static/schema.json"
     },
     {
       "name": "Nightwatch.js",
       "description": "nightwatch.js config",
-      "fileMatch": ["nightwatch.json"],
+      "fileMatch": [
+        "nightwatch.json"
+      ],
       "url": "https://www.schemastore.org/nightwatch.json"
     },
     {
@@ -5507,37 +6710,53 @@
     {
       "name": "nlu.json",
       "description": "NPM-Link-Up",
-      "fileMatch": ["nlu.json", ".nlu.json"],
+      "fileMatch": [
+        "nlu.json",
+        ".nlu.json"
+      ],
       "url": "https://raw.githubusercontent.com/oresoftware/npm-link-up/master/assets/nlu.schema.json"
     },
     {
       "name": ".nodehawkrc",
       "description": ".nodehawkrc configuration files",
-      "fileMatch": [".nodehawkrc"],
+      "fileMatch": [
+        ".nodehawkrc"
+      ],
       "url": "https://www.schemastore.org/nodehawkrc.json"
     },
     {
       "name": "Nika workflow",
       "description": "Nika workflow language (*.nika.yaml) · the nika: v1 envelope, four verbs, stdlib builtins",
-      "fileMatch": ["*.nika.yaml", "*.nika.yml"],
+      "fileMatch": [
+        "*.nika.yaml",
+        "*.nika.yml"
+      ],
       "url": "https://raw.githubusercontent.com/supernovae-st/nika-spec/main/schemas/workflow.schema.json"
     },
     {
       "name": "nodemon.json",
       "description": "nodemon.json configuration files",
-      "fileMatch": ["nodemon.json"],
+      "fileMatch": [
+        "nodemon.json"
+      ],
       "url": "https://www.schemastore.org/nodemon.json"
     },
     {
       "name": "notebook.mod.json",
       "description": "Metadata file for notebook mods",
-      "fileMatch": ["notebook.mod.json"],
+      "fileMatch": [
+        "notebook.mod.json"
+      ],
       "url": "https://raw.githubusercontent.com/BookkeepersMC/notebook-schemas/master/notebook.mod.json/schemas/main.json"
     },
     {
       "name": "NOX Framework (Service)",
       "description": "NOX service definition",
-      "fileMatch": ["service.nox.yaml", "service.nox.yml", "service.nox.json"],
+      "fileMatch": [
+        "service.nox.yaml",
+        "service.nox.yml",
+        "service.nox.json"
+      ],
       "url": "https://noxorg.dev/schemas/NoxConfiguration.json"
     },
     {
@@ -5558,7 +6777,9 @@
     {
       "name": "nuclei-template.yaml",
       "description": "Nuclei Template YAML files",
-      "fileMatch": ["**/nuclei-templates/**/*.yaml"],
+      "fileMatch": [
+        "**/nuclei-templates/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/projectdiscovery/nuclei/master/nuclei-jsonschema.json"
     },
     {
@@ -5578,13 +6799,18 @@
     {
       "name": "nswag.json",
       "description": "nswag configuration",
-      "fileMatch": ["nswag.json"],
+      "fileMatch": [
+        "nswag.json"
+      ],
       "url": "https://www.schemastore.org/nswag.json"
     },
     {
       "name": "Nullstone config",
       "description": "Nullstone config.yml file",
-      "fileMatch": ["**/.nullstone/*.yml", "**/.nullstone/*.yaml"],
+      "fileMatch": [
+        "**/.nullstone/*.yml",
+        "**/.nullstone/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/nullstone-io/iac/master/.schema/config.0.1.json",
       "versions": {
         "0.1": "https://raw.githubusercontent.com/nullstone-io/iac/master/.schema/config.0.1.json"
@@ -5615,61 +6841,91 @@
     {
       "name": "ocelot.json",
       "description": "the Ocelot Api Gateway",
-      "fileMatch": ["ocelot.json"],
+      "fileMatch": [
+        "ocelot.json"
+      ],
       "url": "https://www.schemastore.org/ocelot.json"
     },
     {
       "name": "October CMS columns",
       "description": "October CMS columns files",
-      "fileMatch": ["columns.yaml", "*_columns.yaml"],
+      "fileMatch": [
+        "columns.yaml",
+        "*_columns.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/columns.json"
     },
     {
       "name": "October CMS fields",
       "description": "October CMS fields files",
-      "fileMatch": ["fields.yaml", "*_fields.yaml"],
+      "fileMatch": [
+        "fields.yaml",
+        "*_fields.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/inetis-ch/october-schemas/master/fields.json"
     },
     {
       "name": "ODGS Standard Metrics",
       "description": "Open Data Governance Standard (ODGS) metric definitions — KPI logic, lineage, and compliance mappings",
-      "fileMatch": ["*.odgs-metrics.json"],
+      "fileMatch": [
+        "*.odgs-metrics.json"
+      ],
       "url": "https://www.schemastore.org/odgs-standard-metrics.json"
     },
     {
       "name": "ODGS Data Rules",
       "description": "ODGS validation and permissibility rules — mechanically executable data governance constraints",
-      "fileMatch": ["*.odgs-rules.json"],
+      "fileMatch": [
+        "*.odgs-rules.json"
+      ],
       "url": "https://www.schemastore.org/odgs-data-rules.json"
     },
     {
       "name": "ODGS Ontology Graph",
       "description": "ODGS business-entity ontology graph for AI graph traversal",
-      "fileMatch": ["*.odgs-ontology.json"],
+      "fileMatch": [
+        "*.odgs-ontology.json"
+      ],
       "url": "https://www.schemastore.org/odgs-ontology-graph.json"
     },
     {
       "name": "ogen",
       "description": "ogen code generator configuration, see https://ogen.dev/docs/config",
-      "fileMatch": ["ogen.yml", "ogen.yaml", ".ogen.yml", ".ogen.yaml"],
+      "fileMatch": [
+        "ogen.yml",
+        "ogen.yaml",
+        ".ogen.yml",
+        ".ogen.yaml"
+      ],
       "url": "https://www.schemastore.org/ogen.json"
     },
     {
       "name": "Oh My Posh",
       "description": "Oh My Posh configuration file",
-      "fileMatch": ["*.omp.json", "*.omp.toml", "*.omp.yaml", "*.omp.yml"],
+      "fileMatch": [
+        "*.omp.json",
+        "*.omp.toml",
+        "*.omp.yaml",
+        "*.omp.yml"
+      ],
       "url": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json"
     },
     {
       "name": "Okteto",
       "description": "The Okteto Manifest",
-      "fileMatch": ["okteto.yml", "okteto.yaml", "okteto.json"],
+      "fileMatch": [
+        "okteto.yml",
+        "okteto.yaml",
+        "okteto.json"
+      ],
       "url": "https://raw.githubusercontent.com/okteto/okteto/refs/heads/master/schema.json"
     },
     {
       "name": "omnisharp.json",
       "description": "Omnisharp Configuration file",
-      "fileMatch": ["omnisharp.json"],
+      "fileMatch": [
+        "omnisharp.json"
+      ],
       "url": "https://www.schemastore.org/omnisharp.json"
     },
     {
@@ -5738,31 +6994,42 @@
     {
       "name": "OpenUtau character yaml",
       "description": "OpenUtau voicebank configuration file, character.yaml",
-      "fileMatch": ["character.yaml"],
+      "fileMatch": [
+        "character.yaml"
+      ],
       "url": "https://www.schemastore.org/openutau-character.json"
     },
     {
       "name": "OpenUtau ustx",
       "description": "OpenUtau project file, ustx",
-      "fileMatch": ["*.ustx"],
+      "fileMatch": [
+        "*.ustx"
+      ],
       "url": "https://www.schemastore.org/openutau-ustx.json"
     },
     {
       "name": "ops.yaml",
       "description": "Ops configuration file (ops.yaml)",
-      "fileMatch": ["ops.yml", "ops.yaml"],
+      "fileMatch": [
+        "ops.yml",
+        "ops.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/LeShaunJ/ops-schema/main/ops.schema.json"
     },
     {
       "name": "ONe's service descriptor",
       "description": "ONe's service descriptor",
-      "fileMatch": ["service-descriptor.yml"],
+      "fileMatch": [
+        "service-descriptor.yml"
+      ],
       "url": "https://www.schemastore.org/one-service-descriptor-schema-0.1.json"
     },
     {
       "name": "ONe's changelog entry",
       "description": "ONe's changelog entry",
-      "fileMatch": ["**/changelogs/*.yml"],
+      "fileMatch": [
+        "**/changelogs/*.yml"
+      ],
       "url": "https://www.schemastore.org/one-changelog-schema-0.1.json"
     },
     {
@@ -5773,7 +7040,9 @@
     {
       "name": "OpenRewrite Resource",
       "description": "OpenRewrite resource descriptors",
-      "fileMatch": ["**/META-INF/rewrite/*.yml"],
+      "fileMatch": [
+        "**/META-INF/rewrite/*.yml"
+      ],
       "url": "https://raw.githubusercontent.com/openrewrite/rewrite/main/rewrite-core/openrewrite.json"
     },
     {
@@ -5794,7 +7063,10 @@
     {
       "name": "Open Data Contract Standard (ODCS)",
       "description": "Open Data Contract Standard contract file, from the Bitol project at The Linux Foundation",
-      "fileMatch": ["*.odcs.yaml", "*.odcs.yml"],
+      "fileMatch": [
+        "*.odcs.yaml",
+        "*.odcs.yml"
+      ],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-contract-standard/main/schema/odcs-json-schema-latest.json",
       "versions": {
         "v3.0.2": "https://github.com/bitol-io/open-data-contract-standard/blob/main/schema/odcs-json-schema-v3.0.2.json",
@@ -5806,7 +7078,10 @@
     {
       "name": "Open Data Product Standard (ODPS)",
       "description": "Open Data Product Standard descriptor file, from the Bitol project at The Linux Foundation",
-      "fileMatch": ["*.odps.yaml", "*.odps.yml"],
+      "fileMatch": [
+        "*.odps.yaml",
+        "*.odps.yml"
+      ],
       "url": "https://raw.githubusercontent.com/bitol-io/open-data-product-standard/main/schema/odps-json-schema-latest.json",
       "versions": {
         "v0.9.0": "https://github.com/bitol-io/open-data-product-standard/blob/main/schema/odps-json-schema-v0.9.0.json"
@@ -5815,7 +7090,9 @@
     {
       "name": "Open Pentest Format",
       "description": "OPF finding library or engagement export (*.opf.json): portable penetration test findings",
-      "fileMatch": ["*.opf.json"],
+      "fileMatch": [
+        "*.opf.json"
+      ],
       "url": "https://cairnsecurity.com/opf/schema/opf-1.1.schema.json"
     },
     {
@@ -5834,7 +7111,10 @@
     {
       "name": "Outblocks project configuration",
       "description": "Outblocks project configuration files",
-      "fileMatch": ["project.outblocks.yaml", "project.outblocks.yml"],
+      "fileMatch": [
+        "project.outblocks.yaml",
+        "project.outblocks.yml"
+      ],
       "url": "https://raw.githubusercontent.com/outblocks/outblocks-cli/master/schema/schema-project.json"
     },
     {
@@ -5862,19 +7142,30 @@
     {
       "name": "ORT Server repository environment configuration",
       "description": "Repository environment configuration to configure infrastructure services, environment variables, and package-manager specific settings",
-      "fileMatch": [".ort.env.yml", ".ort.env.yaml"],
+      "fileMatch": [
+        ".ort.env.yml",
+        ".ort.env.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/eclipse-apoapsis/ort-server/refs/heads/main/integrations/schemas/repository-environment-config.json"
     },
     {
       "name": "Ory Kratos configuration",
       "description": "Ory Kratos configuration file",
-      "fileMatch": ["kratos.json", "kratos.yml", "kratos.yaml", "kratos.toml"],
+      "fileMatch": [
+        "kratos.json",
+        "kratos.yml",
+        "kratos.yaml",
+        "kratos.toml"
+      ],
       "url": "https://raw.githubusercontent.com/ory/kratos/master/.schema/version.schema.json"
     },
     {
       "name": "OSCAL Assessment Plan (AP)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Assessment Plan. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*assessment-plan.json", "oscal*assessment_plan.json"],
+      "fileMatch": [
+        "oscal*assessment-plan.json",
+        "oscal*assessment_plan.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_assessment-plan_schema.json",
@@ -5913,7 +7204,9 @@
     {
       "name": "OSCAL Catalog",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Catalog. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*catalog.json"],
+      "fileMatch": [
+        "oscal*catalog.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_catalog_schema.json",
@@ -5931,7 +7224,10 @@
     {
       "name": "OSCAL Component Definition (CDef)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Component Definition. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*component.json", "oscal*cdef.json"],
+      "fileMatch": [
+        "oscal*component.json",
+        "oscal*cdef.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_component_schema.json",
@@ -5949,7 +7245,9 @@
     {
       "name": "OSCAL Plan of Action and Milestones (POA&M)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Plan of Action and Milestones. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*poam.json"],
+      "fileMatch": [
+        "oscal*poam.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_poam_schema.json",
@@ -5967,7 +7265,9 @@
     {
       "name": "OSCAL Profile",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) Profile. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*profile.json"],
+      "fileMatch": [
+        "oscal*profile.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_profile_schema.json",
@@ -5985,7 +7285,9 @@
     {
       "name": "OSCAL System Security Plan (SSP)",
       "description": "NIST Open Security Controls Assessment Language (OSCAL) System Security Plan. (https://pages.nist.gov/OSCAL-Reference)",
-      "fileMatch": ["oscal*ssp.json"],
+      "fileMatch": [
+        "oscal*ssp.json"
+      ],
       "url": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
       "versions": {
         "1.1.2": "https://github.com/usnistgov/OSCAL/releases/download/v1.1.2/oscal_ssp_schema.json",
@@ -6003,7 +7305,10 @@
     {
       "name": "OSS Review Toolkit configuration",
       "description": "ORT's main configuration file",
-      "fileMatch": ["**/.ort/config/config.yml", "**/.ort/config/config.yaml"],
+      "fileMatch": [
+        "**/.ort/config/config.yml",
+        "**/.ort/config/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/ort-configuration-schema.json"
     },
     {
@@ -6044,31 +7349,43 @@
     {
       "name": "OSS Review Toolkit repository configuration",
       "description": "ORT's repository configuration file",
-      "fileMatch": ["*.ort.yml", "*.ort.yaml"],
+      "fileMatch": [
+        "*.ort.yml",
+        "*.ort.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/repository-configuration-schema.json"
     },
     {
       "name": "OSS Review Toolkit resolutions",
       "description": "ORT's resolutions file",
-      "fileMatch": ["resolutions.yml", "resolutions.yaml"],
+      "fileMatch": [
+        "resolutions.yml",
+        "resolutions.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/oss-review-toolkit/ort/main/integrations/schemas/resolutions-schema.json"
     },
     {
       "name": "package.json",
       "description": "NPM configuration file",
-      "fileMatch": ["package.json"],
+      "fileMatch": [
+        "package.json"
+      ],
       "url": "https://www.schemastore.org/package.json"
     },
     {
       "name": "package.yaml",
       "description": "PNPM configuration file",
-      "fileMatch": ["package.yaml"],
+      "fileMatch": [
+        "package.yaml"
+      ],
       "url": "https://www.schemastore.org/package.json"
     },
     {
       "name": "package.manifest",
       "description": "Umbraco package configuration file",
-      "fileMatch": ["package.manifest"],
+      "fileMatch": [
+        "package.manifest"
+      ],
       "url": "https://www.schemastore.org/package.manifest.json",
       "versions": {
         "8.0.0": "https://www.schemastore.org/package.manifest-8.0.0.json",
@@ -6078,55 +7395,77 @@
     {
       "name": "Packer",
       "description": "Packer template JSON configuration",
-      "fileMatch": ["packer.json"],
+      "fileMatch": [
+        "packer.json"
+      ],
       "url": "https://www.schemastore.org/packer.json"
     },
     {
       "name": "PactSpec",
       "description": "AI agent capability declaration (pactspec.dev)",
-      "fileMatch": ["*.pactspec.json", "*.pactspec.yaml"],
+      "fileMatch": [
+        "*.pactspec.json",
+        "*.pactspec.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pactspec.json"
     },
     {
       "name": "Panache",
       "description": "Configuration file for Panache, a language server, formatter, and linter for Markdown, Quarto, and R Markdown documents",
-      "fileMatch": ["panache.toml", ".panache.toml"],
+      "fileMatch": [
+        "panache.toml",
+        ".panache.toml"
+      ],
       "url": "https://panache.bz/panache.schema.json"
     },
     {
       "name": "Paper paper-plugin.yml",
       "description": "Paper Plugins YAML",
-      "fileMatch": ["paper-plugin.yml"],
+      "fileMatch": [
+        "paper-plugin.yml"
+      ],
       "url": "https://www.schemastore.org/paper-plugin.json"
     },
     {
       "name": "PDM",
       "description": "A modern Python package and dependency manager supporting the latest PEP standard (pdm.toml config file)",
-      "fileMatch": ["pdm.toml"],
+      "fileMatch": [
+        "pdm.toml"
+      ],
       "url": "https://www.schemastore.org/pdm.json"
     },
     {
       "name": "pgap_yaml_input_reader",
       "description": "NCBI Prokaryotic Genome Annotation Pipeline (PGAP) input metadata (submol) JSON/YAML configuration file",
-      "fileMatch": ["submol*.json", "submol*.yml", "submol*.yaml"],
+      "fileMatch": [
+        "submol*.json",
+        "submol*.yml",
+        "submol*.yaml"
+      ],
       "url": "https://www.schemastore.org/pgap_yaml_input_reader.json"
     },
     {
       "name": "pgrls",
       "description": "Configuration for pgrls, the Postgres Row-Level Security linter (pgrls.toml)",
-      "fileMatch": ["pgrls.toml"],
+      "fileMatch": [
+        "pgrls.toml"
+      ],
       "url": "https://www.schemastore.org/pgrls.json"
     },
     {
       "name": "pattern.json",
       "description": "Patternplate pattern manifest file",
-      "fileMatch": ["pattern.json"],
+      "fileMatch": [
+        "pattern.json"
+      ],
       "url": "https://www.schemastore.org/pattern.json"
     },
     {
       "name": "pixi.toml",
       "description": "Pixi configuration file",
-      "fileMatch": ["pixi.toml"],
+      "fileMatch": [
+        "pixi.toml"
+      ],
       "url": "https://raw.githubusercontent.com/prefix-dev/pixi/main/schema/schema.json"
     },
     {
@@ -6138,19 +7477,26 @@
     {
       "name": ".pmbot.yml",
       "description": "Pmbot configuration file",
-      "fileMatch": [".pmbot.yml"],
+      "fileMatch": [
+        ".pmbot.yml"
+      ],
       "url": "https://raw.githubusercontent.com/pmbot-io/config/master/pmbot.yml.schema.json"
     },
     {
       "name": "PocketMine plugin.yml",
       "description": "PocketMine plugin manifest file",
-      "fileMatch": ["plugin.yml"],
+      "fileMatch": [
+        "plugin.yml"
+      ],
       "url": "https://www.schemastore.org/pocketmine-plugin.json"
     },
     {
       "name": "plagiarize.yaml",
       "description": "Yaml Plagiarize",
-      "fileMatch": ["plagiarize.yaml", "plagiarize.json"],
+      "fileMatch": [
+        "plagiarize.yaml",
+        "plagiarize.json"
+      ],
       "url": "https://www.schemastore.org/plagiarize.json",
       "versions": {
         "0.0": "https://www.schemastore.org/plagiarize-0.0.json"
@@ -6159,7 +7505,10 @@
     {
       "name": "plagiarize-me.yaml",
       "description": "Yaml Plagiarize MEe",
-      "fileMatch": ["plagiarize-me.yaml", "plagiarize-me.json"],
+      "fileMatch": [
+        "plagiarize-me.yaml",
+        "plagiarize-me.json"
+      ],
       "url": "https://www.schemastore.org/plagiarize-me.json",
       "versions": {
         "0.0": "https://www.schemastore.org/plagiarize-me-0.0.json"
@@ -6174,25 +7523,36 @@
     {
       "name": "podbard.yaml",
       "description": "Configuration file for Podbard - a podcast site generator",
-      "fileMatch": ["podbard.yaml"],
+      "fileMatch": [
+        "podbard.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/Songmu/podbard/main/schema.yaml"
     },
     {
       "name": "POPxf",
       "description": "Polynomial Observable Predictions in High-Energy Physics",
-      "fileMatch": ["*.popxf", "*.popxf.json"],
+      "fileMatch": [
+        "*.popxf",
+        "*.popxf.json"
+      ],
       "url": "https://www.schemastore.org/popxf-1.0.json"
     },
     {
       "name": "POPxf Correlations",
       "description": "Correlations for Polynomial Observable Predictions in High-Energy Physics",
-      "fileMatch": ["*.popxf-corr", "*.popxf-corr.json"],
+      "fileMatch": [
+        "*.popxf-corr",
+        "*.popxf-corr.json"
+      ],
       "url": "https://www.schemastore.org/popxf-corr-1.0.json"
     },
     {
       "name": "portman.json",
       "description": "Portman's configuration file",
-      "fileMatch": ["portman-config.json", "portman.json"],
+      "fileMatch": [
+        "portman-config.json",
+        "portman.json"
+      ],
       "url": "https://raw.githubusercontent.com/apideck-libraries/portman/main/src/utils/portman-config-schema.json"
     },
     {
@@ -6209,7 +7569,9 @@
     {
       "name": "Postman collection",
       "description": "Postman collections",
-      "fileMatch": ["*.postman_collection.json"],
+      "fileMatch": [
+        "*.postman_collection.json"
+      ],
       "url": "https://schema.postman.com/collection/json/v2.1.0/draft-07/collection.json",
       "versions": {
         "1.0.0": "https://schema.postman.com/collection/json/v1.0.0/draft-07/collection.json",
@@ -6220,19 +7582,27 @@
     {
       "name": ".powerpages-web-template-manifest",
       "description": "Custom manifest declaration for Web templates",
-      "fileMatch": [".powerpages-web-template-manifest"],
+      "fileMatch": [
+        ".powerpages-web-template-manifest"
+      ],
       "url": "https://www.schemastore.org/powerpages-web-template-manifest.json"
     },
     {
       "name": ".pre-commit-config.yml",
       "description": "pre-commit configuration file",
-      "fileMatch": [".pre-commit-config.yml", ".pre-commit-config.yaml"],
+      "fileMatch": [
+        ".pre-commit-config.yml",
+        ".pre-commit-config.yaml"
+      ],
       "url": "https://www.schemastore.org/pre-commit-config.json"
     },
     {
       "name": ".pre-commit-hooks.yml",
       "description": "pre-commit hooks definition file",
-      "fileMatch": [".pre-commit-hooks.yml", ".pre-commit-hooks.yaml"],
+      "fileMatch": [
+        ".pre-commit-hooks.yml",
+        ".pre-commit-hooks.yaml"
+      ],
       "url": "https://www.schemastore.org/pre-commit-hooks.json"
     },
     {
@@ -6254,31 +7624,42 @@
     {
       "name": ".phrase.yml",
       "description": "Phrase configuration file",
-      "fileMatch": [".phrase.yml"],
+      "fileMatch": [
+        ".phrase.yml"
+      ],
       "url": "https://www.schemastore.org/phrase.json"
     },
     {
       "name": ".phraseapp.yml",
       "description": "PhraseApp configuration file",
-      "fileMatch": [".phraseapp.yml"],
+      "fileMatch": [
+        ".phraseapp.yml"
+      ],
       "url": "https://www.schemastore.org/phraseapp.json"
     },
     {
       "name": "prefect.toml",
       "description": "Prefect configuration file",
-      "fileMatch": ["prefect.toml"],
+      "fileMatch": [
+        "prefect.toml"
+      ],
       "url": "https://raw.githubusercontent.com/PrefectHQ/prefect/refs/heads/main/schemas/settings.schema.json"
     },
     {
       "name": "prefect.yaml",
       "description": "Prefect deployment configuration file",
-      "fileMatch": ["prefect.yaml", "prefect.yml"],
+      "fileMatch": [
+        "prefect.yaml",
+        "prefect.yml"
+      ],
       "url": "https://raw.githubusercontent.com/PrefectHQ/prefect/refs/heads/main/schemas/prefect.yaml.schema.json"
     },
     {
       "name": "prek",
       "description": "Configuration file for prek, a tool for managing git hooks",
-      "fileMatch": ["prek.toml"],
+      "fileMatch": [
+        "prek.toml"
+      ],
       "url": "https://www.schemastore.org/prek.json"
     },
     {
@@ -6300,73 +7681,101 @@
     {
       "name": "prisma.yml",
       "description": "prisma.yml service definition file",
-      "fileMatch": ["prisma.yml"],
+      "fileMatch": [
+        "prisma.yml"
+      ],
       "url": "https://www.schemastore.org/prisma.json"
     },
     {
       "name": "ProActions AI-Kit Configuration",
       "description": "Eidosmedia ProActions AI-Kit main configuration file",
-      "fileMatch": ["*.ai-kit.yaml"],
+      "fileMatch": [
+        "*.ai-kit.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/ai-kit.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Services",
       "description": "Eidosmedia ProActions AI-Kit services configuration files",
-      "fileMatch": ["*.ai-kit.serv.yaml"],
+      "fileMatch": [
+        "*.ai-kit.serv.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-services.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Menus",
       "description": "Eidosmedia ProActions AI-Kit menu configuration files",
-      "fileMatch": ["*.ai-kit.menu.yaml"],
+      "fileMatch": [
+        "*.ai-kit.menu.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-floatingMenu.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Templates",
       "description": "Eidosmedia ProActions AI-Kit template configuration files",
-      "fileMatch": ["*.ai-kit.templ.yaml"],
+      "fileMatch": [
+        "*.ai-kit.templ.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-templates.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Sections",
       "description": "Eidosmedia ProActions AI-Kit section configuration files",
-      "fileMatch": ["*.ai-kit.sect.yaml"],
+      "fileMatch": [
+        "*.ai-kit.sect.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-section.schema.json"
     },
     {
       "name": "ProActions AI-Kit Configuration for Steps",
       "description": "Eidosmedia ProActions AI-Kit step configuration files",
-      "fileMatch": ["*.ai-kit.step.yaml"],
+      "fileMatch": [
+        "*.ai-kit.step.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/em-al-wi/proactions-schema/main/schema/partial-step.schema.json"
     },
     {
       "name": "Problem package format",
       "description": "Problem package metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": ["problem.yml", "problem.yaml"],
+      "fileMatch": [
+        "problem.yml",
+        "problem.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/problem_yaml_schema.json"
     },
     {
       "name": "Problem package generators",
       "description": "Generators for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": ["generators.yml", "generators.yaml"],
+      "fileMatch": [
+        "generators.yml",
+        "generators.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/generators_yaml_schema.json"
     },
     {
       "name": "Problem package submissions",
       "description": "Submissions metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": ["submissions.yml", "submissions.yaml"],
+      "fileMatch": [
+        "submissions.yml",
+        "submissions.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/submissions_yaml_schema.json"
     },
     {
       "name": "Problem package test group metadata",
       "description": "Test group metadata for programming tasks in the Kattis/CLICS problem package format",
-      "fileMatch": ["test_group.yml", "test_group.yaml"],
+      "fileMatch": [
+        "test_group.yml",
+        "test_group.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/RagnarGrootKoerkamp/BAPCtools/refs/heads/main/bapctools/resources/support/schemas/test_group_yaml_schema.json"
     },
     {
       "name": "project.json",
       "description": "ASP.NET vNext project configuration file",
-      "fileMatch": ["project.json"],
+      "fileMatch": [
+        "project.json"
+      ],
       "url": "https://www.schemastore.org/project.json",
       "versions": {
         "1.0.0-beta3": "https://www.schemastore.org/project-1.0.0-beta3.json",
@@ -6417,13 +7826,18 @@
     {
       "name": "project.owasp.yaml",
       "description": "OWASP project",
-      "fileMatch": ["project.owasp.yaml"],
+      "fileMatch": [
+        "project.owasp.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/OWASP/nest-schema/main/project.json"
     },
     {
       "name": "prometheus.json",
       "description": "Prometheus configuration file",
-      "fileMatch": ["prometheus.yml", "prometheus.yaml"],
+      "fileMatch": [
+        "prometheus.yml",
+        "prometheus.yaml"
+      ],
       "url": "https://www.schemastore.org/prometheus.json"
     },
     {
@@ -6455,31 +7869,42 @@
     {
       "name": "prometheus-alertmanager.json",
       "description": "Prometheus Alertmanager configuration file",
-      "fileMatch": ["alertmanager.yml", "alertmanager.yaml"],
+      "fileMatch": [
+        "alertmanager.yml",
+        "alertmanager.yaml"
+      ],
       "url": "https://www.schemastore.org/prometheus-alertmanager.json"
     },
     {
       "name": "proxies.json",
       "description": "Azure Function Proxies proxies.json files",
-      "fileMatch": ["proxies.json"],
+      "fileMatch": [
+        "proxies.json"
+      ],
       "url": "https://www.schemastore.org/proxies.json"
     },
     {
       "name": "publiccode.yml",
       "description": "publiccode.yml",
-      "fileMatch": ["publiccode.yml"],
+      "fileMatch": [
+        "publiccode.yml"
+      ],
       "url": "https://www.schemastore.org/publiccode.json"
     },
     {
       "name": "pubspec.yaml",
       "description": "pubspecs, the format used by Dart's dependency manager",
-      "fileMatch": ["pubspec.yaml"],
+      "fileMatch": [
+        "pubspec.yaml"
+      ],
       "url": "https://www.schemastore.org/pubspec.json"
     },
     {
       "name": "Pull Request Labeler",
       "description": "A GitHub Action for automatically labelling pull requests",
-      "fileMatch": ["**/.github/labeler.yml"],
+      "fileMatch": [
+        "**/.github/labeler.yml"
+      ],
       "url": "https://www.schemastore.org/pull-request-labeler.json",
       "versions": {
         "4": "https://www.schemastore.org/pull-request-labeler-4.json",
@@ -6489,19 +7914,25 @@
     {
       "name": ".putout.json",
       "description": "🐊Putout configuration file",
-      "fileMatch": [".putout.json"],
+      "fileMatch": [
+        ".putout.json"
+      ],
       "url": "https://www.schemastore.org/putout.json"
     },
     {
       "name": "pyrseas-0.8.json",
       "description": "Pyrseas database versioning for Postgres databases, v0.8",
-      "fileMatch": ["pyrseas-0.8.json"],
+      "fileMatch": [
+        "pyrseas-0.8.json"
+      ],
       "url": "https://www.schemastore.org/pyrseas-0.8.json"
     },
     {
       "name": "RadioHound",
       "description": "RadioHound data format for spectrum monitoring",
-      "fileMatch": ["*.rh.json"],
+      "fileMatch": [
+        "*.rh.json"
+      ],
       "url": "https://www.schemastore.org/radiohound-v0.json",
       "versions": {
         "v0": "https://www.schemastore.org/radiohound-v0.json"
@@ -6510,19 +7941,26 @@
     {
       "name": "PyGTA Config",
       "description": "Configuration file used by pyglotaran and pyglotaran-extras",
-      "fileMatch": ["pygta_config.yaml", "pygta_config.yml"],
+      "fileMatch": [
+        "pygta_config.yaml",
+        "pygta_config.yml"
+      ],
       "url": "https://pyglotaran-extras.readthedocs.io/en/latest/_static/pygta_config.schema.json"
     },
     {
       "name": "Rancher Fleet",
       "description": "Rancher Fleet fleet.yaml configuration file",
-      "fileMatch": ["**/fleet.yaml"],
+      "fileMatch": [
+        "**/fleet.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/rancher/fleet/main/schemas/fleet.yaml.json"
     },
     {
       "name": "config.yaml",
       "description": "Projektor settings",
-      "fileMatch": ["**/.projektor/config.yaml"],
+      "fileMatch": [
+        "**/.projektor/config.yaml"
+      ],
       "url": "https://www.schemastore.org/projektor.json"
     },
     {
@@ -6539,19 +7977,26 @@
     {
       "name": "Pulumi",
       "description": "Pulumi project metadata and configuration",
-      "fileMatch": ["Pulumi.yaml", "pulumi.yaml"],
+      "fileMatch": [
+        "Pulumi.yaml",
+        "pulumi.yaml"
+      ],
       "url": "https://www.schemastore.org/pulumi.json"
     },
     {
       "name": "PyProject",
       "description": "Python project metadata and configuration",
-      "fileMatch": ["pyproject.toml"],
+      "fileMatch": [
+        "pyproject.toml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/pyproject.json"
     },
     {
       "name": "Pyright",
       "description": "Pyright Configuration",
-      "fileMatch": ["pyrightconfig.json"],
+      "fileMatch": [
+        "pyrightconfig.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/pyright/main/packages/vscode-pyright/schemas/pyrightconfig.schema.json"
     },
     {
@@ -6575,73 +8020,101 @@
     {
       "name": "QType AI DSL",
       "description": "A DSL for rapid prototyping of AI applications",
-      "fileMatch": ["qtype.config.yaml", "*.qtype.yaml"],
+      "fileMatch": [
+        "qtype.config.yaml",
+        "*.qtype.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/bazaarvoice/qtype/refs/heads/main/schema/qtype.schema.json"
     },
     {
       "name": "Railway",
       "description": "Use Railway config as code to define settings for building and deploying your services",
-      "fileMatch": ["railway.toml", "railway.json"],
+      "fileMatch": [
+        "railway.toml",
+        "railway.json"
+      ],
       "url": "https://railway.com/railway.schema.json"
     },
     {
       "name": "Railpack",
       "description": "Configuration file for Railpack deployment tool",
-      "fileMatch": ["railpack.json"],
+      "fileMatch": [
+        "railpack.json"
+      ],
       "url": "https://schema.railpack.com"
     },
     {
       "name": "Rattler-build",
       "description": "Rattler-build recipe",
-      "fileMatch": ["recipe.yaml", "recipe.yml"],
+      "fileMatch": [
+        "recipe.yaml",
+        "recipe.yml"
+      ],
       "url": "https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json"
     },
     {
       "name": "rc3 auth",
       "description": "RC auth that can be stored at Collection, Folder, or Request levels",
-      "fileMatch": ["rc-auth.json"],
+      "fileMatch": [
+        "rc-auth.json"
+      ],
       "url": "https://www.schemastore.org/rc3-auth-0.0.3.json"
     },
     {
       "name": "rc3 collection",
       "description": "RC collection information",
-      "fileMatch": ["rc-collection.json"],
+      "fileMatch": [
+        "rc-collection.json"
+      ],
       "url": "https://www.schemastore.org/rc3-collection-0.0.3.json"
     },
     {
       "name": "rc3 environment",
       "description": "RC environment for both Global and per Collection environments",
-      "fileMatch": ["**/environments/*.json", "rc-global.json"],
+      "fileMatch": [
+        "**/environments/*.json",
+        "rc-global.json"
+      ],
       "url": "https://www.schemastore.org/rc3-environment-0.0.3.json"
     },
     {
       "name": "rc3 folder",
       "description": "RC folder information",
-      "fileMatch": ["rc-folder.json"],
+      "fileMatch": [
+        "rc-folder.json"
+      ],
       "url": "https://www.schemastore.org/rc3-folder-0.0.3.json"
     },
     {
       "name": "rc3 request",
       "description": "RC request information",
-      "fileMatch": ["**/*.request"],
+      "fileMatch": [
+        "**/*.request"
+      ],
       "url": "https://www.schemastore.org/rc3-request-0.0.3.json"
     },
     {
       "name": "rc3 settings",
       "description": "RC settings stored in the users RC_HOME directory",
-      "fileMatch": ["rc-settings.json"],
+      "fileMatch": [
+        "rc-settings.json"
+      ],
       "url": "https://www.schemastore.org/rc3-settings-0.0.3.json"
     },
     {
       "name": "Red-DiscordBot Cog",
       "description": "Red-DiscordBot Cog metadata file",
-      "fileMatch": ["info.json"],
+      "fileMatch": [
+        "info.json"
+      ],
       "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json"
     },
     {
       "name": "Red-DiscordBot Cog Repo",
       "description": "Red-DiscordBot Cog Repo metadata file",
-      "fileMatch": ["info.json"],
+      "fileMatch": [
+        "info.json"
+      ],
       "url": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog_repo.schema.json"
     },
     {
@@ -6663,19 +8136,26 @@
     {
       "name": "release-please-config.json",
       "description": "Release Please manifest configuration file",
-      "fileMatch": ["release-please-config.json"],
+      "fileMatch": [
+        "release-please-config.json"
+      ],
       "url": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
     },
     {
       "name": "release-please-manifest.json",
       "description": "Release Please manifest versions file",
-      "fileMatch": [".release-please-manifest.json"],
+      "fileMatch": [
+        ".release-please-manifest.json"
+      ],
       "url": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json"
     },
     {
       "name": "release-plz.toml",
       "description": "Release-plz configuration file",
-      "fileMatch": ["release-plz.toml", ".release-plz.toml"],
+      "fileMatch": [
+        "release-plz.toml",
+        ".release-plz.toml"
+      ],
       "url": "https://raw.githubusercontent.com/MarcoIeni/release-plz/main/.schema/latest.json"
     },
     {
@@ -6692,49 +8172,68 @@
     {
       "name": "Replit config",
       "description": "replit.com, a cloud IDE and code runner",
-      "fileMatch": ["replit.toml"],
+      "fileMatch": [
+        "replit.toml"
+      ],
       "url": "https://www.schemastore.org/replit.json"
     },
     {
       "name": "github-settings-as-code",
       "description": "Declarative GitHub repository settings applied by the github-settings-as-code action; accepts Probot Settings app files as-is. Documentation: https://github.com/Vivswan/github-settings-as-code",
-      "fileMatch": ["**/.github/settings.yml"],
+      "fileMatch": [
+        "**/.github/settings.yml"
+      ],
       "url": "https://raw.githubusercontent.com/Vivswan/github-settings-as-code/main/lib/settings.schema.json"
     },
     {
       "name": "reposets Configuration",
       "description": "Configuration for the reposets CLI tool for syncing GitHub repository settings",
-      "fileMatch": ["reposets.config.toml", "reposets.config.json"],
+      "fileMatch": [
+        "reposets.config.toml",
+        "reposets.config.json"
+      ],
       "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json"
     },
     {
       "name": "reposets Credentials",
       "description": "Authentication profiles for the reposets CLI tool",
-      "fileMatch": ["reposets.credentials.toml", "reposets.credentials.json"],
+      "fileMatch": [
+        "reposets.credentials.toml",
+        "reposets.credentials.json"
+      ],
       "url": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json"
     },
     {
       "name": "*.resjson",
       "description": "Windows App localization file",
-      "fileMatch": ["*.resjson"],
+      "fileMatch": [
+        "*.resjson"
+      ],
       "url": "https://www.schemastore.org/resjson.json"
     },
     {
       "name": "Rubocop",
       "description": "A Ruby code style checker (linter) and formatter",
-      "fileMatch": ["*.rubocop.yml"],
+      "fileMatch": [
+        "*.rubocop.yml"
+      ],
       "url": "https://www.rubyschema.org/rubocop.json"
     },
     {
       "name": "Ruff",
       "description": "Ruff, a fast Python linter",
-      "fileMatch": ["ruff.toml", ".ruff.toml"],
+      "fileMatch": [
+        "ruff.toml",
+        ".ruff.toml"
+      ],
       "url": "https://www.schemastore.org/ruff.json"
     },
     {
       "name": "Rust Project",
       "description": "non-Cargo based Rust projects",
-      "fileMatch": ["rust-project.json"],
+      "fileMatch": [
+        "rust-project.json"
+      ],
       "url": "https://www.schemastore.org/rust-project.json"
     },
     {
@@ -6815,13 +8314,18 @@
     {
       "name": "renv.lock",
       "description": "Lockfile for recording R project dependencies with renv package",
-      "fileMatch": ["renv.lock"],
+      "fileMatch": [
+        "renv.lock"
+      ],
       "url": "https://raw.githubusercontent.com/rstudio/renv/refs/heads/main/inst/schema/draft-07.renv.lock.schema.json"
     },
     {
       "name": "RoadRunner",
       "description": "Spiral Roadrunner config file",
-      "fileMatch": [".rr*.yml", ".rr*.yaml"],
+      "fileMatch": [
+        ".rr*.yml",
+        ".rr*.yaml"
+      ],
       "url": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/3.0.schema.json",
       "versions": {
         "1.0": "https://cdn.jsdelivr.net/gh/roadrunner-server/roadrunner@latest/schemas/config/1.0.schema.json",
@@ -6832,7 +8336,9 @@
     {
       "name": "Rockcraft",
       "description": "Rockcraft project. Documentation: https://documentation.ubuntu.com/rockcraft/stable/",
-      "fileMatch": ["rockcraft.yaml"],
+      "fileMatch": [
+        "rockcraft.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/canonical/rockcraft/main/schema/rockcraft.json"
     },
     {
@@ -6849,49 +8355,70 @@
     {
       "name": "runny",
       "description": "runny, a rool for running things",
-      "fileMatch": [".runny.yaml", ".runny.yml"],
+      "fileMatch": [
+        ".runny.yaml",
+        ".runny.yml"
+      ],
       "url": "https://raw.githubusercontent.com/simonwhitaker/runny/main/schema/runny.schema.json"
     },
     {
       "name": "rumdl",
       "description": "Configuration file for rumdl, a fast Markdown linter and formatter",
-      "fileMatch": [".rumdl.toml", "rumdl.toml"],
+      "fileMatch": [
+        ".rumdl.toml",
+        "rumdl.toml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/rumdl.json"
     },
     {
       "name": "rustfmt",
       "description": "rustfmt, a tool to format Rust code. Documentation: https://rust-lang.github.io/rustfmt",
-      "fileMatch": ["rustfmt.toml", ".rustfmt.toml"],
+      "fileMatch": [
+        "rustfmt.toml",
+        ".rustfmt.toml"
+      ],
       "url": "https://www.schemastore.org/rustfmt.json"
     },
     {
       "name": "ryl",
       "description": "ryl, a fast YAML linter written in Rust",
-      "fileMatch": ["ryl.toml", ".ryl.toml"],
+      "fileMatch": [
+        "ryl.toml",
+        ".ryl.toml"
+      ],
       "url": "https://www.schemastore.org/ryl.json"
     },
     {
       "name": "Rust toolchain",
       "description": "A declarative managing the Rust toolchain",
-      "fileMatch": ["rust-toolchain.toml"],
+      "fileMatch": [
+        "rust-toolchain.toml"
+      ],
       "url": "https://www.schemastore.org/rust-toolchain.json"
     },
     {
       "name": "samt",
       "description": "SAMT configuration files",
-      "fileMatch": ["samt.yaml"],
+      "fileMatch": [
+        "samt.yaml"
+      ],
       "url": "https://www.schemastore.org/samt.json"
     },
     {
       "name": "samtrc",
       "description": "SAMT linter configuration files",
-      "fileMatch": [".samtrc.yaml"],
+      "fileMatch": [
+        ".samtrc.yaml"
+      ],
       "url": "https://www.schemastore.org/samtrc.json"
     },
     {
       "name": "Sapphire CLI Config",
       "description": "Scheme for Sapphire CLI Config (@sapphire/cli)",
-      "fileMatch": [".sapphirerc.json", ".sapphirerc.yml"],
+      "fileMatch": [
+        ".sapphirerc.json",
+        ".sapphirerc.yml"
+      ],
       "url": "https://raw.githubusercontent.com/sapphiredev/cli/main/templates/schemas/.sapphirerc.scheme.json"
     },
     {
@@ -6962,7 +8489,9 @@
     {
       "name": "scalingo.json configuration",
       "description": "scalingo.json configuration files",
-      "fileMatch": ["scalingo.json"],
+      "fileMatch": [
+        "scalingo.json"
+      ],
       "url": "https://raw.githubusercontent.com/Scalingo/developers-documentation/refs/heads/master/scalingo.schema.json"
     },
     {
@@ -6993,13 +8522,17 @@
     {
       "name": "Scarb",
       "description": "Scarb manifest file (Scarb.toml)",
-      "fileMatch": ["Scarb.toml"],
+      "fileMatch": [
+        "Scarb.toml"
+      ],
       "url": "https://www.schemastore.org/scarb.json"
     },
     {
       "name": "Scoop manifest",
       "description": "Scoop bucket app manifest",
-      "fileMatch": ["**/bucket/**.json"],
+      "fileMatch": [
+        "**/bucket/**.json"
+      ],
       "url": "https://raw.githubusercontent.com/lukesampson/scoop/master/schema.json"
     },
     {
@@ -7035,13 +8568,17 @@
     {
       "name": "Secure SDLC Evidence Bundle",
       "description": "Auditable release-readiness evidence bundle produced by the Secure SDLC Evidence Collector",
-      "fileMatch": ["**/*.evidence-bundle.json"],
+      "fileMatch": [
+        "**/*.evidence-bundle.json"
+      ],
       "url": "https://www.schemastore.org/evidence-bundle.json"
     },
     {
       "name": "Semantic Data Fabric (SDF) file",
       "description": "SDF blocks",
-      "fileMatch": ["*.sdf.yml"],
+      "fileMatch": [
+        "*.sdf.yml"
+      ],
       "url": "https://cdn.sdf.com/schemas/sdf-schema-1.3.json",
       "versions": {
         "1.0": "https://cdn.sdf.com/schemas/sdf-schema-1.0.json",
@@ -7106,19 +8643,28 @@
     {
       "name": "Serenity Code Generator (Sergen)",
       "description": "Serenity code generator (sergen) configuration file",
-      "fileMatch": ["sergen.json", "sergen.*.json", "*.sergen.json"],
+      "fileMatch": [
+        "sergen.json",
+        "sergen.*.json",
+        "*.sergen.json"
+      ],
       "url": "https://www.schemastore.org/sergen.json"
     },
     {
       "name": "settings.job",
       "description": "Azure Webjob settings file",
-      "fileMatch": ["settings.job"],
+      "fileMatch": [
+        "settings.job"
+      ],
       "url": "https://www.schemastore.org/settings.job.json"
     },
     {
       "name": "Settings.paf",
       "description": "Qualisys Project Automation Framework settings file",
-      "fileMatch": ["settings.paf", "Settings.paf"],
+      "fileMatch": [
+        "settings.paf",
+        "Settings.paf"
+      ],
       "url": "https://raw.githubusercontent.com/qualisys/qualisys-schemas/master/paf-module.schema.json"
     },
     {
@@ -7135,13 +8681,17 @@
     {
       "name": "Sigma Detection Rule",
       "description": "The Sigma detection rule format. Documentation: https://github.com/SigmaHQ/sigma-specification/blob/main/specification/sigma-rules-specification.md and https://github.com/SigmaHQ/sigma",
-      "fileMatch": ["**/sigma/**/*.yml"],
+      "fileMatch": [
+        "**/sigma/**/*.yml"
+      ],
       "url": "https://raw.githubusercontent.com/SigmaHQ/sigma-specification/main/json-schema/sigma-detection-rule-schema.json"
     },
     {
       "name": "Sigrid scope configuration file",
       "description": "Analysis scope configuration file used by Sigrid (sigrid-says.com)",
-      "fileMatch": ["sigrid.yaml"],
+      "fileMatch": [
+        "sigrid.yaml"
+      ],
       "url": "https://www.schemastore.org/sigrid-scope-file.schema.json"
     },
     {
@@ -7171,7 +8721,9 @@
     {
       "name": "size-limit configuration",
       "description": "Configuration file for size-limit",
-      "fileMatch": [".size-limit.json"],
+      "fileMatch": [
+        ".size-limit.json"
+      ],
       "url": "https://www.schemastore.org/size-limit.json"
     },
     {
@@ -7199,7 +8751,9 @@
     {
       "name": "skill-map provider kind",
       "description": "Node-kind descriptor a skill-map Provider plugin declares",
-      "fileMatch": ["**/.skill-map/plugins/*/kinds/*/kind.json"],
+      "fileMatch": [
+        "**/.skill-map/plugins/*/kinds/*/kind.json"
+      ],
       "url": "https://skill-map.ai/spec/v1/extensions/provider-kind.schema.json"
     },
     {
@@ -7210,19 +8764,28 @@
     {
       "name": "skyuxconfig.json",
       "description": "SKY UX CLI configuration file",
-      "fileMatch": ["skyuxconfig.json", "skyuxconfig.*.json"],
+      "fileMatch": [
+        "skyuxconfig.json",
+        "skyuxconfig.*.json"
+      ],
       "url": "https://raw.githubusercontent.com/blackbaud/skyux-config/4.x.x/skyuxconfig-schema.json"
     },
     {
       "name": "Snapcraft",
       "description": "Snapcraft project. Documentation: https://documentation.ubuntu.com/snapcraft/stable/",
-      "fileMatch": [".snapcraft.yaml", "snapcraft.yaml"],
+      "fileMatch": [
+        ".snapcraft.yaml",
+        "snapcraft.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/canonical/snapcraft/main/schema/snapcraft.json"
     },
     {
       "name": "snowflake-config",
       "description": "Configuration file for Snowflake",
-      "fileMatch": ["**/.snowflake/config.toml", "**/snowflake/config.toml"],
+      "fileMatch": [
+        "**/.snowflake/config.toml",
+        "**/snowflake/config.toml"
+      ],
       "url": "https://www.schemastore.org/snowflake-config.json"
     },
     {
@@ -7237,169 +8800,227 @@
     {
       "name": "Solarxy project config",
       "description": "Solarxy 3D model viewer and validator project configuration",
-      "fileMatch": ["solarxy.toml"],
+      "fileMatch": [
+        "solarxy.toml"
+      ],
       "url": "https://www.schemastore.org/solarxy-config.json"
     },
     {
       "name": "Solidarity",
       "description": "CLI config for enforcing environment settings",
-      "fileMatch": [".solidarity", ".solidarity.json"],
+      "fileMatch": [
+        ".solidarity",
+        ".solidarity.json"
+      ],
       "url": "https://www.schemastore.org/solidaritySchema.json"
     },
     {
       "name": "Solution filters",
       "description": "File that specifies which MSBuild solution to launch and which projects to load",
-      "fileMatch": ["*.slnf"],
+      "fileMatch": [
+        "*.slnf"
+      ],
       "url": "https://www.schemastore.org/solution-filter.json"
     },
     {
       "name": "Source Maps v3",
       "description": "Source Map files version 3",
-      "fileMatch": ["*.map"],
+      "fileMatch": [
+        "*.map"
+      ],
       "url": "https://www.schemastore.org/sourcemap-v3.json"
     },
     {
       "name": "Sourcery",
       "description": "Sourcery YAML files",
-      "fileMatch": [".sourcery.yaml"],
+      "fileMatch": [
+        ".sourcery.yaml"
+      ],
       "url": "https://www.schemastore.org/sourcery_yaml_schema.json"
     },
     {
       "name": "Spack bootstrap.yaml",
       "description": "Spack package manager bootstrap.yaml config file",
-      "fileMatch": ["**/*spack/**/bootstrap.yaml"],
+      "fileMatch": [
+        "**/*spack/**/bootstrap.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/bootstrap.json"
     },
     {
       "name": "Spack cdash.yaml",
       "description": "Spack package manager cdash.yaml config file",
-      "fileMatch": ["**/*spack/**/cdash.yaml"],
+      "fileMatch": [
+        "**/*spack/**/cdash.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/cdash.json"
     },
     {
       "name": "Spack ci.yaml",
       "description": "Spack package manager ci.yaml config file",
-      "fileMatch": ["**/*spack/**/ci.yaml"],
+      "fileMatch": [
+        "**/*spack/**/ci.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/ci.json"
     },
     {
       "name": "Spack compilers.yaml",
       "description": "Spack package manager compilers.yaml config file",
-      "fileMatch": ["**/*spack/**/compilers.yaml"],
+      "fileMatch": [
+        "**/*spack/**/compilers.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/compilers.json"
     },
     {
       "name": "Spack concretizer.yaml",
       "description": "Spack package manager concretizer.yaml config file",
-      "fileMatch": ["**/*spack/**/concretizer.yaml"],
+      "fileMatch": [
+        "**/*spack/**/concretizer.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/concretizer.json"
     },
     {
       "name": "Spack config.yaml",
       "description": "Spack package manager config.yaml file",
-      "fileMatch": ["**/*spack/**/config.yaml"],
+      "fileMatch": [
+        "**/*spack/**/config.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/config.json"
     },
     {
       "name": "Spack definitions.yaml",
       "description": "Spack package manager definitions.yaml config",
-      "fileMatch": ["**/*spack/**/definitions.yaml"],
+      "fileMatch": [
+        "**/*spack/**/definitions.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/definitions.json"
     },
     {
       "name": "Spack develop.yaml",
       "description": "Spack package manager develop.yaml config file",
-      "fileMatch": ["**/*spack/**/develop.yaml"],
+      "fileMatch": [
+        "**/*spack/**/develop.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/develop.json"
     },
     {
       "name": "Spack env_vars.yaml",
       "description": "Spack package manager env_vars.yaml config file",
-      "fileMatch": ["**/*spack/**/env_vars.yaml"],
+      "fileMatch": [
+        "**/*spack/**/env_vars.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/env_vars.json"
     },
     {
       "name": "Spack include.yaml",
       "description": "Spack package manager include.yaml config file",
-      "fileMatch": ["**/*spack/**/include.yaml"],
+      "fileMatch": [
+        "**/*spack/**/include.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/include.json"
     },
     {
       "name": "Spack mirrors.yaml",
       "description": "Spack package manager mirrors.yaml config file",
-      "fileMatch": ["**/*spack/**/mirrors.yaml"],
+      "fileMatch": [
+        "**/*spack/**/mirrors.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/mirrors.json"
     },
     {
       "name": "Spack modules.yaml",
       "description": "Spack package manager modules.yaml config file",
-      "fileMatch": ["**/*spack/**/modules.yaml"],
+      "fileMatch": [
+        "**/*spack/**/modules.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/modules.json"
     },
     {
       "name": "Spack packages.yaml",
       "description": "Spack package manager packages.yaml config file",
-      "fileMatch": ["**/*spack/**/packages.yaml"],
+      "fileMatch": [
+        "**/*spack/**/packages.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/packages.json"
     },
     {
       "name": "Spack repos.yaml",
       "description": "Spack package manager repos.yaml config file",
-      "fileMatch": ["**/*spack/**/repos.yaml"],
+      "fileMatch": [
+        "**/*spack/**/repos.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/repos.json"
     },
     {
       "name": "Spack environment",
       "description": "Spack package manager environment file",
-      "fileMatch": ["spack.yaml"],
+      "fileMatch": [
+        "spack.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/spack.json"
     },
     {
       "name": "Spack toolchains.yaml",
       "description": "Spack package manager toolchains.yaml config file",
-      "fileMatch": ["**/*spack/**/toolchains.yaml"],
+      "fileMatch": [
+        "**/*spack/**/toolchains.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/toolchains.json"
     },
     {
       "name": "Spack upstreams.yaml",
       "description": "Spack package manager upstreams.yaml config file",
-      "fileMatch": ["**/*spack/**/upstreams.yaml"],
+      "fileMatch": [
+        "**/*spack/**/upstreams.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/upstreams.json"
     },
     {
       "name": "Spack view.yaml",
       "description": "Spack package manager view.yaml config file",
-      "fileMatch": ["**/*spack/**/view.yaml"],
+      "fileMatch": [
+        "**/*spack/**/view.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spack/schemas/refs/heads/main/schemas/view.json"
     },
     {
       "name": "Speakeasy Lint Configuration File",
       "description": "Configuration file for Speakeasy's OpenAPI document linting. Find out more at https://www.speakeasy.com/docs/linting",
-      "fileMatch": ["**/.speakeasy/lint.yaml"],
+      "fileMatch": [
+        "**/.speakeasy/lint.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/lint.schema.json"
     },
     {
       "name": "Speakeasy Test Generation Configuration File",
       "description": "Configuration file for Speakeasy's test generation",
-      "fileMatch": ["**/.speakeasy/tests.yaml"],
+      "fileMatch": [
+        "**/.speakeasy/tests.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/tests.schema.json"
     },
     {
       "name": "Speakeasy Workflow File",
       "description": "Workflow configuration file. Read more at https://www.speakeasy.com/docs/workflow-file-reference",
-      "fileMatch": ["**/.speakeasy/workflow.yaml"],
+      "fileMatch": [
+        "**/.speakeasy/workflow.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/workflow.schema.json"
     },
     {
       "name": "Speakeasy Generation Config File",
       "description": "Speakeasy generation configuration file. Read more at https://www.speakeasy.com/docs/speakeasy-reference/generation/gen-yaml",
-      "fileMatch": ["**/.speakeasy/gen.yaml"],
+      "fileMatch": [
+        "**/.speakeasy/gen.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/speakeasy-api/sdk-gen-config/main/schemas/gen.config.schema.json"
     },
     {
       "name": "SpecIF",
       "description": "The Specification Integration Facility (SpecIF) integrates partial system models from different methods and tools in a semantic net. Documentation: https://specif.de and https://github.com/GfSE",
-      "fileMatch": ["*.specif", "*.specif.json"],
+      "fileMatch": [
+        "*.specif",
+        "*.specif.json"
+      ],
       "url": "https://www.schemastore.org/specif-1.1.json",
       "versions": {
         "1.0": "https://www.schemastore.org/specif-1.0.json",
@@ -7409,13 +9030,19 @@
     {
       "name": "Specmatic Configuration",
       "description": "Configuration file for Specmatic, a contract-driven testing tool",
-      "fileMatch": ["specmatic.json", "specmatic.yaml", "specmatic.yml"],
+      "fileMatch": [
+        "specmatic.json",
+        "specmatic.yaml",
+        "specmatic.yml"
+      ],
       "url": "https://www.schemastore.org/specmatic.json"
     },
     {
       "name": "Sponge Mixin configuration",
       "description": "Configuration file for SpongePowered's Mixin library",
-      "fileMatch": ["*.mixins.json"],
+      "fileMatch": [
+        "*.mixins.json"
+      ],
       "url": "https://www.schemastore.org/sponge-mixins.json"
     },
     {
@@ -7434,55 +9061,78 @@
     {
       "name": ".sprite files",
       "description": "image sprite generation files",
-      "fileMatch": ["*.sprite"],
+      "fileMatch": [
+        "*.sprite"
+      ],
       "url": "https://www.schemastore.org/sprite.json"
     },
     {
       "name": "SPDX 2.3",
       "description": "System Package Data Exchange (SPDX) definition",
-      "fileMatch": ["*.spdx.json", "*.spdx.yaml", "*.spdx.yml"],
+      "fileMatch": [
+        "*.spdx.json",
+        "*.spdx.yaml",
+        "*.spdx.yml"
+      ],
       "url": "https://raw.githubusercontent.com/spdx/spdx-spec/refs/tags/v2.3/schemas/spdx-schema.json"
     },
     {
       "name": "sqlc configuration",
       "description": "Configuration file for sqlc v2",
-      "fileMatch": ["sqlc.yaml", "sqlc.json", "*.sqlc.yaml"],
+      "fileMatch": [
+        "sqlc.yaml",
+        "sqlc.json",
+        "*.sqlc.yaml"
+      ],
       "url": "https://www.schemastore.org/sqlc-2.0.json"
     },
     {
       "name": "Azure Static Web Apps configuration file",
       "description": "Documentation: https://learn.microsoft.com/en-us/azure/static-web-apps/configuration",
-      "fileMatch": ["staticwebapp.config.json"],
+      "fileMatch": [
+        "staticwebapp.config.json"
+      ],
       "url": "https://www.schemastore.org/staticwebapp.config.json"
     },
     {
       "name": "Azure Static Web Apps CLI configuration file",
       "description": "Documentation: https://github.com/Azure/static-web-apps-cli#swa-cliconfigjson-file",
-      "fileMatch": ["swa-cli.config.json"],
+      "fileMatch": [
+        "swa-cli.config.json"
+      ],
       "url": "https://www.schemastore.org/swa-cli.config.json"
     },
     {
       "name": "StackBlitz",
       "description": "WebContainer project configuration",
-      "fileMatch": [".stackblitzrc", "**/.stackblitz/config.json"],
+      "fileMatch": [
+        ".stackblitzrc",
+        "**/.stackblitz/config.json"
+      ],
       "url": "https://www.schemastore.org/stackblitzrc.json"
     },
     {
       "name": "Stale",
       "description": "Configuration file for Stale for closing abandoned issues and pull requests. Documentation: https://probot.github.io/apps/stale/",
-      "fileMatch": ["**/.github/stale.yml"],
+      "fileMatch": [
+        "**/.github/stale.yml"
+      ],
       "url": "https://www.schemastore.org/stale.json"
     },
     {
       "name": "Starfish",
       "description": "Configuration file for Starfish",
-      "fileMatch": ["starfish.yml"],
+      "fileMatch": [
+        "starfish.yml"
+      ],
       "url": "https://raw.githubusercontent.com/veepee-oss/json-schema/refs/heads/main/starfish/1-latest/starfish-schema.json"
     },
     {
       "name": "Starship",
       "description": "Configuration file for Starship. Documentation: https://starship.rs",
-      "fileMatch": ["starship.toml"],
+      "fileMatch": [
+        "starship.toml"
+      ],
       "url": "https://starship.rs/config-schema.json"
     },
     {
@@ -7497,37 +9147,51 @@
     {
       "name": "Stella configuration file",
       "description": "Configuration file for stella. Documentation: https://github.com/Shravan-1908/stellapy",
-      "fileMatch": ["stella.yml", "stella.json"],
+      "fileMatch": [
+        "stella.yml",
+        "stella.json"
+      ],
       "url": "https://raw.githubusercontent.com/Shravan-1908/stellapy/master/schema.json"
     },
     {
       "name": "Streamlit configuration file",
       "description": "Streamlit configuration file",
-      "fileMatch": ["**/.streamlit/config.toml"],
+      "fileMatch": [
+        "**/.streamlit/config.toml"
+      ],
       "url": "https://www.schemastore.org/streamlit-config.json"
     },
     {
       "name": "stripe-app.json",
       "description": "Stripe Apps manifest file",
-      "fileMatch": ["stripe-app.json"],
+      "fileMatch": [
+        "stripe-app.json"
+      ],
       "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app.schema.json"
     },
     {
       "name": "stripe-app-local.json",
       "description": "Stripe Apps local manifest file",
-      "fileMatch": ["stripe-app.*.json"],
+      "fileMatch": [
+        "stripe-app.*.json"
+      ],
       "url": "https://raw.githubusercontent.com/stripe/stripe-apps/main/schema/stripe-app-local.schema.json"
     },
     {
       "name": "Stryker Mutator",
       "description": "Configuration file for Stryker Mutator, the mutation testing framework for JavaScript and friends. Documentation: https://stryker-mutator.io",
-      "fileMatch": ["stryker.conf.json", "stryker-*.conf.json"],
+      "fileMatch": [
+        "stryker.conf.json",
+        "stryker-*.conf.json"
+      ],
       "url": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/api/schema/stryker-core.json"
     },
     {
       "name": "StyleCop Analyzers Configuration",
       "description": "Configuration file for StyleCop Analyzers",
-      "fileMatch": ["stylecop.json"],
+      "fileMatch": [
+        "stylecop.json"
+      ],
       "url": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
     },
     {
@@ -7544,37 +9208,52 @@
     {
       "name": "SWADL",
       "description": "Symphony Workflow Automation Definition Language. Documentation: https://developers.symphony.com/",
-      "fileMatch": ["*.swadl.yaml", "*.swadl.yml"],
+      "fileMatch": [
+        "*.swadl.yaml",
+        "*.swadl.yml"
+      ],
       "url": "https://raw.githubusercontent.com/SymphonyPlatformSolutions/symphony-wdk/master/workflow-language/src/main/resources/swadl-schema-1.0.json"
     },
     {
       "name": "Swagger API 2.0",
       "description": "Swagger API 2.0",
-      "fileMatch": ["swagger.json"],
+      "fileMatch": [
+        "swagger.json"
+      ],
       "url": "https://spec.openapis.org/oas/2.0/schema/2017-08-27"
     },
     {
       "name": "Symfony Routing Configuration",
       "description": "Symfony routing configuration file (config/routes)",
-      "fileMatch": ["**/config/routes.yaml", "**/config/routes/**/*.yaml"],
+      "fileMatch": [
+        "**/config/routes.yaml",
+        "**/config/routes/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Routing/Loader/schema/routing.schema.json"
     },
     {
       "name": "Symfony Serializer Mapping",
       "description": "Symfony serializer mapping configuration file",
-      "fileMatch": ["**/config/serializer/**/*.yaml"],
+      "fileMatch": [
+        "**/config/serializer/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Serializer/Mapping/Loader/schema/serialization.schema.json"
     },
     {
       "name": "Symfony Services Configuration",
       "description": "Symfony parameters and services configuration file (config/services)",
-      "fileMatch": ["**/config/services.yaml", "**/config/services_*.yaml"],
+      "fileMatch": [
+        "**/config/services.yaml",
+        "**/config/services_*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json"
     },
     {
       "name": "Symfony Validation Mapping",
       "description": "Symfony validation mapping configuration file",
-      "fileMatch": ["**/config/validator/**/*.yaml"],
+      "fileMatch": [
+        "**/config/validator/**/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/symfony/symfony/8.1/src/Symfony/Component/Validator/Mapping/Loader/schema/validation.schema.json"
     },
     {
@@ -7590,73 +9269,103 @@
     {
       "name": "Tach",
       "description": "Tach configuration file",
-      "fileMatch": ["tach.toml"],
+      "fileMatch": [
+        "tach.toml"
+      ],
       "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-toml-schema.json"
     },
     {
       "name": "Tach Domain",
       "description": "Tach domain configuration file",
-      "fileMatch": ["tach.domain.toml"],
+      "fileMatch": [
+        "tach.domain.toml"
+      ],
       "url": "https://raw.githubusercontent.com/gauge-sh/tach/refs/heads/main/public/tach-domain-toml-schema.json"
     },
     {
       "name": "task.json",
       "description": "VSCode Task file",
-      "fileMatch": ["task.json", "tasks.json"],
+      "fileMatch": [
+        "task.json",
+        "tasks.json"
+      ],
       "url": "https://www.schemastore.org/task.json"
     },
     {
       "name": "Talhelper",
       "description": "A helper tool to help creating Talos Kubernetes cluster",
-      "fileMatch": ["talconfig.yaml", "talconfig.yml"],
+      "fileMatch": [
+        "talconfig.yaml",
+        "talconfig.yml"
+      ],
       "url": "https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json"
     },
     {
       "name": "Talisman configuration",
       "description": "Configuration for .talismanrc",
-      "fileMatch": [".talismanrc"],
+      "fileMatch": [
+        ".talismanrc"
+      ],
       "url": "https://raw.githubusercontent.com/thoughtworks/talisman/main/examples/schema-store-talismanrc.json"
     },
     {
       "name": "Taurus",
       "description": "Taurus bzt cli framework config",
-      "fileMatch": ["bzt.yml", "bzt.yaml", "taurus.yml", "taurus.yaml"],
+      "fileMatch": [
+        "bzt.yml",
+        "bzt.yaml",
+        "taurus.yml",
+        "taurus.yaml"
+      ],
       "url": "https://www.schemastore.org/taurus.json"
     },
     {
       "name": "Tauticord",
       "description": "Tauticord configuration (v2)",
-      "fileMatch": ["tauticord.yml", "tauticord.yaml"],
+      "fileMatch": [
+        "tauticord.yml",
+        "tauticord.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/nwithan8/tauticord/master/.schema/config_v2.schema.json"
     },
     {
       "name": "template.json",
       "description": ".NET template files",
-      "fileMatch": ["**/.template.config/template.json"],
+      "fileMatch": [
+        "**/.template.config/template.json"
+      ],
       "url": "https://www.schemastore.org/template.json"
     },
     {
       "name": "templatsources.json",
       "description": "SideWaffle template source",
-      "fileMatch": ["templatesources.json"],
+      "fileMatch": [
+        "templatesources.json"
+      ],
       "url": "https://www.schemastore.org/templatesources.json"
     },
     {
       "name": "Tier.run pricing.json",
       "description": "Tier.run pricing model configuration",
-      "fileMatch": ["pricing.json"],
+      "fileMatch": [
+        "pricing.json"
+      ],
       "url": "https://raw.githubusercontent.com/tierrun/tier/main/pricing/schema.json"
     },
     {
       "name": "Tikibase",
       "description": "Tikibase configuration file",
-      "fileMatch": ["tikibase.json"],
+      "fileMatch": [
+        "tikibase.json"
+      ],
       "url": "https://raw.githubusercontent.com/kevgo/tikibase/main/doc/tikibase.schema.json"
     },
     {
       "name": "theme.json",
       "description": "WordPress block theme global settings and styles configuration file",
-      "fileMatch": ["theme.json"],
+      "fileMatch": [
+        "theme.json"
+      ],
       "url": "https://schemas.wp.org/trunk/theme.json",
       "versions": {
         "v1": "https://raw.githubusercontent.com/WordPress/gutenberg/b40b61fabf13a6229c616527689d9a7024f81535/schemas/json/theme.json",
@@ -7666,31 +9375,43 @@
     {
       "name": "Threagile",
       "description": "Threagile Threat Model file",
-      "fileMatch": ["threagile.yaml", "threat-model.yaml"],
+      "fileMatch": [
+        "threagile.yaml",
+        "threat-model.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/Threagile/threagile/refs/heads/master/support/schema.json"
     },
     {
       "name": "tizen_workspace.json",
       "description": "Tizen project workspace configuration file",
-      "fileMatch": ["tizen_workspace.yaml"],
+      "fileMatch": [
+        "tizen_workspace.yaml"
+      ],
       "url": "https://www.schemastore.org/tizen_workspace.json"
     },
     {
       "name": "tldr",
       "description": "tldr configuration file",
-      "fileMatch": [".tldr.json"],
+      "fileMatch": [
+        ".tldr.json"
+      ],
       "url": "https://www.schemastore.org/tldr.json"
     },
     {
       "name": "Tombi",
       "description": "Tombi (鳶) is a toolkit for TOML; providing a formatter/linter and language server",
-      "fileMatch": ["tombi.toml", "**/tombi/config.toml"],
+      "fileMatch": [
+        "tombi.toml",
+        "**/tombi/config.toml"
+      ],
       "url": "https://www.schemastore.org/tombi.json"
     },
     {
       "name": "tox",
       "description": "tox configuration for automating Python testing and task management",
-      "fileMatch": ["tox.toml"],
+      "fileMatch": [
+        "tox.toml"
+      ],
       "url": "https://raw.githubusercontent.com/tox-dev/tox/main/src/tox/tox.schema.json"
     },
     {
@@ -7707,25 +9428,34 @@
     {
       "name": "TestEnvironment.json",
       "description": "Visual Studio's test environment config",
-      "fileMatch": ["testEnvironments.json"],
+      "fileMatch": [
+        "testEnvironments.json"
+      ],
       "url": "https://www.schemastore.org/testenvironments.json"
     },
     {
       "name": "Turborepo",
       "description": "Turborepo, a tool for managing monorepos",
-      "fileMatch": ["turbo.json"],
+      "fileMatch": [
+        "turbo.json"
+      ],
       "url": "https://turborepo.org/schema.json"
     },
     {
       "name": "Travis CI (.travis.yml)",
       "description": "Travis CI configuration file",
-      "fileMatch": [".travis.yml"],
+      "fileMatch": [
+        ".travis.yml"
+      ],
       "url": "https://www.schemastore.org/travis.json"
     },
     {
       "name": "Traefik v2",
       "description": "Traefik v2 YAML configuration file",
-      "fileMatch": ["traefik.yml", "traefik.yaml"],
+      "fileMatch": [
+        "traefik.yml",
+        "traefik.yaml"
+      ],
       "url": "https://www.schemastore.org/traefik-v2.json"
     },
     {
@@ -7746,25 +9476,42 @@
     {
       "name": "transcend.yml",
       "description": "Configure as Code for Transcend",
-      "fileMatch": ["transcend.yml", "transcend.yaml"],
+      "fileMatch": [
+        "transcend.yml",
+        "transcend.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/transcend-io/tools/refs/heads/main/packages/cli/schema/transcend-yml-schema-latest.json"
     },
     {
       "name": "trime.yaml",
       "description": "trime configuration file",
-      "fileMatch": ["trime.yaml", "trime.yml", "*.trime.yaml", "*.trime.yml"],
+      "fileMatch": [
+        "trime.yaml",
+        "trime.yml",
+        "*.trime.yaml",
+        "*.trime.yml"
+      ],
       "url": "https://raw.githubusercontent.com/osfans/trime/develop/doc/trime-schema.json"
     },
     {
       "name": "Trivy",
       "description": "Configuration file for Trivy security scanner (trivy.yaml)",
-      "fileMatch": ["trivy.yaml", "trivy.yml", ".trivy.yaml", ".trivy.yml"],
+      "fileMatch": [
+        "trivy.yaml",
+        "trivy.yml",
+        ".trivy.yaml",
+        ".trivy.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aquasecurity/trivy/main/schema/trivy-config.json"
     },
     {
       "name": "TrueScript for *.tscript files",
       "description": "The Ultimate Script Language for monday.com - © 2024 MakeITSimple",
-      "fileMatch": ["*.tscript", "*.tscript.yaml", "*.tscript.yml"],
+      "fileMatch": [
+        "*.tscript",
+        "*.tscript.yaml",
+        "*.tscript.yml"
+      ],
       "url": "https://www.schemastore.org/truescript.json",
       "versions": {
         "latest": "https://www.schemastore.org/truescript.json"
@@ -7773,91 +9520,129 @@
     {
       "name": "trunk.yaml",
       "description": "Configuration trunk, a powerful linter runner. Documentation: https://docs.trunk.io",
-      "fileMatch": ["trunk.yaml"],
+      "fileMatch": [
+        "trunk.yaml"
+      ],
       "url": "https://static.trunk.io/pub/trunk-yaml-schema.json"
     },
     {
       "name": "tsbuild",
       "description": "Configuration for the tsbuild TypeScript build system",
-      "fileMatch": ["tsbuild.json"],
+      "fileMatch": [
+        "tsbuild.json"
+      ],
       "url": "https://www.schemastore.org/tsbuild.json"
     },
     {
       "name": "tsconfig.json",
       "description": "TypeScript compiler configuration file",
-      "fileMatch": ["tsconfig*.json"],
+      "fileMatch": [
+        "tsconfig*.json"
+      ],
       "url": "https://www.schemastore.org/tsconfig.json"
     },
     {
       "name": "tsd.json",
       "description": "DefinitelyTyped description manager (TSD)",
-      "fileMatch": ["tsd.json"],
+      "fileMatch": [
+        "tsd.json"
+      ],
       "url": "https://www.schemastore.org/tsd.json"
     },
     {
       "name": "tsdoc.json",
       "description": "TSDoc configuration file",
-      "fileMatch": ["tsdoc.json"],
+      "fileMatch": [
+        "tsdoc.json"
+      ],
       "url": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json"
     },
     {
       "name": "tsdrc.json",
       "description": "TypeScript Definition manager (tsd) global settings file",
-      "fileMatch": [".tsdrc"],
+      "fileMatch": [
+        ".tsdrc"
+      ],
       "url": "https://www.schemastore.org/tsdrc.json"
     },
     {
       "name": "ts-force-config.json",
       "description": "Generated Typescript classes for Salesforce",
-      "fileMatch": ["ts-force-config.json"],
+      "fileMatch": [
+        "ts-force-config.json"
+      ],
       "url": "https://www.schemastore.org/ts-force-config.json"
     },
     {
       "name": "tslint.json",
       "description": "TypeScript Lint configuration file",
-      "fileMatch": ["tslint.json", "tslint.yaml", "tslint.yml"],
+      "fileMatch": [
+        "tslint.json",
+        "tslint.yaml",
+        "tslint.yml"
+      ],
       "url": "https://www.schemastore.org/tslint.json"
     },
     {
       "name": "TSON",
       "description": "TSON (Tuning-Spectrum Object Notation) data",
-      "fileMatch": ["*.tson", "*.tson.yaml", "*.tson.yml", "*.tson.json"],
+      "fileMatch": [
+        "*.tson",
+        "*.tson.yaml",
+        "*.tson.yml",
+        "*.tson.json"
+      ],
       "url": "https://raw.githubusercontent.com/spectral-discord/TSON/main/schema/tson.json"
     },
     {
       "name": "TSTyche",
       "description": "TSTyche configuration file",
-      "fileMatch": ["tstyche.json", "tstyche.config.json"],
+      "fileMatch": [
+        "tstyche.json",
+        "tstyche.config.json"
+      ],
       "url": "https://tstyche.org/schemas/config.json"
     },
     {
       "name": "tsup",
       "description": "Configuration options for tsup",
-      "fileMatch": ["tsup.config.json"],
+      "fileMatch": [
+        "tsup.config.json"
+      ],
       "url": "https://cdn.jsdelivr.net/npm/tsup/schema.json"
     },
     {
       "name": "tusk.yml",
       "description": "tusk CLI configuration file",
-      "fileMatch": ["tusk.yml", "tusk.yaml"],
+      "fileMatch": [
+        "tusk.yml",
+        "tusk.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/rliebz/tusk/main/tusk.schema.json"
     },
     {
       "name": "twee-ts",
       "description": "twee-ts compiler configuration file",
-      "fileMatch": ["twee-ts.config.json"],
+      "fileMatch": [
+        "twee-ts.config.json"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/twee-ts.config.json"
     },
     {
       "name": "typewiz.json",
       "description": "Typewiz configuration file",
-      "fileMatch": ["typewiz.json"],
+      "fileMatch": [
+        "typewiz.json"
+      ],
       "url": "https://www.schemastore.org/typewiz.json"
     },
     {
       "name": "typo3.json",
       "description": "the Typo3 CMS",
-      "fileMatch": ["**/sites/*/config.yaml", "**/sites/*/config.yml"],
+      "fileMatch": [
+        "**/sites/*/config.yaml",
+        "**/sites/*/config.yml"
+      ],
       "url": "https://www.schemastore.org/typo3.json"
     },
     {
@@ -7873,31 +9658,44 @@
     {
       "name": "typos.toml",
       "description": "typos configuration file",
-      "fileMatch": ["typos.toml", "_typos.toml", ".typos.toml"],
+      "fileMatch": [
+        "typos.toml",
+        "_typos.toml",
+        ".typos.toml"
+      ],
       "url": "https://raw.githubusercontent.com/crate-ci/typos/master/config.schema.json"
     },
     {
       "name": "typings.json",
       "description": "Typings TypeScript definitions manager definition file",
-      "fileMatch": ["typings.json"],
+      "fileMatch": [
+        "typings.json"
+      ],
       "url": "https://www.schemastore.org/typings.json"
     },
     {
       "name": "typingsrc.json",
       "description": "Typings TypeScript definitions manager configuration file",
-      "fileMatch": [".typingsrc"],
+      "fileMatch": [
+        ".typingsrc"
+      ],
       "url": "https://www.schemastore.org/typingsrc.json"
     },
     {
       "name": "Ubuntu Server Autoinstall",
       "description": "Settings file for Ubuntu Autoinstall",
-      "fileMatch": ["user-data", "autoinstall.yaml"],
+      "fileMatch": [
+        "user-data",
+        "autoinstall.yaml"
+      ],
       "url": "https://www.schemastore.org/ubuntu-server-autoinstall.json"
     },
     {
       "name": "up.json",
       "description": "Up configuration file",
-      "fileMatch": ["up.json"],
+      "fileMatch": [
+        "up.json"
+      ],
       "url": "https://www.schemastore.org/up.json"
     },
     {
@@ -7939,7 +9737,10 @@
     {
       "name": "UTAM Page Object",
       "description": "UI Test Automation Model page object. Documentation: https://utam.dev/",
-      "fileMatch": ["*.utam.json", ".utam.json"],
+      "fileMatch": [
+        "*.utam.json",
+        ".utam.json"
+      ],
       "url": "https://www.schemastore.org/utam-page-object.json",
       "versions": {
         "current": "https://www.schemastore.org/utam-page-object.json",
@@ -7951,7 +9752,9 @@
     {
       "name": "umpire.json",
       "description": "Umpire form-logic configuration",
-      "fileMatch": ["*.umpire.json"],
+      "fileMatch": [
+        "*.umpire.json"
+      ],
       "url": "https://spec.umpire.tools/umpire.schema.json"
     },
     {
@@ -7985,19 +9788,28 @@
     {
       "name": "uv",
       "description": "uv, a fast Python package installer",
-      "fileMatch": ["uv.toml"],
+      "fileMatch": [
+        "uv.toml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/uv.json"
     },
     {
       "name": "Vector",
       "description": "Configuration file for Vector, an observability data pipeline agent and aggregator",
-      "fileMatch": ["vector.json", "vector.toml", "vector.yaml"],
+      "fileMatch": [
+        "vector.json",
+        "vector.toml",
+        "vector.yaml"
+      ],
       "url": "https://www.schemastore.org/vector.json"
     },
     {
       "name": "vega.json",
       "description": "Vega visualization specification file",
-      "fileMatch": ["*.vg", "*.vg.json"],
+      "fileMatch": [
+        "*.vg",
+        "*.vg.json"
+      ],
       "url": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega/v6.4.0.json",
       "versions": {
         "v2.0.0": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega/v2.0.0.json",
@@ -8164,7 +9976,10 @@
     {
       "name": "vega-lite.json",
       "description": "Vega-Lite visualization specification file",
-      "fileMatch": ["*.vl", "*.vl.json"],
+      "fileMatch": [
+        "*.vl",
+        "*.vl.json"
+      ],
       "url": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega-lite/v6.4.3.json",
       "versions": {
         "v0.0.4": "https://raw.githubusercontent.com/vega/schema/refs/heads/master/vega-lite/v0.0.4.json",
@@ -8373,7 +10188,10 @@
     {
       "name": "Vela Pipeline Configuration",
       "description": "Vela Pipeline Configuration File",
-      "fileMatch": [".vela.yml", ".vela.yaml"],
+      "fileMatch": [
+        ".vela.yml",
+        ".vela.yaml"
+      ],
       "url": "https://github.com/go-vela/server/releases/latest/download/schema.json"
     },
     {
@@ -8436,13 +10254,18 @@
     {
       "name": "version.json",
       "description": "A project version descriptor file used by Nerdbank.GitVersioning",
-      "fileMatch": ["version.json"],
+      "fileMatch": [
+        "version.json"
+      ],
       "url": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json"
     },
     {
       "name": ".versionrc.json",
       "description": "Conventional Changelog Configuration file",
-      "fileMatch": [".versionrc", ".versionrc.json"],
+      "fileMatch": [
+        ".versionrc",
+        ".versionrc.json"
+      ],
       "url": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/2.2.0/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/conventional-changelog/conventional-changelog-config-spec/master/versions/1.0.0/schema.json",
@@ -8465,13 +10288,17 @@
     {
       "name": "vim-addon-info",
       "description": "vim plugin addon-info.json metadata files",
-      "fileMatch": ["**/*vim*/addon-info.json"],
+      "fileMatch": [
+        "**/*vim*/addon-info.json"
+      ],
       "url": "https://www.schemastore.org/vim-addon-info.json"
     },
     {
       "name": "Vogi",
       "description": "Repository configuration for Vogi agents",
-      "fileMatch": [".vogi.yaml"],
+      "fileMatch": [
+        ".vogi.yaml"
+      ],
       "url": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json",
       "versions": {
         "1": "https://vogi-control-plane-265712319769.us-central1.run.app/integrations/schema.v1.json"
@@ -8480,49 +10307,68 @@
     {
       "name": "vsls.json",
       "description": "Visual Studio Live Share configuration file",
-      "fileMatch": [".vsls.json"],
+      "fileMatch": [
+        ".vsls.json"
+      ],
       "url": "https://www.schemastore.org/vsls.json"
     },
     {
       "name": "vs-2017.3.host.json",
       "description": "Visual Studio template host file",
-      "fileMatch": ["vs-2017.3.host.json"],
+      "fileMatch": [
+        "vs-2017.3.host.json"
+      ],
       "url": "https://www.schemastore.org/vs-2017.3.host.json"
     },
     {
       "name": "vs-nesting.json",
       "description": "Visual Studio's file nesting feature",
-      "fileMatch": ["*.filenesting.json", ".filenesting.json"],
+      "fileMatch": [
+        "*.filenesting.json",
+        ".filenesting.json"
+      ],
       "url": "https://www.schemastore.org/vs-nesting.json"
     },
     {
       "name": ".vsconfig",
       "description": "Visual Studio component configuration files",
-      "fileMatch": ["*.vsconfig"],
+      "fileMatch": [
+        "*.vsconfig"
+      ],
       "url": "https://www.schemastore.org/vsconfig.json"
     },
     {
       "name": ".vsext",
       "description": "Visual Studio extension pack manifests",
-      "fileMatch": ["*.vsext"],
+      "fileMatch": [
+        "*.vsext"
+      ],
       "url": "https://www.schemastore.org/vsext.json"
     },
     {
       "name": "VSIX CLI publishing",
       "description": "Visual Studio extension publishing",
-      "fileMatch": ["vs-publish.json"],
+      "fileMatch": [
+        "vs-publish.json"
+      ],
       "url": "https://www.schemastore.org/vsix-publish.json"
     },
     {
       "name": "vss-extension.json",
       "description": "Azure DevOps Extensions",
-      "fileMatch": ["vss-extension.json"],
+      "fileMatch": [
+        "vss-extension.json"
+      ],
       "url": "https://www.schemastore.org/vss-extension.json"
     },
     {
       "name": "vtesttree.yaml",
       "description": "Vector test execution tree description",
-      "fileMatch": ["*.vtesttree.yaml", "*.vtesttree.yml", "*.vtesttree.json"],
+      "fileMatch": [
+        "*.vtesttree.yaml",
+        "*.vtesttree.yml",
+        "*.vtesttree.json"
+      ],
       "url": "https://www.schemastore.org/vtesttree-schema-v2.4.0.json",
       "versions": {
         "1.0.0": "https://www.schemastore.org/vtesttree-schema-v1.0.0.json",
@@ -8536,55 +10382,83 @@
     {
       "name": "vtestunit.yaml",
       "description": "Vector test unit description",
-      "fileMatch": ["*.vtestunit.yaml", "*.vtestunit.yml", "*.vtestunit.json"],
+      "fileMatch": [
+        "*.vtestunit.yaml",
+        "*.vtestunit.yml",
+        "*.vtestunit.json"
+      ],
       "url": "https://www.schemastore.org/vtestunit-schema.json"
     },
     {
       "name": "v8r",
       "description": "v8r configuration file",
-      "fileMatch": [".v8rrc.json", ".v8rrc.yaml", ".v8rrc.yml"],
+      "fileMatch": [
+        ".v8rrc.json",
+        ".v8rrc.yaml",
+        ".v8rrc.yml"
+      ],
       "url": "https://raw.githubusercontent.com/chris48s/v8r/main/config-schema.json"
     },
     {
       "name": "WebExtensions",
       "description": "WebExtension manifest files",
-      "fileMatch": ["manifest.json"],
+      "fileMatch": [
+        "manifest.json"
+      ],
       "url": "https://www.schemastore.org/webextension.json"
     },
     {
       "name": "Web App Manifest",
       "description": "Web Application manifest file",
-      "fileMatch": ["manifest.json", "*.webmanifest"],
+      "fileMatch": [
+        "manifest.json",
+        "*.webmanifest"
+      ],
       "url": "https://www.schemastore.org/web-manifest-combined.json"
     },
     {
       "name": "webjobs-list.json",
       "description": "Azure Webjob list file",
-      "fileMatch": ["webjobs-list.json"],
+      "fileMatch": [
+        "webjobs-list.json"
+      ],
       "url": "https://www.schemastore.org/webjobs-list.json"
     },
     {
       "name": "webjobpublishsettings.json",
       "description": "Azure Webjobs publish settings file",
-      "fileMatch": ["webjobpublishsettings.json"],
+      "fileMatch": [
+        "webjobpublishsettings.json"
+      ],
       "url": "https://www.schemastore.org/webjob-publish-settings.json"
     },
     {
       "name": "Web types",
       "description": "JSON standard for web component libraries metadata",
-      "fileMatch": ["web-types.json", "*.web-types.json"],
+      "fileMatch": [
+        "web-types.json",
+        "*.web-types.json"
+      ],
       "url": "https://www.schemastore.org/web-types.json"
     },
     {
       "name": "WP-CLI",
       "description": "WP-CLI is the official command-line tool for WordPress",
-      "fileMatch": ["wp-cli.local.yml", "wp-cli.yml", "**/.wp-cli/config.yml"],
+      "fileMatch": [
+        "wp-cli.local.yml",
+        "wp-cli.yml",
+        "**/.wp-cli/config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/wp-cli/wp-cli/refs/heads/main/schemas/wp-cli-config.json"
     },
     {
       "name": "Wrangler CLI",
       "description": "Wrangler is a command-line tool for building with Cloudflare developer products",
-      "fileMatch": ["wrangler.json", "wrangler.jsonc", "wrangler.toml"],
+      "fileMatch": [
+        "wrangler.json",
+        "wrangler.jsonc",
+        "wrangler.toml"
+      ],
       "url": "https://www.unpkg.com/wrangler/config-schema.json"
     },
     {
@@ -8601,19 +10475,26 @@
     {
       "name": "KSP-AVC",
       "description": "The .version file format for KSP-AVC",
-      "fileMatch": ["*.version"],
+      "fileMatch": [
+        "*.version"
+      ],
       "url": "https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/master/KSP-AVC.schema.json"
     },
     {
       "name": "KSP-CKAN",
       "description": "Metadata spec for CKAN meta files",
-      "fileMatch": ["*.ckan"],
+      "fileMatch": [
+        "*.ckan"
+      ],
       "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/CKAN.schema"
     },
     {
       "name": "KSP-NetKAN",
       "description": "Metadata spec for NetKAN files",
-      "fileMatch": ["*.netkan", "*.frozen"],
+      "fileMatch": [
+        "*.netkan",
+        "*.frozen"
+      ],
       "url": "https://raw.githubusercontent.com/KSP-CKAN/CKAN/master/NetKAN.schema"
     },
     {
@@ -8624,7 +10505,9 @@
     {
       "name": "JSON Schema Draft 7",
       "description": "Meta-validation JSON Schema Draft 7",
-      "fileMatch": ["*.schema.json"],
+      "fileMatch": [
+        "*.schema.json"
+      ],
       "url": "https://json-schema.org/draft-07/schema"
     },
     {
@@ -8640,7 +10523,10 @@
     {
       "name": "xunit.runner.json",
       "description": "Configuration file for unit test projects using xUnit.net",
-      "fileMatch": ["xunit.runner.json", "*.xunit.runner.json"],
+      "fileMatch": [
+        "xunit.runner.json",
+        "*.xunit.runner.json"
+      ],
       "url": "https://www.schemastore.org/xunit.runner.schema.json",
       "versions": {
         "v2.2": "https://xunit.net/schema/v2.2/xunit.runner.schema.json",
@@ -8651,19 +10537,25 @@
     {
       "name": "servicehub.service.json",
       "description": "Microsoft ServiceHub Service",
-      "fileMatch": ["*.servicehub.service.json"],
+      "fileMatch": [
+        "*.servicehub.service.json"
+      ],
       "url": "https://www.schemastore.org/servicehub.service.schema.json"
     },
     {
       "name": "servicehub.config.json",
       "description": "Microsoft ServiceHub Configuration",
-      "fileMatch": ["servicehub.config.json"],
+      "fileMatch": [
+        "servicehub.config.json"
+      ],
       "url": "https://www.schemastore.org/servicehub.config.schema.json"
     },
     {
       "name": ".cryproj (generic)",
       "description": "A CRYENGINE projects (.cryproj files)",
-      "fileMatch": ["*.cryproj"],
+      "fileMatch": [
+        "*.cryproj"
+      ],
       "url": "https://www.schemastore.org/cryproj.json",
       "versions": {
         "dev": "https://www.schemastore.org/cryproj.dev.schema.json",
@@ -8676,7 +10568,9 @@
     {
       "name": "typedoc.json",
       "description": "A the Typedoc configuration file",
-      "fileMatch": ["typedoc.json"],
+      "fileMatch": [
+        "typedoc.json"
+      ],
       "url": "https://typedoc.org/schema.json"
     },
     {
@@ -8695,13 +10589,19 @@
     {
       "name": "huskyrc",
       "description": "Husky can prevent bad `git commit`, `git push` and more 🐶 woof!",
-      "fileMatch": [".huskyrc", ".huskyrc.json"],
+      "fileMatch": [
+        ".huskyrc",
+        ".huskyrc.json"
+      ],
       "url": "https://www.schemastore.org/huskyrc.json"
     },
     {
       "name": "lychee",
       "description": "lychee link checker configuration file",
-      "fileMatch": ["lychee.toml", ".lychee.toml"],
+      "fileMatch": [
+        "lychee.toml",
+        ".lychee.toml"
+      ],
       "url": "https://www.schemastore.org/lychee.json"
     },
     {
@@ -8768,43 +10668,61 @@
     {
       "name": "mta.yaml",
       "description": "A MTA projects v3.3",
-      "fileMatch": ["mta.yaml", "mta.yml"],
+      "fileMatch": [
+        "mta.yaml",
+        "mta.yml"
+      ],
       "url": "https://www.schemastore.org/mta.json"
     },
     {
       "name": "mtad.yaml",
       "description": "A MTA deployment descriptors v3.3",
-      "fileMatch": ["mtad.yaml", "mtad.yml"],
+      "fileMatch": [
+        "mtad.yaml",
+        "mtad.yml"
+      ],
       "url": "https://www.schemastore.org/mtad.json"
     },
     {
       "name": "Motif config",
       "description": "A Motif config file",
-      "fileMatch": ["motif.json"],
+      "fileMatch": [
+        "motif.json"
+      ],
       "url": "https://motif.land/api/motif.schema.json"
     },
     {
       "name": ".mtaext",
       "description": "A MTA extension descriptors v3.3",
-      "fileMatch": ["*.mtaext"],
+      "fileMatch": [
+        "*.mtaext"
+      ],
       "url": "https://www.schemastore.org/mtaext.json"
     },
     {
       "name": "xs-app.json",
       "description": "the SAP Application Router v8.2.2",
-      "fileMatch": ["xs-app.json"],
+      "fileMatch": [
+        "xs-app.json"
+      ],
       "url": "https://www.schemastore.org/xs-app.json"
     },
     {
       "name": "Opctl",
       "description": "Opctl describing an op",
-      "fileMatch": ["**/.opspec/*/*.yml", "**/.opspec/*/*.yaml"],
+      "fileMatch": [
+        "**/.opspec/*/*.yml",
+        "**/.opspec/*/*.yaml"
+      ],
       "url": "https://www.schemastore.org/opspec-io-0.1.7.json"
     },
     {
       "name": "HEMTT",
       "description": "HEMTT Project File",
-      "fileMatch": ["hemtt.json", "hemtt.toml"],
+      "fileMatch": [
+        "hemtt.json",
+        "hemtt.toml"
+      ],
       "url": "https://www.schemastore.org/hemtt-0.6.2.json",
       "versions": {
         "0.6.2": "https://www.schemastore.org/hemtt-0.6.2.json"
@@ -8813,31 +10731,42 @@
     {
       "name": "Node.js configuration",
       "description": "The Node.js configuration file",
-      "fileMatch": ["node.config.json"],
+      "fileMatch": [
+        "node.config.json"
+      ],
       "url": "https://nodejs.org/docs/latest/node-config-schema.json"
     },
     {
       "name": "now",
       "description": "ZEIT Now project configuration file",
-      "fileMatch": ["now.json"],
+      "fileMatch": [
+        "now.json"
+      ],
       "url": "https://www.schemastore.org/now.json"
     },
     {
       "name": "taskcat",
       "description": "taskcat",
-      "fileMatch": [".taskcat.yml"],
+      "fileMatch": [
+        ".taskcat.yml"
+      ],
       "url": "https://raw.githubusercontent.com/aws-quickstart/taskcat/master/taskcat/cfg/config_schema.json"
     },
     {
       "name": "BizTalkServerApplicationSchema",
       "description": "BizTalk server application inventory json file",
-      "fileMatch": ["BizTalkServerInventory.json"],
+      "fileMatch": [
+        "BizTalkServerInventory.json"
+      ],
       "url": "https://www.schemastore.org/BizTalkServerApplicationSchema.json"
     },
     {
       "name": "httpmockrc",
       "description": "Http-mocker is a tool for mock local requests or proxy remote requests",
-      "fileMatch": [".httpmockrc", ".httpmock.json"],
+      "fileMatch": [
+        ".httpmockrc",
+        ".httpmock.json"
+      ],
       "url": "https://www.schemastore.org/httpmockrc.json"
     },
     {
@@ -8862,37 +10791,51 @@
     {
       "name": "release drafter",
       "description": "Release Drafter configuration file",
-      "fileMatch": ["**/.github/release-drafter.yml"],
+      "fileMatch": [
+        "**/.github/release-drafter.yml"
+      ],
       "url": "https://raw.githubusercontent.com/release-drafter/release-drafter/refs/heads/main/drafter/schema.json"
     },
     {
       "name": "zuul",
       "description": "Zuul CI configuration file",
-      "fileMatch": ["**/*zuul.d/*.yaml", ".zuul.yaml"],
+      "fileMatch": [
+        "**/*zuul.d/*.yaml",
+        ".zuul.yaml"
+      ],
       "url": "https://www.schemastore.org/zuul.json"
     },
     {
       "name": "Briefcase",
       "description": "Microsoft Briefcase configuration file",
-      "fileMatch": ["briefcase.yaml"],
+      "fileMatch": [
+        "briefcase.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/Briefcase/master/mlbriefcase/briefcase-schema.json"
     },
     {
       "name": "httparchive",
       "description": "HTTP Archive",
-      "fileMatch": ["*.har"],
+      "fileMatch": [
+        "*.har"
+      ],
       "url": "https://raw.githubusercontent.com/ahmadnassri/har-schema/master/lib/har.json"
     },
     {
       "name": "jsdoc",
       "description": "JSDoc configuration file",
-      "fileMatch": ["conf.json", "jsdoc.json"],
+      "fileMatch": [
+        "conf.json",
+        "jsdoc.json"
+      ],
       "url": "https://www.schemastore.org/jsdoc-1.0.0.json"
     },
     {
       "name": "Ray",
       "description": "Ray autocluster configuration file",
-      "fileMatch": ["ray-*-cluster.yaml"],
+      "fileMatch": [
+        "ray-*-cluster.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/ray-schema.json"
     },
     {
@@ -8909,37 +10852,51 @@
     {
       "name": "Hatch",
       "description": "Python package build tool",
-      "fileMatch": ["hatch.toml"],
+      "fileMatch": [
+        "hatch.toml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/hatch.json"
     },
     {
       "name": "helmfile",
       "description": "Helmfile is a declarative spec for deploying helm charts",
-      "fileMatch": ["helmfile.yaml", "**/helmfile.d/**/*.yaml"],
+      "fileMatch": [
+        "helmfile.yaml",
+        "**/helmfile.d/**/*.yaml"
+      ],
       "url": "https://www.schemastore.org/helmfile.json"
     },
     {
       "name": "helmwave",
       "description": "Helmwave is a declarative spec for deploying helm charts",
-      "fileMatch": ["helmwave.yml"],
+      "fileMatch": [
+        "helmwave.yml"
+      ],
       "url": "https://github.com/helmwave/helmwave/releases/latest/download/schema.json"
     },
     {
       "name": "Container Structure Test",
       "description": "The Container Structure Tests provide a powerful framework to validate the structure of a container image",
-      "fileMatch": ["container-structure-test.yaml", "structure-test.yaml"],
+      "fileMatch": [
+        "container-structure-test.yaml",
+        "structure-test.yaml"
+      ],
       "url": "https://www.schemastore.org/container-structure-test.json"
     },
     {
       "name": "Žinoma",
       "description": "Žinoma incremental build configuration",
-      "fileMatch": ["zinoma.yml"],
+      "fileMatch": [
+        "zinoma.yml"
+      ],
       "url": "https://github.com/fbecart/zinoma/releases/latest/download/zinoma-schema.json"
     },
     {
       "name": "Windows Package Manager Singleton Manifest",
       "description": "Windows Package Manager Singleton Manifest file",
-      "fileMatch": ["**/manifests/?/*/*/*/*.*.yaml"],
+      "fileMatch": [
+        "**/manifests/?/*/*/*/*.*.yaml"
+      ],
       "url": "https://www.schemastore.org/winget-pkgs-singleton-1.0.0.json",
       "versions": {
         "0.1": "https://www.schemastore.org/winget-pkgs-singleton-0.1.json",
@@ -8949,7 +10906,9 @@
     {
       "name": "Windows Package Manager Installer Manifest",
       "description": "Windows Package Manager Installer Manifest file, used for detailing installer specific metadata",
-      "fileMatch": ["**/manifests/?/*/*/*/*.*.installer.yaml"],
+      "fileMatch": [
+        "**/manifests/?/*/*/*/*.*.installer.yaml"
+      ],
       "url": "https://www.schemastore.org/winget-pkgs-installer-1.0.0.json"
     },
     {
@@ -8982,7 +10941,9 @@
     {
       "name": "Uniswap Token List",
       "description": "A list of tokens compatible with the Uniswap Interface",
-      "fileMatch": ["*.tokenlist.json"],
+      "fileMatch": [
+        "*.tokenlist.json"
+      ],
       "url": "https://uniswap.org/tokenlist.schema.json"
     },
     {
@@ -9000,19 +10961,28 @@
     {
       "name": "yamllint",
       "description": "yamllint uses a set of rules to check source files for problems",
-      "fileMatch": ["**/.yamllint", "**/.yamllint.yaml", "**/.yamllint.yml"],
+      "fileMatch": [
+        "**/.yamllint",
+        "**/.yamllint.yaml",
+        "**/.yamllint.yml"
+      ],
       "url": "https://www.schemastore.org/yamllint.json"
     },
     {
       "name": "yap.json",
       "description": "YAP (Yet Another Packager) multi-package project file",
-      "fileMatch": ["yap.json"],
+      "fileMatch": [
+        "yap.json"
+      ],
       "url": "https://www.schemastore.org/yap.json"
     },
     {
       "name": "Yippee-Ki-JSON configuration YML",
       "description": "Action and rule configuration descriptor for Yippee-Ki-JSON transformations",
-      "fileMatch": ["**/yippee-*.yml", "**/*.yippee.yml"],
+      "fileMatch": [
+        "**/yippee-*.yml",
+        "**/*.yippee.yml"
+      ],
       "url": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
       "versions": {
         "latest": "https://raw.githubusercontent.com/nagyesta/yippee-ki-json/main/schema/yippee-ki-json_config_schema.json",
@@ -9037,7 +11007,10 @@
     {
       "name": "devinit",
       "description": "Devinit configuration file",
-      "fileMatch": ["devinit.json", ".devinit.json"],
+      "fileMatch": [
+        "devinit.json",
+        ".devinit.json"
+      ],
       "url": "https://www.schemastore.org/devinit.schema-6.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/devinit.schema-1.0.json",
@@ -9051,25 +11024,33 @@
     {
       "name": "djlint",
       "description": "djLint configuration file",
-      "fileMatch": [".djlintrc"],
+      "fileMatch": [
+        ".djlintrc"
+      ],
       "url": "https://www.schemastore.org/djlint.json"
     },
     {
       "name": "tsoa",
       "description": "the tsoa configuration file",
-      "fileMatch": ["**/tsoa.json"],
+      "fileMatch": [
+        "**/tsoa.json"
+      ],
       "url": "https://www.schemastore.org/tsoa.json"
     },
     {
       "name": "API Builder",
       "description": "apibuilder.io",
-      "fileMatch": ["**/api.json"],
+      "fileMatch": [
+        "**/api.json"
+      ],
       "url": "https://www.schemastore.org/apibuilder.json"
     },
     {
       "name": "Apollo Router",
       "description": "Apollo Router: The runtime for graph-based API orchestration",
-      "fileMatch": ["apollo-router-*.json"],
+      "fileMatch": [
+        "apollo-router-*.json"
+      ],
       "url": "https://www.schemastore.org/apollo-router-2.9.0.json",
       "versions": {
         "2.8.1": "https://www.schemastore.org/apollo-router-2.8.1.json",
@@ -9080,7 +11061,10 @@
     {
       "name": "Gradle Enterprise",
       "description": "Gradle Enterprise configuration",
-      "fileMatch": ["*gradle-enterprise.yml", "*gradle-enterprise.yaml"],
+      "fileMatch": [
+        "*gradle-enterprise.yml",
+        "*gradle-enterprise.yaml"
+      ],
       "url": "https://docs.gradle.com/downloads/gradle-enterprise-config-schema/gradle-enterprise-config-schema-16.json",
       "versions": {
         "1.0": "https://docs.gradle.com/develocity/helm-admin/schema/gradle-enterprise-config-schema-1.json",
@@ -9117,25 +11101,33 @@
     {
       "name": "Yarn Config (.yarnrc.yml)",
       "description": "Yarnrc configuration files",
-      "fileMatch": [".yarnrc.yml"],
+      "fileMatch": [
+        ".yarnrc.yml"
+      ],
       "url": "https://yarnpkg.com/configuration/yarnrc.json"
     },
     {
       "name": "Better Code Hub",
       "description": "Configuration file for Better Code Hub to override the default configuration",
-      "fileMatch": [".bettercodehub.yml"],
+      "fileMatch": [
+        ".bettercodehub.yml"
+      ],
       "url": "https://www.schemastore.org/bettercodehub.json"
     },
     {
       "name": "Starlake Data Pipeline",
       "description": "Starlake Data Pipeline",
-      "fileMatch": ["*.sl.yml"],
+      "fileMatch": [
+        "*.sl.yml"
+      ],
       "url": "https://www.schemastore.org/starlake.json"
     },
     {
       "name": "swcrc",
       "description": "swc configuration files",
-      "fileMatch": [".swcrc"],
+      "fileMatch": [
+        ".swcrc"
+      ],
       "url": "https://swc.rs/schema.json"
     },
     {
@@ -9170,7 +11162,12 @@
     {
       "name": ".taskrc.yaml",
       "description": "Taskfile configuration files",
-      "fileMatch": [".taskrc.yaml", ".taskrc.yml", "taskrc.yaml", "taskrc.yml"],
+      "fileMatch": [
+        ".taskrc.yaml",
+        ".taskrc.yml",
+        "taskrc.yaml",
+        "taskrc.yml"
+      ],
       "url": "https://taskfile.dev/schema-taskrc.json"
     },
     {
@@ -9187,37 +11184,54 @@
     {
       "name": "Containerlab",
       "description": "Containerlab topology definition files",
-      "fileMatch": ["*-clab.yaml", "*-clab.yml", "*.clab.yaml", "*.clab.yml"],
+      "fileMatch": [
+        "*-clab.yaml",
+        "*-clab.yml",
+        "*.clab.yaml",
+        "*.clab.yml"
+      ],
       "url": "https://raw.githubusercontent.com/srl-labs/containerlab/main/schemas/clab.schema.json"
     },
     {
       "name": "ContractGuard",
       "description": "ContractGuard API contract prescribing the signatures a built .NET assembly must expose",
-      "fileMatch": ["*.contract.json"],
+      "fileMatch": [
+        "*.contract.json"
+      ],
       "url": "https://raw.githubusercontent.com/lxman/ContractGuard/main/schema/contractguard.schema.json"
     },
     {
       "name": "User Journey Map",
       "description": "user journey map definition files",
-      "fileMatch": ["*.jm.yaml", "*.jm.yml"],
+      "fileMatch": [
+        "*.jm.yaml",
+        "*.jm.yml"
+      ],
       "url": "https://raw.githubusercontent.com/arvinxx/components/master/packages/journey-map/schema/journey-map.schema.json"
     },
     {
       "name": "Render Blueprints",
       "description": "Blueprints are Render’s infrastructure-as-code model for defining, deploying, and managing multiple resources with a single YAML file",
-      "fileMatch": ["**/*render.yaml"],
+      "fileMatch": [
+        "**/*render.yaml"
+      ],
       "url": "https://render.com/schema/render.yaml.json"
     },
     {
       "name": "RKE Cluster Configuration YAML",
       "description": "the cluster.yml configuration file for RKE",
-      "fileMatch": ["cluster.yml", "cluster.yaml"],
+      "fileMatch": [
+        "cluster.yml",
+        "cluster.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.yml.json"
     },
     {
       "name": "RKE Cluster Configuration JSON",
       "description": "the cluster.json configuration file for RKE",
-      "fileMatch": ["cluster.json"],
+      "fileMatch": [
+        "cluster.json"
+      ],
       "url": "https://raw.githubusercontent.com/dcermak/vscode-rke-cluster-config/main/schemas/cluster.json"
     },
     {
@@ -9237,7 +11251,10 @@
     {
       "name": "Liquibase Flow File",
       "description": "liquibase flow JSON/YAML files",
-      "fileMatch": ["*.flowfile.yaml", "*.flowfile.yml"],
+      "fileMatch": [
+        "*.flowfile.yaml",
+        "*.flowfile.yml"
+      ],
       "url": "https://www.liquibase.org/json/schema/liquibase-flow-file-latest.json"
     },
     {
@@ -9253,7 +11270,10 @@
     {
       "name": "skaffold.yaml",
       "description": "the skaffold.yaml configuration file for Skaffold. Documentation: https://skaffold.dev",
-      "fileMatch": ["skaffold.yaml", "skaffold.yml"],
+      "fileMatch": [
+        "skaffold.yaml",
+        "skaffold.yml"
+      ],
       "url": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v2/content/en/schemas/v3.json",
       "versions": {
         "v1alpha1": "https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/docs-v1/content/en/schemas/v1alpha1.json",
@@ -9343,31 +11363,42 @@
     {
       "name": "markdown-link-check",
       "description": "markdown-link-check",
-      "fileMatch": [".markdown-link-check.json"],
+      "fileMatch": [
+        ".markdown-link-check.json"
+      ],
       "url": "https://www.schemastore.org/markdown-link-check.json"
     },
     {
       "name": "maturin",
       "description": "Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages",
-      "fileMatch": ["maturin.toml"],
+      "fileMatch": [
+        "maturin.toml"
+      ],
       "url": "https://www.schemastore.org/maturin.json"
     },
     {
       "name": "Mason Registry",
       "description": "Package definitions for Mason, a package manager for Neovim",
-      "fileMatch": ["**/packages/*/package.yaml"],
+      "fileMatch": [
+        "**/packages/*/package.yaml"
+      ],
       "url": "https://github.com/mason-org/registry-schema/releases/latest/download/package.schema.json"
     },
     {
       "name": "SauceCTL Configuration",
       "description": "SauceCTL configuration files",
-      "fileMatch": ["**/.sauce/*.yml"],
+      "fileMatch": [
+        "**/.sauce/*.yml"
+      ],
       "url": "https://raw.githubusercontent.com/saucelabs/saucectl/main/api/saucectl.schema.json"
     },
     {
       "name": "fulibWorkflows",
       "description": "fulibWorkflows",
-      "fileMatch": ["*.es.yaml", "*.es.yml"],
+      "fileMatch": [
+        "*.es.yaml",
+        "*.es.yml"
+      ],
       "url": "https://raw.githubusercontent.com/fujaba/fulibWorkflows/main/schemas/fulibWorkflows.schema.json"
     },
     {
@@ -9384,19 +11415,28 @@
     {
       "name": "Netin Diagnostic System Template",
       "description": "Device template",
-      "fileMatch": ["*.ndst.yml", "*.ndst.yaml", "*.ndst.json"],
+      "fileMatch": [
+        "*.ndst.yml",
+        "*.ndst.yaml",
+        "*.ndst.json"
+      ],
       "url": "https://s3.eu-central-1.amazonaws.com/files.netin.io/spider-schemas/template.schema.json"
     },
     {
       "name": "noodl config",
       "description": "NOODL application config",
-      "fileMatch": ["*.noodl.yml"],
+      "fileMatch": [
+        "*.noodl.yml"
+      ],
       "url": "https://noodl.s3.us-west-1.amazonaws.com/noodl.schema.json"
     },
     {
       "name": "mboats",
       "description": "MBOATS Configuration",
-      "fileMatch": ["*.mboats.yaml", "*.mboats.yml"],
+      "fileMatch": [
+        "*.mboats.yaml",
+        "*.mboats.yml"
+      ],
       "url": "https://www.schemastore.org/mboats-config-0.2.json",
       "versions": {
         "0.1": "https://www.schemastore.org/mboats-config-0.1.json",
@@ -9417,19 +11457,28 @@
     {
       "name": "Serverless Framework Configuration",
       "description": "Serverless framework configuration files",
-      "fileMatch": ["serverless.yml"],
+      "fileMatch": [
+        "serverless.yml"
+      ],
       "url": "https://raw.githubusercontent.com/lalcebo/json-schema/master/serverless/reference.json"
     },
     {
       "name": "Alacritty Configuration",
       "description": "Alacritty configuration yaml file",
-      "fileMatch": [".alacritty.yml", "alacritty.yml", "alacritty.toml"],
+      "fileMatch": [
+        ".alacritty.yml",
+        "alacritty.yml",
+        "alacritty.toml"
+      ],
       "url": "https://raw.githubusercontent.com/distinction-dev/alacritty-schema/main/alacritty/reference.json"
     },
     {
       "name": "Serverless Workflow",
       "description": "serverless workflows",
-      "fileMatch": ["*.sw.json", "*.sw.yml"],
+      "fileMatch": [
+        "*.sw.json",
+        "*.sw.yml"
+      ],
       "url": "https://raw.githubusercontent.com/serverlessworkflow/specification/main/schema/workflow.yaml",
       "versions": {
         "v0.9": "https://raw.githubusercontent.com/serverlessworkflow/specification/0.9.x/schema/workflow.json",
@@ -9442,13 +11491,19 @@
     {
       "name": "Shopware 6 Configuration",
       "description": "Shopware 6 custom configurations",
-      "fileMatch": ["shopware.yml", "shopware.yaml"],
+      "fileMatch": [
+        "shopware.yml",
+        "shopware.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/shopware/platform/trunk/config-schema.json"
     },
     {
       "name": "Shopware CLI Extension Store Configuration",
       "description": "Shopware CLI Extension Store Configuration",
-      "fileMatch": [".shopware-extension.yml", ".shopware-extension.yaml"],
+      "fileMatch": [
+        ".shopware-extension.yml",
+        ".shopware-extension.yaml"
+      ],
       "url": "https://shopware.github.io/shopware-cli/shopware-extension-schema.json"
     },
     {
@@ -9465,13 +11520,19 @@
     {
       "name": "Qodana",
       "description": "A standard qodana.yaml (or qodana.yml) format for Qodana configuration. Documentation: https://jetbrains.com/qodana",
-      "fileMatch": ["qodana.yaml", "qodana.yml"],
+      "fileMatch": [
+        "qodana.yaml",
+        "qodana.yml"
+      ],
       "url": "https://www.schemastore.org/qodana-1.0.json"
     },
     {
       "name": "Tye",
       "description": "Tye configuration files",
-      "fileMatch": ["tye.yaml", "tye.yml"],
+      "fileMatch": [
+        "tye.yaml",
+        "tye.yml"
+      ],
       "url": "https://raw.githubusercontent.com/dotnet/tye/main/src/schema/tye-schema.json"
     },
     {
@@ -9489,7 +11550,11 @@
     {
       "name": "Hugo",
       "description": "Hugo static site generator config file",
-      "fileMatch": ["hugo.toml", "hugo.json", "hugo.yaml"],
+      "fileMatch": [
+        "hugo.toml",
+        "hugo.json",
+        "hugo.yaml"
+      ],
       "url": "https://www.schemastore.org/hugo.json"
     },
     {
@@ -9522,7 +11587,9 @@
     {
       "name": "Butane Config",
       "description": "Fedora CoreOS Butane config file",
-      "fileMatch": ["*.bu"],
+      "fileMatch": [
+        "*.bu"
+      ],
       "url": "https://relativ-it.github.io/Butane-Schemas/Butane-Schema.json"
     },
     {
@@ -9552,7 +11619,9 @@
     {
       "name": "Updatecli Policy Metadata",
       "description": "Updatecli Policy Metadata",
-      "fileMatch": ["**/updatecli/**/Policy.yaml"],
+      "fileMatch": [
+        "**/updatecli/**/Policy.yaml"
+      ],
       "url": "https://www.updatecli.io/schema/latest/policy/metadata/config.json"
     },
     {
@@ -9563,7 +11632,9 @@
     {
       "name": "clang-format (.clang-format)",
       "description": "yaml clang-format config",
-      "fileMatch": [".clang-format"],
+      "fileMatch": [
+        ".clang-format"
+      ],
       "url": "https://www.schemastore.org/clang-format-21.x.json",
       "versions": {
         "18.x": "https://www.schemastore.org/clang-format-18.x.json",
@@ -9573,13 +11644,20 @@
     {
       "name": "Estuary Flow Catalog",
       "description": "Flow catalog files. Documentation: https://github.com/estuary/flow",
-      "fileMatch": ["flow.yaml", "*.flow.yaml", "flow.json", "*.flow.json"],
+      "fileMatch": [
+        "flow.yaml",
+        "*.flow.yaml",
+        "flow.json",
+        "*.flow.json"
+      ],
       "url": "https://raw.githubusercontent.com/estuary/flow/master/flow.schema.json"
     },
     {
       "name": "V2Ray",
       "description": "V2Ray jsonv4/jsonv5 configuration format",
-      "fileMatch": ["**/v2ray/*.json"],
+      "fileMatch": [
+        "**/v2ray/*.json"
+      ],
       "url": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
       "versions": {
         "jsonv4": "https://raw.githubusercontent.com/EHfive/v2ray-jsonschema/main/v4-config.schema.json",
@@ -9589,19 +11667,29 @@
     {
       "name": "GherKing",
       "description": "GherKing configuration",
-      "fileMatch": [".gherking.json", ".gherkingrc", "gherking.json"],
+      "fileMatch": [
+        ".gherking.json",
+        ".gherkingrc",
+        "gherking.json"
+      ],
       "url": "https://raw.githubusercontent.com/gherking/gherking/master/schema/gherking.schema.json"
     },
     {
       "name": "CICS TS region tagging",
       "description": "CICS region tagging in IBM CICS Transaction Server for z/OS",
-      "fileMatch": ["cicstags.yaml", "cicstags.yml"],
+      "fileMatch": [
+        "cicstags.yaml",
+        "cicstags.yml"
+      ],
       "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicstags.json"
     },
     {
       "name": "CICS TS resource import",
       "description": "resource import in IBM CICS Transaction Server for z/OS",
-      "fileMatch": ["*.cicsresourceimport.yaml", "*.cicsresourceimport.yml"],
+      "fileMatch": [
+        "*.cicsresourceimport.yaml",
+        "*.cicsresourceimport.yml"
+      ],
       "url": "https://public.dhe.ibm.com/ibmdl/export/pub/software/htp/cics/schemas/json/cicsts-resourceimport.json"
     },
     {
@@ -9629,103 +11717,146 @@
     {
       "name": "Webman package recipe",
       "description": "YAML a webman package",
-      "fileMatch": ["*.webman-pkg.yml"],
+      "fileMatch": [
+        "*.webman-pkg.yml"
+      ],
       "url": "https://raw.githubusercontent.com/candrewlee14/webman/main/schema/pkg_schema.json"
     },
     {
       "name": "webhint.io",
       "description": "A configuration file for hint",
-      "fileMatch": [".hintrc"],
+      "fileMatch": [
+        ".hintrc"
+      ],
       "url": "https://raw.githubusercontent.com/webhintio/hint/main/packages/hint/src/lib/config/config-schema.json"
     },
     {
       "name": "AVA Configuration",
       "description": "configuring AVA, the Node.js test runner",
-      "fileMatch": ["ava.config.json"],
+      "fileMatch": [
+        "ava.config.json"
+      ],
       "url": "https://www.schemastore.org/ava.json"
     },
     {
       "name": "Datahub Ingestion Recipe",
       "description": "Datahub Ingestion recipe. Documentation: https://datahubproject.io/docs/metadata-ingestion",
-      "fileMatch": ["*.dhub.yml", "*.dhub.yaml", "*.dhub.json"],
+      "fileMatch": [
+        "*.dhub.yml",
+        "*.dhub.yaml",
+        "*.dhub.json"
+      ],
       "url": "https://datahubproject.io/schemas/datahub_ingestion_schema.json"
     },
     {
       "name": "Quali Torque Blueprint Spec 2",
       "description": "Torque bluerpint",
-      "fileMatch": ["**/blueprints/**.yaml"],
+      "fileMatch": [
+        "**/blueprints/**.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/QualiTorque/torque-vs-code-extensions/master/client/schemas/blueprint-spec2-schema.json"
     },
     {
       "name": "jscpd Configuration",
       "description": "Copy/paste detector for programming source code",
-      "fileMatch": [".jscpd.json"],
+      "fileMatch": [
+        ".jscpd.json"
+      ],
       "url": "https://www.schemastore.org/jscpd.json"
     },
     {
       "name": "Pterodactyl",
       "description": "Pterodactyl, a free game server control panel",
-      "fileMatch": ["egg-*.json"],
+      "fileMatch": [
+        "egg-*.json"
+      ],
       "url": "https://www.schemastore.org/pterodactyl.json"
     },
     {
       "name": "Hardware Sentry Configuration",
       "description": "Hardware Sentry configuration file",
-      "fileMatch": ["*hws-config*.yaml", "*hws-config*.yml"],
+      "fileMatch": [
+        "*hws-config*.yaml",
+        "*hws-config*.yml"
+      ],
       "url": "https://www.schemastore.org/hws-config.json"
     },
     {
       "name": "devspace.yaml",
       "description": "yaml devspace.yaml",
-      "fileMatch": ["devspace.yaml"],
+      "fileMatch": [
+        "devspace.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/loft-sh/devspace/main/devspace-schema.json"
     },
     {
       "name": "macro.json",
       "description": "Macro configuration file",
-      "fileMatch": ["macro.json"],
+      "fileMatch": [
+        "macro.json"
+      ],
       "url": "https://raw.githubusercontent.com/rebaz94/macro_kit/refs/heads/main/macro_schema.json"
     },
     {
       "name": "Monika Configuration",
       "description": "Monika configuration file",
-      "fileMatch": ["*monika*.yaml", "*monika*.yml", "monika.json"],
+      "fileMatch": [
+        "*monika*.yaml",
+        "*monika*.yml",
+        "monika.json"
+      ],
       "url": "https://www.schemastore.org/monika-config-schema.json"
     },
     {
       "name": "Istanbul",
       "description": "Istanbul, a JavaScript code coverage tool",
-      "fileMatch": [".nycrc", ".nycrc.json", ".nycrc.yaml", ".nycrc.yml"],
+      "fileMatch": [
+        ".nycrc",
+        ".nycrc.json",
+        ".nycrc.yaml",
+        ".nycrc.yml"
+      ],
       "url": "https://www.schemastore.org/nycrc.json"
     },
     {
       "name": "MongoDB Atlas Search Index Definition",
       "description": "MongoDB Atlas Search index",
-      "fileMatch": ["*-index.json"],
+      "fileMatch": [
+        "*-index.json"
+      ],
       "url": "https://www.schemastore.org/mongodb-atlas-search-index-definition.json"
     },
     {
       "name": "KODE/CI build.yaml",
       "description": "yaml kode/ci build",
-      "fileMatch": ["**/.kode/*.yaml"],
+      "fileMatch": [
+        "**/.kode/*.yaml"
+      ],
       "url": "https://www.schemastore.org/kode-ci-build-1.0.0.json"
     },
     {
       "name": "Kong DBLess config",
       "description": "dbless configuration YAML",
-      "fileMatch": ["kong.yaml", "kong.yml"],
+      "fileMatch": [
+        "kong.yaml",
+        "kong.yml"
+      ],
       "url": "https://www.schemastore.org/kong_json_schema.json"
     },
     {
       "name": "Embrace Config",
       "description": "Embrace configuration file",
-      "fileMatch": ["embrace-config.json"],
+      "fileMatch": [
+        "embrace-config.json"
+      ],
       "url": "https://www.schemastore.org/embrace-config-schema-1.0.0.json"
     },
     {
       "name": "petstore-v1.0",
       "description": "petstore yaml validation",
-      "fileMatch": ["petstore-v1.0.json"],
+      "fileMatch": [
+        "petstore-v1.0.json"
+      ],
       "url": "https://www.schemastore.org/petstore-v1.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/petstore-v1.0.json",
@@ -9744,13 +11875,18 @@
     {
       "name": "Safebox Config",
       "description": "Documentation: https://github.com/monebag/safebox",
-      "fileMatch": ["*safebox*.yaml", "*safebox*.yml"],
+      "fileMatch": [
+        "*safebox*.yaml",
+        "*safebox*.yml"
+      ],
       "url": "https://www.schemastore.org/safebox-schema-v1.0.0.json"
     },
     {
       "name": "Sublime Syntax",
       "description": "Sublime Text/Merge syntax highlighting definition",
-      "fileMatch": ["*.sublime-syntax"],
+      "fileMatch": [
+        "*.sublime-syntax"
+      ],
       "url": "https://www.schemastore.org/sublime-syntax.json"
     },
     {
@@ -9767,7 +11903,9 @@
     {
       "name": "ize.toml",
       "description": "ize Infra Tool",
-      "fileMatch": ["ize.toml"],
+      "fileMatch": [
+        "ize.toml"
+      ],
       "url": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
       "versions": {
         "1.1.5": "https://raw.githubusercontent.com/hazelops/ize/1.1.5/internal/schema/ize-spec.json",
@@ -9777,13 +11915,20 @@
     {
       "name": "Uplift",
       "description": "Uplift configuration file",
-      "fileMatch": [".uplift.yml", ".uplift.yaml", "uplift.yml", "uplift.yaml"],
+      "fileMatch": [
+        ".uplift.yml",
+        ".uplift.yaml",
+        "uplift.yml",
+        "uplift.yaml"
+      ],
       "url": "https://upliftci.dev/static/schema.json"
     },
     {
       "name": "QueryFirst config file",
       "description": "Config options for QueryFirst, SQL wrapper generator",
-      "fileMatch": ["qfconfig.json"],
+      "fileMatch": [
+        "qfconfig.json"
+      ],
       "url": "https://www.schemastore.org/qfconfig.json",
       "versions": {
         "1.0": "https://www.schemastore.org/qfconfig.json"
@@ -9792,25 +11937,33 @@
     {
       "name": "UET BuildConfig.json",
       "description": "UET is an unofficial tool for Unreal Engine. The BuildConfig.json file allows you to specify how UET should build an Unreal Engine plugin, project or the engine itself",
-      "fileMatch": ["BuildConfig.json"],
+      "fileMatch": [
+        "BuildConfig.json"
+      ],
       "url": "https://raw.githubusercontent.com/RedpointGames/uet-schema/main/root.json"
     },
     {
       "name": "Unreal Engine Uplugin",
       "description": "Unreal Engine plugin configuration file",
-      "fileMatch": [".uplugin"],
+      "fileMatch": [
+        ".uplugin"
+      ],
       "url": "https://www.schemastore.org/uplugin.json"
     },
     {
       "name": "Unreal Engine Uproject",
       "description": "Unreal Engine project configuration file",
-      "fileMatch": [".uproject"],
+      "fileMatch": [
+        ".uproject"
+      ],
       "url": "https://www.schemastore.org/uproject.json"
     },
     {
       "name": "Pantsbuild",
       "description": "Pantsbuild configuration file",
-      "fileMatch": ["pants*.toml"],
+      "fileMatch": [
+        "pants*.toml"
+      ],
       "url": "https://www.schemastore.org/pantsbuild-2.32.0.json",
       "versions": {
         "2.14.0": "https://www.schemastore.org/pantsbuild-2.14.0.json",
@@ -9831,133 +11984,186 @@
     {
       "name": "All Contributors configuration file",
       "description": "The configuration file used by the All Contributors CLI and GitHub bot",
-      "fileMatch": [".all-contributorsrc"],
+      "fileMatch": [
+        ".all-contributorsrc"
+      ],
       "url": "https://www.schemastore.org/all-contributors.json"
     },
     {
       "name": "ES6 Import Sorter (.es6importsorterrc.json)",
       "description": "The configuration file used for ES6 Import Sorter, a VSCode extension",
-      "fileMatch": [".es6importsorterrc.json"],
+      "fileMatch": [
+        ".es6importsorterrc.json"
+      ],
       "url": "https://www.schemastore.org/es6importsorterrc.json"
     },
     {
       "name": "completely.yml",
       "description": "Completely completion",
-      "fileMatch": ["completely.yml", "completely.yaml"],
+      "fileMatch": [
+        "completely.yml",
+        "completely.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/completely/master/schemas/completely.json"
     },
     {
       "name": "Madness (madness.yml)",
       "description": "Madness settings",
-      "fileMatch": ["madness.yml", "madness.yaml"],
+      "fileMatch": [
+        "madness.yml",
+        "madness.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/madness/master/schemas/madness.json"
     },
     {
       "name": "Bashly (bashly.yml)",
       "description": "Bashly CLI",
-      "fileMatch": ["bashly.yml", "bashly.yaml"],
+      "fileMatch": [
+        "bashly.yml",
+        "bashly.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/bashly.json"
     },
     {
       "name": "Bashly Settings (bashly-settings.yml)",
       "description": "Bashly settings",
-      "fileMatch": ["bashly-settings.yml", "bashly-settings.yaml"],
+      "fileMatch": [
+        "bashly-settings.yml",
+        "bashly-settings.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/settings.json"
     },
     {
       "name": "bashly-strings.yml",
       "description": "Bashly strings",
-      "fileMatch": ["bashly-strings.yml", "bashly-strings.yaml"],
+      "fileMatch": [
+        "bashly-strings.yml",
+        "bashly-strings.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/bashly/master/schemas/strings.json"
     },
     {
       "name": "bpkg",
       "description": "A lightweight Bash package manager",
-      "fileMatch": ["bpkg.json"],
+      "fileMatch": [
+        "bpkg.json"
+      ],
       "url": "https://www.schemastore.org/bpkg.json"
     },
     {
       "name": "micro-settings.json",
       "description": "Micro settings",
-      "fileMatch": ["**/.config/micro/settings.json"],
+      "fileMatch": [
+        "**/.config/micro/settings.json"
+      ],
       "url": "https://raw.githubusercontent.com/zyedidia/micro/master/data/micro.json"
     },
     {
       "name": "quilt.mod.json",
       "description": "Metadata file used by the QuiltMC mod loader",
-      "fileMatch": ["quilt.mod.json"],
+      "fileMatch": [
+        "quilt.mod.json"
+      ],
       "url": "https://raw.githubusercontent.com/QuiltMC/quilt-json-schemas/main/quilt.mod.json/schemas/main.json"
     },
     {
       "name": "AutoAPICase",
       "description": "auto api case",
-      "fileMatch": ["**/test_data/**/*.yml"],
+      "fileMatch": [
+        "**/test_data/**/*.yml"
+      ],
       "url": "https://www.schemastore.org/case_schema.json"
     },
     {
       "name": "secrethub.yml",
       "description": "secrethub",
-      "fileMatch": ["secrethub.yml", "secrethub.yaml"],
+      "fileMatch": [
+        "secrethub.yml",
+        "secrethub.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/DannyBen/secret_hub/master/schemas/secrethub.json"
     },
     {
       "name": "Dynamic Bash Aliases (.aliases)",
       "description": "Dynamic Bash aliases",
-      "fileMatch": [".aliases"],
+      "fileMatch": [
+        ".aliases"
+      ],
       "url": "https://www.schemastore.org/aliases.json"
     },
     {
       "name": "Micro Editor Syntax",
       "description": "Micro Editor syntaxes",
-      "fileMatch": ["**/micro/runtime/syntax/*.yaml"],
+      "fileMatch": [
+        "**/micro/runtime/syntax/*.yaml"
+      ],
       "url": "https://www.schemastore.org/micro-syntax.json"
     },
     {
       "name": "lazygit",
       "description": "lazygit settings",
-      "fileMatch": ["**/lazygit/config.yml", "lazygit.yml", ".lazygit.yml"],
+      "fileMatch": [
+        "**/lazygit/config.yml",
+        "lazygit.yml",
+        ".lazygit.yml"
+      ],
       "url": "https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json"
     },
     {
       "name": "lazydocker",
       "description": "lazydocker settings",
-      "fileMatch": ["**/lazydocker/config.yml"],
+      "fileMatch": [
+        "**/lazydocker/config.yml"
+      ],
       "url": "https://www.schemastore.org/lazydocker.json"
     },
     {
       "name": "custom-elements.json",
       "description": "A file format for describing custom elements",
-      "fileMatch": ["custom-elements.json"],
+      "fileMatch": [
+        "custom-elements.json"
+      ],
       "url": "https://raw.githubusercontent.com/webcomponents/custom-elements-manifest/main/schema.json"
     },
     {
       "name": "warp-keysets.json",
       "description": "Warp keyboard shortcut presets",
-      "fileMatch": ["**/.warp/keybindings.yaml"],
+      "fileMatch": [
+        "**/.warp/keybindings.yaml"
+      ],
       "url": "https://www.schemastore.org/warp-keysets.json"
     },
     {
       "name": "warp-themes.json",
       "description": "Warp themes",
-      "fileMatch": ["**/.warp/themes/*.yaml"],
+      "fileMatch": [
+        "**/.warp/themes/*.yaml"
+      ],
       "url": "https://www.schemastore.org/warp-themes.json"
     },
     {
       "name": "warp-workflows.json",
       "description": "Warp workflows",
-      "fileMatch": ["**/.warp/workflows/*.yaml"],
+      "fileMatch": [
+        "**/.warp/workflows/*.yaml"
+      ],
       "url": "https://www.schemastore.org/warp-workflows.json"
     },
     {
       "name": "Goblet",
       "description": "Goblet serverless framework config",
-      "fileMatch": ["**/.goblet/config.json"],
+      "fileMatch": [
+        "**/.goblet/config.json"
+      ],
       "url": "https://raw.githubusercontent.com/goblet/goblet/main/goblet.schema.json"
     },
     {
       "name": "Declarative Automation Bundles",
       "description": "Declarative Automation Bundles config",
-      "fileMatch": ["databricks.yml", "databricks.yaml"],
+      "fileMatch": [
+        "databricks.yml",
+        "databricks.yaml"
+      ],
       "url": "https://github.com/databricks/cli/releases/latest/download/jsonschema.json"
     },
     {
@@ -9986,19 +12192,26 @@
     {
       "name": "Endurica",
       "description": "Endurica Input File",
-      "fileMatch": ["*.ki.json"],
+      "fileMatch": [
+        "*.ki.json"
+      ],
       "url": "https://enduricastorage.blob.core.windows.net/public/endurica-cl-schema.json"
     },
     {
       "name": "TunnelHub",
       "description": "TunnelHub Automation Configuration File",
-      "fileMatch": ["tunnelhub.yml", "tunnelhub.yaml"],
+      "fileMatch": [
+        "tunnelhub.yml",
+        "tunnelhub.yaml"
+      ],
       "url": "https://www.schemastore.org/tunnelhub.json"
     },
     {
       "name": "ty",
       "description": "ty, a fast Python type checker",
-      "fileMatch": ["ty.toml"],
+      "fileMatch": [
+        "ty.toml"
+      ],
       "url": "https://www.schemastore.org/ty.json"
     },
     {
@@ -10036,13 +12249,22 @@
     {
       "name": "Minecraft Custom Main Menu Mod",
       "description": "Minecraft 1.12 Forge mod 'Custom Main Menu' config",
-      "fileMatch": ["mainmenu.yml", "mainmenu.yaml", "mainmenu.json"],
+      "fileMatch": [
+        "mainmenu.yml",
+        "mainmenu.yaml",
+        "mainmenu.json"
+      ],
       "url": "https://www.schemastore.org/minecraft-custom-main-menu-mod.json"
     },
     {
       "name": "rivet.yaml (legacy)",
       "description": "Legacy Rivet game configuration file",
-      "fileMatch": ["rivet.yaml", "rivet.*.yaml", "rivet.toml", "rivet.*.toml"],
+      "fileMatch": [
+        "rivet.yaml",
+        "rivet.*.yaml",
+        "rivet.toml",
+        "rivet.*.toml"
+      ],
       "url": "https://rivet.gg/rivet.schema.json"
     },
     {
@@ -10059,19 +12281,27 @@
     {
       "name": "nixd configuration",
       "description": "Configuration file for nixd",
-      "fileMatch": [".nixd.json"],
+      "fileMatch": [
+        ".nixd.json"
+      ],
       "url": "https://raw.githubusercontent.com/nix-community/nixd/main/nixd/docs/nixd-schema.json"
     },
     {
       "name": "Rudder techniques",
       "description": "Rudder techniques",
-      "fileMatch": ["technique.yml", "technique.ids.yml"],
+      "fileMatch": [
+        "technique.yml",
+        "technique.ids.yml"
+      ],
       "url": "https://www.schemastore.org/rudder-techniques.json"
     },
     {
       "name": "SkyPilot Task JSON",
       "description": "SkyPilot Task JSON to specify a task (resource requirements, setup commands, run commands, file mounts, storage mounts, and so on)",
-      "fileMatch": ["skypilot-task.yml", "skypilot-task.yaml"],
+      "fileMatch": [
+        "skypilot-task.yml",
+        "skypilot-task.yaml"
+      ],
       "url": "https://www.schemastore.org/skypilot-task.json"
     },
     {
@@ -10086,13 +12316,20 @@
     {
       "name": "Subsquid squid manifest",
       "description": "Squid manifest for Subsquid Cloud deployments",
-      "fileMatch": ["squid.yaml", "*.squid.yaml", "squid.yml", "*.squid.yml"],
+      "fileMatch": [
+        "squid.yaml",
+        "*.squid.yaml",
+        "squid.yml",
+        "*.squid.yml"
+      ],
       "url": "https://cdn.subsquid.io/schemas/squid_manifest.json"
     },
     {
       "name": "GitLab Agent for Kubernetes configuration",
       "description": "GitLab Agent for Kubernetes configuration file",
-      "fileMatch": ["**/.gitlab/agents/*/config.yaml"],
+      "fileMatch": [
+        "**/.gitlab/agents/*/config.yaml"
+      ],
       "url": "https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/raw/master/pkg/agentcfg/agentcfg_schemas/gitlab.agent.agentcfg.ConfigurationFile.jsonschema.bundle.json"
     },
     {
@@ -10104,25 +12341,35 @@
     {
       "name": "GlazeWM settings",
       "description": "GlazeWM settings",
-      "fileMatch": ["**/.glaze-wm/config.yaml", "**/glazewm/config.yaml"],
+      "fileMatch": [
+        "**/.glaze-wm/config.yaml",
+        "**/glazewm/config.yaml"
+      ],
       "url": "https://www.schemastore.org/glazewm.json"
     },
     {
       "name": "CGS Card Game Specification (cgs.json)",
       "description": "Card Game Simulator (CGS) Card Game Specification",
-      "fileMatch": ["cgs.json"],
+      "fileMatch": [
+        "cgs.json"
+      ],
       "url": "https://www.cardgamesimulator.com/schema/cgs.json"
     },
     {
       "name": "Custom Machinery Machine",
       "description": "Custom machinery machine specification (Minecraft mod)",
-      "fileMatch": ["**/data/*/machines/*.json", "**/data/*/machine/*.json"],
+      "fileMatch": [
+        "**/data/*/machines/*.json",
+        "**/data/*/machine/*.json"
+      ],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_machine.json"
     },
     {
       "name": "Custom Machinery Recipe",
       "description": "Custom machinery recipes specification (Minecraft mod)",
-      "fileMatch": ["**/data/*/recipes/**/*.json"],
+      "fileMatch": [
+        "**/data/*/recipes/**/*.json"
+      ],
       "url": "https://alec016.github.io/Custom-Machinery/Json%20Schema/src/main/resources/schemas/custom_machinery_recipe.json"
     },
     {
@@ -10137,7 +12384,10 @@
     {
       "name": "bioimageio resource description",
       "description": "Bioimage.io resource descriptions may be produced or consumed by bioimage.io-compatible software",
-      "fileMatch": ["bioimageio.yaml", "*.bioimageio.yaml"],
+      "fileMatch": [
+        "bioimageio.yaml",
+        "*.bioimageio.yaml"
+      ],
       "url": "https://bioimage-io.github.io/spec-bioimage-io/bioimageio_schema_latest.json"
     },
     {
@@ -10149,13 +12399,17 @@
     {
       "name": "CWL",
       "description": "The Common Workflow Language Configuration",
-      "fileMatch": ["*.cwl"],
+      "fileMatch": [
+        "*.cwl"
+      ],
       "url": "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.json"
     },
     {
       "name": "shard.yml",
       "description": "Shards configuration file",
-      "fileMatch": ["shard.yml"],
+      "fileMatch": [
+        "shard.yml"
+      ],
       "url": "https://raw.githubusercontent.com/crystal-lang/shards/master/docs/shard.yml.schema.json"
     },
     {
@@ -10174,13 +12428,18 @@
     {
       "name": "Erda Runtime",
       "description": "Erda Runtime Configuration File",
-      "fileMatch": ["dice.yaml", "erda.yml"],
+      "fileMatch": [
+        "dice.yaml",
+        "erda.yml"
+      ],
       "url": "https://raw.githubusercontent.com/erda-project/erda/master/.erda/schemas/dice.yaml.json"
     },
     {
       "name": "KSY",
       "description": "Kaitai Struct format description file",
-      "fileMatch": ["*.ksy"],
+      "fileMatch": [
+        "*.ksy"
+      ],
       "url": "https://raw.githubusercontent.com/kaitai-io/ksy_schema/master/ksy_schema.json"
     },
     {
@@ -10244,31 +12503,45 @@
     {
       "name": "changelogging",
       "description": "changelogging configuration file",
-      "fileMatch": ["**/changelogging.toml"],
+      "fileMatch": [
+        "**/changelogging.toml"
+      ],
       "url": "https://raw.githubusercontent.com/nekitdev/changelogging/main/changelogging.schema.json"
     },
     {
       "name": "Configu .cfgu files",
       "description": "A human-readable format for declaring configurations and their characteristics",
-      "fileMatch": ["*.cfgu.json", "*.cfgu.yaml", "*.cfgu.yml"],
+      "fileMatch": [
+        "*.cfgu.json",
+        "*.cfgu.yaml",
+        "*.cfgu.yml"
+      ],
       "url": "https://raw.githubusercontent.com/configu/configu/main/packages/schema/.cfgu.json"
     },
     {
       "name": "Configu .configu file",
       "description": "An optional configuration file used by the various Configu interfaces to customize its behavior",
-      "fileMatch": [".configu"],
+      "fileMatch": [
+        ".configu"
+      ],
       "url": "https://raw.githubusercontent.com/configu/configu/main/packages/schema/.configu.json"
     },
     {
       "name": "Qt Creator workspace file",
       "description": "Qt Creator project json file",
-      "fileMatch": ["**/.qtcreator/project.json"],
+      "fileMatch": [
+        "**/.qtcreator/project.json"
+      ],
       "url": "https://download.qt.io/official_releases/qtcreator/latest/installer_source/jsonschemas/project.json"
     },
     {
       "name": "mprocs Configuration file",
       "description": "mprocs (https://github.com/pvolok/mprocs) Configuration file using JSON/YAML",
-      "fileMatch": ["mprocs.json", "mprocs.yaml", "mprocs.yml"],
+      "fileMatch": [
+        "mprocs.json",
+        "mprocs.yaml",
+        "mprocs.yml"
+      ],
       "url": "https://www.schemastore.org/mprocs-0.6.4.json"
     },
     {
@@ -10301,7 +12574,10 @@
     {
       "name": "zerops.yml",
       "description": "Zerops build, deploy and run configuration YAML file",
-      "fileMatch": ["zerops.yml", "zerops.yaml"],
+      "fileMatch": [
+        "zerops.yml",
+        "zerops.yaml"
+      ],
       "url": "https://api.app-prg1.zerops.io/api/rest/public/settings/zerops-yml-json-schema.json"
     },
     {
@@ -10318,19 +12594,27 @@
     {
       "name": "Microsoft RulesEngine workflow rules",
       "description": "Microsoft RulesEngine workflow rules definition https://github.com/microsoft/RulesEngine",
-      "fileMatch": ["*.workflow-rules.json", "**/workflow-rules/*.json"],
+      "fileMatch": [
+        "*.workflow-rules.json",
+        "**/workflow-rules/*.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/RulesEngine/main/schema/workflow-schema.json"
     },
     {
       "name": "Microsoft RulesEngine workflow rules list",
       "description": "Microsoft RulesEngine workflow list definition https://github.com/microsoft/RulesEngine",
-      "fileMatch": ["*.workflow-rules-list.json"],
+      "fileMatch": [
+        "*.workflow-rules-list.json"
+      ],
       "url": "https://raw.githubusercontent.com/microsoft/RulesEngine/main/schema/workflow-list-schema.json"
     },
     {
       "name": "spicepod.yaml",
       "description": "Spice.ai OSS Spicepod Manifest file",
-      "fileMatch": ["spicepod.yml", "spicepod.yaml"],
+      "fileMatch": [
+        "spicepod.yml",
+        "spicepod.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/.schema/spicepod.schema.json"
     },
     {
@@ -10351,7 +12635,11 @@
     {
       "name": "CRS WAF test file",
       "description": "Definition of a test for verifying WAF behavior",
-      "fileMatch": ["*.waft", ".waft.yaml", ".waft.yml"],
+      "fileMatch": [
+        "*.waft",
+        ".waft.yaml",
+        ".waft.yml"
+      ],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.2.0/waf-tests-schema-v2.2.0.json",
       "versions": {
         "2.0.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/main/spec/v2.0.0/waf-tests-schema-v2.0.0.json",
@@ -10362,7 +12650,11 @@
     {
       "name": "CRS WAF test platform overrides file",
       "description": "Definition of platform specific overrides for WAF tests",
-      "fileMatch": ["*.wafto", ".wafto.yaml", ".wafto.yml"],
+      "fileMatch": [
+        "*.wafto",
+        ".wafto.yaml",
+        ".wafto.yml"
+      ],
       "url": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.2.0/waf-platform-overrides-schema-v2.2.0.json",
       "versions": {
         "2.0.0": "https://raw.githubusercontent.com/coreruleset/ftw-tests-schema/master/spec/v2.0.0/waf-platform-overrides-schema-v2.0.0.json",
@@ -10388,13 +12680,18 @@
     {
       "name": "Tycho",
       "description": "Tycho.yaml file",
-      "fileMatch": ["**/tycho.yml", "**/tycho.yaml"],
+      "fileMatch": [
+        "**/tycho.yml",
+        "**/tycho.yaml"
+      ],
       "url": "https://deployments.allegrogroup.com/tycho/schema"
     },
     {
       "name": "Elm",
       "description": "elm.json file",
-      "fileMatch": ["elm.json"],
+      "fileMatch": [
+        "elm.json"
+      ],
       "url": "https://www.schemastore.org/elm.json"
     },
     {
@@ -10405,7 +12702,10 @@
     {
       "name": "Cloud Run Spec v1",
       "description": "Specification for Cloud Run Admin API v1",
-      "fileMatch": ["cloud-run-v1.yml", "cloud-run-v1.yaml"],
+      "fileMatch": [
+        "cloud-run-v1.yml",
+        "cloud-run-v1.yaml"
+      ],
       "url": "https://www.schemastore.org/cloud-run-v1.json"
     },
     {
@@ -10417,55 +12717,75 @@
     {
       "name": "Settings for a Cinnamon spice",
       "description": "Settings for a Cinnamon spice",
-      "fileMatch": ["**/*@*/**/settings-schema.json"],
+      "fileMatch": [
+        "**/*@*/**/settings-schema.json"
+      ],
       "url": "https://www.schemastore.org/cinnamon-spice-settings.json"
     },
     {
       "name": "Metadata for a Cinnamon spice",
       "description": "Metadata for a Cinnamon spice",
-      "fileMatch": ["**/*@*/**/metadata.json"],
+      "fileMatch": [
+        "**/*@*/**/metadata.json"
+      ],
       "url": "https://www.schemastore.org/cinnamon-spice-metadata.json"
     },
     {
       "name": "Yandex Workflow Language",
       "description": "YaWL specification file",
-      "fileMatch": ["*.yawl.yaml", "*.yawl.yml"],
+      "fileMatch": [
+        "*.yawl.yaml",
+        "*.yawl.yml"
+      ],
       "url": "https://raw.githubusercontent.com/yandex-cloud/json-schema-store/master/serverless/workflows/yawl.json"
     },
     {
       "name": "Application list for a WinUtil",
       "description": "Application list for a WinUtil",
-      "fileMatch": ["**/*winutil*/config/applications.json"],
+      "fileMatch": [
+        "**/*winutil*/config/applications.json"
+      ],
       "url": "https://www.schemastore.org/winutil-applications.json"
     },
     {
       "name": "Preset list for a \"ChrisTitusTech/winutil\"",
       "description": "Preset list for a WinUtil",
-      "fileMatch": ["**/*winutil*/config/preset.json"],
+      "fileMatch": [
+        "**/*winutil*/config/preset.json"
+      ],
       "url": "https://www.schemastore.org/winutil-presets.json"
     },
     {
       "name": "GitHub Actions typing",
       "description": "Describe types of inputs and outputs for GitHub Actions' actions",
-      "fileMatch": ["action-types.yml", "action-types.yaml"],
+      "fileMatch": [
+        "action-types.yml",
+        "action-types.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/typesafegithub/github-actions-typing/refs/heads/schema-latest/github-actions-typing.schema.json"
     },
     {
       "name": "Tab list for a LinUtil",
       "description": "Tab list for a LinUtil",
-      "fileMatch": ["**/*linutil*/**/tabs.toml"],
+      "fileMatch": [
+        "**/*linutil*/**/tabs.toml"
+      ],
       "url": "https://www.schemastore.org/linutil-tabs.json"
     },
     {
       "name": "Tab data for a LinUtil",
       "description": "Tab data for a LinUtil",
-      "fileMatch": ["**/*linutil*/**/tab_data.toml"],
+      "fileMatch": [
+        "**/*linutil*/**/tab_data.toml"
+      ],
       "url": "https://www.schemastore.org/linutil-tab-data.json"
     },
     {
       "name": "ArchitectFX",
       "description": "Grammar for ArchitectFX's trees",
-      "fileMatch": ["*.jdsl"],
+      "fileMatch": [
+        "*.jdsl"
+      ],
       "url": "https://www.schemastore.org/architectfx.json"
     },
     {
@@ -10495,13 +12815,17 @@
     {
       "name": "ccmod.json",
       "description": "Mod manifset file for the CCLoader mod loader for the game CrossCode",
-      "fileMatch": ["ccmod.json"],
+      "fileMatch": [
+        "ccmod.json"
+      ],
       "url": "https://raw.githubusercontent.com/CCDirectLink/CCModDB/refs/heads/master/ccmod-json-schema.json"
     },
     {
       "name": "moon.yml",
       "description": "Moonrepo project configuration file",
-      "fileMatch": ["moon.yml"],
+      "fileMatch": [
+        "moon.yml"
+      ],
       "url": "https://raw.githubusercontent.com/moonrepo/moon/master/website/static/schemas/project.json"
     },
     {
@@ -10533,19 +12857,27 @@
     {
       "name": "WireMock CLI local service configuration",
       "description": "WireMock CLI and Runner local service config file format",
-      "fileMatch": ["wiremock.yaml"],
+      "fileMatch": [
+        "wiremock.yaml"
+      ],
       "url": "https://static.wiremock.io/schemas/wiremock.yaml-schema.json"
     },
     {
       "name": "WireMock CLI import configuration",
       "description": "WireMock CLI import and record config file format",
-      "fileMatch": ["wiremock-import-config.yaml"],
+      "fileMatch": [
+        "wiremock-import-config.yaml"
+      ],
       "url": "https://static.wiremock.io/schemas/wiremock-import-config.yaml-schema.json"
     },
     {
       "name": "Bitmovin Encoding Template",
       "description": "An encoding workflow from a single configuration template",
-      "fileMatch": ["*.bitmovin.json", "*.bitmovin.yml", "*.bitmovin.yaml"],
+      "fileMatch": [
+        "*.bitmovin.json",
+        "*.bitmovin.yml",
+        "*.bitmovin.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json"
     },
     {
@@ -10564,31 +12896,41 @@
     {
       "name": "pnpm Workspace (pnpm-workspace.yaml)",
       "description": "Workspace file for pnpm",
-      "fileMatch": ["pnpm-workspace.yaml"],
+      "fileMatch": [
+        "pnpm-workspace.yaml"
+      ],
       "url": "https://www.schemastore.org/pnpm-workspace.json"
     },
     {
       "name": "Chamaleon template",
       "description": "Chamaleon template",
-      "fileMatch": ["template.chamaleon.json"],
+      "fileMatch": [
+        "template.chamaleon.json"
+      ],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/template-schema.json"
     },
     {
       "name": "Chamaleon environment",
       "description": "Chamaleon environment",
-      "fileMatch": ["*.environment.chamaleon.json"],
+      "fileMatch": [
+        "*.environment.chamaleon.json"
+      ],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/environment-schema.json"
     },
     {
       "name": "Chamaleon properties",
       "description": "Chamaleon properties",
-      "fileMatch": ["properties.chamaleon.json"],
+      "fileMatch": [
+        "properties.chamaleon.json"
+      ],
       "url": "https://raw.githubusercontent.com/gerardorodriguezdev/chamaleon/refs/heads/master/schemas/properties-schema.json"
     },
     {
       "name": "ctfd-setup configuration file",
       "description": "CTFer.io ctfd-setup utility configuration file",
-      "fileMatch": [".ctfd.yaml"],
+      "fileMatch": [
+        ".ctfd.yaml"
+      ],
       "url": "https://www.schemastore.org/ctfd.json"
     },
     {
@@ -10600,7 +12942,10 @@
     {
       "name": "DonateCaseBetterCasino menu",
       "description": "Configuration file for dcbc addon menus",
-      "fileMatch": ["*dcbc.yml", "*dcbc.yaml"],
+      "fileMatch": [
+        "*dcbc.yml",
+        "*dcbc.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/Jodexx/DCBetterCasinoMenuSchema/refs/heads/main/schema.json"
     },
     {
@@ -10615,7 +12960,10 @@
     {
       "name": "gematik health care provider list",
       "description": "A list of health care providers in german telemedicine",
-      "fileMatch": ["**/testdata/hcp/hcp.yml", "**/testdata/hcp/hcp.yaml"],
+      "fileMatch": [
+        "**/testdata/hcp/hcp.yml",
+        "**/testdata/hcp/hcp.yaml"
+      ],
       "url": "https://www.schemastore.org/gematik-test-hcps.json"
     },
     {
@@ -10639,67 +12987,95 @@
     {
       "name": "gematik tiger test environment configuration",
       "description": "A configuration file for the test environment of the gematik Tiger test platform",
-      "fileMatch": ["**/tiger.yml", "**/tiger.yaml"],
+      "fileMatch": [
+        "**/tiger.yml",
+        "**/tiger.yaml"
+      ],
       "url": "https://www.schemastore.org/gematik-tiger.json"
     },
     {
       "name": "Tugboat QA config.yml",
       "description": "Configuration file for Tugboat QA",
-      "fileMatch": ["**/.tugboat/config.yml"],
+      "fileMatch": [
+        "**/.tugboat/config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/TugboatQA/docs/refs/heads/main/static/config-schema.json"
     },
     {
       "name": "C4InterFlow",
       "description": "C4InterFlow Architecture as Code file",
-      "fileMatch": ["**/*.c4interflow.yaml", "**/*.c4interflow.json"],
+      "fileMatch": [
+        "**/*.c4interflow.yaml",
+        "**/*.c4interflow.json"
+      ],
       "url": "https://raw.githubusercontent.com/SlavaVedernikov/C4InterFlow/refs/heads/master/C4InterFlow/schema.json"
     },
     {
       "name": "Wake",
       "description": "Wake - development, testing, and static analysis framework for Solidity",
-      "fileMatch": ["**/*wake.toml", "**/*.wake.toml"],
+      "fileMatch": [
+        "**/*wake.toml",
+        "**/*.wake.toml"
+      ],
       "url": "https://raw.githubusercontent.com/Ackee-Blockchain/wake/refs/heads/main/docs/wake-schema.json"
     },
     {
       "name": "Trident",
       "description": "Trident - Rust-based fuzzing framework for Solana programs to help ship secure code",
-      "fileMatch": ["**/*Trident.toml", "**/*.Trident.toml"],
+      "fileMatch": [
+        "**/*Trident.toml",
+        "**/*.Trident.toml"
+      ],
       "url": "https://raw.githubusercontent.com/Ackee-Blockchain/trident/refs/heads/master/trident-spec.json"
     },
     {
       "name": "Unified Tenant Configuration Management (UTCM) Monitor",
       "description": "Configuration file for the Unified Tenant Configuration Management (UTCM) Monitor",
-      "fileMatch": ["*.utcm-monitor.json"],
+      "fileMatch": [
+        "*.utcm-monitor.json"
+      ],
       "url": "https://www.schemastore.org/utcm-monitor.json"
     },
     {
       "name": "UpCloud CLI (upctl) configuration",
       "description": "Configuration file for the UpCloud CLI (upctl)",
-      "fileMatch": ["**/upctl.yaml"],
+      "fileMatch": [
+        "**/upctl.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/UpCloudLtd/upcloud-cli/refs/heads/main/docs/upctl.schema.json"
     },
     {
       "name": "Restate",
       "description": "Restate Server configuration file",
-      "fileMatch": ["**/restate.toml", "**/restate-server.toml"],
+      "fileMatch": [
+        "**/restate.toml",
+        "**/restate-server.toml"
+      ],
       "url": "https://docs.restate.dev/schemas/restate-server-configuration-schema.json"
     },
     {
       "name": "Telefonistka",
       "description": "Telefonistka - Safe and Controlled GitOps Promotion Across Environments/Failure-Domains",
-      "fileMatch": ["**/telefonistka.yaml"],
+      "fileMatch": [
+        "**/telefonistka.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/commercetools/telefonistka/refs/heads/main/schema/telefonistka.json"
     },
     {
       "name": "version",
       "description": "Project version information",
-      "fileMatch": [".version.json"],
+      "fileMatch": [
+        ".version.json"
+      ],
       "url": "https://raw.githubusercontent.com/ljonesfl/bump/refs/heads/master/version-schema.json"
     },
     {
       "name": "Viash Component Config",
       "description": "Viash component config file",
-      "fileMatch": ["*.vsh.yaml", "*.vsh.yml"],
+      "fileMatch": [
+        "*.vsh.yaml",
+        "*.vsh.yml"
+      ],
       "url": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/latest/config.schema.json",
       "versions": {
         "0.7.5": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/0.7.5/config.schema.json",
@@ -10718,7 +13094,10 @@
     {
       "name": "Viash Package Config",
       "description": "Viash package config file",
-      "fileMatch": ["_viash.yaml", "_viash.yml"],
+      "fileMatch": [
+        "_viash.yaml",
+        "_viash.yml"
+      ],
       "url": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/latest/package.schema.json",
       "versions": {
         "0.7.5": "https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/0.7.5/package.schema.json",
@@ -10748,7 +13127,9 @@
     {
       "name": "Tyk Gateway - Open Source v5.7+",
       "description": "Tyk Gateway Open Source Configuration File",
-      "fileMatch": ["tyk.conf"],
+      "fileMatch": [
+        "tyk.conf"
+      ],
       "url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/refs/heads/main/JSON/draft-07/schema_tyk.oss.conf"
     },
     {
@@ -10760,7 +13141,9 @@
     {
       "name": "vtcfg",
       "description": "Vector VT System Configuration",
-      "fileMatch": ["*.vtcfg"],
+      "fileMatch": [
+        "*.vtcfg"
+      ],
       "url": "https://www.schemastore.org/vtcfg-v19.0.0.json",
       "versions": {
         "19.0.0": "https://www.schemastore.org/vtcfg-v19.0.0.json"
@@ -10769,7 +13152,9 @@
     {
       "name": "sake",
       "description": "Configuration for Sake, Swift-based utility for managing project commands",
-      "fileMatch": [".sake.yml"],
+      "fileMatch": [
+        ".sake.yml"
+      ],
       "url": "https://www.schemastore.org/sake.json"
     },
     {
@@ -10800,31 +13185,44 @@
     {
       "name": "Google Digital Assetlinks",
       "description": "JSON-encoded statement list in a well-known location on a principal",
-      "fileMatch": ["assetlinks.json"],
+      "fileMatch": [
+        "assetlinks.json"
+      ],
       "url": "https://www.schemastore.org/assetlinks.json"
     },
     {
       "name": "Pylock",
       "description": "PEP 751 lock file",
-      "fileMatch": ["pylock.toml", "pylock.*.toml"],
+      "fileMatch": [
+        "pylock.toml",
+        "pylock.*.toml"
+      ],
       "url": "https://www.schemastore.org/pylock.json"
     },
     {
       "name": "Stylua Config",
       "description": "Stylua configuration",
-      "fileMatch": [".stylua.toml", "stylua.toml"],
+      "fileMatch": [
+        ".stylua.toml",
+        "stylua.toml"
+      ],
       "url": "https://www.schemastore.org/stylua.json"
     },
     {
       "name": "Taplo",
       "description": "Taplo configuration file",
-      "fileMatch": [".taplo.toml", "taplo.toml"],
+      "fileMatch": [
+        ".taplo.toml",
+        "taplo.toml"
+      ],
       "url": "https://www.schemastore.org/taplo.json"
     },
     {
       "name": "Aider",
       "description": "Aider configuration file",
-      "fileMatch": [".aider.conf.yml"],
+      "fileMatch": [
+        ".aider.conf.yml"
+      ],
       "url": "https://www.schemastore.org/aider-0.82.json"
     },
     {
@@ -10860,7 +13258,11 @@
     {
       "name": "tm_devices configuration file",
       "description": "Definition of the configuration file of the tm_devices Python package. Documentation: https://tm-devices.readthedocs.io/stable/configuration/",
-      "fileMatch": ["tm_devices.yml", "tm_devices.yaml", "tm_devices.toml"],
+      "fileMatch": [
+        "tm_devices.yml",
+        "tm_devices.yaml",
+        "tm_devices.toml"
+      ],
       "url": "https://raw.githubusercontent.com/tektronix/tm_devices/main/src/tm_devices/tm_devices_config_schema.json"
     },
     {
@@ -10877,7 +13279,9 @@
     {
       "name": "Power Pages Configuration",
       "description": "Power Pages configuration file for Bring Your Own Code (BYOC) sites",
-      "fileMatch": ["powerpages.config.json"],
+      "fileMatch": [
+        "powerpages.config.json"
+      ],
       "url": "https://www.schemastore.org/powerpages.config.json"
     },
     {
@@ -10894,49 +13298,69 @@
     {
       "name": "Revel Digital Gadget Definition File",
       "description": "Revel Digital gadget definition file. See https://developer.reveldigital.com/gadgets for more information",
-      "fileMatch": ["gadget.yml", "gadget.yaml"],
+      "fileMatch": [
+        "gadget.yml",
+        "gadget.yaml"
+      ],
       "url": "https://www.schemastore.org/gadget-yaml.json"
     },
     {
       "name": "Jujutsu (jj) VCS config",
       "description": "Jujutsu (jj) configuration file",
-      "fileMatch": ["**/.jj/repo/config.toml", "**/jj/config.toml"],
+      "fileMatch": [
+        "**/.jj/repo/config.toml",
+        "**/jj/config.toml"
+      ],
       "url": "https://jj-vcs.github.io/jj/latest/config-schema.json"
     },
     {
       "name": "AWS Copilot Manifest",
       "description": "Manifest YAML files for AWS Copilot services, environments, and pipelines. Documentation: https://aws.github.io/copilot-cli/docs/manifest/overview/",
-      "fileMatch": ["**/copilot/**/manifest.yml"],
+      "fileMatch": [
+        "**/copilot/**/manifest.yml"
+      ],
       "url": "https://sootyowl.github.io/aws-copilot-schemas/copilot-schema.json"
     },
     {
       "name": "Terrateam config",
       "description": "Terrateam configuration file",
-      "fileMatch": ["**/.terrateam/config.yaml", "**/.terrateam/config.yml"],
+      "fileMatch": [
+        "**/.terrateam/config.yaml",
+        "**/.terrateam/config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/terrateamio/terrateam/refs/heads/main/api_schemas/terrat/config-schema.json"
     },
     {
       "name": "Lake configuration file",
       "description": "`lakefile.toml`, the .toml configuration file for Lake, the package manager of the Lean programming language and theorem prover",
-      "fileMatch": ["lakefile.toml"],
+      "fileMatch": [
+        "lakefile.toml"
+      ],
       "url": "https://raw.githubusercontent.com/leanprover/lean4/refs/heads/master/src/lake/schemas/lakefile-toml-schema.json"
     },
     {
       "name": "Zarf Package Configuration",
       "description": "Zarf Packages contain a comprehensive description of system software and all of it's components for declaratively deploying in a disconnected environment",
-      "fileMatch": ["**/zarf.yaml", "**/zarf.yml"],
+      "fileMatch": [
+        "**/zarf.yaml",
+        "**/zarf.yml"
+      ],
       "url": "https://www.schemastore.org/zarf.json"
     },
     {
       "name": "Robust Station Image",
       "description": "Space Station 14 RSI validation",
-      "fileMatch": ["**/*.rsi/meta.json"],
+      "fileMatch": [
+        "**/*.rsi/meta.json"
+      ],
       "url": "https://raw.githubusercontent.com/space-wizards/RobustToolbox/refs/heads/master/Schemas/rsi.json"
     },
     {
       "name": "EUDR IOP Standard Exchange Format (EUDR-X)",
       "description": "structured exchange of data related to the EU Deforestation Regulation (EUDR)",
-      "fileMatch": ["*eudr-x.json"],
+      "fileMatch": [
+        "*eudr-x.json"
+      ],
       "url": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/heads/main/json/schema.json",
       "versions": {
         "1.0.0": "https://raw.githubusercontent.com/initiative-online-print/eudr-iop-standard-exchange-format/refs/tags/v1.0.0/json/schema.json",
@@ -10960,7 +13384,12 @@
     {
       "name": "Evolving Resolutive Process notation",
       "description": "For describing contradiction-based processes with storing changes and authors",
-      "fileMatch": ["*.erpn.yml", "*.erpn.yaml", "*.erpn.toml", "*.erpn.json"],
+      "fileMatch": [
+        "*.erpn.yml",
+        "*.erpn.yaml",
+        "*.erpn.toml",
+        "*.erpn.json"
+      ],
       "url": "https://www.schemastore.org/evolving-resolutive-process-notation-1.0.json",
       "versions": {
         "1.0": "https://www.schemastore.org/evolving-resolutive-process-notation-1.0.json"
@@ -11012,19 +13441,25 @@
     {
       "name": "git-town.toml",
       "description": "Git Town configuration file",
-      "fileMatch": ["git-town.toml"],
+      "fileMatch": [
+        "git-town.toml"
+      ],
       "url": "https://raw.githubusercontent.com/git-town/git-town/refs/heads/main/docs/git-town.schema.json"
     },
     {
       "name": "Jarl",
       "description": "Configuration for R linter",
-      "fileMatch": ["jarl.toml"],
+      "fileMatch": [
+        "jarl.toml"
+      ],
       "url": "https://github.com/etiennebacher/jarl/releases/latest/download/jarl.schema.json"
     },
     {
       "name": "Zola Configuration",
       "description": "A fast static site generator in a single binary with everything built-in",
-      "fileMatch": ["zola.toml"],
+      "fileMatch": [
+        "zola.toml"
+      ],
       "url": "https://cscnk52.github.io/json-schemas/zola.schema.json"
     },
     {
@@ -11081,19 +13516,25 @@
     {
       "name": "Changepacks",
       "description": "Changepacks are a way to package changes to a project",
-      "fileMatch": ["**/.changepacks/config.json"],
+      "fileMatch": [
+        "**/.changepacks/config.json"
+      ],
       "url": "https://www.schemastore.org/changepacks.json"
     },
     {
       "name": "Devup",
       "description": "JSX Zero-Runtime UI Styling Library",
-      "fileMatch": ["devup.json"],
+      "fileMatch": [
+        "devup.json"
+      ],
       "url": "https://www.schemastore.org/devup.json"
     },
     {
       "name": "Vespertide",
       "description": "Vespertide configuration",
-      "fileMatch": ["**/vespertide.json"],
+      "fileMatch": [
+        "**/vespertide.json"
+      ],
       "url": "https://www.schemastore.org/vespertide.json"
     },
     {
@@ -11119,7 +13560,10 @@
     {
       "name": "openHAB",
       "description": "Configuration files for openHAB",
-      "fileMatch": ["**/conf/yaml/**/*.yml", "**/conf/yaml/**/*.yaml"],
+      "fileMatch": [
+        "**/conf/yaml/**/*.yml",
+        "**/conf/yaml/**/*.yaml"
+      ],
       "url": "https://www.schemastore.org/openhab-5.1.json",
       "versions": {
         "5.1": "https://www.schemastore.org/openhab-5.1.json"
@@ -11128,25 +13572,39 @@
     {
       "name": "unqueryvet",
       "description": "Configuration for unqueryvet - a Go linter for SQL queries",
-      "fileMatch": [".unqueryvet.yaml", ".unqueryvet.yml"],
+      "fileMatch": [
+        ".unqueryvet.yaml",
+        ".unqueryvet.yml"
+      ],
       "url": "https://raw.githubusercontent.com/MirrexOne/unqueryvet/main/schema.json"
     },
     {
       "name": "Bento",
       "description": "Bento stream configuration file",
-      "fileMatch": ["bento.json", "bento.yml", "bento.yaml"],
+      "fileMatch": [
+        "bento.json",
+        "bento.yml",
+        "bento.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/warpstreamlabs/bento/refs/heads/main/resources/schemastore/bento.json"
     },
     {
       "name": "BMML",
       "description": "Business Model Markup Language - a YAML format for describing business models based on Alexander Osterwalder's Business Model Canvas",
-      "fileMatch": ["*.bmml", "*.bmml.yaml", "*.bmml.yml"],
+      "fileMatch": [
+        "*.bmml",
+        "*.bmml.yaml",
+        "*.bmml.yml"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bmml.json"
     },
     {
       "name": "pgxgen",
       "description": "pgxgen configuration file",
-      "fileMatch": ["pgxgen.yml", "pgxgen.yaml"],
+      "fileMatch": [
+        "pgxgen.yml",
+        "pgxgen.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/tkcrm/pgxgen/refs/heads/master/schemas/pgxgen-schema.json"
     },
     {
@@ -11162,13 +13620,19 @@
     {
       "name": "pitcms",
       "description": "Configuration file for pitcms - a Git-based headless CMS",
-      "fileMatch": ["pitcms.json", "pitcms.jsonc"],
+      "fileMatch": [
+        "pitcms.json",
+        "pitcms.jsonc"
+      ],
       "url": "https://pitcms.net/schema/pitcms.schema.json"
     },
     {
       "name": "Bluebricks blueprint config",
       "description": "Bluebricks config for blueprints",
-      "fileMatch": ["bricks.json", "bricks.yaml"],
+      "fileMatch": [
+        "bricks.json",
+        "bricks.yaml"
+      ],
       "url": "https://api.bluebricks.co/docs/schemas/latest/bricks.schema.json"
     },
     {
@@ -11190,13 +13654,19 @@
     {
       "name": "oxfmt",
       "description": "Configuration file for Oxfmt, a high-performance formatter for the JavaScript ecosystem",
-      "fileMatch": ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc"],
+      "fileMatch": [
+        "**/.oxfmtrc.json",
+        "**/.oxfmtrc.jsonc"
+      ],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json"
     },
     {
       "name": "oxlint",
       "description": "Configuration file for Oxlint, a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack",
-      "fileMatch": ["**/.oxlintrc.json", "**/.oxlintrc.jsonc"],
+      "fileMatch": [
+        "**/.oxlintrc.json",
+        "**/.oxlintrc.jsonc"
+      ],
       "url": "https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxlint/configuration_schema.json"
     },
     {
@@ -11213,13 +13683,18 @@
     {
       "name": "Cursor Agent Environment",
       "description": "Cursor cloud agent environment configuration",
-      "fileMatch": ["**/.cursor/environment.json"],
+      "fileMatch": [
+        "**/.cursor/environment.json"
+      ],
       "url": "https://cursor.com/schemas/environment.schema.json"
     },
     {
       "name": "nexus-rpc-gen",
       "description": "nexus-rpc-gen configuration for generating Nexus RPC service stubs",
-      "fileMatch": ["*.nexusrpc.yaml", "*.nexusrpc.yml"],
+      "fileMatch": [
+        "*.nexusrpc.yaml",
+        "*.nexusrpc.yml"
+      ],
       "url": "https://raw.githubusercontent.com/nexus-rpc/nexus-rpc-gen/main/schemas/nexus-rpc-gen.json"
     },
     {
@@ -11234,7 +13709,9 @@
     {
       "name": "AgentCore CLI",
       "description": "Configuration file for Amazon Bedrock AgentCore CLI projects",
-      "fileMatch": ["**/agentcore/agentcore.json"],
+      "fileMatch": [
+        "**/agentcore/agentcore.json"
+      ],
       "url": "https://schema.agentcore.aws.dev/v1/agentcore.json",
       "versions": {
         "1.0": "https://schema.agentcore.aws.dev/v1/agentcore.json"
@@ -11243,25 +13720,36 @@
     {
       "name": "AgentCtl config",
       "description": "agentctl config file (.ai/config.yaml): runtimes, project name, and sync settings for AI coding-agent configuration",
-      "fileMatch": ["**/.ai/config.yaml", "**/.ai/config.yml"],
+      "fileMatch": [
+        "**/.ai/config.yaml",
+        "**/.ai/config.yml"
+      ],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/config.schema.json"
     },
     {
       "name": "AgentCtl MCP",
       "description": "agentctl MCP server declarations (.ai/mcp.yaml): Model Context Protocol servers rendered into each runtime's format",
-      "fileMatch": ["**/.ai/mcp.yaml", "**/.ai/mcp.yml"],
+      "fileMatch": [
+        "**/.ai/mcp.yaml",
+        "**/.ai/mcp.yml"
+      ],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/mcp.schema.json"
     },
     {
       "name": "AgentCtl permissions",
       "description": "agentctl runtime-neutral permissions (.ai/permissions.yaml): filesystem and shell rules using deny-over-allow precedence",
-      "fileMatch": ["**/.ai/permissions.yaml", "**/.ai/permissions.yml"],
+      "fileMatch": [
+        "**/.ai/permissions.yaml",
+        "**/.ai/permissions.yml"
+      ],
       "url": "https://raw.githubusercontent.com/itslab42/agentctl/main/schemas/permissions.schema.json"
     },
     {
       "name": "AgentLoopKit",
       "description": "Configuration file for AgentLoopKit, a repo-level engineering loop for coding agents",
-      "fileMatch": ["agentloop.config.json"],
+      "fileMatch": [
+        "agentloop.config.json"
+      ],
       "url": "https://raw.githubusercontent.com/abhiyoheswaran1/AgentLoopKit/main/schema/agentloop.config.schema.json"
     },
     {
@@ -11277,19 +13765,29 @@
     {
       "name": "Qwen Code Settings",
       "description": "Configuration file for Qwen Code",
-      "fileMatch": ["**/.qwen/settings.json"],
+      "fileMatch": [
+        "**/.qwen/settings.json"
+      ],
       "url": "https://www.schemastore.org/qwen-code-settings.json"
     },
     {
       "name": "Raid Profile",
       "description": "Definition for one or more Raid Profiles",
-      "fileMatch": ["*.raid.yaml", "*.raid.yml", "*.raid.json"],
+      "fileMatch": [
+        "*.raid.yaml",
+        "*.raid.yml",
+        "*.raid.json"
+      ],
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-profile.schema.json"
     },
     {
       "name": "Raid Repo Configuration",
       "description": "Definition for a single repository",
-      "fileMatch": ["raid.yaml", "raid.yml", "raid.json"],
+      "fileMatch": [
+        "raid.yaml",
+        "raid.yml",
+        "raid.json"
+      ],
       "url": "https://raw.githubusercontent.com/8bitAlex/raid/main/schemas/raid-repo.schema.json"
     },
     {
@@ -11323,25 +13821,35 @@
     {
       "name": "Envelope Team Definition",
       "description": "Open standard for AI agent team definitions — declare agents, roles, tools, access policies, and pipelines in a single versioned document",
-      "fileMatch": ["*.envelope.json", "team.envelope.json"],
+      "fileMatch": [
+        "*.envelope.json",
+        "team.envelope.json"
+      ],
       "url": "https://schema.openenvelope.org/team/v1.json"
     },
     {
       "name": "Acton",
       "description": "Configuration file for Acton projects",
-      "fileMatch": ["Acton.toml"],
+      "fileMatch": [
+        "Acton.toml"
+      ],
       "url": "https://raw.githubusercontent.com/ton-blockchain/acton/master/crates/acton-config/schemas/acton.schema.json"
     },
     {
       "name": "act3",
       "description": "act3 configuration file",
-      "fileMatch": ["**/act3/act3.yml"],
+      "fileMatch": [
+        "**/act3/act3.yml"
+      ],
       "url": "https://www.schemastore.org/act3.json"
     },
     {
       "name": "memnex",
       "description": "Open specification for portable meeting outputs — transcripts, summaries, action items, and decisions. https://memnex.org",
-      "fileMatch": ["*.memnex.json", "meeting-output.json"],
+      "fileMatch": [
+        "*.memnex.json",
+        "meeting-output.json"
+      ],
       "url": "https://memnex.org/schema/v0.2/meeting-output.schema.json",
       "versions": {
         "0.1": "https://memnex.org/schema/v0.1/meeting-output.schema.json",
@@ -11351,79 +13859,107 @@
     {
       "name": "runspec",
       "description": "Interface specification for anything runnable — scripts, apps, and MCP tools",
-      "fileMatch": ["runspec.toml"],
+      "fileMatch": [
+        "runspec.toml"
+      ],
       "url": "https://raw.githubusercontent.com/JasonFinestone/runspec/main/schema/runspec.schema.json"
     },
     {
       "name": "dacier.yml",
       "description": "Dacier configuration file",
-      "fileMatch": ["*.dacier.yml", "*.dacier.yaml"],
+      "fileMatch": [
+        "*.dacier.yml",
+        "*.dacier.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/daciertech/SchedulerStartup/refs/heads/main/.schemas/dacier-schema-vscode.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Project",
       "description": "QTCP project definition",
-      "fileMatch": ["**/qtcp_project.yaml"],
+      "fileMatch": [
+        "**/qtcp_project.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/project.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Task",
       "description": "Task definition within QTCP project",
-      "fileMatch": ["**/qtcp_tasks/*/task.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/task.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Dataset",
       "description": "Dataset definition within QTCP task",
-      "fileMatch": ["**/qtcp_tasks/*/datasets/*.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/datasets/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.dataset.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Schedule",
       "description": "Scheduling definition for QTCP tasks",
-      "fileMatch": ["**/qtcp_tasks/*/schedule.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/schedule.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.schedule.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Data Model",
       "description": "Data model definition for QTCP tasks",
-      "fileMatch": ["**/qtcp_tasks/*/model.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/model.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.model.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Source Selection",
       "description": "Source selection definition for QTCP tasks",
-      "fileMatch": ["**/qtcp_tasks/*/sourceSelection.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/sourceSelection.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.sourceselection.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Transformation Rules",
       "description": "Transformation rules definition for QTCP tasks",
-      "fileMatch": ["**/qtcp_tasks/*/transformationRules.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/transformationRules.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.transformationrules.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - Transformation Data Flow",
       "description": "Transformation data flow definition for QTCP tasks",
-      "fileMatch": ["**/qtcp_tasks/*/transformationDataFlows/*.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/*/transformationDataFlows/*.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/task.transformationdataflow.schema.json"
     },
     {
       "name": "Qlik Talend Cloud Pipeline - New Task Defaults",
       "description": "Default configurations for creating new QTCP tasks (via the UI)",
-      "fileMatch": ["**/qtcp_tasks/newTaskDefaults.yaml"],
+      "fileMatch": [
+        "**/qtcp_tasks/newTaskDefaults.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/qlik-oss/schemas/refs/heads/main/qtcp/newtaskdefaults.schema.json"
     },
     {
       "name": "QuikRun Configuration",
       "description": "Configuration for QuikRun",
-      "fileMatch": ["quikrun.toml"],
+      "fileMatch": [
+        "quikrun.toml"
+      ],
       "url": "https://www.schemastore.org/quikrun.json"
     },
     {
       "name": "Caido Proxy Configuration",
       "description": "Caido Proxy configuration file",
-      "fileMatch": ["caido.yml", "caido.yaml"],
+      "fileMatch": [
+        "caido.yml",
+        "caido.yaml"
+      ],
       "url": "https://raw.githubusercontent.com/caido/schemas/main/.schemastore/proxy/config.schema.json"
     },
     {
@@ -11464,19 +14000,26 @@
     {
       "name": "Slang Server Configuration",
       "description": "Configuration file for the slang-server SystemVerilog language server. Documentation: https://hudson-trading.github.io/slang-server",
-      "fileMatch": ["**/.slang/server.json", "**/.slang/local/server.json"],
+      "fileMatch": [
+        "**/.slang/server.json",
+        "**/.slang/local/server.json"
+      ],
       "url": "https://raw.githubusercontent.com/hudson-trading/slang-server/refs/heads/main/clients/vscode/resources/config.schema.json"
     },
     {
       "name": "Heloisa Assistant Plugins Marketplace",
       "description": "Validation rules for the Heloísa assistant's plugin catalog",
-      "fileMatch": ["heloisa-marketplace.json"],
+      "fileMatch": [
+        "heloisa-marketplace.json"
+      ],
       "url": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/heloisa-marketplace.json"
     },
     {
       "name": "OKF Graph",
       "description": "Graph generated for an OKF bundle",
-      "fileMatch": ["okf.json"],
+      "fileMatch": [
+        "okf.json"
+      ],
       "url": "https://www.schemastore.org/okf-0.2.json",
       "versions": {
         "0.1": "https://www.schemastore.org/okf-0.1.json",
@@ -11486,13 +14029,17 @@
     {
       "name": "Claude Code Launch Preview",
       "description": "Configuration for preview servers in Claude Code Desktop",
-      "fileMatch": ["**/.claude/launch.json"],
+      "fileMatch": [
+        "**/.claude/launch.json"
+      ],
       "url": "https://www.schemastore.org/claude-code-launch.json"
     },
     {
       "name": "ArchSmith diagram IR",
       "description": "Intermediate representation consumed by ArchSmith to validate and render architecture diagrams",
-      "fileMatch": ["*.archsmith.json"],
+      "fileMatch": [
+        "*.archsmith.json"
+      ],
       "url": "https://ayeshlk.github.io/archsmith/schema/latest/diagram-schema.json",
       "versions": {
         "0.3.0": "https://ayeshlk.github.io/archsmith/schema/0.3.0/diagram-schema.json"
@@ -11501,19 +14048,28 @@
     {
       "name": "yaml-workflow",
       "description": "Workflow definition for the yaml-workflow engine — params, tasks, steps, imports, and flows",
-      "fileMatch": ["**/*.yaml-workflow.yaml", "**/*.yaml-workflow.yml"],
+      "fileMatch": [
+        "**/*.yaml-workflow.yaml",
+        "**/*.yaml-workflow.yml"
+      ],
       "url": "https://raw.githubusercontent.com/orieg/yaml-workflow/main/schema/workflow-schema.json"
     },
     {
       "name": "servercn",
       "description": "Servercn is the backend component registry for node.js inspired by shadcn/ui",
-      "fileMatch": ["servercn.config.json", "servercn.json"],
+      "fileMatch": [
+        "servercn.config.json",
+        "servercn.json"
+      ],
       "url": "https://www.akkaldhami.com.np/schema/servercn.config.json"
     },
     {
       "name": "hitf-cli-md",
       "description": "hitf-cli translation toolkit    configuration file",
-      "fileMatch": [".hias-hitf.json", ".hias-hitf.jsonc"],
+      "fileMatch": [
+        ".hias-hitf.json",
+        ".hias-hitf.jsonc"
+      ],
       "url": "https://www.schemastore.org/hias-hitf.json"
     }
   ]


### PR DESCRIPTION
Adds a catalog entry for [Context Passport](https://github.com/contextpassport/spec), an open specification for tamper-evident records of AI agent events.

A passport is a JSON document recording what an agent was asked, what it decided, and a SHA-256 `integrity` block linking it to the record before it. Editing any record changes its hash and breaks verification of every record after it, so the chain is checkable by anyone holding it, offline.

**Schema:** `https://contextpassport.com/schema/v2.json` — JSON Schema draft-07, with `$id` set, served as `application/json`.

### On `fileMatch`

`["*.passport.json"]`, which the specification defines in [§3.5](https://github.com/contextpassport/spec/blob/main/SPEC.md#35-file-naming-non-normative). The convention was added specifically so a pattern could be specific rather than generic — I read the guidance about `config.toml` and did not want to submit anything in that shape.

Only the singular form is registered. The specification also defines `*.passports.json` for a file holding an *array* of records, but this schema describes a single object, so matching the plural would report every valid chain as invalid. If an array schema is published later I would submit that separately.

### Honest note on uptake

This is a new specification and I am not going to claim adoption it does not have. What I can point to concretely:

- CC0 specification with a published [conformance suite](https://github.com/contextpassport/conformance-tests) and CC0 test vectors
- Two Apache-2.0 reference implementations, [Python](https://github.com/contextpassport/python) and [TypeScript](https://github.com/contextpassport/typescript), on PyPI and npm
- Four implementations listed in [IMPLEMENTATIONS.md](https://github.com/contextpassport/spec/blob/main/IMPLEMENTATIONS.md), each at the conformance level it has actually passed
- The format is already emitted by an MCP server published in the official [MCP registry](https://registry.modelcontextprotocol.io)

Happy to withdraw if you would rather wait for evidence of wider use. I would rather ask than take up review time under a false impression.