### PR TITLE
Sync bunfig's schema with the latest parser/docs

### DIFF
--- a/src/schemas/json/bunfig.json
+++ b/src/schemas/json/bunfig.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/bunfig.json",
   "title": "Bun configuration",
-  "description": "Bun configuration schema for `bunfig.toml`. See https://bun.sh/docs/runtime/bunfig",
+  "description": "Bun configuration schema for `bunfig.toml`.\nhttps://bun.com/docs/runtime/bunfig",
   "additionalProperties": true,
   "type": "object",
   "properties": {
@@ -66,8 +66,8 @@
       "additionalProperties": true
     },
     "loader": {
-      "$comment": "https://bun.sh/docs/runtime/bunfig#loader",
-      "description": "Configure how Bun maps file extensions to loaders. This is useful for loading files that aren't natively supported by Bun\nhttps://bun.sh/docs/runtime/bunfig#loader",
+      "$comment": "https://bun.com/docs/bundler/loaders",
+      "description": "Map file extensions to Bun's built-in loaders.\nhttps://bun.com/docs/bundler/loaders",
       "type": "object",
       "additionalProperties": {
         "type": "string",
@@ -79,13 +79,42 @@
           "css",
           "file",
           "json",
+          "jsonc",
+          "json5",
           "toml",
+          "yaml",
+          "xml",
           "wasm",
           "napi",
           "base64",
           "dataurl",
-          "text"
+          "text",
+          "sqlite",
+          "sqlite_embedded",
+          "html",
+          "md",
+          "sh",
+          "mjs",
+          "cjs",
+          "cts",
+          "mts",
+          "node",
+          "txt",
+          "markdown"
         ]
+      }
+    },
+    "debug": {
+      "$comment": "https://bun.com/docs/runtime/utils#bunopenineditor",
+      "description": "Configure Bun's debugging tools.\nhttps://bun.com/docs/runtime/utils#bunopenineditor",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "editor": {
+          "description": "Set the editor that Bun.openInEditor() opens.\nhttps://bun.com/docs/runtime/utils#bunopenineditor",
+          "type": "string",
+          "examples": ["code"]
+        }
       }
     },
     "telemetry": {
@@ -143,6 +172,47 @@
           "maximum": 65535,
           "default": 3000,
           "examples": [3000]
+        },
+        "static": {
+          "$comment": "https://bun.com/docs/bundler/fullstack#plugins",
+          "description": "Configure how Bun serves and bundles static routes.\nhttps://bun.com/docs/bundler/fullstack#plugins",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "plugins": {
+              "description": "Load plugins to bundle static routes.\nhttps://bun.com/docs/bundler/fullstack#plugins",
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ],
+              "examples": [["bun-plugin-tailwind"]]
+            },
+            "sourcemap": {
+              "description": "Select how Bun emits sourcemaps for static routes.\nhttps://bun.com/docs/bundler/fullstack#sourcemaps",
+              "oneOf": [
+                { "type": "boolean" },
+                {
+                  "type": "string",
+                  "enum": ["none", "linked", "inline", "external"]
+                }
+              ],
+              "examples": ["linked", false]
+            },
+            "env": {
+              "description": "Select which environment variables Bun inlines into static routes. Use `inline` for all variables, `disable` for none, or a prefix with `*` for matching variables.\nhttps://bun.com/docs/bundler/fullstack#inline-environment-variables",
+              "oneOf": [
+                { "type": "boolean" },
+                {
+                  "type": "string",
+                  "anyOf": [
+                    { "enum": ["inline", "disable"] },
+                    { "pattern": "\\*" }
+                  ]
+                }
+              ],
+              "examples": ["PUBLIC_*", "inline", false]
+            }
+          }
         }
       }
     },
