### PR TITLE
Skip the Make Commit workflow on forks

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: 'ubuntu-latest'
+    if: ${{ github.repository_owner == 'SchemaStore' }}
     permissions:
       contents: 'write'
       pull-requests: 'write'


### PR DESCRIPTION
The scheduled `Make Commit` workflow (auto-update.yml) runs in every fork that leaves Actions enabled: every day at 23:30 UTC it builds the xregistry and opens an update PR against the fork itself, until the fork owner notices and disables the workflow by hand.

github-pages.yml already guards both of its jobs with `if: ${{ github.repository_owner == 'SchemaStore' }}`. This applies the same guard to the auto-update job, so forks skip the scheduled run while everything keeps working in the upstream repository.