### PR TITLE
Add Decision Reasoning Format (DRF) and Context Reasoning Format (CRF) schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1741,6 +1741,12 @@
       "url": "https://raw.githubusercontent.com/conda-forge/conda-smithy/main/conda_smithy/data/conda-forge.json"
     },
     {
+      "name": "Context Reasoning Format (CRF)",
+      "description": "Organizational context as a graph of entities - organizations, systems, policies, facts, capabilities - that decision records reference and are validated against",
+      "fileMatch": ["*.crf.yaml", "*.crf.yml", "*.crf.json"],
+      "url": "https://raw.githubusercontent.com/reasoning-formats/reasoning-formats/main/crf/schema/crf-schema.json"
+    },
+    {
       "name": "Convex",
       "description": "Configuration for Convex project settings",
       "fileMatch": ["convex.json"],
@@ -1991,6 +1997,12 @@
       "description": "Configuration file for the DebtLens maintainability scanner",
       "fileMatch": ["debtlens.config.json", ".debtlensrc.json"],
       "url": "https://raw.githubusercontent.com/ColumbusLabs/DebtLens/main/schema/debtlens.config.schema.json"
+    },
+    {
+      "name": "Decision Reasoning Format (DRF)",
+      "description": "Decision record capturing the reasoning behind a decision - constraints, objectives, assumptions, tensions and synthesis - as structured, validatable fields",
+      "fileMatch": ["*.drf.yaml", "*.drf.yml", "*.drf.json"],
+      "url": "https://raw.githubusercontent.com/reasoning-formats/reasoning-formats/main/drf/schema/drf-schema.json"
     },
     {
       "name": "Deck config",


### PR DESCRIPTION
Registers two self-hosted schemas in `catalog.json`. Schema files stay in their own repository and the catalog points at the raw URLs, following [How to add a JSON Schema that's self-hosted/remote/external](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-thats-self-hostedremoteexternal), so there is no second copy to keep in sync.

```json
{
  "name": "Decision Reasoning Format (DRF)",
  "description": "Decision record capturing the reasoning behind a decision - constraints, objectives, assumptions, tensions and synthesis - as structured, validatable fields",
  "fileMatch": ["*.drf.yaml", "*.drf.yml", "*.drf.json"],
  "url": "https://raw.githubusercontent.com/reasoning-formats/reasoning-formats/main/drf/schema/drf-schema.json"
}
```

```json
{
  "name": "Context Reasoning Format (CRF)",
  "description": "Organizational context as a graph of entities - organizations, systems, policies, facts, capabilities - that decision records reference and are validated against",
  "fileMatch": ["*.crf.yaml", "*.crf.yml", "*.crf.json"],
  "url": "https://raw.githubusercontent.com/reasoning-formats/reasoning-formats/main/crf/schema/crf-schema.json"
}
```

## What these are

[Reasoning Formats](https://github.com/reasoning-formats/reasoning-formats) is a pair of vendor-neutral specifications for architecture decision records. Where the common ADR formats are Markdown templates, a DRF decision is a YAML document validated against a JSON Schema, with the reasoning split into named fields rather than prose. CRF is its companion: organizational context - policies, systems, facts - as a graph that decisions reference and can be validated against.

Editor support is exactly what these need. The fields are structured enough that completion and inline validation help substantially while writing, and today authors get neither.

## On `fileMatch`

Per [Avoid Generic `fileMatch` Patterns](https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#avoid-generic-filematch-patterns), the patterns are namespaced by a format-specific infix rather than claiming a bare extension. `*.drf.yaml` cannot collide with unrelated YAML.

The `.drf` / `.crf` naming is a documented convention in both specifications, not something invented for this PR - see [DRF File Naming](https://github.com/reasoning-formats/reasoning-formats/blob/main/drf/spec/drf-specification.md#file-naming). The `.ya?ml` extension is retained so `fileMatch` behaves correctly with the RedHat YAML language server, per the caveat in About `catalog.json`.

## Checks

- Both entries inserted in alphabetical position (`conda-forge` → **Context Reasoning Format (CRF)** → `Convex`; `DebtLens` → **Decision Reasoning Format (DRF)** → `Deck config`), key order matching the `catalog.json` prettier override.
- `prettier --config .prettierrc.cjs --check src/api/json/catalog.json` → *All matched files use Prettier code style!*
- `node ./cli.js check` → passes, no new errors.
- Both schemas are draft-07, Apache-2.0, and served from a repository with CI that validates every example against them on each push.

**Disclosure:** I maintain the schemas being registered.