### PR TITLE
Add production delivery manifest schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11669,6 +11669,12 @@
       "description": "Configuration file for urai-ecma: AST commentary, pruning, and LLM context packaging engine for ECMAScript codebases",
       "fileMatch": ["urai.config.jsonc", "urai.config.json"],
       "url": "https://www.schemastore.org/urai-ecma.json"
+    },
+    {
+      "name": "Production delivery manifest",
+      "description": "Rights-labelled video-production delivery manifest",
+      "fileMatch": ["production-delivery-manifest.json"],
+      "url": "https://raw.githubusercontent.com/SHARProduction/production-delivery-manifest-schema/v1.0.0/schema.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers the existing, versioned **Production delivery manifest** schema as a remote SchemaStore entry.

- Exact file match: `production-delivery-manifest.json`
- Remote schema URL is pinned to the public `v1.0.0` Git tag.
- The format is used with the accompanying open-source validator and rights-labelled fixtures: https://github.com/SHARProduction/production-delivery-manifest-schema

## Verification

- Schema repository: `node --test` — 2 passed
- Stable remote schema URL — HTTP 200
- `catalog.json` parses as JSON
- `git diff --check`
- SchemaStore: `npm ci`, `npm run typecheck`

This is a narrow file match, avoiding generic JSON association.