### PR TITLE
Update crucible-code schema for 0.39.0

### DIFF
--- a/src/negative_test/crucible-code-schema/duplicate-sandbox-path.json
+++ b/src/negative_test/crucible-code-schema/duplicate-sandbox-path.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "filesystem": {
+      "writable": ["build", "build"]
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/excessive-sandbox-concurrency.json
+++ b/src/negative_test/crucible-code-schema/excessive-sandbox-concurrency.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "limits": {
+      "concurrentCommands": 17
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/excessive-sandbox-output.json
+++ b/src/negative_test/crucible-code-schema/excessive-sandbox-output.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "limits": {
+      "outputBytes": 67108865
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/not-a-sandbox-binding.json
+++ b/src/negative_test/crucible-code-schema/not-a-sandbox-binding.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "network": {
+      "allowLocalBinding": "true"
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/not-a-sandbox-path.json
+++ b/src/negative_test/crucible-code-schema/not-a-sandbox-path.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "filesystem": {
+      "readOnly": [""]
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/unknown-sandbox-network-key.json
+++ b/src/negative_test/crucible-code-schema/unknown-sandbox-network-key.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "network": {
+      "allowAll": true
+    }
+  }
+}

--- a/src/negative_test/crucible-code-schema/zero-sandbox-command-time.json
+++ b/src/negative_test/crucible-code-schema/zero-sandbox-command-time.json
@@ -1,0 +1,7 @@
+{
+  "sandbox": {
+    "limits": {
+      "commandSeconds": 0
+    }
+  }
+}

--- a/src/schemas/json/crucible-code-schema.json
+++ b/src/schemas/json/crucible-code-schema.json
@@ -595,6 +595,155 @@
           "default": false,
           "description": "Require verified operating-system confinement for commands; off by default, and only user configuration may disable it",
           "type": "boolean"
+        },
+        "filesystem": {
+          "additionalProperties": false,
+          "description": "Filesystem access relative to the workspace root or at an absolute path",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "protected": {
+              "default": [],
+              "description": "Readable paths that no nested writable grant may reopen",
+              "items": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "readOnly": {
+              "default": [],
+              "description": "Readable paths without write access; projects may only narrow existing access",
+              "items": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "unreadable": {
+              "default": [],
+              "description": "Paths hidden from sandboxed commands on Linux/WSL2 and macOS; nonempty lists are unsupported on native Windows",
+              "items": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "writable": {
+              "default": [],
+              "description": "Additional writable paths; only user configuration may grant access",
+              "items": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "type": "object"
+        },
+        "limits": {
+          "additionalProperties": false,
+          "description": "Command resource ceilings; project configuration may only lower them",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "commandSeconds": {
+              "default": 1200,
+              "description": "Maximum wall time for each command, including background commands",
+              "maximum": 86400,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "concurrentCommands": {
+              "default": 4,
+              "description": "Maximum simultaneously running commands",
+              "maximum": 16,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "outputBytes": {
+              "default": 10485760,
+              "description": "Maximum combined command output before its process scope is stopped",
+              "maximum": 67108864,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "network": {
+          "additionalProperties": false,
+          "description": "Domain mediation and explicit local connections",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "$comment": {
+              "type": "string"
+            },
+            "allowLocalBinding": {
+              "default": false,
+              "description": "Allow sandboxed processes to create local listeners on Linux/WSL2 and macOS; true is unsupported on native Windows",
+              "type": "boolean"
+            },
+            "allowUnixSockets": {
+              "default": [],
+              "description": "Exact host Unix socket paths on Linux/WSL2 and macOS; projects may only narrow user grants; nonempty lists are unsupported on native Windows",
+              "items": {
+                "maxLength": 4096,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "allowedDomains": {
+              "default": [],
+              "description": "Allowed hostnames, IP literals, *.domain patterns or * on Linux/WSL2 and macOS; projects may only narrow user grants; unsupported on native Windows",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "uniqueItems": true
+            },
+            "deniedDomains": {
+              "default": [],
+              "description": "Overriding denied hostnames, IP literals or domain patterns on Linux/WSL2 and macOS; nonempty lists are unsupported on native Windows",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/src/test/crucible-code-schema/config.json
+++ b/src/test/crucible-code-schema/config.json
@@ -84,6 +84,11 @@
       "effort": "high",
       "model": "claude-opus-5"
     },
+    "google": {
+      "apiKeyEnv": "WORK_GEMINI_KEY",
+      "effort": "high",
+      "model": "gemini-3.8-flash"
+    },
     "openai": {
       "contextWindow": {
         "gpt-5.2-pro": 400000
@@ -93,7 +98,24 @@
     }
   },
   "sandbox": {
-    "enabled": true
+    "enabled": true,
+    "filesystem": {
+      "protected": [".git"],
+      "readOnly": ["vendor"],
+      "unreadable": [".env"],
+      "writable": ["/home/you/build"]
+    },
+    "limits": {
+      "commandSeconds": 1200,
+      "concurrentCommands": 4,
+      "outputBytes": 10485760
+    },
+    "network": {
+      "allowLocalBinding": false,
+      "allowUnixSockets": ["/run/example.sock"],
+      "allowedDomains": ["example.com"],
+      "deniedDomains": ["private.example.com"]
+    }
   },
   "systemPrompt": {
     "append": "This repository is deployed on Fridays; never push to main.",


### PR DESCRIPTION
Updates Crucible Code’s schema for v0.39.0, adding filesystem policy, network policy and command limits under the opt-in `sandbox.enabled` setting. The removed `sandbox.mode` remains rejected.

The schema is copied from the released generator output with only Prettier formatting. Fixtures exercise all sandbox fields, Gemini configuration, invalid path and boolean values, unknown keys, duplicate paths and resource bounds.

Release: https://github.com/augments-labs/crucible-code/releases/tag/v0.39.0

Validation: semantic equality with the Crucible schema; Prettier checks; `node cli.js check --schema-name=crucible-code-schema.json`. Based on current upstream `master`, including the merged v0.38.0 update in #6312.
