### PR TITLE
fix: make multi-ecosystem patterns optional

### DIFF
--- a/src/schemas/json/dependabot-2.0.json
+++ b/src/schemas/json/dependabot-2.0.json
@@ -1214,20 +1214,6 @@
               "required": ["directory"]
             }
           ]
-        },
-        {
-          "$comment": "If multi-ecosystem-group is specified, patterns is required",
-          "if": {
-            "required": ["multi-ecosystem-group"]
-          },
-          "then": {
-            "properties": {
-              "patterns": {
-                "$ref": "#/definitions/update/properties/patterns"
-              }
-            },
-            "required": ["patterns"]
-          }
         }
       ]
     },


### PR DESCRIPTION
Fixes #6219

Removes the conditional that required `patterns` whenever `multi-ecosystem-group` is present. GitHub documents `patterns` as optional in this configuration, with omission applying the group to all dependencies in the ecosystem.

Validation:
- `python3 -m json.tool src/schemas/json/dependabot-2.0.json`
- `npm run prettier`
- `npm run typecheck`
- `npm run eslint`
