### PR TITLE
Migrate Renovate 39 and 40 schemas to draft-07

### DIFF
--- a/src/schemas/json/renovate-39.json
+++ b/src/schemas/json/renovate-39.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/renovate-39.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/renovate-39.json",
   "title": "JSON schema for Renovate config files (https://renovatebot.com/)",
   "type": "object",
   "properties": {

--- a/src/schemas/json/renovate-40.json
+++ b/src/schemas/json/renovate-40.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://json.schemastore.org/renovate-40.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/renovate-40.json",
   "title": "JSON schema for Renovate config files (https://renovatebot.com/)",
   "type": "object",
   "properties": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

## Summary

Migrate the remaining Renovate 39 and 40 schemas from JSON Schema draft-04 to draft-07. This updates `$schema` and replaces the draft-04 `id` keyword with `$id`.

## Validation

- `python3 -m json.tool src/schemas/json/renovate-39.json`
- `python3 -m json.tool src/schemas/json/renovate-40.json`
- `npm run prettier -- src/schemas/json/renovate-39.json src/schemas/json/renovate-40.json`
- `npm run typecheck`
- `git diff --check`

Part of #6019
