### PR TITLE
feat: add missing settings and fix enum in `pnpm-workspace` schema

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -475,6 +475,15 @@
       "description": "Sets the maximum allowed length of directory names inside the virtual store directory (node_modules/.pnpm).",
       "type": "number"
     },
+    "virtualStoreType": {
+      "description": "Determines where the virtual store is located. When set to project, a separate virtual store is created in each project's node_modules/.pnpm. When set to global, a single store is shared by every project on the machine, with each project's node_modules holding only symlinks into it. Added in pnpm v11.23.0.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["project", "global"]
+        }
+      ]
+    },
     "packageImportMethod": {
       "description": "Controls the way packages are imported from the store (if you want to disable symlinks inside node_modules, then you need to change the nodeLinker setting, not this one).",
       "oneOf": [
@@ -498,6 +507,14 @@
     },
     "verifyStoreIntegrity": {
       "description": "By default, if a file in the store has been modified, the content of this file is checked before linking it to a project's node_modules. ",
+      "type": "boolean"
+    },
+    "useRunningStoreServer": {
+      "description": "Deprecated. Only allows installation with a store server. If no store server is running, installation will fail.",
+      "type": "boolean"
+    },
+    "frozenStore": {
+      "description": "Makes pnpm install work against a read-only package store (such as a Nix store or OCI image layer). When enabled, pnpm opens the store's SQLite database in immutable mode and never writes to the store. Works best together with --offline and --frozen-lockfile; incompatible with --force. Added in pnpm v11.7.0.",
       "type": "boolean"
     },
     "strictStorePkgContentCheck": {
@@ -830,6 +847,28 @@
       "description": "Allows to set the target directory for the bin files of globally installed packages.",
       "type": "string"
     },
+    "globalShims": {
+      "description": "Controls which globally installed packages get project-aware shims, which are global commands that run the version specified by the current project instead of the globally installed one. A boolean disables (false) or resets to the defaults (true), while an object maps package names to a policy: \"auto\" (or true) to switch automatically when publisher-authenticated, \"prompt\" to confirm on each use, \"always\" to switch unconditionally, or false to disable. Object entries merge with the built-in defaults ({\"node\": \"auto\", \"deno\": \"auto\", \"bun\": \"auto\"}). Added in pnpm v12.0.0-rc.2.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["auto", "prompt", "always"]
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "stateDir": {
       "description": "The location where all the packages are saved on the disk.",
       "type": "string"
@@ -844,6 +883,10 @@
     },
     "updateNotifier": {
       "description": "When true, pnpm will check for updates to the installed packages and notify the user.",
+      "type": "boolean"
+    },
+    "ci": {
+      "description": "Explicitly tells pnpm whether the current environment is a Continuous Integration system, overriding pnpm's automatic CI detection. Added in pnpm v10.12.1.",
       "type": "boolean"
     },
     "preferSymlinkedExecutables": {
@@ -1132,7 +1175,7 @@
       "oneOf": [
         {
           "type": "string",
-          "enum": ["node", "workspaces", "dependencies"]
+          "enum": ["none", "workspaces", "dependencies"]
         }
       ]
     }

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -58,3 +58,24 @@ versioning:
 namedRegistries:
   gh: https://npm.pkg.github.example.com/
   work: https://npm.work.example.com/
+
+# https://pnpm.io/settings/node-modules#virtualstoretype
+virtualStoreType: global
+
+# https://pnpm.io/settings/node-modules#hoistinglimits
+hoistingLimits: none
+
+# https://pnpm.io/settings/store#frozenstore
+frozenStore: true
+
+# https://pnpm.io/settings/store#userunningstoreserver (deprecated)
+useRunningStoreServer: false
+
+# https://pnpm.io/settings/other#globalshims
+globalShims:
+  node: prompt
+  deno: always
+  some-pkg: false
+
+# https://pnpm.io/settings/other#ci
+ci: false


### PR DESCRIPTION
Hi there! I discovered that `virtualStoreType` was missing from the schema, and on comparing against [the documentation](https://pnpm.io/settings), I found a few other gaps. See below for what I added/fixed:

- Add [`virtualStoreType`](https://pnpm.io/settings/node-modules#virtualstoretype), [`frozenStore`](https://pnpm.io/settings/store#frozenstore), [`globalShims`](https://pnpm.io/settings/other#globalshims), [`ci`](https://pnpm.io/settings/other#ci), and [`useRunningStoreServer`](https://pnpm.io/settings/store#userunningstoreserver) (deprecated, noted in description), typed per the docs
- Fix [`hoistingLimits`](https://pnpm.io/settings/node-modules#hoistinglimits) enum typo: `"node"` → `"none"` (docs: `none | workspaces | dependencies`)
- Extend the test fixture to cover all new fields

Verified with `node ./cli.js check --schema-name=pnpm-workspace.json`.

Please let me know if you need anything else. Thanks in advance for your review!