### PR TITLE
Add litertlm_manifest.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,3 +115,8 @@ src/schemas/json/podman-desktop-extension.json @podman-desktop-bot @simonrey1 @b
 src/schemas/json/tfpowershell-* @markdomansky
 src/test/tfpowershell-* @markdomansky
 src/negative_test/tfpowershell-* @markdomansky
+
+# Managed by hf-to-litertlm:
+src/schemas/json/litertlm_manifest.json @john-rocky
+src/test/litertlm_manifest/ @john-rocky
+src/negative_test/litertlm_manifest/ @john-rocky

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5023,6 +5023,12 @@
       "url": "https://liquilens.in/protocol/liquilens-evidence-carrier-reference-v1.schema.json"
     },
     {
+      "name": "litertlm_manifest.json",
+      "description": "Deployment manifest for Hugging Face model repos that ship .litertlm bundles for the LiteRT-LM runtime: per-device file selection, verified backends, requirements, and measured performance",
+      "fileMatch": ["litertlm_manifest.json"],
+      "url": "https://www.schemastore.org/litertlm_manifest.json"
+    },
+    {
       "name": "Lively Properties",
       "description": "Lively Wallpaper configuration file. Documentation: https://github.com/rocksdanister/lively/wiki/Web-Guide-IV-:-Interaction#lively-properties",
       "fileMatch": ["LivelyProperties.json"],

--- a/src/negative_test/litertlm_manifest/bad-sha256.json
+++ b/src/negative_test/litertlm_manifest/bad-sha256.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "abc123",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/empty-backends.json
+++ b/src/negative_test/litertlm_manifest/empty-backends.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": [],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/file-not-litertlm.json
+++ b/src/negative_test/litertlm_manifest/file-not-litertlm.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.tflite",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/known-issues-not-strings.json
+++ b/src/negative_test/litertlm_manifest/known-issues-not-strings.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": [42],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/measured-missing-source.json
+++ b/src/negative_test/litertlm_manifest/measured-missing-source.json
@@ -1,0 +1,36 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/missing-variants.json
+++ b/src/negative_test/litertlm_manifest/missing-variants.json
@@ -1,0 +1,8 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct"
+}

--- a/src/negative_test/litertlm_manifest/repo-without-owner.json
+++ b/src/negative_test/litertlm_manifest/repo-without-owner.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/unknown-backend.json
+++ b/src/negative_test/litertlm_manifest/unknown-backend.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["tpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/unknown-platform.json
+++ b/src/negative_test/litertlm_manifest/unknown-platform.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "web",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/negative_test/litertlm_manifest/unsupported-manifest-schema.json
+++ b/src/negative_test/litertlm_manifest/unsupported-manifest-schema.json
@@ -1,0 +1,37 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.2.0",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "known_issues": ["none"],
+      "measured": [
+        {
+          "backend": "cpu",
+          "date": "2026-08-30",
+          "decode_tps": 18.3,
+          "device": "Pixel 8a (Tensor G3)",
+          "prefill_tps": 40.1,
+          "runtime": "litert-lm 0.16.0",
+          "source": "bench log"
+        }
+      ],
+      "quantization": "int8 linears, fp32 activations",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "android",
+          "reason": "verified path"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1234567890
+    }
+  ]
+}

--- a/src/schemas/json/litertlm_manifest.json
+++ b/src/schemas/json/litertlm_manifest.json
@@ -12,7 +12,7 @@
       "description": "Version of the manifest format. The 0.1 line is the compatibility line: a 0.1.x release only adds optional fields, so a 0.2 manifest is rejected rather than half-parsed.",
       "type": "string",
       "pattern": "^0\\.1\\.[0-9]+$",