@@ -203,16 +273,33 @@
           ]
         },
         "coverageThreshold": {
-          "$comment": "https://bun.sh/docs/runtime/bunfig#test-coveragethreshold",
-          "description": "To specify a coverage threshold. By default, no threshold is set. If your test suite does not meet or exceed this threshold, `bun test` will exit with a non-zero exit code to indicate the failure\nhttps://bun.sh/docs/runtime/bunfig#test-coveragethreshold",
+          "$comment": "https://bun.com/docs/test/configuration#coverage-thresholds",
+          "description": "Set a coverage threshold for all metrics or for individual metrics. A test run fails if coverage does not meet the threshold.\nhttps://bun.com/docs/test/configuration#coverage-thresholds",
           "oneOf": [
             { "type": "number" },
             {
               "type": "object",
-              "additionalProperties": true
+              "additionalProperties": false,
+              "properties": {
+                "lines": {
+                  "description": "Set the minimum line coverage.\nhttps://bun.com/docs/test/configuration#coverage-thresholds",
+                  "type": "number"
+                },
+                "functions": {
+                  "description": "Set the minimum function coverage.\nhttps://bun.com/docs/test/configuration#coverage-thresholds",
+                  "type": "number"
+                },
+                "statements": {
+                  "description": "Set the minimum statement coverage. Bun accepts this value but does not enforce it.\nhttps://bun.com/docs/test/configuration#coverage-thresholds",
+                  "type": "number"
+                }
+              }
             }
           ],
-          "examples": [0.9, { "line": 0.7, "function": 0.8, "statement": 0.9 }]
+          "examples": [
+            0.9,
+            { "lines": 0.7, "functions": 0.8, "statements": 0.9 }
+          ]
         },
         "coverageSkipTestFiles": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#test-coverageskiptestfiles",
@@ -227,13 +314,15 @@
           "default": false
         },
         "coverageReporter": {
-          "$comment": "https://bun.sh/docs/runtime/bunfig#test-coveragereporter",
-          "description": "By default, coverage reports will be printed to the console. For persistent code coverage reports in CI environments and for other tools use `lcov`\nhttps://bun.sh/docs/runtime/bunfig#test-coveragereporter",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": ["text", "lcov"]
-          },
+          "$comment": "https://bun.com/docs/test/code-coverage#coverage-reporters",
+          "description": "Select console or LCOV coverage reports. Use one reporter name or an array of names.\nhttps://bun.com/docs/test/code-coverage#coverage-reporters",
+          "oneOf": [
+            { "type": "string", "enum": ["text", "lcov"] },
+            {
+              "type": "array",
+              "items": { "type": "string", "enum": ["text", "lcov"] }
+            }
+          ],
           "default": ["text"]
         },
         "coverageDir": {
@@ -272,9 +361,16 @@
           "examples": [3]
         },
         "concurrentTestGlob": {
-          "$comment": "https://bun.sh/docs/runtime/bunfig#test-concurrenttestglob",
-          "description": "Glob pattern for test files that should run with concurrent test execution enabled.\nhttps://bun.sh/docs/runtime/bunfig#test-concurrenttestglob",
-          "type": "string",
+          "$comment": "https://bun.com/docs/test/configuration#concurrenttestglob",
+          "description": "Select test files that run tests concurrently. Use one glob or an array of globs.\nhttps://bun.com/docs/test/configuration#concurrenttestglob",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "minLength": 1 }
+            }
+          ],
           "examples": ["**/concurrent-*.test.ts"]
         },
         "onlyFailures": {
@@ -359,7 +455,7 @@
           "$comment": "https://bun.com/docs/runtime/bunfig#install-concurrentscripts",
           "description": "The maximum number of concurrent lifecycle scripts to run at once. Defaults to two times the number of CPU cores. Equivalent to the `--concurrent-scripts` flag.\nhttps://bun.com/docs/runtime/bunfig#install-concurrentscripts",
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "examples": [5]
         },
         "saveTextLockfile": {
@@ -369,10 +465,15 @@
           "default": true
         },
         "auto": {
-          "$comment": "https://bun.sh/docs/runtime/bunfig#install-auto",
-          "description": "To configure Bun's package auto-install behavior. Default `\"auto\"` — when no `node_modules` folder is found, Bun will automatically install dependencies on the fly during execution\nhttps://bun.sh/docs/runtime/bunfig#install-auto",
-          "type": "string",
-          "enum": ["auto", "force", "disable", "fallback"],
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-auto",
+          "description": "Set auto-install behavior. The default `\"auto\"` installs dependencies when `node_modules` is absent. Bun also accepts a boolean.\nhttps://bun.com/docs/runtime/bunfig#install-auto",
+          "oneOf": [
+            { "type": "boolean" },
+            {
+              "type": "string",
+              "enum": ["auto", "force", "disable", "fallback"]
+            }
+          ],
           "default": "auto"
         },
         "prefer": {
@@ -381,6 +482,12 @@
           "type": "string",
           "enum": ["online", "offline", "latest"],
           "default": "online"
+        },
+        "offline": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-offline",
+          "description": "Use only packages and metadata in the local cache. Fail if an item is missing. Default `false`.\nhttps://bun.com/docs/runtime/bunfig#install-offline",
+          "type": "boolean",
+          "default": false
         },
         "frozenLockfile": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-frozenlockfile",
@@ -426,6 +533,14 @@
                   "description": "The token to use for authentication\nhttps://bun.sh/docs/runtime/bunfig#install-registry",
                   "type": "string",
                   "examples": ["123456"]
