### PR TITLE
Add rollForward for dotnet-tools.json

### DIFF
--- a/src/schemas/json/dotnet-tools.json
+++ b/src/schemas/json/dotnet-tools.json
@@ -42,6 +42,11 @@
                 "title": "Tool Command",
                 "description": "A command made available by this tool which can be invoked according to the naming convention of its executable. If the command is in the format `dotnet-<toolName>`, it should be invoked using 'dotnet <toolName>'. If the command is in the format '<toolName>', it can be directly invoked using just '<toolName>'. If null, no specific commands are specified."
               }
+            },
+            "rollForward": {
+              "type": "boolean",
+              "title": "Allow roll-forward",
+              "description": "Allow tool to use a newer version of the .NET runtime if the runtime it targets isn't installed."
             }
           }
         }


### PR DESCRIPTION
The `rollForward` property was added in 9.0.100, and was implemented here: dotnet/sdk#37231

It corresponds to the `--allow-roll-forward` argument for [`dotnet tool install`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install).