### PR TITLE
feat(claude-code-settings): add modelPicker, spinnerTipsOverride tipsFile/label

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-model-picker-row.json
+++ b/src/negative_test/claude-code-settings/invalid-model-picker-row.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "modelPicker": {
+    "options": [
+      {
+        "label": "Missing the required model field"
+      }
+    ]
+  }
+}

--- a/src/negative_test/claude-code-settings/invalid-spinner-tip-cooldown.json
+++ b/src/negative_test/claude-code-settings/invalid-spinner-tip-cooldown.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "tips": [
+      {
+        "cooldownSessions": 1001,
+        "id": "valid-id",
+        "text": "Cooldown must not exceed 1000 sessions"
+      }
+    ]
+  }
+}

--- a/src/negative_test/claude-code-settings/invalid-spinner-tip-entry.json
+++ b/src/negative_test/claude-code-settings/invalid-spinner-tip-entry.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "tips": [
+      {
+        "id": "not a valid id",
+        "text": "The id may only contain letters, digits, dots, underscores and hyphens"
+      }
+    ]
+  }
+}

--- a/src/negative_test/claude-code-settings/invalid-spinner-tip-label.json
+++ b/src/negative_test/claude-code-settings/invalid-spinner-tip-label.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "label": "This spinner-tip prefix deliberately exceeds forty characters",
+    "tips": ["Use a label with at most forty characters"]
+  }
+}

--- a/src/negative_test/claude-code-settings/invalid-spinner-tip-priority.json
+++ b/src/negative_test/claude-code-settings/invalid-spinner-tip-priority.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "tips": [
+      {
+        "id": "valid-id",
+        "priority": 11,
+        "text": "Priority must be between minus ten and ten"
+      }
+    ]
+  }
+}

--- a/src/negative_test/claude-code-settings/invalid-spinner-tips-file-relative.json
+++ b/src/negative_test/claude-code-settings/invalid-spinner-tips-file-relative.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "tipsFile": "tips/spinner-tips.json"
+  }
+}

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -3383,7 +3383,7 @@
     },
     "spinnerTipsOverride": {
       "type": "object",
-      "description": "Add your own tips to the spinner tip rotation shown while Claude is working. See https://code.claude.com/docs/en/settings#available-settings",
+      "description": "Add your own tips to the spinner tip rotation shown while Claude is working. See https://code.claude.com/docs/en/settings-reference#spinnertipsoverride",
       "properties": {
         "excludeDefault": {
           "type": "boolean",
@@ -3417,11 +3417,14 @@
                   "cooldownSessions": {
                     "type": "integer",
                     "minimum": 0,
+                    "maximum": 1000,
                     "description": "Sessions to wait before showing this tip again",
                     "default": 0
                   },
                   "priority": {
                     "type": "number",
+                    "minimum": -10,
+                    "maximum": 10,
                     "description": "Tie-break weight among never-shown tips",
                     "default": 0
                   }
@@ -3436,10 +3439,11 @@
         },
         "tipsFile": {
           "type": "string",
-          "description": "Absolute or ~/ local path to a JSON file holding an array of tips (same shapes as `tips`); honored from user, --settings and on-disk managed settings only. Read once per CLI process (restart to pick up edits)"
+          "description": "Absolute or ~/ local path to a JSON file holding an array of tips or an object with a `tips` array (same shapes as `tips`), up to 256 KB; honored from user, --settings and on-disk managed settings only. Read once per CLI process (restart to pick up edits)"
         },
         "label": {
           "type": "string",
+          "maxLength": 40,
           "description": "Prefix shown before your tips in the spinner",
           "default": "Tip"
         }

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -2011,6 +2011,43 @@
         }
       ]
     },
