### PR TITLE
Support alternate Hum manifest filenames

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4296,7 +4296,13 @@
     {
       "name": "hum",
       "description": "Hum project process manifest",
-      "fileMatch": ["hum.yaml", "hum.*.yaml", "*.hum.yaml", "hum.yml", "*.hum.yml"],
+      "fileMatch": [
+        "hum.yaml",
+        "hum.*.yaml",
+        "*.hum.yaml",
+        "hum.yml",
+        "*.hum.yml"
+      ],
       "url": "https://raw.githubusercontent.com/brettinternet/hum/main/hum.schema.json"
     },
     {

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -4296,7 +4296,7 @@
     {
       "name": "hum",
       "description": "Hum project process manifest",
-      "fileMatch": ["hum.yaml"],
+      "fileMatch": ["hum.yaml", "hum.*.yaml", "*.hum.yaml", "hum.yml", "*.hum.yml"],
       "url": "https://raw.githubusercontent.com/brettinternet/hum/main/hum.schema.json"
     },
     {


### PR DESCRIPTION
Follow-up to #6344.

Updates the existing `hum` catalog entry’s `fileMatch` patterns to recognize:
`hum.yaml`, `hum.*.yaml`, `*.hum.yaml`, `hum.yml`, and `*.hum.yml`.

Project repository: https://github.com/brettinternet/hum

Preserves the external schema URL. JSON parses successfully, and `git diff --check` passes.

Thank you to the maintainers.