### PR TITLE
Add Tesseract configuration (tesseract_config.yaml)

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -7681,6 +7681,12 @@
       "url": "https://www.schemastore.org/tfpowershell-settings.json"
     },
     {
+      "name": "Tesseract configuration",
+      "description": "Configuration file for a Tesseract (tesseract_config.yaml)",
+      "fileMatch": ["tesseract_config.yaml", "tesseract_config.yml"],
+      "url": "https://docs.pasteurlabs.ai/projects/tesseract-core/stable/tesseract_config.schema.json"
+    },
+    {
       "name": "Tier.run pricing.json",
       "description": "Tier.run pricing model configuration",
       "fileMatch": ["pricing.json"],


### PR DESCRIPTION
Adds a catalog entry for `tesseract_config.yaml`, the configuration file for a [Tesseract](https://github.com/pasteurlabs/tesseract-core) — a tool for packaging simulation/ML components into differentiable, containerized units.

### What this registers
- **`fileMatch`**: `tesseract_config.yaml` / `tesseract_config.yml` — a distinctive, non-generic filename, so no false-positive risk against other configs.
- **`url`**: points at our self-hosted schema, regenerated from the `TesseractConfig` model on every docs build and served from the `stable` docs alias, which always tracks the latest tagged release. No per-release re-submission needed.

### Self-hosted, so catalog-only
Following the [self-hosted/remote/external](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal) guidance, this PR only registers the catalog entry, no in-repo schema file or test fixtures, since those key to a local `src/schemas/json/*.json` that doesn't exist for an external URL.

Verified locally with `node ./cli.js check` (passes) and `prettier --check`.