+                },
+                "username": {
+                  "description": "Set the registry user name.\nhttps://bun.com/docs/pm/npmrc#configure-options-for-a-specific-registry",
+                  "type": "string"
+                },
+                "password": {
+                  "description": "Set the registry password.\nhttps://bun.com/docs/pm/npmrc#configure-options-for-a-specific-registry",
+                  "type": "string"
                 }
               }
             }
@@ -447,12 +562,17 @@
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-scopes",
           "description": "To configure a registry for a particular scope (e.g. `@myorg/<package>`) use `install.scopes`. You can reference environment variables with `$variable` notation\nhttps://bun.sh/docs/runtime/bunfig#install-scopes",
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": {
+            "$ref": "#/properties/install/properties/registry"
+          }
         },
         "ca": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
-          "description": "The CA certificate as a string\nhttps://bun.sh/docs/runtime/bunfig#install-ca-and-install-cafile",
-          "type": "string",
+          "description": "Set one CA certificate or an array of certificates.\nhttps://bun.com/docs/runtime/bunfig#install-ca-and-install-cafile",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ],
           "examples": [
             "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
           ]
@@ -464,28 +584,34 @@
           "examples": ["path/to/cafile"]
         },
         "cache": {
-          "$comment": "https://bun.sh/docs/runtime/bunfig#install-cache",
-          "description": "To configure the cache behavior\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "dir": {
-              "description": "The directory to use for the cache\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
-              "type": "string",
-              "default": "~/.bun/install/cache",
-              "examples": ["~/.bun/install/cache"]
-            },
-            "disable": {
-              "description": "When true, don't load from the global cache.\n\nBun may still write to `node_modules/.cache`\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
-              "type": "boolean",
-              "default": false
-            },
-            "disableManifest": {
-              "description": "When true, always resolve the latest versions from the registry\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
-              "type": "boolean",
-              "default": false
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-cache",
+          "description": "Configure the cache with an object. Bun also accepts a directory string or `false` to disable both caches.\nhttps://bun.com/docs/runtime/bunfig#install-cache",
+          "oneOf": [
+            { "type": "boolean" },
+            { "type": "string" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "dir": {
+                  "description": "The directory to use for the cache\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
+                  "type": "string",
+                  "default": "~/.bun/install/cache",
+                  "examples": ["~/.bun/install/cache"]
+                },
+                "disable": {
+                  "description": "When true, don't load from the global cache.\n\nBun may still write to `node_modules/.cache`\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
+                  "type": "boolean",
+                  "default": false
+                },
+                "disableManifest": {
+                  "description": "When true, always resolve the latest versions from the registry\nhttps://bun.sh/docs/runtime/bunfig#install-cache",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
             }
-          }
+          ]
         },
         "lockfile": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-lockfile",
