### PR TITLE
Add mise task schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -8855,6 +8855,11 @@
       "url": "https://mise.jdx.dev/schema/mise.json"
     },
     {
+      "name": "mise task",
+      "description": "mise config for `task_config.includes` tasks",
+      "url": "https://mise.jdx.dev/schema/mise-task.json"
+    },
+    {
       "name": "mta.yaml",
       "description": "A MTA projects v3.3",
       "fileMatch": ["mta.yaml", "mta.yml"],


### PR DESCRIPTION
There is no predefined filename patterns so I omit the `fileMatch` property.

mise docs
- mise toml schema \
  https://mise.en.dev/configuration.html#mise-toml-schema
- `task_config.includes` setting \
  https://mise.en.dev/tasks/task-configuration.html#task_config.includes

<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->