-      "examples": ["0.1.0", "0.1.1"]
+      "examples": ["0.1.0", "0.1.1", "0.1.2"]
     },
     "repo": {
       "description": "Hugging Face repo id (owner/name) the manifest lives in. Together with a variant's file name this is the download address.",
@@ -291,6 +291,16 @@
         "runs": {
           "description": "Number of runs the row summarizes.",
           "type": "integer"
+        },
+        "load_s": {
+          "description": "Engine load time in seconds under the row's cache condition (manifest 0.1.2 and later).",
+          "type": "number",
+          "minimum": 0
+        },
+        "peak_memory_mb": {
+          "description": "Peak resident memory during the run, in megabytes (manifest 0.1.2 and later).",
+          "type": "number",
+          "minimum": 0
         },
         "date": {
           "description": "Date of the measurement (YYYY-MM-DD).",

--- a/src/schemas/json/litertlm_manifest.json
+++ b/src/schemas/json/litertlm_manifest.json
@@ -1,0 +1,407 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.schemastore.org/litertlm_manifest.json",
+  "$comment": "Mirror of manifest/litertlm_manifest.schema.json in the hf-to-litertlm repository, for the manifest_schema 0.1 line. Keep the two in sync.",
+  "title": "litertlm deployment manifest",
+  "description": "litertlm_manifest.json sits at the root of a Hugging Face model repo that ships .litertlm bundles for the LiteRT-LM runtime. It describes every bundle in the repo: the backends each file is verified on, which file a device should pick, what it requires, and how fast it measured.\nhttps://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["manifest_schema", "repo", "generated", "model", "variants"],
+  "properties": {
+    "manifest_schema": {
+      "description": "Version of the manifest format. The 0.1 line is the compatibility line: a 0.1.x release only adds optional fields, so a 0.2 manifest is rejected rather than half-parsed.",
+      "type": "string",
+      "pattern": "^0\\.1\\.[0-9]+$",
+      "examples": ["0.1.0", "0.1.1"]
+    },
+    "repo": {
+      "description": "Hugging Face repo id (owner/name) the manifest lives in. Together with a variant's file name this is the download address.",
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$"
+    },
+    "generated": {
+      "description": "Date the manifest was generated (YYYY-MM-DD).",
+      "type": "string",
+      "format": "date"
+    },
+    "generator": {
+      "description": "Tool that produced the manifest.",
+      "type": "string"
+    },
+    "model": {
+      "$ref": "#/definitions/model"
+    },
+    "variants": {
+      "description": "One entry per .litertlm file in the repo.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/variant"
+      }
+    }
+  },
+  "definitions": {
+    "backend": {
+      "description": "LiteRT-LM execution backend.",
+      "type": "string",
+      "enum": ["cpu", "gpu", "npu"]
+    },
+    "platform": {
+      "description": "Target platform of a recommendation.",
+      "type": "string",
+      "enum": ["android", "ios", "macos", "windows", "linux"]
+    },
+    "speed": {
+      "description": "A measured value: a number, or a \"lo-hi\" range string when the runs spread (CPU rows on phones spread with thermal throttling).",
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "channelMarkers": {
+      "description": "Exact marker strings of a channel, whitespace included.",
+      "type": "object",
+      "properties": {
+        "start": {
+          "description": "Opening marker, e.g. \"<think>\".",
+          "type": "string"
+        },
+        "end": {
+          "description": "Closing marker, e.g. \"</think>\".",
+          "type": "string"
+        }
+      }
+    },
+    "declaredChannel": {
+      "description": "One entry of the bundle's declared channel set (manifest 0.1.1 and later).",
+      "type": "object",
+      "required": ["name", "start", "end"],
+      "properties": {
+        "name": {
+          "description": "Channel name as declared in the bundle header.",
+          "type": "string"
+        },
+        "start": {
+          "description": "Opening marker, whitespace included.",
+          "type": "string"
+        },
+        "end": {
+          "description": "Closing marker, whitespace included.",
+          "type": "string"
+        },
+        "is_reasoning": {
+          "description": "True when the bundle marks this channel as its reasoning channel.",
+          "type": "boolean"
+        }
+      }
+    },
+    "capabilities": {
+      "description": "Capability flags derived from the bundle header, so they are readable before download.",
+      "type": "object",
+      "properties": {
+        "vision": {
+          "description": "Derived: the bundle declares image input.",
+          "type": "boolean"
+        },
+        "audio": {
+          "description": "Derived: the bundle declares audio input.",
+          "type": "boolean"
+        },
+        "thinking": {
+          "description": "Derived: whether the bundle declares a thinking channel, and its markers. Mirrors the first declared channel.",
+          "type": "object",
+          "properties": {
+            "declared": {
+              "description": "True when the bundle declares a channel.",
+              "type": "boolean"
+            },
+            "channel": {
+              "$ref": "#/definitions/channelMarkers"
+            }
+          }
+        },
+        "channels": {
+          "description": "Derived (manifest 0.1.1 and later): the bundle's full declared channel set, whether thinking, tool-call, or anything else the model declares.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/declaredChannel"
+          }
+        }
+      }
+    },
+    "sessionDefaults": {
+      "description": "Curated session knobs a wrapper should set that the engine cannot infer. An open object: readers take keys by name and ignore what they do not consume.",
+      "type": "object",
+      "properties": {
+        "max_output_tokens_min": {
+          "description": "A floor on the output-token budget (e.g. 2048 for reasoning models), never a cap.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "notes": {
+          "description": "Curated guidance worth surfacing to the app developer.",
+          "type": "string"
+        },
+        "temperature": {
+          "description": "Sampler hint.",
+          "type": "number"
+        },
+        "top_k": {
+          "description": "Sampler hint.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "top_p": {
+          "description": "Sampler hint.",
+          "type": "number"
+        }
+      }
+    },
+    "model": {
+      "description": "Model-level facts. Fields marked Derived are read out of the bundle header by the generator; the rest are curated.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["display_name"],
+      "properties": {
+        "display_name": {
+          "description": "Human-readable model name.",
+          "type": "string"
+        },
+        "base_model": {
+          "description": "Hugging Face id of the source model.",
+          "type": "string"
+        },
+        "architecture": {
+          "description": "Free-text architecture label, e.g. \"lfm2-hybrid\" or \"qwen3-dense\".",
+          "type": "string"
+        },
+        "parameters_b": {
+          "description": "Parameter count in billions.",
+          "type": "number"
+        },
+        "license": {
+          "description": "SPDX identifier, or a pointer to the license file.",
+          "type": "string"
+        },
+        "context_length": {
+          "description": "Derived: the bundle's max_num_tokens.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "capabilities": {
+          "$ref": "#/definitions/capabilities"
+        },
+        "session_defaults": {
+          "$ref": "#/definitions/sessionDefaults"
+        }
+      }
+    },
+    "recommendation": {
+      "description": "The fastest verified backend for a platform, optionally narrowed to a device class.",
+      "type": "object",
+      "required": ["platform", "backend"],
+      "properties": {
+        "platform": {
+          "$ref": "#/definitions/platform"
+        },
+        "device_class": {
+          "description": "Free-text device class the recommendation applies to, e.g. \"midrange\" or \"flagship\".",
+          "type": "string"
+        },
+        "backend": {
+          "$ref": "#/definitions/backend",
+          "description": "Backend to use on this platform. Must be one of the variant's verified backends; resolvers ignore a recommendation naming an unlisted backend."
+        },
+        "reason": {
+          "description": "Why this backend wins on this platform, in words that carry the evidence.",
+          "type": "string"
+        }
+      }
+    },
+    "requirements": {
+      "description": "What the variant needs beyond the runtime version.",
+      "type": "object",
+      "properties": {
+        "peak_ram_mb": {
+          "description": "Peak resident memory observed while generating, in megabytes.",
+          "type": "integer"
+        },
+        "platform_notes": {
+          "description": "Platform caveats to surface to the app developer.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "measuredRow": {
+      "description": "One measured performance row. Every row states its conditions and its provenance; rows come from generation-verified backends only.",
+      "type": "object",
+      "required": ["device", "backend", "runtime", "date", "source"],
+      "properties": {
+        "device": {
+          "description": "Device the row was measured on, e.g. \"Pixel 8a (Tensor G3)\".",
+          "type": "string"
+        },
+        "os": {
+          "description": "Operating system of the device.",
+          "type": "string"
+        },
+        "backend": {
+          "$ref": "#/definitions/backend",
+          "description": "Backend the row was measured on."
+        },
+        "runtime": {
+          "description": "LiteRT-LM release and build the row was measured with.",
+          "type": "string"
+        },
+        "prompt_tokens": {
+          "description": "Prompt length in tokens.",
+          "type": "integer"
+        },
+        "decode_tokens": {
+          "description": "Number of generated tokens.",
+          "type": "integer"
+        },
+        "prefill_tps": {
+          "$ref": "#/definitions/speed",
+          "description": "Prefill throughput in tokens per second."
+        },
+        "decode_tps": {
+          "$ref": "#/definitions/speed",
+          "description": "Decode throughput in tokens per second."
+        },
+        "ttft_s": {
+          "$ref": "#/definitions/speed",
+          "description": "Time to first token in seconds."
+        },
+        "max_num_tokens": {
+          "description": "Context budget (max_num_tokens) the run used.",
+          "type": "integer"
+        },
+        "cache": {
+          "description": "Whether a compiled-model cache was in use. \"no\" means a cold compile; caches mask load regressions and inflate disk cost.",
+          "type": "string"
+        },
+        "runs": {
+          "description": "Number of runs the row summarizes.",
+          "type": "integer"
+        },
+        "date": {
+          "description": "Date of the measurement (YYYY-MM-DD).",
+          "type": "string",
+          "format": "date"
+        },
+        "source": {
+          "description": "Provenance of the numbers: which log or model-card table they come from.",
+          "type": "string"
+        },
+        "evidence": {
+          "description": "Pointer to the primary log. Stripped from published manifests and kept in the converter's own records.",
+          "type": "string"
+        }
+      }
+    },
+    "section": {
+      "description": "Derived: one row of the bundle's section table.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Section data type as named in the bundle header, e.g. \"LlmMetadataProto\", \"HF_Tokenizer_Zlib\" or \"TFLiteModel\".",
+          "type": "string"
+        },
+        "size_bytes": {
+          "description": "Section size in bytes.",
+          "type": "integer"
+        },
+        "model_type": {
+          "description": "The section's model_type item when present, e.g. \"tf_lite_prefill_decode\" or \"tf_lite_embedder\".",
+          "type": "string"
+        },
+        "backend_constraint": {
+          "description": "The section's backend_constraint item when present: a comma-separated list of backends the engine will load it on.",
+          "type": "string"
+        }
+      }
+    },
+    "variant": {
+      "description": "One .litertlm file. Fields marked Derived are read from Hub metadata or the bundle header; the rest are curated and carry evidence.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["file", "quantization", "backends"],
+      "properties": {
+        "file": {
+          "description": "File name inside the repo.",
+          "type": "string",
+          "pattern": "\\.litertlm$"
+        },
+        "sha256": {
+          "description": "Derived: SHA-256 of the file from Hub LFS metadata. Verify after download.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "size_bytes": {
+          "description": "Derived: file size in bytes.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "quantization": {
+          "description": "Quantization recipe, stated honestly, e.g. \"int4 block-32 linears, fp32 activations\".",
+          "type": "string"
+        },
+        "backends": {
+          "description": "Backends this file is verified to generate on, not merely load. A resolver never returns a backend absent from this list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/backend"
+          }
+        },
+        "default_backend": {
+          "$ref": "#/definitions/backend",
+          "description": "Backend to pick with no device knowledge."
+        },
+        "min_runtime_version": {
+          "description": "Earliest LiteRT-LM release the file is verified on, e.g. \"0.15.0\".",
+          "type": "string"
+        },
+        "recommended": {
+          "description": "The fastest verified choice per platform and device class.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/recommendation"
+          }
+        },
+        "requirements": {
+          "$ref": "#/definitions/requirements"
+        },
+        "measured": {
+          "description": "Measured performance rows with conditions and provenance.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/measuredRow"
+          }
+        },
+        "known_issues": {
+          "description": "Short, factual known issues, with upstream links where they exist.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sections": {
+          "description": "Derived: the bundle's section table.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/section"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/litertlm_manifest/full-0.1.1.json
+++ b/src/test/litertlm_manifest/full-0.1.1.json
@@ -1,0 +1,187 @@
+{
+  "generated": "2026-09-01",
+  "generator": "make_manifest.py",
+  "manifest_schema": "0.1.1",
+  "model": {
+    "architecture": "example-dense (28 layers) + vision encoder",
+    "base_model": "example-org/Example-3B-Thinking-VL-src",
+    "capabilities": {
+      "audio": false,
+      "channels": [
+        {
+          "end": "\n</think>",
+          "is_reasoning": true,
+          "name": "thinking",
+          "start": "<think>\n"
+        },
+        {
+          "end": "</tool_call>",
+          "name": "tool_call",
+          "start": "<tool_call>"
+        }
+      ],
+      "thinking": {
+        "channel": {
+          "end": "\n</think>",
+          "start": "<think>\n"
+        },
+        "declared": true
+      },
+      "vision": true
+    },
+    "context_length": 8192,
+    "display_name": "Example-3B-Thinking-VL",
+    "license": "apache-2.0",
+    "parameters_b": 3.1,
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model: it emits a <think>...</think> chain before the answer. At a short output budget it is cut off mid-thought and never answers.",
+      "temperature": 0.6,
+      "top_k": 20,
+      "top_p": 0.95
+    }
+  },
+  "repo": "example-org/Example-3B-Thinking-VL",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "gpu",
+      "file": "Example-3B-Thinking-VL_int4.litertlm",
+      "known_issues": [
+        "Block-32 int4 can corrupt output on some Metal drivers; device-verify before recommending iPhone GPU"
+      ],
+      "measured": [
+        {
+          "backend": "gpu",
+          "cache": "no",
+          "date": "2026-08-30",
+          "decode_tokens": 256,
+          "decode_tps": 54.2,
+          "device": "Apple M4 Max",
+          "evidence": "example_work/bench_mac.log",
+          "max_num_tokens": 4096,
+          "os": "macOS",
+          "prefill_tps": 1210.5,
+          "prompt_tokens": 256,
+          "runs": 3,
+          "runtime": "litert-lm 0.16.0 (pip CLI benchmark)",
+          "source": "ship-lane Mac bench log; model card Performance table",
+          "ttft_s": 0.21
+        },
+        {
+          "backend": "cpu",
+          "cache": "no",
+          "date": "2026-08-30",
+          "decode_tokens": 205,
+          "decode_tps": "15.2-24.3",
+          "device": "Pixel 8a (Tensor G3)",
+          "max_num_tokens": 4096,
+          "os": "Android",
+          "prefill_tps": "38.2-53.9",
+          "prompt_tokens": 263,
+          "runs": 3,
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "source": "ship-lane Pixel 8a bench log (CPU rows spread with thermal throttling)",
+          "ttft_s": "4.9-7.0"
+        }
+      ],
+      "min_runtime_version": "0.16.0",
+      "quantization": "dynamic int4 block-32 linears, fp32 activations; vision encoder fp16",
+      "recommended": [
+        {
+          "backend": "gpu",
+          "device_class": "flagship",
+          "platform": "android",
+          "reason": "4x prefill vs CPU on the same file"
+        },
+        {
+          "backend": "cpu",
+          "device_class": "midrange",
+          "platform": "android",
+          "reason": "GPU shader compile takes 40 s on this class; CPU wins on time to first answer"
+        },
+        {
+          "backend": "gpu",
+          "platform": "ios",
+          "reason": "Metal path verified end to end"
+        },
+        {
+          "backend": "gpu",
+          "platform": "macos",
+          "reason": "~10x prefill vs CPU"
+        },
+        {
+          "backend": "cpu",
+          "platform": "windows",
+          "reason": "GPU backend not verified on Windows for this file"
+        },
+        {
+          "backend": "cpu",
+          "platform": "linux",
+          "reason": "GPU backend not verified on Linux for this file"
+        }
+      ],
+      "requirements": {
+        "peak_ram_mb": 3200,
+        "platform_notes": [
+          "GPU backends keep a compiled-model cache (~2x model size) next to the model until the OS purges it"
+        ]
+      },
+      "sections": [
+        {
+          "size_bytes": 3321,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 2142162,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "backend_constraint": "cpu,gpu",
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 1985000000,
+          "type": "TFLiteModel"
+        },
+        {
+          "backend_constraint": "cpu,gpu",
+          "model_type": "tf_lite_vision_encoder",
+          "size_bytes": 500000,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "size_bytes": 1987654321
+    },
+    {
+      "backends": ["npu"],
+      "default_backend": "npu",
+      "file": "npu/Example-3B-Thinking-VL_int8_soc-x.litertlm",
+      "known_issues": [],
+      "measured": [
+        {
+          "backend": "npu",
+          "date": "2026-08-30",
+          "decode_tps": 31,
+          "device": "SoC-X reference phone",
+          "prefill_tps": 950,
+          "runs": 5,
+          "runtime": "litert-lm 0.16.0 (vendor NPU delegate)",
+          "source": "vendor lab bench log",
+          "ttft_s": 0.3
+        }
+      ],
+      "min_runtime_version": "0.16.0",
+      "quantization": "int8 weights and activations (per-SoC NPU build)",
+      "recommended": [
+        {
+          "backend": "npu",
+          "device_class": "soc-x",
+          "platform": "android",
+          "reason": "only file that runs on the SoC-X NPU"
+        }
+      ],
+      "sha256": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+      "size_bytes": 3456789012
+    }
+  ]
+}

--- a/src/test/litertlm_manifest/full-0.1.2.json
+++ b/src/test/litertlm_manifest/full-0.1.2.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-09-01",
   "generator": "make_manifest.py",
-  "manifest_schema": "0.1.1",
+  "manifest_schema": "0.1.2",
   "model": {
     "architecture": "example-dense (28 layers) + vision encoder",
     "base_model": "example-org/Example-3B-Thinking-VL-src",
@@ -59,8 +59,10 @@
           "decode_tps": 54.2,
           "device": "Apple M4 Max",
           "evidence": "example_work/bench_mac.log",
+          "load_s": 1.8,
           "max_num_tokens": 4096,
           "os": "macOS",
+          "peak_memory_mb": 2140,
           "prefill_tps": 1210.5,
           "prompt_tokens": 256,
           "runs": 3,

--- a/src/test/litertlm_manifest/lfm2.5-1.2b-instruct.json
+++ b/src/test/litertlm_manifest/lfm2.5-1.2b-instruct.json
@@ -1,0 +1,228 @@
+{
+  "generated": "2026-08-24",
+  "generator": "make_manifest.py",
+  "manifest_schema": "0.1.0",
+  "model": {
+    "architecture": "lfm2-hybrid (short-conv + attention)",
+    "base_model": "LiquidAI/LFM2.5-1.2B-Instruct",
+    "capabilities": {
+      "audio": false,
+      "thinking": {
+        "channel": {
+          "end": "</think>",
+          "start": "<think>"
+        },
+        "declared": true
+      },
+      "vision": false
+    },
+    "context_length": 4096,
+    "display_name": "LFM2.5-1.2B-Instruct",
+    "license": "see LICENSE file in repo",
+    "parameters_b": 1.2
+  },
+  "repo": "litert-community/LFM2.5-1.2B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu"],
+      "default_backend": "cpu",
+      "file": "LFM2.5-1.2B-Instruct_int4.litertlm",
+      "known_issues": [
+        "This export lineage emits INT64 ops + GATHER_ND in the short-conv patch: GPU engine creation fails — use the _int4_gpu re-export for GPU backends"
+      ],
+      "min_runtime_version": "0.15.0",
+      "quantization": "dynamic int4 block-32 linears, fp32 activations (CPU-lineage export)",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "device_class": "midrange",
+          "platform": "android",
+          "reason": "on phone-class memory bandwidth int4 decodes ~1.7x faster than int8 and is 41% smaller"
+        },
+        {
+          "backend": "cpu",
+          "platform": "ios",
+          "reason": "iOS CPU is the verified path for this family"
+        }
+      ],
+      "sections": [
+        {
+          "size_bytes": 1856,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 1421,
+          "type": "ExecutorMetadataProto"
+        },
+        {
+          "size_bytes": 906962,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 735049088,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "a28b5c59ac204e2e51c1f98d2d6db6982f0e12da59a268fe498edcb33237e906",
+      "size_bytes": 736015744
+    },
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "gpu",
+      "file": "LFM2.5-1.2B-Instruct_int4_gpu.litertlm",
+      "known_issues": [
+        "iPhone Metal: engine fails on this family at runtime (Mac WebGPU passes the same file) — use CPU on iOS; tracked upstream"
+      ],
+      "measured": [
+        {
+          "backend": "gpu",
+          "cache": "no",
+          "date": "2026-08-12",
+          "decode_tokens": 256,
+          "decode_tps": 318.3,
+          "device": "Apple M4 Max",
+          "max_num_tokens": 4096,
+          "os": "macOS",
+          "prefill_tps": 3765.0,
+          "prompt_tokens": 256,
+          "runs": 3,
+          "runtime": "litert-lm 0.16.0 (pip CLI benchmark)",
+          "source": "ship-lane Mac bench log; model card Performance table",
+          "ttft_s": 0.071
+        },
+        {
+          "backend": "cpu",
+          "cache": "no",
+          "date": "2026-08-12",
+          "decode_tokens": 256,
+          "decode_tps": 80.5,
+          "device": "Apple M4 Max",
+          "max_num_tokens": 4096,
+          "os": "macOS",
+          "prefill_tps": 337.0,
+          "prompt_tokens": 256,
+          "runs": 3,
+          "runtime": "litert-lm 0.16.0 (pip CLI benchmark)",
+          "source": "ship-lane Mac bench log; model card Performance table",
+          "ttft_s": 0.77
+        },
+        {
+          "backend": "gpu",
+          "date": "2026-08-12",
+          "decode_tokens": 115,
+          "decode_tps": "21.0-21.2",
+          "device": "Pixel 8a (Tensor G3)",
+          "max_num_tokens": 4096,
+          "os": "Android",
+          "prefill_tps": "188.3-192.6",
+          "prompt_tokens": 263,
+          "runs": 3,
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag (OpenCL)",
+          "source": "ship-lane Pixel 8a bench log; model card Performance table",
+          "ttft_s": "1.41-1.44"
+        },
+        {
+          "backend": "cpu",
+          "date": "2026-08-12",
+          "decode_tokens": 205,
+          "decode_tps": "15.2-24.3",
+          "device": "Pixel 8a (Tensor G3)",
+          "max_num_tokens": 4096,
+          "os": "Android",
+          "prefill_tps": "38.2-53.9",
+          "prompt_tokens": 263,
+          "runs": 3,
+          "runtime": "litert_lm_main built from the litert-lm v0.16.0 release tag",
+          "source": "ship-lane Pixel 8a bench log (CPU rows spread with thermal throttling); model card Performance table",
+          "ttft_s": "4.9-7.0"
+        }
+      ],
+      "min_runtime_version": "0.15.0",
+      "quantization": "dynamic int4 block-32 linears, fp32 activations; GPU-capable re-export (no INT64/GATHER_ND in the short-conv patch)",
+      "recommended": [
+        {
+          "backend": "gpu",
+          "device_class": "midrange-2023+",
+          "platform": "android",
+          "reason": "3-6x prefill and TTFT vs CPU on Tensor G3; decode is bandwidth-bound and roughly a wash"
+        },
+        {
+          "backend": "gpu",
+          "platform": "macos",
+          "reason": "~11x prefill, ~4x decode vs CPU on the same file"
+        },
+        {
+          "backend": "cpu",
+          "platform": "ios",
+          "reason": "the Metal GPU engine fails on this model family at runtime (tracked upstream); CPU is verified"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "Large --max-num-tokens costs decode speed on this family (~-24% at 4096 vs 1024)",
+          "GPU backends keep a compiled-model cache (~2x model size) next to the model until the OS purges it"
+        ]
+      },
+      "sections": [
+        {
+          "size_bytes": 1856,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 1421,
+          "type": "ExecutorMetadataProto"
+        },
+        {
+          "size_bytes": 906962,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 735254112,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "36f7f0221bcc42c75291da1d7e3422901024a5b06b9bfa3c02d7feface04f70a",
+      "size_bytes": 736220768
+    },
+    {
+      "backends": ["cpu"],
+      "default_backend": "cpu",
+      "file": "LFM2.5-1.2B-Instruct_int8.litertlm",
+      "known_issues": [
+        "Same CPU-lineage export as _int4: GPU engine creation fails on this file"
+      ],
+      "min_runtime_version": "0.15.0",
+      "quantization": "int8 linears only (wi8), fp32 activations (CPU-lineage export)",
+      "recommended": [
+        {
+          "backend": "cpu",
+          "platform": "macos",
+          "reason": "highest-fidelity variant; on desktop CPU it prefills ~3x faster than int4 — pick it when quality outranks size"
+        }
+      ],
+      "sections": [
+        {
+          "size_bytes": 1856,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 1421,
+          "type": "ExecutorMetadataProto"
+        },
+        {
+          "size_bytes": 906962,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 1246124784,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "e002a91545cec6328be2a86e9b8b4fccb2dd9dde7e6c8b29d730f915a0a697fe",
+      "size_bytes": 1247091440
+    }
+  ]
+}

--- a/src/test/litertlm_manifest/minimal.json
+++ b/src/test/litertlm_manifest/minimal.json
@@ -1,0 +1,15 @@
+{
+  "generated": "2026-09-01",
+  "manifest_schema": "0.1.0",
+  "model": {
+    "display_name": "Example-1B-Instruct"
+  },
+  "repo": "example-org/Example-1B-Instruct",
+  "variants": [
+    {
+      "backends": ["cpu"],
+      "file": "Example-1B-Instruct_int8.litertlm",
+      "quantization": "int8 linears, fp32 activations"
+    }
+  ]
+}

--- a/src/test/litertlm_manifest/qwen3-4b-thinking-2507.json
+++ b/src/test/litertlm_manifest/qwen3-4b-thinking-2507.json
@@ -1,0 +1,144 @@
+{
+  "generated": "2026-08-31",
+  "generator": "make_manifest.py",
+  "manifest_schema": "0.1.0",
+  "model": {
+    "architecture": "qwen3-dense (36 layers)",
+    "base_model": "Qwen/Qwen3-4B-Thinking-2507",
+    "capabilities": {
+      "audio": false,
+      "thinking": {
+        "channel": {
+          "end": "\n</think>",
+          "start": "<think>\n"
+        },
+        "declared": true
+      },
+      "vision": false
+    },
+    "context_length": 4096,
+    "display_name": "Qwen3-4B-Thinking-2507",
+    "license": "apache-2.0",
+    "parameters_b": 4.0,
+    "session_defaults": {
+      "max_output_tokens_min": 2048,
+      "notes": "Reasoning model: it emits a <think>...</think> chain before the answer. At a short output budget it is cut off mid-thought and never answers."
+    }
+  },
+  "repo": "litert-community/Qwen3-4B-Thinking-2507",
+  "variants": [
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "cpu",
+      "file": "Qwen3_4b_thinking_dynamic_wi4b32_afp32.litertlm",
+      "known_issues": [
+        "Block-32 int4 corrupts GPU output beyond iPhone: macOS Metal also degenerates (question-echo loops, truncated reasoning; measured 2026-08-31 before and after the metadata repair, pre-existing). Use this file on CPU; it delegated and generated on the Galaxy S26 Android GPU gate (2026-08-24). The block-128 file is the GPU-safe choice"
+      ],
+      "min_runtime_version": "0.15.0",
+      "quantization": "dynamic int4 block-32 weights, fp32 activations; GPU graph optimizations (RoPE/fused-QKV/fused-GateUp composites), static prefill allocation",
+      "sections": [
+        {
+          "size_bytes": 3228,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 4967,
+          "type": "ExecutorMetadataProto"
+        },
+        {
+          "size_bytes": 2142162,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 2271997712,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "a412d77da3a15047232ce525d126a8cdb803691d29df791f13a9ef4cffab309a",
+      "size_bytes": 2274193168
+    },
+    {
+      "backends": ["cpu", "gpu"],
+      "default_backend": "gpu",
+      "file": "model.litertlm",
+      "known_issues": [],
+      "measured": [
+        {
+          "backend": "gpu",
+          "cache": "no",
+          "date": "2026-08-11",
+          "decode_tokens": 256,
+          "decode_tps": 68.5,
+          "device": "Apple M4 Max",
+          "max_num_tokens": 4096,
+          "os": "macOS",
+          "prefill_tps": 999.3,
+          "prompt_tokens": 256,
+          "runs": 3,
+          "runtime": "litert-lm 0.15.0 (pip CLI benchmark)",
+          "source": "cardbench Mac LLM sweep; model card Performance table",
+          "ttft_s": 0.28
+        },
+        {
+          "backend": "cpu",
+          "cache": "no",
+          "date": "2026-08-11",
+          "decode_tokens": 256,
+          "decode_tps": 17.8,
+          "device": "Apple M4 Max",
+          "max_num_tokens": 4096,
+          "os": "macOS",
+          "prefill_tps": 111.0,
+          "prompt_tokens": 256,
+          "runs": 3,
+          "runtime": "litert-lm 0.15.0 (pip CLI benchmark)",
+          "source": "cardbench Mac LLM sweep; model card Performance table",
+          "ttft_s": 2.49
+        }
+      ],
+      "min_runtime_version": "0.15.0",
+      "quantization": "int4 block-128 symmetric weights + OCTAV optimal clipping; int8 embeddings (externalized section)",
+      "recommended": [
+        {
+          "backend": "gpu",
+          "platform": "macos",
+          "reason": "~9x prefill and ~3.8x decode vs CPU on the same file"
+        },
+        {
+          "backend": "gpu",
+          "platform": "ios",
+          "reason": "block-128 is the iPhone-safe int4 recipe for this family; prefer this file over the block-32 variant on iPhone GPU"
+        }
+      ],
+      "requirements": {
+        "platform_notes": [
+          "4B-class file (2.47 GB): budget device RAM accordingly; on Android import via AI Edge Gallery and enable the GPU toggle at import",
+          "iPhone 17 Pro Metal decode was observed at ~14 tok/s in an earlier on-device note; its run log is not retained, so it is not listed as a measured row"
+        ]
+      },
+      "sections": [
+        {
+          "size_bytes": 191,
+          "type": "LlmMetadataProto"
+        },
+        {
+          "size_bytes": 2142162,
+          "type": "HF_Tokenizer_Zlib"
+        },
+        {
+          "model_type": "tf_lite_prefill_decode",
+          "size_bytes": 2079558192,
+          "type": "TFLiteModel"
+        },
+        {
+          "model_type": "tf_lite_embedder",
+          "size_bytes": 392606640,
+          "type": "TFLiteModel"
+        }
+      ],
+      "sha256": "356b2d7778d27d55fbb0d2e0c5e8801e9de136db59849c41c882bd97333840d5",
+      "size_bytes": 2474357680
+    }
+  ]
+}


### PR DESCRIPTION
`litertlm_manifest.json` sits at the root of a Hugging Face model repo that ships `.litertlm` bundles for the LiteRT-LM on-device runtime. It tells a client which file fits which device: the backends each file is verified on, what it requires, and how fast it measured, with conditions and provenance. I maintain the spec, the generator, and the reference readers, so the CODEOWNERS entry points at me for follow-ups.

**Uptake**

- 27 model repos on the Hub ship one today (`litert-community/*`, `mlboydaisuke/*`), all produced by the same generator.
- `flutter_gemma_litertlm` 1.6.0+ reads it for manifest-driven installs (`LitertlmManifestResolver`).

**Schema notes**

- Draft-07. Every object the spec declares open keeps `additionalProperties: true`, so a 0.1.x manifest that adds optional fields still validates.
- Backend and platform enums are closed: the reference readers type them as closed unions, and the resolver refuses a backend outside the list.
- Speed fields accept a number or a string, matching the generator (a "lo-hi" range string is used when runs spread).
- All 27 published manifests validate against this schema. Two of them are the positive tests, plus a minimal and a full 0.1.2 sample. Ten negative tests each fail on exactly one constraint.

**Links**

- Spec: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/SCHEMA.md
- Schema the generator validates against: https://github.com/john-rocky/hf-to-litertlm/blob/main/manifest/litertlm_manifest.schema.json
- Reference readers (TypeScript, Dart): https://github.com/john-rocky/hf-to-litertlm/tree/main/readers
- flutter_gemma_litertlm changelog: https://pub.dev/packages/flutter_gemma_litertlm/changelog

`node ./cli.js check`, `npm run prettier`, and codespell pass locally. Thanks for maintaining the catalog.
