### PR TITLE
Add Onyx v1 schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,5 @@ repos:
         args:
           [
             '--ignore-words-list',
-            'crate,optIn,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,dout,foto,vor,wel,NAM,BRIN,everyTime,afterAll,beforeAll,ontainer,mis-match,explicilty,hashin,paket',
+            'crate,optIn,ninjs,ans,specif,seh,specifid,deriver,isnt,tye,forin,dependees,rouge,interm,fo,wast,nome,statics,ue,aack,gost,inout,provId,handels,bu,testng,ags,edn,aks,te,decorder,provid,branche,alse,nd,mape,wil,clude,wit,flate,omlet,THIRDPARTY,NotIn,notIn,CopyIn,Requestor,requestor,re-use,ofo,abl,dout,foto,vor,wel,NAM,BRIN,everyTime,afterAll,beforeAll,ontainer,mis-match,explicilty,hashin,paket,brunch,bein,burnin',
           ]

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5732,6 +5732,12 @@
       "url": "https://app.gitpod.io/jsonschema/v1/ona_config.jsonschema.json"
     },
     {
+      "name": "Onyx v1",
+      "description": "A portable personal food and body-weight diary",
+      "fileMatch": ["*.onyx.json", "*.onx.json"],
+      "url": "https://www.schemastore.org/onyx-v1.json"
+    },
+    {
       "name": "openapi.json",
       "description": "An OpenAPI documentation file",
       "fileMatch": [

--- a/src/negative_test/onyx-v1/absent-required-members-stay-absent.json
+++ b/src/negative_test/onyx-v1/absent-required-members-stay-absent.json
@@ -1,0 +1,26 @@
+{
+  "bodyMeasurements": [
+    {
+      "value": {
+        "unit": "kg",
+        "value": 70
+      }
+    },
+    {
+      "type": "bodyMass"
+    }
+  ],
+  "days": [
+    {
+      "entries": [
+        {
+          "name": "Oats"
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/confidence-out-of-range.json
+++ b/src/negative_test/onyx-v1/confidence-out-of-range.json
@@ -1,0 +1,28 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "confidence": 90,
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 389
+            }
+          },
+          "source": "estimated"
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Writes Percentages"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/not-an-onyx-document.json
+++ b/src/negative_test/onyx-v1/not-an-onyx-document.json
@@ -1,0 +1,6 @@
+{
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "format": "some-other-format",
+  "producer": { "name": "Wrong Format" },
+  "specVersion": "1.0.0"
+}

--- a/src/negative_test/onyx-v1/present-but-empty-members-survive.json
+++ b/src/negative_test/onyx-v1/present-but-empty-members-survive.json
@@ -1,0 +1,31 @@
+{
+  "bodyMeasurements": [
+    {
+      "observedAt": "",
+      "type": "",
+      "value": {
+        "unit": "kg",
+        "value": 70
+      }
+    }
+  ],
+  "days": [
+    {
+      "date": "",
+      "entries": [
+        {
+          "loggedAt": "",
+          "name": "Oats"
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "",
+    "version": "3.1.0"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/quantity-without-a-value.json
+++ b/src/negative_test/onyx-v1/quantity-without-a-value.json
@@ -1,0 +1,25 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Drops The Number"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/ragged-array-survives.json
+++ b/src/negative_test/onyx-v1/ragged-array-survives.json
@@ -1,0 +1,37 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 389
+            }
+          }
+        },
+        "a stray string where an entry should be",
+        {
+          "loggedAt": "2026-08-10T13:00:00+02:00",
+          "name": "Soup",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 210
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Writes A Ragged Array"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/unit-not-ucum.json
+++ b/src/negative_test/onyx-v1/unit-not-ucum.json
@@ -1,0 +1,22 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+03:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": { "unit": "calories", "value": 389 },
+            "protein": { "unit": "grams", "value": 16.9 }
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T12:00:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Invented Units" },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/negative_test/onyx-v1/utc-normalised-measurement.json
+++ b/src/negative_test/onyx-v1/utc-normalised-measurement.json
@@ -1,0 +1,19 @@
+{
+  "bodyMeasurements": [
+    {
+      "observedAt": "2026-08-10T00:30:00Z",
+      "type": "bodyMass",
+      "value": {
+        "unit": "kg",
+        "value": 70.5
+      }
+    }
+  ],
+  "exportedAt": "2026-08-10T09:00:00+09:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Normalises Only Measurements"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Asia/Tokyo"
+}

--- a/src/negative_test/onyx-v1/utc-normalised-timestamps.json
+++ b/src/negative_test/onyx-v1/utc-normalised-timestamps.json
@@ -1,0 +1,19 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T05:30:00Z",
+          "name": "Oats",
+          "nutrients": { "energy": { "unit": "kcal", "value": 389 } }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00Z",
+  "format": "onyx",
+  "producer": { "name": "Normalises To UTC" },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/schema-validation.jsonc
+++ b/src/schema-validation.jsonc
@@ -304,7 +304,8 @@
     "enonic-xp-task-8.0.0.json",
     "enonic-xp-webapp-8.0.0.json",
     "cfgd-module-0.5.0.json",
-    "cfgd-module-0.10.0.json"
+    "cfgd-module-0.10.0.json",
+    "onyx-v1.json"
   ],
   "missingCatalogUrl": [
     // Below this line are subschemas that are included from other schema

--- a/src/schemas/json/onyx-v1.json
+++ b/src/schemas/json/onyx-v1.json
@@ -1,0 +1,343 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.schemastore.org/onyx-v1.json",
+  "$defs": {
+    "timestamp": {
+      "type": "string",
+      "description": "RFC 3339 carrying the subject's local offset at that moment. Not normalised to UTC: 'Z' keeps the instant and discards the local wall clock, which is what answers which day a meal belonged to.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?[+-]\\d{2}:\\d{2}$"
+    },
+    "quantity": {
+      "type": "object",
+      "description": "A value with a UCUM unit code. Never a bare number.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "description": "UCUM code: kcal, kJ, g, mg, ug, mL, kg, [lb_av], cm, [in_i], a, %, 1.",
+          "examples": ["kcal", "g", "kg", "[lb_av]", "cm", "a"]
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "properties": {
+        "sex": {
+          "type": "string",
+          "examples": ["male", "female", "other", "unknown"],
+          "description": " Not exhaustive: a consumer treats a value it does not recognise as absent, never as an error."
+        },
+        "age": {
+          "$ref": "#/$defs/duration",
+          "description": "UCUM 'a' (years)."
+        },
+        "height": {
+          "$ref": "#/$defs/length"
+        },
+        "preferredUnits": {
+          "type": "object",
+          "description": "Units the subject prefers to read. NOT the units used in this file.",
+          "properties": {
+            "mass": {
+              "type": "string"
+            },
+            "energy": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "goal": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "examples": ["targetWeight", "weightDirection"]
+        },
+        "value": {
+          "$ref": "#/$defs/quantity"
+        },
+        "direction": {
+          "type": "string",
+          "examples": ["loss", "maintain", "gain"],
+          "description": " Not exhaustive: a consumer treats a value it does not recognise as absent, never as an error."
+        }
+      }
+    },
+    "day": {
+      "type": "object",
+      "required": ["date"],
+      "properties": {
+        "date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "LOCAL calendar date. MUST NOT be derived by converting a timestamp to UTC."
+        },
+        "energyTarget": {
+          "$ref": "#/$defs/energy"
+        },
+        "energyConsumed": {
+          "$ref": "#/$defs/energy",
+          "description": "As recorded. May legitimately differ from the sum of entries."
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/foodEntry"
+          }
+        },
+        "note": {
+          "type": "string"
+        }
+      }
+    },
+    "foodEntry": {
+      "type": "object",
+      "required": ["loggedAt"],
+      "properties": {
+        "loggedAt": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "mealType": {
+          "type": "string",
+          "examples": ["breakfast", "lunch", "dinner", "snack"],
+          "description": "Which meal this entry belongs to. Not exhaustive: a consumer treats a value it does not recognise as absent, never as an error."
+        },
+        "name": {
+          "type": "string",
+          "description": "Plain text. The fallback identity when no identifier resolves."
+        },
+        "identifiers": {
+          "type": "object",
+          "description": "Any subset. A consumer resolves whichever it knows.",
+          "properties": {
+            "gtin": {
+              "type": "string",
+              "description": "Barcode: GTIN-8/12/13/14."
+            },
+            "fdcId": {
+              "type": "integer",
+              "description": "USDA FoodData Central id."
+            },
+            "offId": {
+              "type": "string",
+              "description": "Open Food Facts product code."
+            }
+          }
+        },
+        "quantity": {
+          "$ref": "#/$defs/portion",
+          "description": "The amount consumed. A mass or volume is that amount directly; the dimensionless code '1' is a count of the servings named by servingDescription, so 2 with \"slice\" means two slices."
+        },
+        "servingDescription": {
+          "type": "string",
+          "examples": ["1 cup", "2 slices"]
+        },
+        "nutrients": {
+          "type": "object",
+          "description": "FOR THE PORTION CONSUMED. Never per 100 g, never per serving.",
+          "properties": {
+            "energy": {
+              "$ref": "#/$defs/energy"
+            },
+            "protein": {
+              "$ref": "#/$defs/mass"
+            },
+            "carbohydrate": {
+              "$ref": "#/$defs/mass"
+            },
+            "fat": {
+              "$ref": "#/$defs/mass"
+            }
+          }
+        },
+        "source": {
+          "type": "string",
+          "examples": ["manual", "barcode", "database", "estimated"],
+          "description": "How the nutrition data was obtained, not how it was typed. Not exhaustive: a consumer treats a value it does not recognise as absent, never as an error."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Only meaningful when source is 'estimated'."
+        },
+        "note": {
+          "type": "string"
+        }
+      }
+    },
+    "measurement": {
+      "type": "object",
+      "required": ["observedAt", "type", "value"],
+      "properties": {
+        "observedAt": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "type": {
+          "type": "string",
+          "examples": ["bodyMass"]
+        },
+        "value": {
+          "$ref": "#/$defs/quantity"
+        }
+      }
+    },
+    "energy": {
+      "type": "object",
+      "description": "A quantity of energy with a UCUM code. Never a bare number.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["kcal", "kJ"]
+        }
+      }
+    },
+    "mass": {
+      "type": "object",
+      "description": "A mass with a UCUM code. Never a bare number.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["g", "mg", "ug", "kg", "[lb_av]", "[oz_av]"]
+        }
+      }
+    },
+    "length": {
+      "type": "object",
+      "description": "A length with a UCUM code. Never a bare number.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["mm", "cm", "m", "[in_i]", "[ft_i]"]
+        }
+      }
+    },
+    "duration": {
+      "type": "object",
+      "description": "A duration with a UCUM code. UCUM 'a' is years.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["a", "mo", "d"]
+        }
+      }
+    },
+    "portion": {
+      "type": "object",
+      "description": "A portion with a UCUM code. A mass, a volume, or the dimensionless code '1' meaning a count of the servings named by servingDescription.",
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "g",
+            "mg",
+            "ug",
+            "kg",
+            "[lb_av]",
+            "[oz_av]",
+            "mL",
+            "L",
+            "[foz_us]",
+            "1",
+            "%"
+          ]
+        }
+      }
+    }
+  },
+  "title": "Onyx",
+  "description": "A portable personal food and body-weight diary. Consumers MUST ignore members they do not recognise; no object in this schema is closed, which is what allows a minor version to add members without breaking existing readers.",
+  "type": "object",
+  "required": ["format", "specVersion", "exportedAt", "producer"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "format": {
+      "const": "onyx",
+      "description": "Identifies the format independently of file name or location."
+    },
+    "specVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver. Consumers accept any MINOR of a MAJOR they know and refuse a newer MAJOR."
+    },
+    "exportedAt": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "timeZone": {
+      "type": "string",
+      "description": "IANA zone name (e.g. Europe/Berlin). Offsets alone cannot resolve which local day an instant belongs to."
+    },
+    "producer": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      }
+    },
+    "subject": {
+      "$ref": "#/$defs/subject"
+    },
+    "goals": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/goal"
+      }
+    },
+    "days": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/day"
+      }
+    },
+    "bodyMeasurements": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/measurement"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Vendor-private data keyed by reverse-DNS namespace (e.g. ltd.bein.burnin). Consumers MUST ignore namespaces they do not own.",
+      "propertyNames": {
+        "pattern": "^[a-z0-9]+(\\.[a-z0-9-]+)+$"
+      }
+    }
+  }
+}

