### PR TITLE
fix: support confirmModulesPurge in pnpm workspace schema

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -472,6 +472,11 @@
       "description": "When false, pnpm will not write any files to the modules directory (node_modules).",
       "type": "boolean"
     },
+    "confirmModulesPurge": {
+      "description": "Controls whether pnpm asks for confirmation before removing and reinstalling a modules directory that is incompatible with the current install settings. Confirmation is disabled in CI. Supported by pnpm v11.",
+      "type": "boolean",
+      "default": true
+    },
     "virtualStoreDir": {
       "description": "The directory with links to the store.",
       "type": "string"

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -65,6 +65,9 @@ virtualStoreType: global
 # https://pnpm.io/settings/node-modules#hoistinglimits
 hoistingLimits: none
 
+# https://pnpm.io/settings/node-modules#confirmmodulespurge
+confirmModulesPurge: false
+
 # https://pnpm.io/settings/store#frozenstore
 frozenStore: true
 


### PR DESCRIPTION
## Summary

- recognize the pnpm 11 confirmModulesPurge workspace setting as a boolean
- document its confirmation and CI behavior in schema tooling
- cover the setting in the existing positive pnpm workspace fixture

This prevents SchemaStore-backed YAML tooling from reporting a valid pnpm 11 setting as an unsupported property.

## Validation

- node ./cli.js check --schema-name=pnpm-workspace.json
- node ./cli.js check
- node ./cli.js coverage
- npm run typecheck
- npm run eslint
- npm run prettier
- uvx pre-commit run --files src/schemas/json/pnpm-workspace.json src/test/pnpm-workspace/pnpm-workspace.yaml

Refs pnpm/pnpm#14316.

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>