### PR TITLE
fix: "misc" typo

### DIFF
--- a/src/schemas/json/minecraft-recipe.json
+++ b/src/schemas/json/minecraft-recipe.json
@@ -356,7 +356,7 @@
       "properties": {
         "category": {
           "type": "string",
-          "enum": ["food", "blocks", "misc "]
+          "enum": ["food", "blocks", "misc"]
         }
       }
     },


### PR DESCRIPTION
Fixes a typo introduced in #2699

[Reference](https://www.minecraft.net/en-us/article/minecraft-snapshot-22w42a)
