### PR TITLE
feat: add Arity, Badness, and Fatou schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -582,6 +582,12 @@
       "url": "https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/jsonschema/schema.json"
     },
     {
+      "name": "Arity",
+      "description": "Configuration file for Arity, a language server, formatter, and linter for R",
+      "fileMatch": ["arity.toml"],
+      "url": "https://arity.cc/arity.schema.json"
+    },
+    {
       "name": "artifacthub-repo.yml",
       "description": "Artifact Hub repository metadata file",
       "fileMatch": ["artifacthub-repo.yml"],
@@ -1138,6 +1144,12 @@
       "url": "https://fasterci.com/config.schema.json"
     },
     {
+      "name": "Fatou",
+      "description": "Configuration file for Fatou, a language server, formatter, and linter for Julia",
+      "fileMatch": ["fatou.toml"],
+      "url": "https://fatou.dev/fatou.schema.json"
+    },
+    {
       "name": "Fence configuration",
       "description": "Configuration file for fence, a lightweight, container-free sandbox for running commands with network and filesystem restrictions",
       "fileMatch": ["fence.json"],
@@ -1217,6 +1229,12 @@
       "description": "Backport configuration file",
       "fileMatch": [".backportrc.json"],
       "url": "https://www.schemastore.org/backportrc.json"
+    },
+    {
+      "name": "Badness",
+      "description": "Configuration file for Badness, a language server, formatter, and linter for LaTeX",
+      "fileMatch": ["badness.toml"],
+      "url": "https://badness.dev/badness.schema.json"
     },
     {
       "name": "basedpyright",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

This PR adds schemas for three different tools, which are all all-in-one language server + linter + formatter combos:

- Badness (https://badness.dev), for LaTeX
- Fatou (https://fatou.dev), for Julia
- Arity (https://arity.cc), for R

All schemas are published at the respective websites and use draft-07. They are schemas for the configration (TOML) files for each tool
