### PR TITLE
fix: support runtime in pnpm workspace schema

### DIFF
--- a/src/schemas/json/pnpm-workspace.json
+++ b/src/schemas/json/pnpm-workspace.json
@@ -1213,6 +1213,10 @@
         }
       ]
     },
+    "runtime": {
+      "description": "Controls whether pnpm installs runtime entries declared in `devEngines.runtime`. Set to false when the runtime is provisioned separately, such as in a CI matrix.",
+      "type": "boolean"
+    },
     "runtimeOnFail": {
       "description": "Overrides the `onFail` field of `devEngines.runtime` (and `engines.runtime`) in the root project's `package.json`. This is useful when you want a different local behavior than what is written in the manifest — for instance, forcing pnpm to download the declared runtime even when the manifest sets `onFail: \"warn\"`.",
       "oneOf": [

--- a/src/test/pnpm-workspace/pnpm-workspace.yaml
+++ b/src/test/pnpm-workspace/pnpm-workspace.yaml
@@ -79,3 +79,6 @@ globalShims:
 
 # https://pnpm.io/settings/other#ci
 ci: false
+
+# https://pnpm.io/blog/releases/11.1#--no-runtime-for-ci-matrices
+runtime: false


### PR DESCRIPTION
## Summary

- recognize the pnpm 11.1 runtime workspace setting as a boolean
- document its use when runtimes are provisioned separately
- cover the setting in the existing positive pnpm workspace fixture

This prevents SchemaStore-backed YAML tooling from reporting a valid pnpm setting as an unsupported property.

## Validation

- node ./cli.js check --schema-name=pnpm-workspace.json
- node ./cli.js check
- node ./cli.js coverage
- npm run typecheck
- npm run eslint
- npm run prettier
- uvx pre-commit run --files src/schemas/json/pnpm-workspace.json src/test/pnpm-workspace/pnpm-workspace.yaml

Fixes #6310.

Co-authored-by: insisong <emmanuelisaacnsisong@gmail.com>