### PR TITLE
Document rumdl ALL selector

### DIFF
--- a/src/schemas/json/rumdl.json
+++ b/src/schemas/json/rumdl.json
@@ -73,7 +73,7 @@
       "type": "object",
       "properties": {
         "enable": {
-          "description": "Enabled rules",
+          "description": "Enabled rules. Use \"ALL\" to enable all rules.",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
## Problem

The rumdl schema does not document the supported `ALL` selector for `global.enable`, so editors report it as an unknown rule.

Closes #6290.

## Change

Document that `ALL` enables all rules.

## Verification

- JSON parsing passed
- Prettier check for the modified schema passed
- `git diff --check` passed

## Compatibility / Risk

Documentation-only schema-description change. No validation behavior changes.
