### PR TITLE
Update crucible-code schema for 0.31.0

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-prompt-cache-mode.json
+++ b/src/negative_test/crucible-code-schema/not-a-prompt-cache-mode.json
@@ -1,0 +1,3 @@
+{
+  "promptCaching": { "mode": "automatic" }
+}

--- a/src/negative_test/crucible-code-schema/not-a-retention-class.json
+++ b/src/negative_test/crucible-code-schema/not-a-retention-class.json
@@ -1,0 +1,3 @@
+{
+  "promptCaching": { "requestedRetention": { "class": "forever" } }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -212,6 +212,93 @@
       },
       "type": "object"
     },
+    "promptCaching": {
+      "additionalProperties": false,
+      "description": "Provider-side reuse of an identical prompt prefix, enabled through each provider's verified native mechanism by default",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "allowedMechanisms": {
+          "description": "Provider-neutral cache mechanisms still permitted after capability resolution; layers intersect this list",
+          "items": {
+            "enum": [
+              "providerManagedUsageOnly",
+              "automaticPrefix",
+              "explicitBreakpoints",
+              "persistentContent"
+            ],
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "isolationScope": {
+          "default": "session",
+          "description": "Broadest identity scope allowed to share a cache prefix",
+          "enum": ["run", "session", "workspace", "user"],
+          "type": "string"
+        },
+        "mode": {
+          "default": "prefer",
+          "description": "Whether Crucible observes provider caching, prefers the verified native mechanism, requires it, or requires a documented opt-out",
+          "enum": ["observeOnly", "prefer", "require", "prohibit"],
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Bounded opaque user-owned label included in cache scope identity; never a provider cache key",
+          "examples": ["personal"],
+          "type": "string"
+        },
+        "persistentResources": {
+          "additionalProperties": false,
+          "description": "Separate authority for remotely persisted cached-content resources",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "mode": {
+              "default": "forbid",
+              "description": "Whether remote persistent cache resources are forbidden, reusable, creatable, or required; creation authority must come from user configuration",
+              "enum": ["forbid", "reuse", "create", "require"],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "requestedRetention": {
+          "additionalProperties": false,
+          "description": "Optional provider-neutral retention request under a hard duration ceiling",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "class": {
+              "default": "providerDefault",
+              "description": "Provider-neutral retention class; extended retention must be chosen in the user configuration",
+              "enum": ["providerDefault", "ephemeral", "extended"],
+              "type": "string"
+            },
+            "maxSeconds": {
+              "description": "Hard maximum provider retention in seconds; required for ephemeral and extended retention",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "provider": {
       "description": "Which provider to ask, by the name --model qualifies a model with. Read only from the configuration file in your home directory",
       "type": "string"

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -30,6 +30,24 @@
     "extraDirectories": ["/home/you/src/shared-library"],
     "mode": "allowEdits"
   },
+  "promptCaching": {
+    "allowedMechanisms": [
+      "providerManagedUsageOnly",
+      "automaticPrefix",
+      "explicitBreakpoints",
+      "persistentContent"
+    ],
+    "isolationScope": "workspace",
+    "mode": "require",
+    "namespace": "personal",
+    "persistentResources": {
+      "mode": "create"
+    },
+    "requestedRetention": {
+      "class": "extended",
+      "maxSeconds": 3600
+    }
+  },
   "provider": "anthropic",
   "providers": {
     "anthropic": {


### PR DESCRIPTION
## Summary

- publish the promptCaching configuration added in crucible-code v0.31.0
- cover every new field in the positive fixture
- add isolated negative cases for invalid cache mode and retention class

Release: https://github.com/augments-labs/crucible-code/releases/tag/v0.31.0

## Verification

- node ./cli.js check --schema-name=crucible-code-schema.json
- node ./cli.js check
- npm run prettier
- npm run typecheck
- canonical JSON matches the schema shipped in v0.31.0