### PR TITLE
fix: enable strict validation for Jovo language model

### DIFF
--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -118,7 +118,6 @@
     "hemtt-0.6.2.json",
     "install.json",
     "jest.json",
-    "jovo-language-model.json",
     "jsdoc-1.0.0.json",
     "jsone.json",
     "kestra-0.18.0.json",

--- a/src/schemas/json/jovo-language-model.json
+++ b/src/schemas/json/jovo-language-model.json
@@ -64,15 +64,22 @@
                   "type": "string"
                 },
                 "type": {
-                  "type": ["string", "object"],
-                  "properties": {
-                    "alexa": {
+                  "oneOf": [
+                    {
                       "type": "string"
                     },
-                    "dialogflow": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "alexa": {
+                          "type": "string"
+                        },
+                        "dialogflow": {
+                          "type": "string"
+                        }
+                      }
                     }
-                  }
+                  ]
                 },
                 "dialogflow": {
                   "$ref": "#/definitions/dialogflowEntity"


### PR DESCRIPTION
Fixes part of #6038.

This replaces the non-strict union type in `jovo-language-model.json` with equivalent `oneOf` branches, then removes the schema from `ajvNotStrictMode`.

Validation completed locally:
- `npm run prettier -- --check src/schemas/json/jovo-language-model.json src/schema-validation.jsonc`
- `npm run typecheck`
- `npm run eslint`
- `node ./cli.js check`
- `node ./cli.js coverage`
- `git diff --check`