### PR TITLE
fix: fix MegaLinter schema URLs

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5089,19 +5089,19 @@
         "*.mega-linter-config.yml",
         "*.megalinter-config.yml"
       ],
-      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
+      "url": "https://raw.githubusercontent.com/oxsecurity/megalinter/main/megalinter/descriptors/schemas/megalinter-configuration.jsonschema.json"
     },
     {
       "name": "MegaLinter Custom Flavor",
       "description": "MegaLinter Custom Flavor definition file",
       "fileMatch": ["megalinter-custom-flavor.yml"],
-      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-custom-flavor.jsonschema.json"
+      "url": "https://raw.githubusercontent.com/oxsecurity/megalinter/main/megalinter/descriptors/schemas/megalinter-custom-flavor.jsonschema.json"
     },
     {
       "name": "MegaLinter descriptor",
       "description": "MegaLinter descriptor files (for MegaLinter contributors)",
       "fileMatch": ["*.megalinter-descriptor.yml"],
-      "url": "https://raw.githubusercontent.com/megalinter/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
+      "url": "https://raw.githubusercontent.com/oxsecurity/megalinter/main/megalinter/descriptors/schemas/megalinter-descriptor.jsonschema.json"
     },
     {
       "name": "Meltano project definition",


### PR DESCRIPTION
MegaLinter moved from megalinter/megalinter to oxsecurity/megalinter. While this may have been redirected for some time, the old URLs result in HTTP status 400 Bad Request now.

All modified URLs verified to work.

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
