### PR TITLE
feat(claude-code-settings): add missing top-level keys

### DIFF
--- a/src/negative_test/claude-code-settings/invalid-enum-values.json
+++ b/src/negative_test/claude-code-settings/invalid-enum-values.json
@@ -2,6 +2,7 @@
   "askUserQuestionTimeout": "30s",
   "autoUpdatesChannel": "beta",
   "browserExternalPageTools": "enabled",
+  "crossSessionInbound": "maybe",
   "defaultShell": "zsh",
   "diffTool": "ide",
   "disableAutoMode": "enabled",

--- a/src/negative_test/claude-code-settings/wrong-property-types.json
+++ b/src/negative_test/claude-code-settings/wrong-property-types.json
@@ -1,6 +1,8 @@
 {
+  "autoContinueAtUsageLimit": "yes",
   "cleanupPeriodDays": "thirty",
   "enableAllProjectMcpServers": 1,
+  "enableWorkflows": "on",
   "fastMode": "yes",
   "hooks": {
     "PreToolUse": [
@@ -21,6 +23,7 @@
     "allow": "should be array",
     "ask": "should be array"
   },
+  "promptSuggestionEnabled": 1,
   "sandbox": {
     "network": {
       "allowAllUnixSockets": "yes",
@@ -33,5 +36,6 @@
       "hostPattern": 123,
       "source": "hostPattern"
     }
-  ]
+  ],
+  "switchModelsOnFlag": "true"
 }

--- a/src/schemas/json/claude-code-settings.json
+++ b/src/schemas/json/claude-code-settings.json
@@ -4254,6 +4254,30 @@
     "requireCoworkFullVmSandbox": {
       "type": "boolean",
       "description": "(Managed settings only) Run Claude's tools inside an isolated virtual machine instead of on your Mac. Disables the desktop app's iOS Simulator pane and Claude's simulator tools entirely, so the pane cannot attach a device while it is set. See https://code.claude.com/docs/en/desktop-ios-simulator#turn-off-simulator-access"
+    },
+    "autoContinueAtUsageLimit": {
+      "type": "boolean",
+      "description": "After a claude.ai usage limit stops your session, wait in the open session and continue the task automatically once the limit resets (default: true). When false, Claude Code does not start the wait on its own and you start one from the usage-limit options menu. Read from user settings, the --settings flag, and managed settings only; when none of those sets it, a project or local settings file that sets it turns the feature off rather than being ignored. Appears in /config as Continue automatically at usage limit. Requires Claude Code v2.1.234 or later. See https://code.claude.com/docs/en/interactive-mode#wait-for-a-usage-limit-to-reset",
+      "default": true
+    },
+    "crossSessionInbound": {
+      "type": "string",
+      "description": "What this session does with messages arriving from your other Claude Code sessions: \"accept\" delivers the message to Claude, \"hold\" shows a notice without delivering it, and \"refuse\" drops it. Unset lets Claude Code decide per message from the two sessions' permission-mode classes. A project or local value applies only when it is stricter than the value managed settings, the --settings flag, or user settings give. Appears in /config as Messages from your other sessions. Requires Claude Code v2.1.224 or later. See https://code.claude.com/docs/en/cross-session-messaging#control-inbound-messages",
+      "enum": ["accept", "hold", "refuse"]
+    },
+    "enableWorkflows": {
+      "type": "boolean",
+      "description": "Turn dynamic workflows on or off for yourself when your plan's default is not what you want. Unset leaves workflows on except on the Pro plan, where they are off. disableWorkflows, an organization's workflows policy, and the CLAUDE_CODE_DISABLE_WORKFLOWS environment variable take precedence, so true cannot turn workflows back on while any of them turns them off. Appears in /config as Dynamic workflows. See https://code.claude.com/docs/en/workflows"
+    },
+    "promptSuggestionEnabled": {
+      "type": "boolean",
+      "description": "Show prompt suggestions, the grayed-out predictions that appear in the prompt input (default: true). Set to false, or turn off Prompt suggestions in /config, to hide them. The CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION environment variable takes precedence for one session. Prompt suggestions need a claude.ai or Console account with telemetry on; on Amazon Bedrock, Google Cloud's Agent Platform, and Microsoft Foundry, or with telemetry off, this key has no effect. See https://code.claude.com/docs/en/interactive-mode#prompt-suggestions",
+      "default": true
+    },
+    "switchModelsOnFlag": {
+      "type": "boolean",
+      "description": "What happens when a safety classifier flags a request: true switches to the fallback model and continues, false pauses an interactive session so you can choose between switching and editing the prompt (where no dialog can show, such as a -p run, the flagged request ends as an error). Appears in /config as Switch models when a message is flagged. Requires Claude Code v2.1.170 or later. See https://code.claude.com/docs/en/model-config#ask-before-switching",
+      "default": true
     }
   },
   "title": "Claude Code Settings"

--- a/src/test/claude-code-settings/enum-coverage.json
+++ b/src/test/claude-code-settings/enum-coverage.json
@@ -3,6 +3,7 @@
   "askUserQuestionTimeout": "10m",
   "browserExternalPageTools": "disabled",
   "channelsEnabled": false,