+    "modelPicker": {
+      "type": "object",
+      "description": "Curate the /model picker: an ordered list of models with your own labels, independent of the built-in lineup and of Claude Code releases. availableModels still applies to these rows. Honored from managed, --settings/SDK, and user settings only (not from a project checkout); the highest-precedence of those that defines modelPicker wins outright (no merging across sources). Typically set in managed settings by enterprise administrators",
+      "properties": {
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Model to select, taken verbatim: an alias (\"opus\"), an Anthropic model ID, or a provider-format ID (Vertex, Bedrock, gateway). Same values --model accepts"
+              },
+              "label": {
+                "type": "string",
+                "description": "Row title. Defaults to the model name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Row subtitle. Defaults to a generic description"
+              }
+            },
+            "required": ["model"],
+            "additionalProperties": false
+          },
+          "description": "Rows to show in the /model picker, in order"
+        },
+        "replaceBuiltInOptions": {
+          "type": "boolean",
+          "description": "When true, the picker shows only the Default row and these options - the built-in lineup, gateway-discovered models and ANTHROPIC_CUSTOM_MODEL_OPTION are hidden. When false or unset, these options are added after the built-in lineup",
+          "default": false
+        }
+      },
+      "required": ["options"],
+      "additionalProperties": false
+    },
     "effortLevel": {
       "type": "string",
       "enum": ["low", "medium", "high", "xhigh"],
@@ -3346,7 +3383,7 @@
     },
     "spinnerTipsOverride": {
       "type": "object",
-      "description": "Customize the tips displayed in the spinner while Claude is working. See https://code.claude.com/docs/en/settings#available-settings",
+      "description": "Add your own tips to the spinner tip rotation shown while Claude is working. See https://code.claude.com/docs/en/settings#available-settings",
       "properties": {
         "excludeDefault": {
           "type": "boolean",
@@ -3356,14 +3393,57 @@
         "tips": {
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 500,
+                "description": "A tip, as a plain string. Maximum 500 characters, one line"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9._-]{1,64}$",
+                    "description": "Stable id (letters, digits, \".\", \"_\", \"-\"; max 64). Used to deduplicate tips and to track when each was last shown"
+                  },
+                  "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 500,
+                    "description": "The tip. Maximum 500 characters, one line"
+                  },
+                  "cooldownSessions": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Sessions to wait before showing this tip again",
+                    "default": 0
+                  },
+                  "priority": {
+                    "type": "number",
+                    "description": "Tie-break weight among never-shown tips",
+                    "default": 0
+                  }
+                },
+                "required": ["id", "text"],
+                "additionalProperties": false
+              }
+            ]
           },
-          "description": "Custom tip strings to display in the spinner",
-          "minItems": 1
+          "minItems": 1,
+          "description": "Custom tips to display in the spinner. Each entry is either a plain string or a tip object"
+        },
+        "tipsFile": {
+          "type": "string",
+          "description": "Absolute or ~/ local path to a JSON file holding an array of tips (same shapes as `tips`); honored from user, --settings and on-disk managed settings only. Read once per CLI process (restart to pick up edits)"
+        },
+        "label": {
+          "type": "string",
+          "description": "Prefix shown before your tips in the spinner",
+          "default": "Tip"
         }
       },
-      "required": ["tips"],
       "additionalProperties": false
     },
     "terminalProgressBarEnabled": {

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -3439,6 +3439,7 @@
         },
         "tipsFile": {
           "type": "string",
+          "pattern": "^(~(/|$)|/|\\\\|[A-Za-z]:[/\\\\])",
           "description": "Absolute or ~/ local path to a JSON file holding an array of tips or an object with a `tips` array (same shapes as `tips`), up to 256 KB; honored from user, --settings and on-disk managed settings only. Read once per CLI process (restart to pick up edits)"
         },
         "label": {

--- a/src/test/claude-code-settings/model-picker.json
+++ b/src/test/claude-code-settings/model-picker.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "modelPicker": {
+    "options": [
+      { "model": "opus" },
+      {
+        "description": "Everyday work",
+        "label": "Sonnet",
+        "model": "sonnet"
+      },
+      {
+        "label": "Sonnet (Bedrock)",
+        "model": "anthropic.claude-sonnet-4-5-20250929-v1:0"
+      }
+    ],
+    "replaceBuiltInOptions": true
+  }
+}

--- a/src/test/claude-code-settings/spinner-tips-file-windows.json
+++ b/src/test/claude-code-settings/spinner-tips-file-windows.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "tipsFile": "C:\\Users\\me\\claude\\spinner-tips.json"
+  }
+}

--- a/src/test/claude-code-settings/spinner-tips-file.json
+++ b/src/test/claude-code-settings/spinner-tips-file.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "excludeDefault": true,
+    "label": "Reminder",
+    "tipsFile": "~/.config/claude/spinner-tips.json"
+  }
+}

