### PR TITLE
perf(layout): optimize site.js loading and add theme-color 🚀 

### DIFF
--- a/src/_Layout.cshtml
+++ b/src/_Layout.cshtml
@@ -29,6 +29,8 @@
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="msapplication-TileImage" content="/img/favicon/mstile-144x144.png" />
     <meta name="msapplication-config" content="/img/favicon/browserconfig.xml" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#17212c">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)"  content="#0b0e12">
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="@Page.Title" />

--- a/src/_Layout.cshtml
+++ b/src/_Layout.cshtml
@@ -40,6 +40,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://schemastore.org" />
     <meta property="og:image" content="http://schemastore.org/img/json-logo.png" />
+    <script src="/js/site.js" defer></script>
 </head>
 <body>
 
@@ -53,12 +54,11 @@
     <div role="main" id="main" class="container">
         @RenderBody()
     </div>
-   
+
     <footer role="contentinfo" class="container">
         @*<p>Learn more at <a href="http://json-schema.org">json-schema.org</a> and <a href="http://spacetelescope.github.io/understanding-json-schema/">Understanding JSON Schema</a></p>*@
         <p>Open source on <a href="https://github.com/schemastore/schemastore/">GitHub</a></p>
     </footer>
 
-    <script src="/js/site.js" async defer></script>
 </body>
 </html>


### PR DESCRIPTION

This PR adds browser theme colors to match the navbar and optimizes script loading for `/js/site.js`.

### **Changes**
* **Added `theme-color` meta tags**: Matches the mobile/browser toolbar [color with the navbar](https://github.com/SchemaStore/schemastore/blob/7d8659ecbca26d6d6d39646ef3f0d92f5f35ded1/src/css/site.css#L16) for both light (`#17212c`) and dark (`#0b0e12`) modes.
* **Optimized `site.js` loading**:
  * Moved the script tag to `<head>` with `defer` so the browser can discover and download it earlier in parallel with HTML parsing.
  * Removed `async` to ensure predictable execution order after the DOM is ready without blocking page rendering.

### **References**
* [web.dev: Efficiently load JavaScript with defer](https://web.dev/articles/efficiently-load-third-party-javascript#defer)
* [Next.js Discussion #24938: Script loading strategies](https://github.com/vercel/next.js/discussions/24938)