### PR TITLE
Update crucible-code schema for 0.28.0

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-rung.json
+++ b/src/negative_test/crucible-code-schema/not-a-rung.json
@@ -1,0 +1,3 @@
+{
+  "providers": { "anthropic": { "effort": "hardest" } }
+}

--- a/src/negative_test/crucible-code-schema/not-a-tone.json
+++ b/src/negative_test/crucible-code-schema/not-a-tone.json
@@ -1,0 +1,3 @@
+{
+  "systemPrompt": { "tone": "verbose" }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -299,6 +299,39 @@
       },
       "type": "object"
     },
+    "systemPrompt": {
+      "additionalProperties": false,
+      "description": "What the model is asked under: how much it explains, and anything you would rather it were told instead",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "append": {
+          "description": "Instructions to add to crucible's own, said after them and every turn",
+          "examples": [
+            "This repository is deployed on Fridays; never push to main."
+          ],
+          "type": "string"
+        },
+        "custom": {
+          "description": "Instructions to ask every turn under in place of crucible's own, replacing them entirely. Read only from the configuration file in your home directory",
+          "examples": [
+            "You are a reviewer. Read and explain; never edit a file."
+          ],
+          "type": "string"
+        },
+        "tone": {
+          "default": "concise",
+          "description": "How much of the reasoning comes back with the answer: concise for the conclusion, explanatory for why it is that one, learning for what to know before touching the code again",
+          "enum": ["concise", "explanatory", "learning"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "updates": {
       "additionalProperties": false,
       "description": "Whether crucible finds out that a newer release exists",

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -46,6 +46,11 @@
       "model": "gpt-5.2"
     }
   },
+  "systemPrompt": {
+    "append": "This repository is deployed on Fridays; never push to main.",
+    "custom": "You are a reviewer. Read and explain; never edit a file.",
+    "tone": "explanatory"
+  },
   "updates": {
     "check": "never"
   }


### PR DESCRIPTION
crucible 0.28.0 adds a `systemPrompt` block to the configuration document, so the served copy no longer describes the newest release. The schema is generated from the program's own shape declaration and a gate keeps the checked-in copy honest, so this is that file with your `prettier` config run over it — the diff is 33 added lines and nothing else moved.

The three keys:

- `tone` — `concise`, `explanatory` or `learning`; how much of the reasoning comes back with an answer.
- `append` — a paragraph added to crucible's own instructions.
- `custom` — instructions replacing them, read only from the user's home configuration file.

`src/test/crucible-code-schema/config.json` exists to exercise every block, so it gains this one. `src/negative_test/crucible-code-schema/not-a-tone.json` covers a tone outside the enum, matching the existing `not-a-choice`, `not-a-mode` and `not-a-send` fixtures.

Verified with `node ./cli.js check --schema-name=crucible-code-schema.json` — exit 0. I also checked the negative test is doing work: changing its tone to a valid one turns the run red with "validation succeeded … but was supposed to fail".

Upstream release: https://github.com/augments-labs/crucible-code/releases/tag/v0.28.0