### PR TITLE
Update crucible-code schema for 0.38.0

### DIFF
--- a/src/negative_test/crucible-code-schema/not-a-sandbox-enabled.json
+++ b/src/negative_test/crucible-code-schema/not-a-sandbox-enabled.json
@@ -1,0 +1,3 @@
+{
+  "sandbox": { "enabled": "required" }
+}

--- a/src/negative_test/crucible-code-schema/not-a-sandbox-mode.json
+++ b/src/negative_test/crucible-code-schema/not-a-sandbox-mode.json
@@ -1,3 +1,0 @@
-{
-  "sandbox": { "mode": "strict" }
-}

--- a/src/negative_test/crucible-code-schema/removed-sandbox-mode.json
+++ b/src/negative_test/crucible-code-schema/removed-sandbox-mode.json
@@ -1,0 +1,3 @@
+{
+  "sandbox": { "mode": "required" }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -591,11 +591,10 @@
         "$comment": {
           "type": "string"
         },
-        "mode": {
-          "default": "required",
-          "description": "Whether commands require verified kernel confinement, may use an explicit compatibility fallback, or run unconfined; only user configuration may weaken required",
-          "enum": ["required", "degraded", "off"],
-          "type": "string"
+        "enabled": {
+          "default": false,
+          "description": "Require verified operating-system confinement for commands; off by default, and only user configuration may disable it",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -93,7 +93,7 @@
     }
   },
   "sandbox": {
-    "mode": "required"
+    "enabled": true
   },
   "systemPrompt": {
     "append": "This repository is deployed on Fridays; never push to main.",


### PR DESCRIPTION
Crucible Code 0.38.0 replaces `sandbox.mode` with the opt-in boolean `sandbox.enabled`, whose default is `false`.

This updates the published schema and its fixtures to accept `enabled: true`, reject non-boolean values, and reject the removed `mode` property.

Release: https://github.com/augments-labs/crucible-code/releases/tag/v0.38.0

Validation:

- `./node_modules/.bin/prettier --check` on all changed JSON files
- `node ./cli.js check --schema-name=crucible-code-schema.json`
