### PR TITLE
Update tox JSON Schema to 4.61.0

### DIFF
--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -531,8 +531,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "type": "object",
       "$ref": "#/properties/env_run_base",
+      "type": "object",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -619,10 +619,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "name"
-      ],
+      "required": ["replace", "name"],
       "additionalProperties": false
     },
     "replace_ref": {
@@ -664,9 +661,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_posargs": {
@@ -689,9 +684,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_glob": {
@@ -724,10 +717,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "pattern"
-      ],
+      "required": ["replace", "pattern"],
       "additionalProperties": false
     },
     "replace_if": {
@@ -749,11 +739,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "condition",
-        "then"
-      ],
+      "required": ["replace", "condition", "then"],
       "additionalProperties": false
     },
     "replace_object": {
@@ -778,9 +764,7 @@
     },
     "factor_range_dict": {
       "type": "object",
-      "required": [
-        "prefix"
-      ],
+      "required": ["prefix"],
       "properties": {
         "prefix": {
           "type": "string"
@@ -800,9 +784,7 @@
     },
     "factor_values_dict": {
       "type": "object",
-      "required": [
-        "values"
-      ],
+      "required": ["values"],
       "properties": {
         "values": {
           "type": "array",
@@ -825,9 +807,7 @@
         "properties": {
           "prefix": {}
         },
-        "required": [
-          "prefix"
-        ]
+        "required": ["prefix"]
       },
       "additionalProperties": {
         "oneOf": [
@@ -870,9 +850,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "product"
-          ],
+          "required": ["product"],
           "properties": {
             "product": {
               "type": "array",

--- a/src/schemas/json/tox.json
+++ b/src/schemas/json/tox.json
@@ -531,8 +531,8 @@
       "additionalProperties": true
     },
     "env_pkg_base": {
-      "$ref": "#/properties/env_run_base",
       "type": "object",
+      "$ref": "#/properties/env_run_base",
       "description": "base configuration for packaging environments",
       "x-taplo": {
         "links": {
@@ -619,7 +619,10 @@
           "type": "string"
         }
       },
-      "required": ["replace", "name"],
+      "required": [
+        "replace",
+        "name"
+      ],
       "additionalProperties": false
     },
     "replace_ref": {
@@ -661,7 +664,9 @@
           "type": "string"
         }
       },
-      "required": ["replace"],
+      "required": [
+        "replace"
+      ],
       "additionalProperties": false
     },
     "replace_posargs": {
@@ -684,7 +689,9 @@
           "type": "string"
         }
       },
-      "required": ["replace"],
+      "required": [
+        "replace"
+      ],
       "additionalProperties": false
     },
     "replace_glob": {
@@ -717,7 +724,10 @@
           "type": "string"
         }
       },
-      "required": ["replace", "pattern"],
+      "required": [
+        "replace",
+        "pattern"
+      ],
       "additionalProperties": false
     },
     "replace_if": {
@@ -739,7 +749,11 @@
           "type": "string"
         }
       },
-      "required": ["replace", "condition", "then"],
+      "required": [
+        "replace",
+        "condition",
+        "then"
+      ],
       "additionalProperties": false
     },
     "replace_object": {
@@ -764,7 +778,9 @@
     },
     "factor_range_dict": {
       "type": "object",
-      "required": ["prefix"],
+      "required": [
+        "prefix"
+      ],
       "properties": {
         "prefix": {
           "type": "string"
@@ -774,23 +790,60 @@
         },
         "stop": {
           "type": "integer"
+        },
+        "default": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
       "description": "range factor group: expands to prefix+N for N in [start, stop]"
+    },
+    "factor_values_dict": {
+      "type": "object",
+      "required": [
+        "values"
+      ],
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "description": "factor group with an explicit list and a default used when none of it is active"
     },
     "factor_labeled_dict": {
       "type": "object",
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": ["prefix"]
+        "properties": {
+          "prefix": {}
+        },
+        "required": [
+          "prefix"
+        ]
       },
       "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/definitions/factor_range_dict"
+          },
+          {
+            "$ref": "#/definitions/factor_values_dict"
+          }
+        ]
       },
       "description": "labeled factor group for {factor:label} substitution"
     },
@@ -817,7 +870,9 @@
         },
         {
           "type": "object",
-          "required": ["product"],
+          "required": [
+            "product"
+          ],
           "properties": {
             "product": {
               "type": "array",


### PR DESCRIPTION
Updates tox's JSON Schema to [aa8f46c79b24de9c20e459f9838c1fcc93dc9eb5](https://github.com/tox-dev/tox/commit/aa8f46c79b24de9c20e459f9838c1fcc93dc9eb5) (release 4.61.0).