### PR TITLE
Add `hum` to SchemaStore

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4294,6 +4294,12 @@
       "url": "https://raw.githubusercontent.com/HaxeFoundation/haxelib/master/schema.json"
     },
     {
+      "name": "hum",
+      "description": "Hum project process manifest",
+      "fileMatch": ["hum.yaml"],
+      "url": "https://raw.githubusercontent.com/brettinternet/hum/main/hum.schema.json"
+    },
+    {
       "name": "Hayson",
       "description": "Project Haystack data",
       "fileMatch": ["*.hayson.json", "*.hayson.yaml", "*.hayson.yml"],


### PR DESCRIPTION
Adds a SchemaStore catalog entry named `hum` matching only `hum.yaml` and pointing to the maintained Hum schema. Local checks passed: `bun cli.js check` and `bun cli.js coverage`.

Hum: https://github.com/brettinternet/hum