### PR TITLE
Add datavzrd configuration schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -2755,6 +2755,12 @@
       "url": "https://www.schemastore.org/datalogic-scan2deploy-ce.json"
     },
     {
+      "name": "datavzrd",
+      "description": "Configuration file for datavzrd, a tool to create visual and interactive HTML reports from tabular data",
+      "fileMatch": ["*.datavzrd.yaml", "*.datavzrd.yml"],
+      "url": "https://datavzrd.github.io/schema/latest/datavzrd.schema.json"
+    },
+    {
       "name": "ddev-global",
       "description": "DDEV global configuration file",
       "fileMatch": ["**/.ddev/global_config.yaml"],


### PR DESCRIPTION
This PR adds a catalog entry for datavzrd, a tool for creating interactive HTML reports from tabular data. The schema is self-hosted and generated directly from datavzrd's configuration types. For more info about the project check out github.com/datavzrd/datavzrd