### PR TITLE
fix: Rename subscriber readiness timeout property

### DIFF
--- a/src/schemas/json/specmatic.json
+++ b/src/schemas/json/specmatic.json
@@ -1658,7 +1658,7 @@
         "replyTimeout": {
           "$ref": "#/definitions/SubstitutableInteger"
         },
-        "subscriberReadinessWaitTimeout": {
+        "subscriberReadinessWaitTime": {
           "$ref": "#/definitions/SubstitutableInteger"
         },
         "servers": {


### PR DESCRIPTION
This PR fixes a typo in a parameter in the Specmatic config file schema. It renames `runOptions.asyncapi`.`subscriberReadinessWaitTimeout` to `subscriberReadinessWaitTime`.