### PR TITLE
Update OpenTelemetry Declarative Configuration to v1.2.0

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5831,8 +5831,9 @@
         "otel-sdk*.yaml",
         "otel-sdk*.yml"
       ],
-      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
+      "url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.2.0/opentelemetry_configuration.json",
       "versions": {
+        "1.2.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.2.0/opentelemetry_configuration.json",
         "1.1.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.1.0/opentelemetry_configuration.json",
         "1.0.0": "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/refs/tags/v1.0.0/opentelemetry_configuration.json"
       }


### PR DESCRIPTION
Reflects the latest release of this schema: https://github.com/open-telemetry/opentelemetry-configuration/releases/tag/v1.2.0