### PR TITLE
Add Defakto CI configuration to catalog.json

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -11675,6 +11675,12 @@
       "description": "Rights-labelled video-production delivery manifest",
       "fileMatch": ["production-delivery-manifest.json"],
       "url": "https://raw.githubusercontent.com/SHARProduction/production-delivery-manifest-schema/v1.0.0/schema.json"
+    },
+    {
+      "name": "Defakto CI",
+      "description": "CI configuration files used at Defakto Security",
+      "fileMatch": ["**/.defakto/ci.yaml"],
+      "url": "https://defakto-security.github.io/build-actions/ci.schema.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Registers a schema for the ci config files that [Defakto Security](https://www.defakto.security/) uses internally.