--- a/src/test/claude-code-settings/spinner-tips-object-entries.json
+++ b/src/test/claude-code-settings/spinner-tips-object-entries.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerTipsOverride": {
+    "excludeDefault": false,
+    "label": "Tip",
+    "tips": [
+      "Run the test suite before pushing",
+      {
+        "id": "style-guide",
+        "text": "Check the style guide before renaming a public API"
+      },
+      {
+        "cooldownSessions": 20,
+        "id": "review.turnaround_1",
+        "priority": 5,
+        "text": "Ask for a review early rather than at the end"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
![agent](https://img.shields.io/badge/agent-claude-D97757)

Claude Code v2.1.243 added `modelPicker`, and v2.1.247 added `tipsFile`, `label` and object-form tip entries to `spinnerTipsOverride`. Neither is described here yet, and the current `spinnerTipsOverride` shape now **rejects valid configurations**.

## `spinnerTipsOverride`

- Add `tipsFile` — a path to a JSON file holding the same tip shapes, so the tip content can live outside `settings.json`. Constrained to the path forms the CLI accepts (absolute or `~`/`~/`-rooted; relative paths are ignored at runtime).
- Add `label` — the prefix shown before custom tips (default `"Tip"`, effective limit 40 characters).
- `tips` entries may now be a plain string **or** `{id, text, cooldownSessions?, priority?}`, with the numeric bounds the CLI applies (`cooldownSessions` 0–1000, `priority` −10…10).
- **Drop `required: ["tips"]`.** The CLI marks `tips` optional, and a `tipsFile`-only override is valid — that is the configuration the new setting exists to enable, and the current schema flags it as an error.

## `modelPicker`

An ordered list of `{model, label?, description?}` rows for the `/model` picker, plus `replaceBuiltInOptions`. Added next to `modelOverrides`.

## Where the descriptions and constraints come from

Field descriptions, the 500-character tip limit, the `^[A-Za-z0-9._-]{1,64}$` id pattern, the numeric bounds, and the notes about which settings tiers each key is read from are taken from the CLI's own schema descriptions and runtime normalization rather than paraphrased, so they should stay accurate against the tool.

Two deliberate judgement calls, flagged so they are easy to overrule:

- The tip object uses `additionalProperties: false`, matching the prevailing style in this file (`spinnerVerbs` and neighbours), even though the CLI itself is permissive there. Happy to relax it if you prefer to mirror the tool exactly.
- `cooldownSessions` is typed `integer` (a session count) while `priority` is `number`, since the CLI accepts any finite number there and truncates it (`Math.trunc` + clamp).

## Tests

Positive — `src/test/claude-code-settings/`:

- `spinner-tips-file.json` — a `tipsFile`-only override, which the current schema rejects
- `spinner-tips-file-windows.json` — a Windows drive-rooted `tipsFile` path
- `spinner-tips-object-entries.json` — mixed string and object tips
- `model-picker.json` — alias, labelled, and provider-format (Bedrock) rows

Negative — `src/negative_test/claude-code-settings/`:

- `invalid-spinner-tip-entry.json` — a tip id containing spaces
- `invalid-spinner-tip-cooldown.json` — `cooldownSessions` above 1000
- `invalid-spinner-tip-priority.json` — `priority` outside −10…10
- `invalid-spinner-tip-label.json` — a `label` longer than 40 characters
- `invalid-spinner-tips-file-relative.json` — a relative `tipsFile` path
- `invalid-model-picker-row.json` — a picker row missing the required `model`

## Review

Copilot's review round is addressed in 96f1dc6 and 01cced6: numeric bounds on `cooldownSessions`/`priority`, `maxLength` on `label`, and a `tipsFile` path pattern — each verified against the CLI's (2.1.251) runtime normalization before adopting. The tip object stays closed per the judgement call above.

## Verification

- `node ./cli.js check --schema-name=claude-code-settings.json` passes.
- `npm run prettier` reports no formatting differences repo-wide.
- `node ./cli.js check-strict --schema-name=claude-code-settings.json` reports **the same single pre-existing error** on this branch as on `master` (`/$defs/hookCommand/anyOf/0/properties/type` missing `title`), so this change adds no new strict-metaschema failures. It is untouched here since it is unrelated.
- Confirmed the negative tests actually bite: temporarily rewriting one to be valid makes `check` fail with "Schema validation succeeded ... but was supposed to fail", and restoring it makes `check` pass again.
