### PR TITLE
Add CanvasXpress figure + cxplot schemas

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1626,18 +1626,13 @@
     {
       "name": "CanvasXpress cxplot",
       "description": "CanvasXpress materialized grammar-of-graphics figure (layers, scales, coordinates, facets).",
-      "fileMatch": [
-        "*.cxplot.json"
-      ],
+      "fileMatch": ["*.cxplot.json"],
       "url": "https://www.canvasxpress.org/schema/cxplot-1.0.schema.json"
     },
     {
       "name": "CanvasXpress figure",
       "description": "Portable, self-describing CanvasXpress figure ({data, config}): a reproducible chart interchange format.",
-      "fileMatch": [
-        "*.cxfigure.json",
-        "*.cx.json"
-      ],
+      "fileMatch": ["*.cxfigure.json", "*.cx.json"],
       "url": "https://www.canvasxpress.org/schema/cxfigure-1.0.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1624,6 +1624,23 @@
       "url": "https://raw.githubusercontent.com/usecannon/cannon/main/packages/lsp/src/schema.json"
     },
     {
+      "name": "CanvasXpress cxplot",
+      "description": "CanvasXpress materialized grammar-of-graphics figure (layers, scales, coordinates, facets).",
+      "fileMatch": [
+        "*.cxplot.json"
+      ],
+      "url": "https://www.canvasxpress.org/schema/cxplot-1.0.schema.json"
+    },
+    {
+      "name": "CanvasXpress figure",
+      "description": "Portable, self-describing CanvasXpress figure ({data, config}): a reproducible chart interchange format.",
+      "fileMatch": [
+        "*.cxfigure.json",
+        "*.cx.json"
+      ],
+      "url": "https://www.canvasxpress.org/schema/cxfigure-1.0.schema.json"
+    },
+    {
       "name": "Carafe",
       "description": "Carafe compatible JavaScript Bundles",
       "url": "https://carafe.fm/schema/draft-02/bundle.schema.json",


### PR DESCRIPTION
Adds two catalog entries for the CanvasXpress figure specification:

- **CanvasXpress figure** (`*.cxfigure.json`, `*.cx.json`) — the portable, self-describing `{data, config}` figure format.
- **CanvasXpress cxplot** (`*.cxplot.json`) — the materialized grammar-of-graphics form.

Both schemas are JSON Schema Draft 2020-12, published at stable URLs with matching `$id`, served as `application/schema+json`:

- https://www.canvasxpress.org/schema/cxfigure-1.0.schema.json
- https://www.canvasxpress.org/schema/cxplot-1.0.schema.json

The format is documented and published independently (CC BY 4.0) at https://github.com/neuhausi/cxspec, with a stated compatibility policy and conformance fixtures. CanvasXpress is the reference implementation.