### PR TITLE
feat(crucible-code): add the mcp settings

### DIFF
--- a/src/negative_test/crucible-code-schema/an-mcp-server-with-no-command.json
+++ b/src/negative_test/crucible-code-schema/an-mcp-server-with-no-command.json
@@ -1,0 +1,9 @@
+{
+  "mcp": {
+    "servers": {
+      "docs": {
+        "requestSeconds": 60
+      }
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/not-an-mcp-server-setting.json
+++ b/src/negative_test/crucible-code-schema/not-an-mcp-server-setting.json
@@ -1,0 +1,3 @@
+{
+  "mcp": { "servers": { "docs": { "command": "docs-mcp", "restart": 1 } } }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -99,9 +99,13 @@
             "description": "Settings for the extension itself, in whatever names its own documentation gives. Read only from the configuration file in your home directory",
             "type": "object"
           },
+          "digest": {
+            "description": "The manifest digest this extension was agreed to at, as --extensions prints it. Read only from the configuration file in your home directory",
+            "type": "string"
+          },
           "enabled": {
             "default": false,
-            "description": "Whether crucible may run this extension. Read only from the configuration file in your home directory",
+            "description": "Whether crucible may run this extension. Not enough on its own: `digest` says which program was agreed to. Read only from the configuration file in your home directory",
             "type": "boolean"
           }
         },
@@ -143,6 +147,154 @@
           "description": "Which press sends a prompt: enter sends and Shift+Enter, Alt+Enter or Ctrl+J opens a line; altEnter swaps the two, for a terminal that keeps Enter for itself",
           "enum": ["enter", "altEnter"],
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "mcp": {
+      "additionalProperties": false,
+      "description": "MCP servers crucible may be asked to start",
+      "properties": {
+        "$schema": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "servers": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "properties": {
+              "$schema": {
+                "type": "string"
+              },
+              "$comment": {
+                "type": "string"
+              },
+              "args": {
+                "description": "What to pass the program, one argument per element, applied verbatim. Read only from the configuration file in your home directory",
+                "items": {
+                  "examples": ["-y", "@example/docs-mcp"],
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "description": "The program to run for this server. An absolute path, or a bare program name for PATH to answer. Read only from the configuration file in your home directory",
+                "examples": [
+                  "npx",
+                  "/usr/local/bin/docs-mcp",
+                  "C:\\Program Files\\docs-mcp\\docs-mcp.exe"
+                ],
+                "type": "string"
+              },
+              "directory": {
+                "description": "An absolute path to start the program in. Left off, the directory crucible was started in. Read only from the configuration file in your home directory",
+                "type": "string"
+              },
+              "env": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Environment variables for this server, applied verbatim — values, so nothing secret belongs here. Read only from the configuration file in your home directory",
+                "properties": {
+                  "$schema": {
+                    "type": "string"
+                  },
+                  "$comment": {
+                    "type": "string"
+                  }
+                },
+                "propertyNames": {
+                  "anyOf": [
+                    {
+                      "pattern": "^[^$]"
+                    },
+                    {
+                      "enum": ["$schema", "$comment"]
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              "envFrom": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Environment variables for this server taken from crucible's own, keyed by the name the server reads and holding the name crucible reads — names, never secrets. Read only from the configuration file in your home directory",
+                "properties": {
+                  "$schema": {
+                    "type": "string"
+                  },
+                  "$comment": {
+                    "type": "string"
+                  }
+                },
+                "propertyNames": {
+                  "anyOf": [
+                    {
+                      "pattern": "^[^$]"
+                    },
+                    {
+                      "enum": ["$schema", "$comment"]
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              "handshakeSeconds": {
+                "default": 10,
+                "description": "How long to wait for the server to agree a protocol version before giving up on it. Read only from the configuration file in your home directory",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "requestSeconds": {
+                "default": 60,
+                "description": "How long to wait for one request to this server before giving up on it. Read only from the configuration file in your home directory",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "required": {
+                "default": false,
+                "description": "Whether a run that selected this server fails when it cannot be prepared, rather than carrying on without its tools. Read only from the configuration file in your home directory",
+                "type": "boolean"
+              },
+              "restarts": {
+                "default": 0,
+                "description": "How many times this server may be started again after it ends. Read only from the configuration file in your home directory",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "shutdownSeconds": {
+                "default": 5,
+                "description": "How long the server is given to stop on its own before it is killed. Read only from the configuration file in your home directory",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": ["command"],
+            "type": "object"
+          },
+          "description": "MCP servers that may be selected, keyed by the identifier their tools are qualified by. Nothing is started by being written here",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            }
+          },
+          "propertyNames": {
+            "anyOf": [
+              {
+                "pattern": "^[^$]"
+              },
+              {
+                "enum": ["$schema", "$comment"]
+              }
+            ]
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -24,6 +24,26 @@
   "input": {
     "send": "altEnter"
   },
+  "mcp": {
+    "servers": {
+      "docs": {
+        "args": ["--catalogue", "public"],
+        "command": "docs-mcp",
+        "directory": "/home/you/src/docs",
+        "env": {
+          "DOCS_LOCALE": "en"
+        },
+        "envFrom": {
+          "DOCS_TOKEN": "MY_DOCS_TOKEN"
+        },
+        "handshakeSeconds": 10,
+        "requestSeconds": 60,
+        "required": true,
+        "restarts": 1,
+        "shutdownSeconds": 5
+      }
+    }
+  },
   "output": {
     "color": "auto",
     "glyphs": "unicode",


### PR DESCRIPTION
## Summary

`crucible-code` 0.36.0 added a top-level `mcp` key that the published schema
does not know about, so a configuration using it is reported as an unknown
property. This regenerates the schema from that release and adds the tests for
the new block.

- `mcp.servers` maps a server name to what it takes to start it: `command`
  (required), `args`, `directory`, `env`, `envFrom`, `handshakeSeconds`,
  `requestSeconds`, `shutdownSeconds`, `restarts` and `required`.
- The positive test gains an `mcp` block exercising every one of those keys.
- Two negative tests cover the two ways a server record goes wrong: a
  misspelled setting (`restart` for `restarts`), and a record with no `command`.

## Checks

`npm clean-install`, then prettier over the four files, then
`node ./cli.js check --schema-name=crucible-code-schema.json` — passes.

The check was confirmed able to fail before it was trusted: typing `restarts`
as a string in the positive test fails Ajv validation, and making either
negative test legal is reported as "supposed to fail". All three edits were
reverted and the check re-run green.

https://claude.ai/code/session_01TtwJEdGWh13be72DxUqHZE