--- a/src/test/onyx-v1/atwater-mismatch.json
+++ b/src/test/onyx-v1/atwater-mismatch.json
@@ -1,0 +1,25 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+03:00",
+          "name": "Oats",
+          "nutrients": {
+            "carbohydrate": { "unit": "g", "value": 66 },
+            "energy": { "unit": "kcal", "value": 117 },
+            "fat": { "unit": "g", "value": 6.9 },
+            "protein": { "unit": "g", "value": 16.9 }
+          },
+          "quantity": { "unit": "g", "value": 30 }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T12:00:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Portion Confusion" },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/duplicate-day.json
+++ b/src/test/onyx-v1/duplicate-day.json
@@ -1,0 +1,17 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "energyConsumed": { "unit": "kcal", "value": 1800 }
+    },
+    {
+      "date": "2026-08-10",
+      "energyConsumed": { "unit": "kcal", "value": 2100 }
+    }
+  ],
+  "exportedAt": "2026-08-14T12:00:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Merged Badly" },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/foreign-document-no-vendor-block.json
+++ b/src/test/onyx-v1/foreign-document-no-vendor-block.json
@@ -1,0 +1,27 @@
+{
+  "bodyMeasurements": [
+    {
+      "observedAt": "2026-08-10T07:00:00+02:00",
+      "type": "bodyMass",
+      "value": { "unit": "[lb_av]", "value": 177.5 }
+    }
+  ],
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "mealType": "breakfast",
+          "name": "Oats",
+          "nutrients": { "energy": { "unit": "kcal", "value": 389 } }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-11T20:00:00+02:00",
+  "format": "onyx",
+  "producer": { "name": "Some Other Tracker" },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/goal-in-the-wrong-dimension.json
+++ b/src/test/onyx-v1/goal-in-the-wrong-dimension.json
@@ -1,0 +1,18 @@
+{
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "goals": [
+    {
+      "type": "targetWeight",
+      "value": {
+        "unit": "kcal",
+        "value": 72
+      }
+    }
+  ],
+  "producer": {
+    "name": "Targets Grams"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/goal-type-outside-the-vocabulary.json
+++ b/src/test/onyx-v1/goal-type-outside-the-vocabulary.json
@@ -1,0 +1,25 @@
+{
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "goals": [
+    {
+      "type": "bodyFatTarget",
+      "value": {
+        "unit": "%",
+        "value": 18
+      }
+    },
+    {
+      "type": "targetWeight",
+      "value": {
+        "unit": "kg",
+        "value": 78
+      }
+    }
+  ],
+  "producer": {
+    "name": "Has A Goal We Do Not Know"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/measurement-folds-by-its-own-offset.json
+++ b/src/test/onyx-v1/measurement-folds-by-its-own-offset.json
@@ -1,0 +1,37 @@
+{
+  "bodyMeasurements": [
+    {
+      "observedAt": "2026-08-10T00:30:00+09:00",
+      "type": "bodyMass",
+      "value": {
+        "unit": "kg",
+        "value": 70.5
+      }
+    }
+  ],
+  "days": [
+    {
+      "date": "2026-08-09",
+      "entries": [
+        {
+          "loggedAt": "2026-08-09T19:00:00+09:00",
+          "mealType": "dinner",
+          "name": "Ramen",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 620
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-10T09:00:00+09:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Travelling Tracker"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/minimal.json
+++ b/src/test/onyx-v1/minimal.json
@@ -1,0 +1,6 @@
+{
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Example Tracker" },
+  "specVersion": "1.0.0"
+}

--- a/src/test/onyx-v1/newer-major.json
+++ b/src/test/onyx-v1/newer-major.json
@@ -1,0 +1,6 @@
+{
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "From The Future" },
+  "specVersion": "2.0.0"
+}

--- a/src/test/onyx-v1/open-vocabulary-value.json
+++ b/src/test/onyx-v1/open-vocabulary-value.json
@@ -1,0 +1,19 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T11:00:00+03:00",
+          "mealType": "brunch",
+          "name": "Shakshuka",
+          "nutrients": { "energy": { "unit": "kcal", "value": 420 } }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Richer Vocabulary" },
+  "specVersion": "1.0.0"
+}

--- a/src/test/onyx-v1/portion-in-percent.json
+++ b/src/test/onyx-v1/portion-in-percent.json
@@ -1,0 +1,30 @@
+{
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "name": "Pizza",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 640
+            }
+          },
+          "quantity": {
+            "unit": "%",
+            "value": 50
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Logs A Percentage"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/producer-export-with-vendor-block.json
+++ b/src/test/onyx-v1/producer-export-with-vendor-block.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://www.schemastore.org/onyx-v1.json",
+  "bodyMeasurements": [
+    {
+      "observedAt": "2026-08-12T07:00:00+03:00",
+      "type": "bodyMass",
+      "value": { "unit": "kg", "value": 80.4 }
+    },
+    {
+      "observedAt": "2026-08-13T07:04:00+03:00",
+      "type": "bodyMass",
+      "value": { "unit": "kg", "value": 80.1 }
+    }
+  ],
+  "days": [
+    {
+      "date": "2026-08-12",
+      "energyConsumed": { "unit": "kcal", "value": 1804 },
+      "entries": [
+        {
+          "identifiers": { "fdcId": 169705 },
+          "loggedAt": "2026-08-12T08:30:00+03:00",
+          "mealType": "breakfast",
+          "name": "Oats",
+          "nutrients": {
+            "carbohydrate": { "unit": "g", "value": 66 },
+            "energy": { "unit": "kcal", "value": 389 },
+            "fat": { "unit": "g", "value": 6.9 },
+            "protein": { "unit": "g", "value": 16.9 }
+          },
+          "quantity": { "unit": "1", "value": 1 },
+          "servingDescription": "1 cup",
+          "source": "database"
+        },
+        {
+          "confidence": 0.62,
+          "loggedAt": "2026-08-12T13:05:00+03:00",
+          "mealType": "lunch",
+          "name": "Chicken bowl",
+          "note": "eyeballed the rice",
+          "nutrients": { "energy": { "unit": "kcal", "value": 715 } },
+          "quantity": { "unit": "1", "value": 1.5 },
+          "servingDescription": "bowl",
+          "source": "estimated"
+        }
+      ]
+    },
+    {
+      "date": "2026-08-13",
+      "energyConsumed": { "unit": "kcal", "value": 0 },
+      "note": "fasted"
+    }
+  ],
+  "exportedAt": "2026-08-14T12:30:15+03:00",
+  "extensions": {
+    "ltd.bein.burnin": {
+      "blockVersion": 1,
+      "entries": {
+        "BURNIN_TDEE_HISTORY": "[{\"date\":\"2026-08-12\",\"tdee\":2180}]",
+        "DAY-Wed Aug 12 2026": "{\"date\":\"2026-08-12T00:00:00.000Z\",\"caloriesConsumed\":1804,\"weight\":80.4,\"smoothedWeight\":80.45,\"runningTDEE\":2180,\"meals\":[]}",
+        "USER": "{\"gender\":false,\"age\":34,\"height\":165,\"targetWeight\":62,\"goalType\":\"loss\",\"unitSystem\":\"metric\"}"
+      }
+    }
+  },
+  "format": "onyx",
+  "goals": [
+    { "type": "targetWeight", "value": { "unit": "kg", "value": 62 } },
+    { "direction": "loss", "type": "weightDirection" }
+  ],
+  "producer": { "name": "Burnin", "platform": "android", "version": "1.2.0" },
+  "specVersion": "1.0.0",
+  "subject": {
+    "age": { "unit": "a", "value": 34 },
+    "height": { "unit": "cm", "value": 165 },
+    "preferredUnits": { "energy": "kcal", "mass": "kg" },
+    "sex": "female"
+  },
+  "timeZone": "Asia/Jerusalem"
+}

--- a/src/test/onyx-v1/spec-version-with-a-leading-zero.json
+++ b/src/test/onyx-v1/spec-version-with-a-leading-zero.json
@@ -1,0 +1,7 @@
+{
+  "exportedAt": "2026-08-14T12:00:00+03:00",
+  "format": "onyx",
+  "producer": { "name": "Leading Zero" },
+  "specVersion": "01.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/two-weigh-ins-on-one-day.json
+++ b/src/test/onyx-v1/two-weigh-ins-on-one-day.json
@@ -1,0 +1,44 @@
+{
+  "bodyMeasurements": [
+    {
+      "observedAt": "2026-08-10T21:00:00+02:00",
+      "type": "bodyMass",
+      "value": {
+        "unit": "kg",
+        "value": 80
+      }
+    },
+    {
+      "observedAt": "2026-08-10T07:00:00+02:00",
+      "type": "bodyMass",
+      "value": {
+        "unit": "kg",
+        "value": 82
+      }
+    }
+  ],
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+02:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": {
+              "unit": "kcal",
+              "value": 389
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "exportedAt": "2026-08-14T09:00:00+02:00",
+  "format": "onyx",
+  "producer": {
+    "name": "Weighs Twice"
+  },
+  "specVersion": "1.0.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/unknown-members-at-every-level.json
+++ b/src/test/onyx-v1/unknown-members-at-every-level.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://example.invalid/onyx/v1/log.schema.json",
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+03:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": { "unit": "kcal", "value": 389 },
+            "selenium": { "unit": "ug", "value": 34 }
+          }
+        }
+      ],
+      "mood": "unknown member"
+    }
+  ],
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "extensions": { "com.example.tracker": { "blockVersion": 4 } },
+  "format": "onyx",
+  "hydration": [
+    {
+      "observedAt": "2026-08-10T09:00:00+03:00",
+      "value": { "unit": "mL", "value": 500 }
+    }
+  ],
+  "producer": {
+    "name": "Later Minor",
+    "quirk": "unknown member",
+    "version": "3.0.0"
+  },
+  "specVersion": "1.7.0",
+  "timeZone": "Europe/Berlin"
+}

--- a/src/test/onyx-v1/unknown-members-survive.json
+++ b/src/test/onyx-v1/unknown-members-survive.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://example.invalid/onyx/v1/log.schema.json",
+  "days": [
+    {
+      "date": "2026-08-10",
+      "entries": [
+        {
+          "loggedAt": "2026-08-10T08:30:00+03:00",
+          "name": "Oats",
+          "nutrients": {
+            "energy": { "unit": "kcal", "value": 389 },
+            "selenium": { "unit": "ug", "value": 34 }
+          }
+        }
+      ],
+      "mood": "unknown member"
+    }
+  ],
+  "exportedAt": "2026-08-10T09:12:00+03:00",
+  "extensions": { "com.example.tracker": { "blockVersion": 4 } },
+  "format": "onyx",
+  "hydration": [
+    {
+      "observedAt": "2026-08-10T09:00:00+03:00",
+      "value": { "unit": "mL", "value": 500 }
+    }
+  ],
+  "producer": {
+    "name": "Later Minor",
+    "quirk": "unknown member",
+    "version": "3.0.0"
+  },
+  "specVersion": "1.7.0",
+  "timeZone": "Europe/Berlin"
+}


### PR DESCRIPTION
Adds `onyx-v1.json`, the JSON Schema for Onyx, an open interchange format for a
personal food and body-weight diary: https://github.com/dsemakin/onyx

- Schema: the published 1.0.0 specification, `spec/v1/log.schema.json` in that
  repository. `$id` is `https://www.schemastore.org/onyx-v1.json`.
- Tests: 15 positive and 9 negative cases from the format's language-agnostic
  conformance corpus, sorted into the two sets by validating each one.
- `fileMatch`: `*.onyx.json` and `*.onx.json`, chosen to be specific enough not to
  collide with anything else.
- The schema is draft 2020-12, so it is listed under `highSchemaVersion` in
  `schema-validation.jsonc` as the check requests. The specification is published
  and versioned, so the draft cannot be lowered in place.

`node ./cli.js check --schema-name=onyx-v1.json` passes, and the files are
formatted with the repository's Prettier config.