+  "crossSessionInbound": "hold",
   "defaultShell": "bash",
   "diffTool": "auto",
   "editorMode": "normal",

--- a/src/test/claude-code-settings/managed-settings.json
+++ b/src/test/claude-code-settings/managed-settings.json
@@ -32,6 +32,7 @@
       "url": "https://github.com/untrusted-org/plugins.git"
     }
   ],
+  "crossSessionInbound": "refuse",
   "deniedMcpServers": [
     {
       "serverName": "dangerous-server"

--- a/src/test/claude-code-settings/modern-complete-config.json
+++ b/src/test/claude-code-settings/modern-complete-config.json
@@ -23,6 +23,7 @@
   },
   "autoCompactEnabled": true,
   "autoConnectIde": true,
+  "autoContinueAtUsageLimit": false,
   "autoInstallIdeExtension": false,
   "autoMemoryDirectory": "~/.claude/custom-memory",
   "autoMemoryEnabled": false,
@@ -55,6 +56,7 @@
   ],
   "cleanupPeriodDays": 60,
   "companyAnnouncements": ["Welcome to the team!"],
+  "crossSessionInbound": "accept",
   "defaultShell": "powershell",
   "diffTool": "terminal",
   "disableAgentView": false,
@@ -76,6 +78,7 @@
   "emojiCompletionEnabled": false,
   "enableAllProjectMcpServers": true,
   "enableArtifact": true,
+  "enableWorkflows": true,
   "enabledPlugins": {
     "formatter@anthropic-tools": true
   },
@@ -409,6 +412,7 @@
   "preferredNotifChannel": "terminal_bell",
   "prefersReducedMotion": true,
   "processWrapper": "/opt/corp/launcher --profile claude",
+  "promptSuggestionEnabled": false,
   "remoteControlAtStartup": false,
   "requireCoworkFullVmSandbox": true,
   "requiredMaximumVersion": "3.0.0",
@@ -516,6 +520,7 @@
     "command": "~/.claude/subagent-statusline.sh",
     "type": "command"
   },
+  "switchModelsOnFlag": false,
   "syntaxHighlightingDisabled": false,
   "teammateDefaultModel": "sonnet",
   "teammateMode": "tmux",


### PR DESCRIPTION
Five settings that Claude Code reads are missing from `claude-code-settings.json`. The schema's top-level `additionalProperties` is `true`, so today they validate silently: editors offer no completion for them, and strict validation can't be turned on for a settings file that uses them.

All five are documented in the Claude Code settings reference and are referenced by the Claude Code 2.1.261 binary.

| Key | Type | Default | Docs |
| --- | --- | --- | --- |
| `autoContinueAtUsageLimit` | boolean | `true` | https://code.claude.com/docs/en/settings-reference#autocontinueatusagelimit |
| `crossSessionInbound` | string enum: `accept`, `hold`, `refuse` | unset | https://code.claude.com/docs/en/settings-reference#crosssessioninbound |
| `enableWorkflows` | boolean | unset | https://code.claude.com/docs/en/settings-reference#enableworkflows |
| `promptSuggestionEnabled` | boolean | `true` | https://code.claude.com/docs/en/settings-reference#promptsuggestionenabled |
| `switchModelsOnFlag` | boolean | `true` | https://code.claude.com/docs/en/settings-reference#switchmodelsonflag |

The `crossSessionInbound` values come from https://code.claude.com/docs/en/cross-session-messaging#control-inbound-messages.

Descriptions follow the conventions already in this file: enum values explained inline in the `description` (as in `autoUpdatesChannel`) rather than via non-standard `enumDescriptions`, with a trailing docs URL. `default` is set only where the docs state one; `enableWorkflows` and `crossSessionInbound` are documented as unset by default, so neither gets a `default`.

### Tests

- `src/test/claude-code-settings/modern-complete-config.json` — all five keys
- `src/test/claude-code-settings/enum-coverage.json` — `crossSessionInbound: "hold"`
- `src/test/claude-code-settings/managed-settings.json` — `crossSessionInbound: "refuse"`, matching the managed-settings example in the docs

Together with `"accept"` in `modern-complete-config.json`, all three enum values are exercised.

Negative tests:

- `src/negative_test/claude-code-settings/invalid-enum-values.json` — `crossSessionInbound: "maybe"`
- `src/negative_test/claude-code-settings/wrong-property-types.json` — a non-boolean for each of the four booleans

### Checks run

```
npm clean-install
node ./cli.js check --schema-name=claude-code-settings.json   # pre-checks + Ajv validation pass
node ./cli.js coverage --schema-name=claude-code-settings.json # 8 passed, 0 failed, 0 warned
npm run prettier                                               # all matched files use Prettier code style
npm run typecheck
npm run eslint
```

I also compiled the schema with Ajv directly and asserted each new constraint bites: the three valid `crossSessionInbound` values validate, `"maybe"` does not, and each boolean rejects a non-boolean. 12/12 as expected.

`pre-commit` was not run locally; the only hooks are Prettier (run above via `npm run prettier`) and codespell, which I ran over the changed files with no findings.