@@ -507,10 +633,9 @@
         },
         "linker": {
           "$comment": "https://bun.sh/docs/runtime/bunfig#install-linker",
-          "description": "Configure the default linker strategy. Default `\"hoisted\"`\nhttps://bun.sh/docs/runtime/bunfig#install-linker",
+          "description": "Set how Bun links dependencies into `node_modules`. New workspaces use `\"isolated\"`; new single-package projects and existing projects use `\"hoisted\"`.\nhttps://bun.com/docs/runtime/bunfig#install-linker",
           "type": "string",
-          "enum": ["hoisted", "isolated"],
-          "default": "hoisted"
+          "enum": ["hoisted", "isolated"]
         },
         "globalStore": {
           "$comment": "https://bun.com/docs/runtime/bunfig#install-globalstore",
@@ -528,11 +653,17 @@
         },
         "hoistPattern": {
           "$comment": "https://bun.com/docs/runtime/bunfig#install-hoistpattern",
-          "description": "When using the `\"isolated\"` linker, packages matching these glob patterns are hoisted to the virtual store root (`node_modules/.bun`) so they can be resolved by other packages in the virtual store. Default `[]`. Similar to pnpm's `hoist-pattern`.\nhttps://bun.com/docs/runtime/bunfig#install-hoistpattern",
+          "description": "When using the `\"isolated\"` linker, Bun links matching packages into the fallback directory (`node_modules/.bun/node_modules`). By default, Bun links all packages, equivalent to `[\"*\"]`.\nhttps://bun.com/docs/runtime/bunfig#install-hoistpattern",
           "type": "array",
           "items": { "type": "string" },
-          "default": [],
+          "default": ["*"],
           "examples": [["*"]]
+        },
+        "hoist": {
+          "$comment": "https://bun.com/docs/runtime/bunfig#install-hoist",
+          "description": "Create a fallback directory for packages in isolated installs. Default `true`. Set to `false` to prevent undeclared packages from resolving through this directory.\nhttps://bun.com/docs/runtime/bunfig#install-hoist",
+          "type": "boolean",
+          "default": true
         },
         "logLevel": {
           "$comment": "https://bun.com/docs/runtime/bunfig#install-loglevel",
@@ -573,7 +704,7 @@
     },
     "run": {
       "$comment": "https://bun.sh/docs/runtime/bunfig#bun-run",
-      "description": "The `bun run` command can be configured under the `[run]` section. These apply to the `bun run` command and the `bun` command when running a file or executable or script.\n\nCurrently, `bunfig.toml` isn't always automatically loaded for `bun run` in a local project (it does check for a global `bunfig.toml`), so you might still need to pass `-c` or `-c=bunfig.toml` to use these settings\nhttps://bun.sh/docs/runtime/bunfig#bun-run",
+      "description": "Configure `bun run` and the `bun` command when they run a file, script, or executable. Bun loads the local project's `bunfig.toml` for these commands.\nhttps://bun.com/docs/runtime/bunfig#bun-run",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/src/test/bunfig/bunfig-variants.toml
+++ b/src/test/bunfig/bunfig-variants.toml
@@ -1,0 +1,18 @@
+#:schema ../../schemas/json/bunfig.json
+# Use other value forms that Bun's config parser accepts.
+
+[install]
+auto = true
+cache = false
+ca = ["certificate-a", "certificate-b"]
+registry = { url = "https://registry.example.com/", username = "user", password = "password" }
+
+[serve.static]
+plugins = "./plugin.ts"
+env = false
+sourcemap = true
+
+[test]
+coverageReporter = "lcov"
+coverageThreshold = { lines = 0.8, functions = 0.9, statements = 0.7 }
+concurrentTestGlob = ["**/concurrent-*.test.ts", "**/parallel-*.test.ts"]

--- a/src/test/bunfig/bunfig.toml
+++ b/src/test/bunfig/bunfig.toml
@@ -19,8 +19,16 @@ env = false
 [console]
 depth = 3
 
+[debug]
+editor = "code"
+
 [serve]
 port = 3000
+
+[serve.static]
+plugins = ["bun-plugin-tailwind"]
+env = "PUBLIC_*"
+sourcemap = "linked"
 
 [define]
 # Replace any usage of "process.env.bagel" with the string `lox`.
@@ -31,6 +39,7 @@ port = 3000
 [install]
 auto = "auto"
 prefer = "online"
+offline = false
 dev = true
 dryRun = false
 saveTextLockfile = true
@@ -48,6 +57,7 @@ registry = "https://registry.npmjs.org"
 linkWorkspacePackages = true
 linker = "isolated"
 globalStore = true
+hoist = false
 publicHoistPattern = ["*eslint*", "*prettier*"]
 hoistPattern = ["*"]
 logLevel = "warn"
@@ -72,11 +82,14 @@ print = "yarn"
 save = true
 
 [install.scopes]
-myorg = "https://username:password@registry.myorg.com/"
+myorg = { url = "https://registry.myorg.com/", token = "test-token" }
+another = "https://registry.another.com/"
 
 [loader]
 # when a .bagel file is imported, treat it like a tsx file
 ".bagel" = "tsx"
+".yaml" = "yaml"
+".html" = "html"
 
 [run]
 # equivalent to `bun --bun` for all `bun run` commands


### PR DESCRIPTION
## Summary

Bun documents `bunfig.toml` settings that the current schema does not describe. Add `install.offline`, `install.hoist`, `debug.editor`, and the documented `[serve.static]` settings for plugins, environment variables, and sourcemaps.

Update existing entries to accept Bun's supported loader names and configuration forms, including a single coverage reporter, detailed coverage thresholds, registry credentials, and scalar cache settings. Correct the linker and hoist pattern defaults. Add TOML fixtures for the new settings and their alternate forms.

I checked the keys against [Bun's configuration parser](https://github.com/oven-sh/bun/blob/6a92015fc89e1da27e3c781a3a3d6540c104dd13/src/bunfig/bunfig.rs) and the [Bun configuration docs](https://bun.com/docs/runtime/bunfig), including the [static route documentation](https://bun.com/docs/bundler/fullstack).

## Validation

- `node ./cli.js check --schema-name=bunfig.json`
- `prettier --check src/schemas/json/bunfig.json src/test/bunfig/*.toml`
