### PR TITLE
Add Vee JSON menu output

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8001,6 +8001,11 @@
       "url": "https://www.schemastore.org/vector.json"
     },
     {
+      "name": "Vee JSON menu output",
+      "description": "Structured JSON printed by a Vee menu-bar plugin, the alternative to the xbar/SwiftBar text protocol",
+      "url": "https://vee.navbytes.io/schemas/json-output.schema.json"
+    },
+    {
       "name": "vega.json",
       "description": "Vega visualization specification file",
       "fileMatch": ["*.vg", "*.vg.json"],


### PR DESCRIPTION
Registers the self-hosted schema for [Vee](https://github.com/navbytes/vee)'s JSON menu output — the structured JSON a Vee menu-bar plugin prints to stdout (the alternative to the xbar/SwiftBar text protocol).

- Schema: https://vee.navbytes.io/schemas/json-output.schema.json (draft 2020-12, served with a stable `$id`, validated in the project's CI against its shipped fixtures)
- Docs: https://vee.navbytes.io/guide/json-output/
- `fileMatch` is omitted intentionally: the JSON is program output, not a well-known filename; authors reference the schema via the inline `$schema` key, which the app ignores.