### PR TITLE
Add `extensions` and `sandbox` to crucible-code-schema

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-sandbox-mode.json
+++ b/src/negative_test/crucible-code-schema/not-a-sandbox-mode.json
@@ -1,0 +1,3 @@
+{
+  "sandbox": { "mode": "strict" }
+}

--- a/src/negative_test/crucible-code-schema/not-an-extension-setting.json
+++ b/src/negative_test/crucible-code-schema/not-an-extension-setting.json
@@ -1,0 +1,3 @@
+{
+  "extensions": { "acme-formatter": { "enable": true } }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -85,6 +85,49 @@
       },
       "type": "object"
     },
+    "extensions": {
+      "additionalProperties": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "type": "string"
+          },
+          "$comment": {
+            "type": "string"
+          },
+          "config": {
+            "description": "Settings for the extension itself, in whatever names its own documentation gives. Read only from the configuration file in your home directory",
+            "type": "object"
+          },
+          "enabled": {
+            "default": false,
+            "description": "Whether crucible may run this extension. Read only from the configuration file in your home directory",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "description": "Per-extension settings, keyed by the identifier the extension's manifest states",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        }
+      },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "pattern": "^[^$]"
+          },
+          {
+            "enum": ["$schema", "$comment"]
+          }
+        ]
+      },
+      "type": "object"
+    },
     "input": {
       "additionalProperties": false,
       "description": "What the keyboard does",
@@ -383,6 +426,25 @@
             "enum": ["$schema", "$comment"]
           }
         ]
+      },
+      "type": "object"
+    },
+    "sandbox": {
+      "additionalProperties": false,
+      "description": "Operating-system confinement for commands and descendant processes",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "mode": {
+          "default": "required",
+          "description": "Whether commands require verified kernel confinement, may use an explicit compatibility fallback, or run unconfined; only user configuration may weaken required",
+          "enum": ["required", "degraded", "off"],
+          "type": "string"
+        }
       },
       "type": "object"
     },

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -13,6 +13,14 @@
     "CRUCIBLE_CODE_MOUSE_SCROLL_SPEED": "12",
     "RUST_LOG": "warn"
   },
+  "extensions": {
+    "acme-formatter": {
+      "config": {
+        "profile": "strict"
+      },
+      "enabled": true
+    }
+  },
   "input": {
     "send": "altEnter"
   },
@@ -63,6 +71,9 @@
       "defaultContextWindow": 272000,
       "model": "gpt-5.2"
     }
+  },
+  "sandbox": {
+    "mode": "required"
   },
   "systemPrompt": {
     "append": "This repository is deployed on Fridays; never push to main.",


### PR DESCRIPTION
crucible 0.35.0 adds two top-level keys to `crucible-code-schema.json`, and
nothing else in the schema moved.

- **`sandbox`** — whether an approved command must run inside operating-system
  confinement. `mode` is `required` (the default), `degraded` for an explicit
  documented compatibility fallback, or `off`.
- **`extensions`** — per-extension settings, keyed by the identifier an
  extension's own manifest states. Each entry takes `enabled` and a `config`
  object in whatever names that extension documents.

The schema is generated from the program's own configuration type, so this is
the generated file from the released tag rather than a hand edit.

Tests changed with it. The positive `config.json` says in its own `$comment`
that it exercises every block, so it gains one of each. Two negative tests are
added: `not-a-sandbox-mode.json` for a value outside the `mode` enum, and
`not-an-extension-setting.json` for a misspelled key inside an extension entry,
which the entry's `additionalProperties: false` refuses.

Checked with `npm clean-install`, then the repository's own prettier config over
the four files, then `node ./cli.js check --schema-name=crucible-code-schema.json`,
which completes pre-checks and Ajv validation. I also confirmed that check can
fail: setting `sandbox.mode` to a value outside the enum in the positive test
makes it exit 1 with `must be equal to one of the allowed values`, and the file
was restored byte-for-byte afterwards.
