### PR TITLE
fix: Narrowed JSON-e types and added tests

### DIFF
--- a/src/negative_test/jsone/let-bad-varname.yaml
+++ b/src/negative_test/jsone/let-bad-varname.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+$let:
+  '': 2
+in:
+  $eval: x

--- a/src/negative_test/jsone/let-without-in.yaml
+++ b/src/negative_test/jsone/let-without-in.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+$let:
+  x: 2

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -112,7 +112,6 @@
     "install.json",
     "jest.json",
     "jsdoc-1.0.0.json",
-    "jsone.json",
     "kestra-0.18.0.json",
     "kestra-0.18.1.json",
     "kestra-0.18.2.json",

--- a/src/schemas/json/jsone.json
+++ b/src/schemas/json/jsone.json
@@ -71,24 +71,11 @@
     },
     "$let": {
       "type": "object",
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/jsone-value",
-            "not": {
-              "type": "object"
-            }
-          },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "patternProperties": {
-              "^[a-zA-Z_][a-zA-Z0-9_]*$": {
-                "$ref": "#/$defs/jsone-value"
-              }
-            }
-          }
-        ]
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+          "$ref": "#/$defs/jsone-value"
+        }
       }
     },
     "$map": {

--- a/src/schemas/json/jsone.json
+++ b/src/schemas/json/jsone.json
@@ -116,13 +116,8 @@
       "$ref": "#"
     }
   },
-  "dependencies": {
-    "let": {
-      "properties": {
-        "in": true
-      },
-      "required": ["in"]
-    }
+  "dependentRequired": {
+    "$let": ["in"]
   },
   "title": "JSON-e templates",
   "type": "object"

--- a/src/schemas/json/jsone.json
+++ b/src/schemas/json/jsone.json
@@ -4,14 +4,14 @@
   "$comment": "https://json-e.js.org",
   "$defs": {
     "jsone-value": {
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#"
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#"
+            "$ref": "#/$defs/jsone-value"
           }
         },
         {
@@ -72,9 +72,23 @@
     "$let": {
       "type": "object",
       "additionalProperties": {
-        "additionalProperties": {
-          "$ref": "#"
-        }
+        "anyOf": [
+          {
+            "$ref": "#/$defs/jsone-value",
+            "not": {
+              "type": "object"
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "patternProperties": {
+              "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+                "$ref": "#/$defs/jsone-value"
+              }
+            }
+          }
+        ]
       }
     },
     "$map": {
@@ -113,6 +127,14 @@
     },
     "in": {
       "$ref": "#"
+    }
+  },
+  "dependencies": {
+    "let": {
+      "properties": {
+        "in": true
+      },
+      "required": ["in"]
     }
   },
   "title": "JSON-e templates",

--- a/src/schemas/json/jsone.json
+++ b/src/schemas/json/jsone.json
@@ -15,7 +15,19 @@
           }
         },
         {
-          "type": ["null", "boolean", "number", "string", "integer"]
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
         }
       ]
     },

--- a/src/test/jsone/additional-property.yaml
+++ b/src/test/jsone/additional-property.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+abc123FAKE_property-num: 1.1
+abc123FAKE_property-obj:
+  $eval: x
+abc123FAKE_property-nul:
+abc123FAKE_property-arr: [2, 3.2]
+abc123FAKE_property-bol: true
+abc123FAKE_property-int: 4

--- a/src/test/jsone/let-mixed-types.yaml
+++ b/src/test/jsone/let-mixed-types.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+$let:
+  x:
+    - 2
+    - 5
+    - 1
+    - 4
+    - $eval: '3'
+in:
+  $sort:
+    $eval: 'x'
+  by(x): 'x'

--- a/src/test/jsone/let-with-in.yaml
+++ b/src/test/jsone/let-with-in.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+$let:
+  x: 2
+in:
+  $eval: x

--- a/src/test/jsone/sort-object.yaml
+++ b/src/test/jsone/sort-object.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../schemas/json/jsone.json
+$let:
+  x:
+    $eval: '[2, 5, 1, 4, 3]'
+in:
+  $sort:
+    $eval: 'x'
+  by(x): 'x'


### PR DESCRIPTION
- Incorporated strict validation in `jsone.json`
- Modified tests were run through the [JSON-e playground](https://json-e.js.org/playground.html), as docs are limited for use as specs.
- Transitive modifications were not tested, as no tests have been written for them yet. This can be done on request.
