### PR TITLE
Restore GitHub action output schema dispatch

### DIFF
--- a/src/negative_test/github-action/composite-output-missing-value.json
+++ b/src/negative_test/github-action/composite-output-missing-value.json
@@ -1,0 +1,18 @@
+{
+  "description": "Composite action with an output missing its value",
+  "name": "Test composite output without value",
+  "outputs": {
+    "result": {
+      "description": "Missing value"
+    }
+  },
+  "runs": {
+    "steps": [
+      {
+        "run": "echo test",
+        "shell": "bash"
+      }
+    ],
+    "using": "composite"
+  }
+}

--- a/src/negative_test/github-action/javascript-output-with-value.json
+++ b/src/negative_test/github-action/javascript-output-with-value.json
@@ -1,0 +1,14 @@
+{
+  "description": "JavaScript action with a composite-only output value",
+  "name": "Test JavaScript output with value",
+  "outputs": {
+    "result": {
+      "description": "Unexpected value",
+      "value": "${{ steps.test.outputs.result }}"
+    }
+  },
+  "runs": {
+    "main": "index.js",
+    "using": "node24"
+  }
+}

--- a/src/schemas/json/github-action.json
+++ b/src/schemas/json/github-action.json
@@ -300,20 +300,7 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false,
-      "dependencies": {
-        "runs": {
-          "type": "object",
-          "properties": {
-            "using": {
-              "not": {
-                "const": "composite"
-              }
-            }
-          },
-          "required": ["using"]
-        }
-      }
+      "additionalProperties": false
     },
     "outputs-composite": {
       "$comment": "https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions",
@@ -340,16 +327,24 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false,
-      "dependencies": {
-        "runs": {
-          "type": "object",
-          "properties": {
-            "using": {
-              "const": "composite"
-            }
-          },
-          "required": ["using"]
+      "additionalProperties": false
+    }
+  },
+  "else": {
+    "properties": {
+      "outputs": {
+        "$ref": "#/definitions/outputs"
+      }
+    }
+  },
+  "if": {
+    "properties": {
+      "runs": {
+        "type": "object",
+        "properties": {
+          "using": {
+            "const": "composite"
+          }
         }
       }
     }
@@ -407,14 +402,7 @@
       "additionalProperties": false
     },
     "outputs": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/outputs-composite"
-        },
-        {
-          "$ref": "#/definitions/outputs"
-        }
-      ]
+      "$comment": "Because of `additionalProperties: false`, this empty schema is needed to allow the `outputs` property. The `outputs` subschema is determined by the if/then/else keywords."
     },
     "runs": {
       "oneOf": [
@@ -719,5 +707,12 @@
     }
   },
   "required": ["name", "description", "runs"],
+  "then": {
+    "properties": {
+      "outputs": {
+        "$ref": "#/definitions/outputs-composite"
+      }
+    }
+  },
   "type": "object"
 }

--- a/src/test/github-action/output-id-runs.json
+++ b/src/test/github-action/output-id-runs.json
@@ -1,0 +1,13 @@
+{
+  "description": "JavaScript action with an output named runs",
+  "name": "Test output named runs",
+  "outputs": {
+    "runs": {
+      "description": "An output whose identifier matches a top-level property"
+    }
+  },
+  "runs": {
+    "main": "index.js",
+    "using": "node24"
+  }
+}

--- a/src/test/github-action/outputs-empty.json
+++ b/src/test/github-action/outputs-empty.json
@@ -1,0 +1,9 @@
+{
+  "description": "JavaScript action with an empty output map",
+  "name": "Test empty outputs",
+  "outputs": {},
+  "runs": {
+    "main": "index.js",
+    "using": "node24"
+  }
+}


### PR DESCRIPTION
## Summary

Restore runtime-dependent validation for action outputs after #6270 moved the discriminator into output definitions, where `runs` refers to an output identifier rather than the top-level action runtime.

## Cause

#6270 replaced top-level `if` / `then` / `else` dispatch with `dependencies` nested inside each output definition. Dependencies evaluate the current output map, so `runs` is interpreted as an output identifier and cannot inspect top-level `runs.using`. The remaining undiscriminated `oneOf` allows the standard and composite output schemas to overlap.

The first commit adds four regression fixtures and records the verbatim failures produced when each fixture is tested independently on `master`. The second commit restores top-level `if` / `then` / `else` dispatch based on `runs.using`, with the object type required by AJV strict validation.

This restores these behaviors:

- Empty output maps are valid.
- `runs` is a valid output identifier.
- JavaScript outputs cannot declare composite-only `value`.
- Composite outputs require `value`.

_AI-generated (GPT-5.6 Sol), session: 735ab2c3-5ca6-4a29-815a-614392508b98 in schemastore._
